### PR TITLE
Add AddRange support to NetList

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
@@ -161,7 +161,7 @@ public sealed class NetList<T> : INetworkSerializer, INetworkReliable, INetworkP
 	/// <summary>
 	/// <inheritdoc cref="List{T}.AddRange"/>
 	/// </summary>
-	public void AddRange( T[] collection )
+	public void AddRange( IEnumerable<T> collection )
 	{
 		if ( !CanWriteChanges() )
 			return;

--- a/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
@@ -159,6 +159,20 @@ public sealed class NetList<T> : INetworkSerializer, INetworkReliable, INetworkP
 	}
 
 	/// <summary>
+	/// <inheritdoc cref="List{T}.AddRange"/>
+	/// </summary>
+	public void AddRange( T[] collection )
+	{
+		if ( !CanWriteChanges() )
+			return;
+
+		foreach ( var value in collection )
+		{
+			list.Add( value );
+		}
+	}
+
+	/// <summary>
 	/// <inheritdoc cref="List{T}.Remove"/>
 	/// </summary>
 	public bool Remove( T value )


### PR DESCRIPTION
**Old behaviour**
```
[Sync] public NetList<string> MyList { get; set; }

public void OldBehaviour()
{
	var valuesToAdd = new string[] { "thing 1", "thing 2" };

	MyList.ToList().AddRange( valuesToAdd );
}
```

**New behaviour**
```
[Sync] public NetList<string> MyList { get; set; }

public void NewBehaviour()
{
	var valuesToAdd = new string[] { "thing 1", "thing 2" };

	MyList.AddRange( valuesToAdd );
}
```