### PR TITLE
InlineEditor cleanup

### DIFF
--- a/game/addons/tools/Code/Widgets/ControlWidgets/DictionaryControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/DictionaryControlWidget.cs
@@ -90,13 +90,14 @@ public class DictionaryControlWidget : ControlWidget
 
 			keyControl.ReadOnly = ReadOnly;
 			keyControl.Enabled = Enabled;
+			keyControl.FixedHeight = MathF.Max( keyControl.MinimumHeight, Theme.ControlHeight );
 
 			valControl.ReadOnly = ReadOnly;
 			valControl.Enabled = Enabled;
 
 			var index = y;
 			//grid.AddCell( 0, y, new IconButton( "drag_handle" ) { IconSize = 13, Foreground = Theme.ControlBackground, Background = Color.Transparent, FixedWidth = Theme.RowHeight, FixedHeight = Theme.RowHeight } );
-			grid.AddCell( 1, y, keyControl, 1, 1, keyControl.CellAlignment );
+			grid.AddCell( 1, y, keyControl, 1, 1, TextFlag.Center );
 			grid.AddCell( 2, y, new IconButton( ":" ) { IconSize = 13, Foreground = Theme.TextControl, Background = Color.Transparent, FixedWidth = Theme.RowHeight, FixedHeight = Theme.RowHeight } );
 			grid.AddCell( 3, y, valControl, 1, 1, valControl.CellAlignment );
 

--- a/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
@@ -174,8 +174,8 @@ public class GenericControlWidget : ControlObjectWidget
 	void BuildInlineEditor( InlineEditorAttribute attribute )
 	{
 		Layout = Layout.Column();
-
-		if ( attribute.Label )
+		
+		if ( attribute.Label && !SerializedProperty.Parent.GetType().IsAssignableTo( typeof( SerializedCollection ) ) )
 		{
 			Layout.Add( ControlSheet.CreateLabel( SerializedProperty ) );
 		}


### PR DESCRIPTION
fixes https://github.com/Facepunch/sbox-public/issues/1666 and https://github.com/Facepunch/sbox-public/issues/2123

Dictionary keys no longer get stretched when using larger InlineEditor values, and it's no longer attempting to add a property name label for inline editor properties that are part of a collection (and thus don't have a name)

<img width="1128" height="566" alt="image" src="https://github.com/user-attachments/assets/deda7ecd-e5f8-4955-a434-032f01afaa2a" />
<img width="1108" height="947" alt="image" src="https://github.com/user-attachments/assets/d32443df-db45-4687-b1fa-ed9ecb764a80" />
<img width="1125" height="917" alt="image" src="https://github.com/user-attachments/assets/711428f8-c226-4fdc-8311-82658d03d2eb" />
