### PR TITLE
Update MapInstance to support scene maps

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -44,8 +44,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 	SceneMap loadedMap;
 	GameObject _mapPhysics;
 	string loadedMapName;
-
-
+	string sceneMapScenePath;
 
 	public MapInstance() : base()
 	{
@@ -119,6 +118,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 	public void UnloadMap()
 	{
 		loadedMapName = null;
+		sceneMapScenePath = "";
 
 		bool hadMap = loadedMap is not null;
 
@@ -268,8 +268,8 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 				}
 				else if ( mapFileName.EndsWith( ".scene" ) )
 				{
-					Log.Warning( $"Package {package.FullIdent} is a scenemap and cannot be loaded by MapInstance" );
-					return false;
+					// Scene maps can be loaded, but we need to do some special work with the GameObjects.
+					sceneMapScenePath = mapFileName;
 				}
 			}
 
@@ -365,7 +365,12 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 	private void LoadMapSceneGameObjects( string mapName )
 	{
-		var scene = Game.Resources.LoadRawGameResource( $"{loadedMap.MapFolder}/world.scene_c" );
+		// If this is being loaded from a vpk, load scene contents from world.scene_c.
+		// If this is from an actual scene, just use that.
+		var path = string.IsNullOrWhiteSpace( sceneMapScenePath )
+			? $"{loadedMap.MapFolder}/world.scene_c"
+			: sceneMapScenePath + "_c";
+		var scene = Game.Resources.LoadRawGameResource( path );
 		if ( scene is not SceneFile sceneFile )
 			return;
 
@@ -406,6 +411,13 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 	private bool ShouldIgnoreGameObject( JsonObject json )
 	{
+		// Don't load another MapInstance if this scene already has one.
+		var comps = json["Components"].AsArray();
+		if ( comps.Any( comp => comp["__type"]?.ToString() == "Sandbox.MapInstance" ) )
+		{
+			return true;
+		}
+
 		if ( !Networking.IsClient || !json.TryGetPropertyValue( JsonKeys.Id, out var id ) )
 			return false;
 


### PR DESCRIPTION
This PR is a band-aid solution that allows the loading of scene maps via the MapInstance component. The changes are very minimal, and my map Street loads perfectly fine.

> 💬 MapInstance sucks, we should get rid of it!

Yes, yes, yes, I've heard that MapInstance is the devil and that Facepunch wants to get rid of it at some point. I'm all for that, but there's no established timeline for when scene maps will be loadable and usable in-game/in-editor.

> 💬 Why create your own component to load the scenes?

I have tried this, but I've run into a bug where a `SceneWorld` created from a `SceneMap` class doesn't get removed properly. This bug can be prevented, but the change must be made at a lower level that normal components can't access. MapInstance appears to clean things up properly with the appropriate level of access, so that's why I've put these changes in here.

<img width="1915" height="983" alt="image" src="https://github.com/user-attachments/assets/93e52520-6146-498d-8a2c-21fab5ffe068" />


_Example of the bug in action. This is out of the scope for this PR and should be addressed separately._