### PR TITLE
Clicking anywhere within a ContentBlockHero brings up the create game modal

### DIFF
--- a/game/addons/menu/Code/MenuUI/ContentBlock/ContentBlockHero.razor
+++ b/game/addons/menu/Code/MenuUI/ContentBlock/ContentBlockHero.razor
@@ -5,7 +5,7 @@
 
 @if (Current == null) return;
 
-<root class="hero bgcolor@BgColor">
+<root class="hero bgcolor@BgColor" onclick="@Clicked">
 
     @if (BackgroundUrl != null)
     {
@@ -14,7 +14,7 @@
 
     <div class="content">
 
-        <div class="left" onclick="@Clicked">
+        <div class="left">
             <div class="icon"><img src="@Current.Thumb" /></div>
             <div class="title">@Current.Title</div>
             <div class="description">@Current.Summary</div>
@@ -40,7 +40,6 @@
 
     protected override async Task OnParametersSetAsync()
     {
-
         Current = Group.Packages.OrderBy( x => Guid.NewGuid() ).FirstOrDefault();
         Current = await Package.FetchAsync( Current.FullIdent, false );
         UpdateBackgroundMedia();
@@ -66,7 +65,6 @@
 
         BackgroundUrl = bg;
         BgColor = Random.Shared.Int(0, 4);
-
     }
 
     void Clicked()

--- a/game/addons/menu/Code/MenuUI/ContentBlock/ContentBlockHero.razor.scss
+++ b/game/addons/menu/Code/MenuUI/ContentBlock/ContentBlockHero.razor.scss
@@ -1,5 +1,4 @@
-
-.hero
+.hero 
 {
 	min-height: 40vh;
 	position: relative;
@@ -12,6 +11,14 @@
 	margin: 4px;
 	margin-top: 2rem;
 	border: 1px solid #fff2;
+	cursor: pointer;
+	transition: all 0.3s ease;
+
+	&:hover 
+	{
+		border: 1px solid #08f4;
+		transition: all 0.1s ease;
+	}
 }
 
 .background-media
@@ -37,7 +44,6 @@
 	max-width: 250px;
 	flex-direction: column;
 	gap: 1rem;
-	cursor: pointer;
 	text-shadow: 1px 1px 2px #000d;
 }
 


### PR DESCRIPTION
**Previous behaviour**
Click anywhere within the hidden zone shown in red to bring up the create game modal.
<img width="1234" height="550" alt="image" src="https://github.com/user-attachments/assets/23406d1a-02fe-43c8-91df-bf9d54b87127" />

**New behaviour**
Click anywhere within the hero to bring up the create game modal. When hovered display the same blue outline that the PackageCards have.
<img width="1246" height="607" alt="image" src="https://github.com/user-attachments/assets/c9ed5ffb-bf73-42cc-877c-6f3b1d74732f" />