### PR TITLE
Remove the double comma from ResourceLoader.cs

### DIFF
--- a/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceLoader.cs
+++ b/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceLoader.cs
@@ -139,7 +139,7 @@ public abstract class ResourceLoader
 	/// </summary>
 	protected virtual object Load()
 	{
-		return null; ;
+		return null;
 	}
 
 	internal void ShutdownInternal()


### PR DESCRIPTION
The Load() method in the ResourceLoader class contained a syntax error with a double semicolon (return null; ;). 