### PR TITLE
Fix rotated child panels translating in the wrong transform space

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.Matrix.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.Matrix.cs
@@ -41,9 +41,12 @@
 			origin.x += style.TransformOriginX.Value.GetPixels( panel.Box.Rect.Width, 0.0f );
 			origin.y += style.TransformOriginY.Value.GetPixels( panel.Box.Rect.Height, 0.0f );
 
-			Matrix *= Matrix.CreateTranslation( -origin );
+			// Transform origin from parent's untransformed space to parent's transformed space
+			Vector3 transformedOrigin = panel.Parent?.GlobalMatrix?.Inverted.Transform( origin ) ?? origin;
+
+			Matrix *= Matrix.CreateTranslation( -transformedOrigin );
 			Matrix *= panel.TransformMatrix;
-			Matrix *= Matrix.CreateTranslation( origin );
+			Matrix *= Matrix.CreateTranslation( transformedOrigin );
 
 			var mi = Matrix.Inverted;
 


### PR DESCRIPTION
Fixes bug https://github.com/Facepunch/sbox-public/issues/645

* In `PanelRenderer.Matrix.cs`, the transform origin is now converted using the parent's inverted global matrix before applying translation, ensuring correct positioning in transformed hierarchies.
* The translation and restoration of the origin now use the transformed origin instead of the raw origin, which aligns panel transformations with the parent's transformed space.

Before:
https://github.com/user-attachments/assets/ef3a9694-4b35-455c-8843-4bc7afbad8b3

After:
https://github.com/user-attachments/assets/e0d356f9-c676-4b54-a89e-329f01c67a63

