### PR TITLE
Only delay FakeLagProcess if no packets were handled

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
@@ -127,10 +127,13 @@ internal class TcpChannel : Connection
 		{
 			while ( !tokenSource.IsCancellationRequested )
 			{
+				var didSomething = false;
+
 				if ( fakeLagIncoming.TryPeek( out var i ) )
 				{
 					if ( i.Item2 )
 					{
+						didSomething = true;
 						InvokeMessageHandler( i.Item3, i.Item1 );
 						fakeLagIncoming.Dequeue();
 					}
@@ -140,13 +143,15 @@ internal class TcpChannel : Connection
 				{
 					if ( o.Item2 )
 					{
+						didSomething = true;
 						sendChannel.Writer.TryWrite( BitConverter.GetBytes( o.Item1.Length ) );
 						sendChannel.Writer.TryWrite( o.Item1 );
 						fakeLagOutgoing.Dequeue();
 					}
 				}
 
-				await Task.Delay( 1 );
+				if ( !didSomething )
+					await Task.Delay( 1 );
 			}
 		}
 		catch ( Exception e )

--- a/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
@@ -127,13 +127,13 @@ internal class TcpChannel : Connection
 		{
 			while ( !tokenSource.IsCancellationRequested )
 			{
-				var didSomething = false;
+				var processedPacket = false;
 
 				if ( fakeLagIncoming.TryPeek( out var i ) )
 				{
 					if ( i.Item2 )
 					{
-						didSomething = true;
+						processedPacket = true;
 						InvokeMessageHandler( i.Item3, i.Item1 );
 						fakeLagIncoming.Dequeue();
 					}
@@ -143,14 +143,14 @@ internal class TcpChannel : Connection
 				{
 					if ( o.Item2 )
 					{
-						didSomething = true;
+						processedPacket = true;
 						sendChannel.Writer.TryWrite( BitConverter.GetBytes( o.Item1.Length ) );
 						sendChannel.Writer.TryWrite( o.Item1 );
 						fakeLagOutgoing.Dequeue();
 					}
 				}
 
-				if ( !didSomething )
+				if ( !processedPacket ) // Maybe something will be ready later?
 					await Task.Delay( 1 );
 			}
 		}


### PR DESCRIPTION
The fake lag process has a 1ms delay in it to prevent it from running at full tilt when no packets are ready to be handled.

However, if a packet is handled, the 1ms delay is still there. This means that if you have a bunch of packets coming in at the same time, they will be delayed by 1ms each, and probably be cancelled and delayed until the following frames.

This PR only uses the 1ms delay if no work was performed during the current loop iteration.
This resolves https://github.com/Facepunch/sbox-public/issues/1134 and https://github.com/Facepunch/sbox-public/issues/622

https://github.com/user-attachments/assets/c7fe9788-e3ef-444d-8f7c-41278faae350

