### PR TITLE
Expose SoundStream and fix LaughterScore on VoiceComponent

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
@@ -55,7 +55,7 @@ public class Voice : Component
 	/// <summary>
 	/// Laughter score for the current audio frame, between 0 and 1
 	/// </summary>
-	public float LaughterScore { get; private set; }
+	public float LaughterScore => sound.IsValid() ? sound.LipSync.LaughterScore : 0;
 
 	/// <summary>
 	/// Gets the underlying audio stream associated with the sound. Can be used to get raw audio data or perform visualizations.

--- a/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
@@ -57,8 +57,12 @@ public class Voice : Component
 	/// </summary>
 	public float LaughterScore { get; private set; }
 
+	/// <summary>
+	/// Gets the underlying audio stream associated with the sound. Can be used to get raw audio data or perform visualizations.
+	/// </summary>
+	public SoundStream SoundStream { get; private set; }
+
 	private bool recording = false;
-	private SoundStream soundStream;
 	private SoundHandle sound;
 	private float[] morphs;
 	private float[] morphVelocity;
@@ -148,7 +152,7 @@ public class Voice : Component
 	{
 		VoiceManager.OnCompressedVoiceData += OnVoice;
 
-		soundStream = new SoundStream( VoiceManager.SampleRate );
+		SoundStream = new SoundStream( VoiceManager.SampleRate );
 
 		if ( Renderer.IsValid() && Renderer.Model.MorphCount > 0 )
 		{
@@ -173,8 +177,8 @@ public class Voice : Component
 
 		sound?.Dispose();
 		sound = null;
-		soundStream?.Dispose();
-		soundStream = null;
+		SoundStream?.Dispose();
+		SoundStream = null;
 	}
 
 	public bool IsRecording
@@ -395,21 +399,21 @@ public class Voice : Component
 	{
 		if ( buffer.Length < 2 )
 			return;
-		if ( soundStream is null )
+		if ( SoundStream is null )
 			return;
 
 		VoiceManager.Uncompress( buffer, samples =>
 		{
 			if ( !sound.IsValid() )
 			{
-				sound = soundStream.Play();
+				sound = SoundStream.Play();
 				sound.TargetMixer = TargetMixer;
 				sound.Distance = Distance;
 				sound.Falloff = Falloff;
 				sound.LipSync.Enabled = true;
 			}
 
-			soundStream.WriteData( samples.Span );
+			SoundStream.WriteData( samples.Span );
 
 			LastPlayed = 0;
 			UpdateSound();


### PR DESCRIPTION
Exposes the SoundStream property on VoiceComponent to allow for getting raw voice data (e.g. playback a player's voice in multiple places at once)

Resolves https://github.com/Facepunch/sbox-public/issues/626

Also LaughterScore has been hooked up to sound.LipSync.LaughterScore as a quick accessor