### PR TITLE
Display s&box version in editor

### DIFF
--- a/engine/Sandbox.Tools/Editor/AboutPopup.cs
+++ b/engine/Sandbox.Tools/Editor/AboutPopup.cs
@@ -43,6 +43,11 @@ public class AboutWidget : BaseWindow
 		messageLabel.Text = "s&box editor © Facepunch Studios Ltd.";
 		messageLabel.TextSelectable = false;
 
+		// Add version
+		var versionLabel = Layout.Add( new Label() );
+		versionLabel.Text = $"Version {Sandbox.Application.Version}";
+		versionLabel.TextSelectable = true;
+
 		// Add content layout
 		ContentLayout = Layout.AddColumn( 1 );
 		ContentLayout.Margin = new Sandbox.UI.Margin( 0, 16, 0, 0 );

--- a/engine/Sandbox.Tools/ManagedTools.cs
+++ b/engine/Sandbox.Tools/ManagedTools.cs
@@ -21,7 +21,7 @@ internal static class ManagedTools
 
 	public static void InitStart()
 	{
-		Log.Info( "Editor Startup" );
+		Log.Info( $"Editor Startup version {Sandbox.Application.Version}" );
 		//
 		// Init steam and log into the api
 		//


### PR DESCRIPTION
After switching back and forth between working on sbox-public and the Steam version, I find myself uncertain which version of the editor I'm currently using.
In game this is easy to see, there's a blue tooltip which shows the version at all times, but I couldn't easily find it in the editor.

This patch adds it to two places in the editor (in these screenshots I've copied over the `.version` file from the Steam release, usually it's `0000000` in sbox-public).

Editor startup log:
![2025-11-27_15-55-25](https://github.com/user-attachments/assets/68cb511b-fd87-490b-8dc1-a063a7f0916b)

About page:
![2025-11-27_16-01-50](https://github.com/user-attachments/assets/32aa3403-a77e-4c3d-abc1-ca281d555aa6)

If you dislike either of these I can change/remove it.