### PR TITLE
Fix ActiveScene name

### DIFF
--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -40,6 +40,11 @@ public partial class Scene : GameObject
 			return false;
 		}
 
+		if ( sceneFile.ResourceName != null )
+		{
+			Name = sceneFile.ResourceName.ToTitleCase();
+		}
+
 		ProcessDeletes();
 
 		if ( !options.IsAdditive )

--- a/engine/Sandbox.Tools/Scene/EditorScene.cs
+++ b/engine/Sandbox.Tools/Scene/EditorScene.cs
@@ -92,7 +92,6 @@ public static class EditorScene
 		var prefabScene = PrefabScene.CreateForEditing();
 		using ( prefabScene.Push() )
 		{
-			prefabScene.Name = resource.ResourceName.ToTitleCase();
 			prefabScene.Load( resource );
 
 			session = new PrefabEditorSession( prefabScene );

--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
@@ -450,7 +450,6 @@ public partial class SceneEditorSession : Scene.ISceneEditorSession
 			var openingScene = Scene.CreateEditorScene();
 			using var _ = openingScene.Push();
 
-			openingScene.Name = sceneFile.ResourceName.ToTitleCase();
 			openingScene.Load( sceneFile );
 
 			var session = new SceneEditorSession( openingScene );
@@ -468,7 +467,6 @@ public partial class SceneEditorSession : Scene.ISceneEditorSession
 			var openingScene = PrefabScene.CreateForEditing();
 			using var _ = openingScene.Push();
 
-			openingScene.Name = prefabFile.ResourceName.ToTitleCase();
 			openingScene.Load( prefabFile );
 
 			var session = new PrefabEditorSession( openingScene );


### PR DESCRIPTION
The name of the active scene was updated in specific cases; now, as soon as a scene is loaded, the name is updated.

Resolves https://github.com/Facepunch/sbox-public/issues/493 
Resolves https://github.com/Facepunch/sbox-public/issues/2037