### PR TITLE
Add effects drawing for underline/strikethrough styles

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Engine/TextBlock.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Engine/TextBlock.cs
@@ -337,7 +337,7 @@ internal sealed class TextBlock : IDisposable
 			var size = style.TextStrokeWidth.Value.GetPixels( 1.0f );
 			var effect = TextEffect.Outline( color.ToSk(), size );
 			effect.StrokeMiter = 2.0f;
-			effect.StrkeJoin = SKStrokeJoin.Round;
+			effect.StrokeJoin = SKStrokeJoin.Round;
 			Style.AddEffect( effect );
 
 			EffectMargin.Left = MathF.Max( EffectMargin.Left, size ).CeilToInt();

--- a/engine/ThirdParty/Topten.RichTextKit/FontRun.cs
+++ b/engine/ThirdParty/Topten.RichTextKit/FontRun.cs
@@ -864,24 +864,24 @@ namespace Topten.RichTextKit
 			// text strokes.
 			//
 			_textBlob = null;
-			CreateTextBlob( ctx, false );
+			var glyphVOffset = CreateTextBlob( ctx, false );
 
 			if ( _textBlob == null )
 				return;
 
-			using ( var effectPaint = new SKPaint() )
+			using var effectPaint = new SKPaint();
+			foreach ( var effect in Style.TextEffects )
 			{
-				foreach ( var effect in Style.TextEffects )
-				{
-					effectPaint.Style = effect.PaintStyle;
-					effectPaint.StrokeWidth = effect.Width;
-					effectPaint.StrokeJoin = effect.StrkeJoin;
-					effectPaint.StrokeMiter = effect.StrokeMiter;
-					effectPaint.Color = effect.Color;
-					effectPaint.ImageFilter = effect.BlurSize > 0 ? SKImageFilter.CreateDropShadow( effect.Offset.X, effect.Offset.Y, effect.BlurSize, effect.BlurSize, effect.Color ) : null;
+				effectPaint.Style = effect.PaintStyle;
+				effectPaint.StrokeWidth = effect.Width;
+				effectPaint.StrokeJoin = effect.StrokeJoin;
+				effectPaint.StrokeMiter = effect.StrokeMiter;
+				effectPaint.Color = effect.Color;
+				effectPaint.ImageFilter = effect.BlurSize > 0 ? SKImageFilter.CreateDropShadow( effect.Offset.X, effect.Offset.Y, effect.BlurSize, effect.BlurSize, effect.Color ) : null;
 
-					ctx.Canvas.DrawText( _textBlob, 0, 0, effectPaint );
-				}
+				ctx.Canvas.DrawText( _textBlob, 0, 0, effectPaint );
+				PaintUnderline( ctx, effectPaint );
+				PaintStrikeThrough( ctx, effectPaint, glyphVOffset );
 			}
 		}
 

--- a/engine/ThirdParty/Topten.RichTextKit/TextEffect.cs
+++ b/engine/ThirdParty/Topten.RichTextKit/TextEffect.cs
@@ -29,7 +29,7 @@ namespace Topten.RichTextKit
 		public SKPaintStyle PaintStyle { get; set; }
 		public SKBlurStyle BlurStyle { get; set; }
 		public float BlurSize { get; set; }
-		public SKStrokeJoin StrkeJoin { get; set; }
+		public SKStrokeJoin StrokeJoin { get; set; }
 		public float StrokeMiter { get; set; }
 
 		public static TextEffect DropShadow( SKColor sKColor, float x, float y, float blurSize )
@@ -58,7 +58,7 @@ namespace Topten.RichTextKit
 				Width = size,
 				PaintStyle = SKPaintStyle.StrokeAndFill,
 				StrokeMiter = 0.5f,
-				StrkeJoin = SKStrokeJoin.Round
+				StrokeJoin = SKStrokeJoin.Round
 			};
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/Facepunch/sbox-public/issues/1704

### Summary
- Paints underlines and strikethroughs with TextEffects to allow for shadows to be drawn for text-decoration styles.

Before:
<img width="2559" height="1260" alt="image" src="https://github.com/user-attachments/assets/acfa2dd7-0c66-4b9e-8b24-ca0164746cc3" />

After:
<img width="2559" height="1260" alt="image" src="https://github.com/user-attachments/assets/e60cf625-93ed-4ea0-906a-9b9285b355e6" />
