### PR TITLE
Clear Bitmap PathEffect

### DIFF
--- a/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pen.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pen.cs
@@ -48,6 +48,7 @@ public partial class Bitmap
 		pen.ColorF = color.ToSkF();
 		pen.StrokeWidth = width;
 		pen.Style = SKPaintStyle.Stroke;
+		pen.PathEffect = null;
 		pen.Shader = default;
 	}
 


### PR DESCRIPTION
It is currently impossible to return to the normal pen after using the dashed pen, my PR fixes this

Resolves https://github.com/Facepunch/sbox-public/issues/640