### PR TITLE
ISceneLoadingEvents.AfterLoad default implementation

### DIFF
--- a/engine/Sandbox.Engine/Scene/Events/ISceneLoadingEvents.cs
+++ b/engine/Sandbox.Engine/Scene/Events/ISceneLoadingEvents.cs
@@ -18,5 +18,5 @@ public interface ISceneLoadingEvents : ISceneEvent<ISceneLoadingEvents>
 	/// <summary>
 	/// Loading has finished
 	/// </summary>
-	void AfterLoad( Scene scene );
+	void AfterLoad( Scene scene ) { }
 }


### PR DESCRIPTION
Gave Sandbox.ISceneLoadingEvents.AfterLoad a default implementation so you aren't forced to implement it