### PR TITLE
Removed IsUnitTest check in Material Load functions

### DIFF
--- a/engine/Sandbox.Engine/Resources/Material/Material.Load.cs
+++ b/engine/Sandbox.Engine/Resources/Material/Material.Load.cs
@@ -14,9 +14,6 @@ public partial class Material
 	{
 		ThreadSafe.AssertIsMainThread();
 
-		if ( Application.IsUnitTest )
-			return default;
-
 		if ( !string.IsNullOrWhiteSpace( filename ) && Directory.TryLoad( filename, ResourceType.Material, out object model ) && model is Material m )
 			return m;
 
@@ -31,9 +28,6 @@ public partial class Material
 	public static async Task<Material> LoadAsync( string filename )
 	{
 		ThreadSafe.AssertIsMainThread();
-
-		if ( Application.IsUnitTest )
-			return default;
 
 		if ( !string.IsNullOrWhiteSpace( filename ) && await Directory.TryLoadAsync( filename, ResourceType.Material ) is Material m )
 			return m;


### PR DESCRIPTION
I have code that i want to test which contains map with material as the key.
unit tests fail as it would always return null.

After some testing it seems that material loading does work when running unit tests.
So removing these checks should be fine?

note that it will just return null if you don't call `Sandbox.Application.InitUnitTest<TestClass>( true,true );`
But that seems logical as Materials are tied to rendering