### PR TITLE
Add min and max zoom to GraphicsView

### DIFF
--- a/engine/Sandbox.Tools/Qt/GraphicsView.cs
+++ b/engine/Sandbox.Tools/Qt/GraphicsView.cs
@@ -76,10 +76,13 @@ namespace Editor
 
 		public IEnumerable<GraphicsItem> SelectedItems => Scene.SelectedItems;
 
+		public float MinZoom { get; set; } = 0.1f;
+		public float MaxZoom { get; set; } = 5.0f;
+		
 		public void Zoom( float adjust, Vector2 viewpos )
 		{
 			_scale *= adjust;
-			_scale = _scale.Clamp( 0.1f, 5.0f );
+			_scale = _scale.Clamp( MinZoom, MaxZoom );
 			var mousePosBefore = ToScene( viewpos );
 			_graphicsview.resetTransform();
 			_graphicsview.scale( _scale.x, _scale.y );


### PR DESCRIPTION
Original Pull Request: https://github.com/Facepunch/sbox-public/pull/11

> 
> GraphicsView has a built-in clamp to limit zooming in and out.
> 
> I am using GraphicsView/GraphicsItems to show and edit pixel art - which often requires more than a 5x zoom to properly view at a reasonable scale on screen. This exposes the clamp limits so GraphicsViews can be customized to better suit user needs.

Please let me know if there are any problems.