### PR TITLE
Fix AssetBrowser view mode persistence and icon update

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
@@ -109,20 +109,18 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		}
 	}
 
-	static AssetListViewMode _viewModeType;
-
 	/// <summary>
 	/// View mode, i.e. thumbs, list or whatever else.
 	/// </summary>
 	public AssetListViewMode ViewModeType
 	{
-		get => _viewModeType;
+		get;
 		set
 		{
-			if ( _viewModeType == value ) return;
-			_viewModeType = value;
+			if ( field == value ) return;
+			field = value;
 
-			AssetList.ViewMode = _viewModeType;
+			AssetList.ViewMode = field;
 			UpdateViewModeIcon();
 			SaveSettings();
 		}
@@ -710,6 +708,12 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		ShowJunkFiles = ProjectCookie.Get( $"{SettingsCookie}.ShowJunkFiles", ShowJunkFiles );
 		HideNonAssets = ProjectCookie.Get( $"{SettingsCookie}.HideNonAssets", HideNonAssets );
 		ShowRecursiveFiles = ProjectCookie.Get( $"{SettingsCookie}.ShowRecursiveFiles", ShowRecursiveFiles );
+		
+		// Set view mode on the asset list since the property setter won't be called if the value is the same as before,
+		// and ViewMode 0 = List, which is the default, which causes the icon to not be updated correctly.
+		// Previously, the backing field for ViewModeType was static, which caused even more issues when loading settings.
+		AssetList.ViewMode = ViewModeType;
+		UpdateViewModeIcon();
 
 		if ( FilterAssetTypes is null )
 		{

--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
@@ -117,9 +117,7 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		get;
 		set
 		{
-			if ( field == value ) return;
 			field = value;
-
 			AssetList.ViewMode = field;
 			UpdateViewModeIcon();
 			SaveSettings();
@@ -708,12 +706,6 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		ShowJunkFiles = ProjectCookie.Get( $"{SettingsCookie}.ShowJunkFiles", ShowJunkFiles );
 		HideNonAssets = ProjectCookie.Get( $"{SettingsCookie}.HideNonAssets", HideNonAssets );
 		ShowRecursiveFiles = ProjectCookie.Get( $"{SettingsCookie}.ShowRecursiveFiles", ShowRecursiveFiles );
-		
-		// Set view mode on the asset list since the property setter won't be called if the value is the same as before,
-		// and ViewMode 0 = List, which is the default, which causes the icon to not be updated correctly.
-		// Previously, the backing field for ViewModeType was static, which caused even more issues when loading settings.
-		AssetList.ViewMode = ViewModeType;
-		UpdateViewModeIcon();
 
 		if ( FilterAssetTypes is null )
 		{

--- a/game/addons/tools/Code/Editor/CloudBrowser/CloudBrowser.cs
+++ b/game/addons/tools/Code/Editor/CloudBrowser/CloudBrowser.cs
@@ -80,20 +80,17 @@ public partial class CloudAssetBrowser : Widget, IBrowser
 		}
 	}
 
-	AssetListViewMode _viewModeType;
-
 	/// <summary>
 	/// View mode, i.e. thumbs, list or whatever else.
 	/// </summary>
 	public AssetListViewMode ViewModeType
 	{
-		get => _viewModeType;
+		get;
 		set
 		{
-			if ( _viewModeType == value ) return;
-			_viewModeType = value;
+			field = value;
 
-			AssetList.ViewMode = _viewModeType;
+			AssetList.ViewMode = field;
 			SaveSettings();
 
 			if ( value == AssetListViewMode.List ) ViewMode.Icon = "view_headline";


### PR DESCRIPTION
Replaces the static backing field for ViewModeType with an instance property to prevent cross-instance issues. Ensures AssetList.ViewMode and the view mode icon are updated correctly when loading settings, addressing problems where the icon would not reflect the current view mode.