### PR TITLE
Fix "QMenu was null when calling clear" error

### DIFF
--- a/engine/Sandbox.Tools/Qt/Menu.cs
+++ b/engine/Sandbox.Tools/Qt/Menu.cs
@@ -386,11 +386,14 @@ namespace Editor
 
 		public void Clear()
 		{
+			if ( _menu.IsNull )
+				return;
+
 			_menu.clear();
 
-			Menus.Clear();
-			Options.Clear();
-			_widgets.Clear();
+			Menus?.Clear();
+			Options?.Clear();
+			_widgets?.Clear();
 		}
 
 		Option lastActive;


### PR DESCRIPTION
Adds an IsNull check to _menu when calling Clear().