### PR TITLE
Extend ISceneEvent RunEvent to support UI panels in Scene

### DIFF
--- a/engine/Sandbox.Engine/Scene/Scene/Scene.Event.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.Event.cs
@@ -1,9 +1,11 @@
-﻿namespace Sandbox;
+﻿using Sandbox.UI;
+
+namespace Sandbox;
 
 public partial class Scene : GameObject
 {
 	/// <summary>
-	/// Run an event on all components. The find argument is unused when calling this on a scene.
+	/// Run an event on all components and panels. The find argument is unused when calling this on a scene.
 	/// </summary>
 	public override void RunEvent<T>( Action<T> action, FindMode find = FindMode.EnabledInSelfAndDescendants )
 	{
@@ -19,6 +21,43 @@ public partial class Scene : GameObject
 			}
 		}
 
+		// Support for ISceneEvent on Panels
+		foreach ( var panelComponent in GetAll<PanelComponent>() )
+		{
+			if ( !panelComponent.Panel.IsValid() )
+			{
+				continue;
+			}
+
+			if ( panelComponent.Panel is T t )
+			{
+				try
+				{
+					action( t );
+				}
+				catch ( System.Exception e )
+				{
+					Log.Warning( e, e.Message );
+				}
+			}
+
+			foreach ( var child in panelComponent.Panel.Descendants )
+			{
+				if ( child is not T ct )
+				{
+					continue;
+				}
+
+				try
+				{
+					action( ct );
+				}
+				catch ( System.Exception e )
+				{
+					Log.Warning( e, e.Message );
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The RunEvent<T> method in Scene now also runs the event on all PanelComponent panels and their descendants that implement the event interface, in addition to components.

Implements https://github.com/Facepunch/sbox-public/issues/3359

I am VERY unsure about the performance implications of this, looping through all descendants could be expensive.