### PR TITLE
Fix Asset Browser clearing on Asset recompile

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
@@ -406,7 +406,6 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		List<object> items = new List<object>();
 		var tagCounts = new Dictionary<string, int>();
 
-		AssetList.Clear();
 
 		await Task.Run( () =>
 		{


### PR DESCRIPTION
Removes an unnecessary AssetList.Clear() call in UpdateAssetListAsync.

Resolves https://github.com/Facepunch/sbox-public/issues/829