### PR TITLE
Fix can paste properties with invalid json

### DIFF
--- a/game/addons/tools/Code/Utility/ClipboardTools.cs
+++ b/game/addons/tools/Code/Utility/ClipboardTools.cs
@@ -51,12 +51,20 @@ public static class ClipboardTools
 		var clipboard = EditorUtility.Clipboard.Paste();
 		if ( string.IsNullOrWhiteSpace( clipboard ) ) return false;
 		if ( !clipboard.StartsWith( "{" ) ) return false;
-		var json = JsonNode.Parse( clipboard );
-		if ( json is null ) return false;
-		if ( json["_group"] is null || json["_group"].ToString() != groupName ) return false;
-		var parentType = properties.FirstOrDefault()?.Parent?.TypeName ?? null;
-		if ( parentType == null ) return false;
-		if ( json["_parentType"] is null || json["_parentType"].ToString() != parentType.ToString() ) return false;
-		return true;
+
+		try
+		{
+			var json = JsonNode.Parse( clipboard );
+			if ( json is null ) return false;
+			if ( json["_group"] is null || json["_group"].ToString() != groupName ) return false;
+			var parentType = properties.FirstOrDefault()?.Parent?.TypeName ?? null;
+			if ( parentType == null ) return false;
+			if ( json["_parentType"] is null || json["_parentType"].ToString() != parentType.ToString() ) return false;
+			return true;
+		}
+		catch ( JsonException )
+		{
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
If you copy invalid JSON and right-click on a property that requires JSON, then the menu no longer appears and an error is displayed.
My PR wraps the JSON parsing in a try-catch block because the parsing method returns an error if the JSON is invalid. If there is an error, I return false.

Resolves https://github.com/Facepunch/sbox-public/issues/573