### PR TITLE
Terrain shader: Fix incorrect tangent normals sampled using seamless UV method

### DIFF
--- a/game/addons/base/Assets/shaders/terrain.shader
+++ b/game/addons/base/Assets/shaders/terrain.shader
@@ -173,7 +173,9 @@ PS
         for ( int i = 0; i < 4; i++ )
         {
             float2 layerUV = texUV * g_TerrainMaterials[ i ].uvscale;
-            float2 seamlessUV = Terrain_SampleSeamlessUV( layerUV );
+
+            float2x2 uvRotation;
+            float2 seamlessUV = Terrain_SampleSeamlessUV( layerUV, uvRotation );
 
             Texture2D tBcr = Bindless::GetTexture2D( g_TerrainMaterials[ i ].bcr_texid );
             Texture2D tNho = Bindless::GetTexture2D( g_TerrainMaterials[ i ].nho_texid );
@@ -183,6 +185,10 @@ PS
 
             float3 normal = ComputeNormalFromRGTexture( nho.rg );
             normal.xz *= g_TerrainMaterials[ i ].normalstrength;
+            
+            // Rotate normal map to match seamless UV angle and avoid shading errors 
+            normal.xy = mul( uvRotation, normal.xy );
+
             normal = normalize( normal );
 
             albedos[i] = SrgbGammaToLinear( bcr.rgb );

--- a/game/addons/base/Assets/shaders/terrain/TerrainCommon.hlsl
+++ b/game/addons/base/Assets/shaders/terrain/TerrainCommon.hlsl
@@ -73,7 +73,7 @@ class Terrain
 
 // Get UV with per-tile UV offset to reduce visible tiling
 // Works by offsetting UVs within each tile using a hash of the tile coordinate
-float2 Terrain_SampleSeamlessUV( float2 uv )
+float2 Terrain_SampleSeamlessUV( float2 uv, out float2x2 uvAngle )
 {
     float2 tileCoord = floor( uv );
     float2 localUV = frac( uv );
@@ -89,11 +89,20 @@ float2 Terrain_SampleSeamlessUV( float2 uv )
     float sinA = sin(angle);
     float2x2 rot = float2x2(cosA, -sinA, sinA, cosA);
 
+    // Output rotation matrix 
+    uvAngle = rot;
+
     // Rotate around center
     localUV = mul(rot, localUV - 0.5) + 0.5;
 
     // Apply random offset
     return tileCoord + frac(localUV + hash);
+}
+
+float2 Terrain_SampleSeamlessUV( float2 uv ) 
+{
+    float2x2 dummy;
+    return Terrain_SampleSeamlessUV( uv, dummy ); 
 }
 
 // Move to another file:


### PR DESCRIPTION
# Issue
Currently, terrain shader samples tangent normal maps using seamless UVs 'as is', which means that normals are not transformed to be inline with the new UV rotation angle. This results in some issues with NdotL shading. Here's a comparison between current, and corrected normals:

<img width="1164" height="1102" alt="image" src="https://github.com/user-attachments/assets/4e14a9b5-2ca2-4ab8-b152-6c87254fd91c" />
<img width="1164" height="1102" alt="image" src="https://github.com/user-attachments/assets/09b97fe7-a3f2-4147-92b2-f7a025b8812e" />

# Fix
The solution for this is to multiply tangent normal with 2x2 rotation matrix that we can access from `Terrain_SampleSeamless2D` in **TerrainCommon.hlsl**. This is probably very stupid, but I had to add an output `out float2x2 uvAngle` so I can access this matrix from other shaders:

```hlsl
float2 Terrain_SampleSeamlessUV( float2 uv, out float2x2 uvAngle )
```

To avoid breaking any shaders that rely on a previous implementation of this function, I've added an overload that has an old set of arguments: 
```hlsl
float2 Terrain_SampleSeamlessUV( float2 uv ) 
{
    float2x2 dummy;
    return Terrain_SampleSeamlessUV( uv, dummy ); 
}
```

In `terrain.shader`, inside the `Terrain_Splat4` function, tangent normal is transformed like this:
```hlsl
<...>
float3 normal = ComputeNormalFromRGTexture( nho.rg );
normal.xz *= g_TerrainMaterials[ i ].normalstrength;
            
// Rotate normal map to match seamless UV angle and avoid shading errors 
normal.xy = mul( uvRotation, normal.xy );

normal = normalize( normal );

albedos[i] = SrgbGammaToLinear( bcr.rgb );
<...>
```

I am not entirely sure if that's a correct way to approach this, and I absolutely don't know if it was a good idea to change seamless UV function like I did, so please let me know if my solution is stupid. 
