### PR TITLE
Fixed the button styles by moving the :hover rules into a nested structure

### DIFF
--- a/game/addons/menu/Code/MenuUI/Layout/MenuHeader/MenuHeader.razor.scss
+++ b/game/addons/menu/Code/MenuUI/Layout/MenuHeader/MenuHeader.razor.scss
@@ -85,6 +85,16 @@ button.circle
     color: #70788b;
     font-size: 28px;
     padding: 0;
+
+    &:hover
+    {
+        color: #fff;
+
+        > .inner
+        {
+            background-color: #272b34;
+        }
+    }
 }
 
 button.circle IconPanel
@@ -97,17 +107,6 @@ button.circle IconPanel
     justify-content: center;
     text-align: center;
 }
-
-ButtonCircle:hover
-{
-    color: #fff;
-
-    > .inner
-    {
-        background-color: #272b34;
-    }
-}
-
 
 menuheader > .container > .links button
 {


### PR DESCRIPTION
I noticed that in the main menu all buttons reacted to hover except for the three buttons in the top-right corner. After checking the scss file, it turned out the hover styles for these buttons were actually defined, but due to a typo (`ButtonCircle:hover` instead of the correct `button.circle:hover` selector), they were never applied.

To prevent similar issues in the future and keep related styles grouped together, I moved the hover rules inside the `button.circle` block using a nested `&:hover` selector.

Hover before changes:
<img width="214" height="103" alt="image" src="https://github.com/user-attachments/assets/e2027ed0-1530-41f4-a0a4-d5a05db88a28" />

Hover after changes:
<img width="181" height="89" alt="image" src="https://github.com/user-attachments/assets/4ab81434-2e34-4d17-9e8f-7af6fe73f4c5" />
