### PR TITLE
Fix gibs being network spawned multiple times

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -536,7 +536,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 				gib.Tags.Add( "debris", "clientside" ); // no physics interactions
 				gib.Enabled = true;
 			}
-			else
+			else if ( !IsProxy )
 			{
 				// Spawn on the network
 				gib.NetworkSpawn( true, null );


### PR DESCRIPTION
This PR fixes an issue where gibs would be spawned multiple times over the network. The core issue of the code was calling `.NetworkSpawn` on a gib component. This was called in an rpc, and there no check to only `.NetworkSpawn` the gib only on the owner of the object. Without this check, the `.NetworkSpawn` method would be called multiple times, which spawned extra gibs for every client. This PR fixes this by checking `!IsProxy` in `CreateGibs()`, which makes only the owner of the prop spawn the gibs.