### PR TITLE
Fix delayed heartbeat and host stats sending every frame

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/Networking.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Networking.cs
@@ -408,6 +408,8 @@ public static partial class Networking
 			SteamNetwork.RunCallbacks();
 			System?.Tick();
 			System?.SendTableUpdates();
+			System?.SendHeartbeat();
+			System?.SendHostStats();
 		}
 		catch ( Exception e )
 		{
@@ -419,8 +421,6 @@ public static partial class Networking
 	{
 		try
 		{
-			System?.SendHeartbeat();
-			System?.SendHostStats();
 			System?.SendTableUpdates();
 		}
 		catch ( Exception e )

--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.cs
@@ -360,6 +360,8 @@ internal partial class NetworkSystem
 		if ( !IsHost ) return;
 		if ( timeSinceSentStats < 1.0f ) return;
 
+		timeSinceSentStats = 0;
+
 		var totalBytesIn = 0f;
 		var totalBytesOut = 0f;
 		var connections = Connection.All.Where( c => c != Connection.Local ).ToArray();

--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -415,10 +415,10 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 				Input.Process();
 			}
 
-            //
-            // Recieve incoming network messages, send heartbeat and other outgoing messages
-            //
-            Networking.PreFrameTick();
+			//
+			// Recieve incoming network messages, send heartbeat and other outgoing messages
+			//
+			Networking.PreFrameTick();
 
 			//
 			// We may have got new assemblies in the network update,

--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -418,7 +418,6 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
             //
             // Recieve incoming network messages, send heartbeat and other outgoing messages
             //
-            //
             Networking.PreFrameTick();
 
 			//

--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -415,10 +415,11 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 				Input.Process();
 			}
 
-			//
-			// Recieve incoming network messages
-			//
-			Networking.PreFrameTick();
+            //
+            // Recieve incoming network messages, send heartbeat and other outgoing messages
+            //
+            //
+            Networking.PreFrameTick();
 
 			//
 			// We may have got new assemblies in the network update,
@@ -437,9 +438,6 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 				RunGameFrame( scene );
 			}
 
-			//
-			// Send heartbeat and other outgoing network messages
-			//
 			Networking.PostFrameTick();
 		}
 


### PR DESCRIPTION
### Fix delayed heartbeat and host stats sending every frame

This PR finishes up https://github.com/Facepunch/sbox-public/issues/709

### Changes

- Fixes heartbeat being delayed by 1 frame
- Fixes host stats sending every frame rather than every second

### Notes

Currently the heartbeat is sent after the frame has rendered but it uses the `Time.Now` value from the previous frame. This means if the frame takes a long time to render the heartbeat will be incorrect and cause unnecessary timing fluctuations on the client. 

I tested this and this is what happens to `Time.Now` on the client after a 2 second delay on the server:

```
[Generic] Frame 185: Time.Now=16.0084 FixedUpdatesSinceLastLog=1 	
[Generic] Frame 186: Time.Now=16.01841 FixedUpdatesSinceLastLog=1 	
[Generic] Frame 187: Time.Now=16.028421 FixedUpdatesSinceLastLog=1 	
[Generic] Frame 188: Time.Now=16.038431 FixedUpdatesSinceLastLog=1 	
[Generic] Frame 189: Time.Now=14.047403 FixedUpdatesSinceLastLog=0 	<-- Heartbeat arrives with 2 second old Time.Now
[Generic] Frame 190: Time.Now=14.057407 FixedUpdatesSinceLastLog=1 	
[Generic] Frame 191: Time.Now=14.068408 FixedUpdatesSinceLastLog=1	

// A short time later

[Generic] Frame 219: Time.Now=14.352655 FixedUpdatesSinceLastLog=1	
[Generic] Frame 220: Time.Now=14.3626585 FixedUpdatesSinceLastLog=1 	
[Generic] Frame 221: Time.Now=16.374989 FixedUpdatesSinceLastLog=201  <-- Next heartbeat arrives, client now needs to skip forward, running lots of Fixed Updates
[Generic] Frame 222: Time.Now=16.384993 FixedUpdatesSinceLastLog=1	
[Generic] Frame 223: Time.Now=16.395042 FixedUpdatesSinceLastLog=1 	
[Generic] Frame 224: Time.Now=16.405169 FixedUpdatesSinceLastLog=1 	
```

With this fix the time keeps on running like it should and the client doesn't run any extra fixed updates when the server has a large frametime spike. 

I also moved `SendHostStats()` to `Networking.PreFrameTick()` because it uses `Time.Now` from the previous frame too. There is no good reason to delay sending it until after the current frame has rendered. It doesn't matter much for host stats but this is more correct.

### Comments

I feel like `Networking.PostFrameTick()` could be removed entirely. It now only has a call to `SendTableUpdates()` which is currently being called 3 times per frame in these places:

- `Networking.PreFrameTick()`
- `GameInstanceDll.FinishLoadingAssemblies()`
- `Networking.PostFrameTick()`

I did a quick test and I only ever saw `PreFrameTick()` actually sending any changes. I haven't tested it extensively though and I don't feel confident enough to remove `PostFrameTick()` without breaking anything. I don't think it's a big deal to call it too many times but it just clutters up the code if it's not needed. 