### PR TITLE
Add MaxLengthAttribute support to ListControlWidget

### DIFF
--- a/engine/Sandbox.Access/Rules/BaseAccess.cs
+++ b/engine/Sandbox.Access/Rules/BaseAccess.cs
@@ -214,6 +214,7 @@ internal static partial class Rules
 		"System.ComponentModel.Annotations/System.ComponentModel.DataAnnotations.RequiredAttribute",
 		"System.ComponentModel.Annotations/System.ComponentModel.DataAnnotations.RegularExpressionAttribute",
 		"System.ComponentModel.Annotations/System.ComponentModel.DataAnnotations.RangeAttribute",
+		"System.ComponentModel.Annotations/System.ComponentModel.DataAnnotations.MaxLengthAttribute",
 
 		"System.Private.CoreLib/System.EventArgs*",
 		"System.Private.CoreLib/System.EventHandler*",

--- a/game/addons/tools/Code/Widgets/ControlWidgets/ListControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/ListControlWidget.cs
@@ -1,4 +1,6 @@
-﻿namespace Editor;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Editor;
 
 [CustomEditor( typeof( List<> ) )]
 [CustomEditor( typeof( Array ) )]
@@ -133,6 +135,19 @@ public class ListControlWidget : ControlWidget
 
 			if ( !ShowAddButton )
 				addButton.Visible = ShowAddButton;
+			
+			if ( SerializedProperty.TryGetAttribute<MaxLengthAttribute>( out var maxLengthAttr ) )
+			{
+				var maxLength = maxLengthAttr.Length;
+				if ( Collection is not null )
+				{
+					addButton.Enabled = Collection.Count() < maxLength;
+				}
+				else
+				{
+					addButton.Enabled = GetMultipleMin() < maxLength;
+				}
+			}
 
 			buttonRow.Add( addButton );
 			buttonRow.AddStretchCell( 1 );


### PR DESCRIPTION
ListControlWidget now respects the MaxLengthAttribute by disabling the add button when the collection reaches the specified maximum length. Also updated access rules to include MaxLengthAttribute.

Implements https://github.com/Facepunch/sbox-public/issues/3750