### PR TITLE
ParticleEmitters aren't finished until they've emitted at least once

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Particles/Emitter/ParticleEmitter.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Emitter/ParticleEmitter.cs
@@ -88,7 +88,7 @@ public abstract class ParticleEmitter : Component, Component.ExecuteInEditor, Co
 	}
 
 	bool IsStarted => time - Delay >= 0;
-	bool IsFinished => time > (Duration + Delay);
+	bool IsFinished => !burstPending && time > (Duration + Delay);
 
 	void OnParticleStep( float delta )
 	{


### PR DESCRIPTION
This resolves https://github.com/Facepunch/sbox-public/issues/1406

This is one way to solve the issue. The other way would be to modify the `Component.ITemporaryEffect.IsActive` function later in the file.
The problem is that if the FPS is low enough, it's probable that you'll have these two frames in a row:
```
0: IsStarted = false, IsFinished = false
1: IsStarted = true, IsFinished = true
```
In that case, burstPending is never changed from its value of `true` and the `IsActive` function always returns true.

With this change, particle emitters will always emit at least once, even if the low FPS/large time delta makes it skip the time frame where emission would be possible.
I ran through the particle scenes in sbox-scenestaging and they still looked okay with this change, but this might need some deeper testing to make sure that it doesn't break anything. I'm not really immersed into this particle system code so I don't know what kind of consequences this change could have.

As mentioned above, another way of resolving the issue above would be to fix the `IsActive` function, but then particles would look broken on lower FPS because they would skip emitting some particles.
On the other hand, this change might hurt FPS by emitting particles when the game is already struggling.