### PR TITLE
Fix 'Open in Editor' not working on prefabs in the Hierarchy

### DIFF
--- a/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
+++ b/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
@@ -1,6 +1,4 @@
-﻿using Editor.MapEditor;
-using Sandbox;
-using static Editor.BaseItemWidget;
+﻿using static Editor.BaseItemWidget;
 namespace Editor;
 
 partial class GameObjectNode : TreeNode<GameObject>
@@ -569,7 +567,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 						{
 							if ( prefabAsset.TryLoadResource<PrefabFile>( out var prefab ) && prefab.IsValid )
 							{
-								// TODO EditorScene.LoadFromPrefab( prefab );
+								EditorScene.OpenPrefab( prefab );
 							}
 						} ).Enabled = !prefabAsset.IsProcedural;
 


### PR DESCRIPTION
Uncommented a forgotten TODO comment and replaced old `EditorScene.LoadFromPrefab` with `EditorScene.OpenPrefab`.



https://github.com/user-attachments/assets/9f77a566-1c25-4139-a0ad-54c320280115

