### PR TITLE
Fix SoundscapeTrigger Error if source or SoundFile is not valid

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Audio/SoundscapeTrigger.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/SoundscapeTrigger.cs
@@ -317,6 +317,12 @@ public class SoundscapeTrigger : Component
 
 		public override void Frame( in Transform head )
 		{
+			if ( source == null || !source.SoundFile.IsValid() )
+			{
+				Finished = true;
+				return;
+			}
+
 			var targetVolume = sourceVolume * internalVolume * Volume;
 			if ( Finished ) targetVolume = 0.0f;
 
@@ -373,6 +379,12 @@ public class SoundscapeTrigger : Component
 
 			if ( timeUntilNextShot > 0 )
 				return;
+
+			if ( source == null || !source.SoundFile.IsValid() )
+			{
+				Finished = true;
+				return;
+			}
 
 			timeUntilNextShot = source.RepeatTime.GetValue();
 


### PR DESCRIPTION
Adds a null check for both looping and sting sound entries on the source and an IsValid() check for source.SoundFile.