### PR TITLE
Handle Networking.QueryServers cancellation without throwing

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/Networking.LobbyQuery.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Networking.LobbyQuery.cs
@@ -62,7 +62,11 @@ public static partial class Networking
 
 			while ( serverList.IsQuerying )
 			{
-				ct.ThrowIfCancellationRequested();
+				if ( ct.IsCancellationRequested )
+				{
+					// Stop waiting on the server list if the caller timed out/cancelled, return anything collected so far
+					return list;
+				}
 
 				await Task.Yield();
 			}
@@ -108,6 +112,11 @@ public static partial class Networking
 
 				list.Add( lobby );
 			}
+		}
+		catch ( OperationCanceledException )
+		{
+			// Caller cancelled, return whatever we gathered instead of bubbling the exception
+			return list;
 		}
 		catch ( Exception e )
 		{


### PR DESCRIPTION
Update `Networking.QueryServers` to stop throwing on cancellation and return any collected server data. 
Catch `OperationCanceledException`, letting callers treat timeouts as empty/partial results.

Fixes "Operation was canceled" errors being spammed when just regularly using Networking.QueryLobbies without any CancellationTokens. Basically if it doesn't change then we just return what we have, if it changes then it changes
```cs
	protected async void FetchLobbies()
	{
		IsSearching = true;
		Lobbies = new();
		StateHasChanged();

		var lobbies = await Networking.QueryLobbies( Game.Ident );

		IsSearching = false;
		Lobbies = lobbies;
		StateHasChanged();
	}
```