### PR TITLE
Physics performance micro-optimizations

### DIFF
--- a/engine/Sandbox.Engine/Resources/Model/Model.Hitbox.cs
+++ b/engine/Sandbox.Engine/Resources/Model/Model.Hitbox.cs
@@ -6,15 +6,18 @@ public class HitboxSet
 
 	internal HitboxSet( ModelBones bones, CHitBoxSet set )
 	{
-		all = new();
+		// Cache count to avoid Native Interop calls in loop condition
+		// and initialize list with correct capacity to avoid resizing
+		int count = (set.IsValid) ? set.numhitboxes() : 0;
+		
+		all = new( count );
 
-		// empty set
-		if ( !set.IsValid || set.numhitboxes() == 0 )
+		if ( count == 0 )
 		{
 			return;
 		}
 
-		for ( int i = 0; i < set.numhitboxes(); i++ )
+		for ( int i = 0; i < count; i++ )
 		{
 			var box = new Box( bones, set.pHitbox( i ) );
 			all.Add( box );

--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.Commands.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.Commands.cs
@@ -20,6 +20,8 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 		}
 
 		list.Add( new CommandListEntry( order, buffer ) );
+		
+		list.Sort( ( a, b ) => a.Priority.CompareTo( b.Priority ) );
 	}
 
 	/// <summary>
@@ -71,7 +73,7 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 
 		if ( commandlists.TryGetValue( stage, out var list ) )
 		{
-			foreach ( var entry in list.OrderBy( x => x.Priority ) )
+			foreach ( var entry in list )
 			{
 				using ( _executeCommandList.Start( entry.List.DebugName ) )
 				{

--- a/engine/Sandbox.Engine/Scene/Components/Camera/CubemapFog.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CubemapFog.cs
@@ -47,7 +47,12 @@ public class CubemapFog : Component
 		// Take it straight from the skybox if it's null
 		if ( tex is null )
 		{
-			var skybox = Scene.GetAllComponents<SkyBox2D>().FirstOrDefault();
+			SkyBox2D skybox = null;
+			foreach ( var s in Scene.GetAllComponents<SkyBox2D>() )
+			{
+				skybox = s;
+				break;
+			}
 
 			if ( skybox.IsValid() && !skybox.Tags.HasAny( camera.RenderExcludeTags ) )
 			{

--- a/engine/Sandbox.Engine/Scene/Components/Collider/CollisionEventSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/CollisionEventSystem.cs
@@ -107,7 +107,17 @@ class CollisionEventSystem : IDisposable
 		if ( other is null )
 			return;
 
-		if ( !TouchingPairs.Any( x => x.Other == other ) )
+		bool pairExists = false;
+		foreach ( var pair in TouchingPairs )
+		{
+			if ( pair.Other == other )
+			{
+				pairExists = true;
+				break;
+			}
+		}
+
+		if ( !pairExists )
 		{
 			TouchingColliders.Add( other );
 
@@ -148,7 +158,17 @@ class CollisionEventSystem : IDisposable
 		if ( !TouchingPairs.Remove( new TouchingPair( self, other, go ) ) )
 			return;
 
-		if ( !TouchingPairs.Any( x => x.Other == other ) )
+		bool pairExists = false;
+		foreach ( var pair in TouchingPairs )
+		{
+			if ( pair.Other == other )
+			{
+				pairExists = true;
+				break;
+			}
+		}
+
+		if ( !pairExists )
 		{
 			TouchingColliders.Remove( other );
 
@@ -202,7 +222,17 @@ class CollisionEventSystem : IDisposable
 		if ( other is null )
 			return;
 
-		if ( TouchingPairs.Any( x => x.GameObject == other ) )
+		bool pairExists = false;
+		foreach ( var pair in TouchingPairs )
+		{
+			if ( pair.GameObject == other )
+			{
+				pairExists = true;
+				break;
+			}
+		}
+
+		if ( pairExists )
 			return;
 
 		if ( !TouchingObjects.Remove( other ) )

--- a/engine/Sandbox.Engine/Scene/Components/Collider/ModelPhysics.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/ModelPhysics.cs
@@ -155,7 +155,22 @@ public sealed partial class ModelPhysics : Component, IScenePhysicsEvents, IHasM
 	/// <summary>
 	/// Returns the total mass of every <see cref="Rigidbody"/>
 	/// </summary>
-	public float Mass => Bodies.Sum( x => x.Component?.Mass ?? default );
+	public float Mass
+	{
+		get
+		{
+			float totalMass = 0.0f;
+			foreach ( var body in Bodies )
+			{
+				var rb = body.Component;
+				if ( rb != null )
+				{
+					totalMass += rb.Mass;
+				}
+			}
+			return totalMass;
+		}
+	}
 
 	/// <summary>
 	/// Returns the local center of mass of every <see cref="Rigidbody"/>

--- a/engine/Sandbox.Engine/Scene/Components/Collider/SphereCollider.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/SphereCollider.cs
@@ -92,10 +92,13 @@ public sealed class SphereCollider : Collider
 			scale.z = MathF.Sign( scale.z ) * MathF.Max( 0.01f, MathF.Abs( scale.z ) );
 
 			const int rings = 8;
-			var points = ArrayPool<Vector3>.Shared.Rent( rings * rings );
+			int count = rings * rings;
+			var points = ArrayPool<Vector3>.Shared.Rent( count );
+			
 			GenerateSphere( rings, Center, Radius, scale, points );
 
-			Shape.UpdateHull( local.Position, local.Rotation, points );
+			// Changed ReadOnlySpan to Span to satisfy updatehull, not good but won't work otherwise.
+			Shape.UpdateHull( local.Position, local.Rotation, new Span<Vector3>( points, 0, count ) );
 
 			ArrayPool<Vector3>.Shared.Return( points );
 		}
@@ -120,10 +123,13 @@ public sealed class SphereCollider : Collider
 			scale.z = MathF.Sign( scale.z ) * MathF.Max( 0.01f, MathF.Abs( scale.z ) );
 
 			const int rings = 8;
-			var points = ArrayPool<Vector3>.Shared.Rent( rings * rings );
+			int count = rings * rings;
+			var points = ArrayPool<Vector3>.Shared.Rent( count );
+			
 			GenerateSphere( rings, Center, Radius, scale, points );
 
-			Shape = targetBody.AddHullShape( local.Position, local.Rotation, points );
+			// span implicitly converts to ReadOnlySpan, so this is safe for AddHullShape too
+			Shape = targetBody.AddHullShape( local.Position, local.Rotation, new Span<Vector3>( points, 0, count ) );
 
 			ArrayPool<Vector3>.Shared.Return( points );
 		}

--- a/engine/Sandbox.Engine/Systems/Physics/PhysicsGroup.cs
+++ b/engine/Sandbox.Engine/Systems/Physics/PhysicsGroup.cs
@@ -236,6 +236,16 @@ namespace Sandbox
 		public PhysicsBody GetBody( int groupIndex ) => native.GetBodyHandle( groupIndex ); // Throw on OOB
 
 		/// <summary>
+		/// Returns amount of joints in this group.
+		/// </summary>
+		public int JointCount => native.GetJointCount();
+
+		/// <summary>
+		/// Get a joint by index without allocating memory.
+		/// </summary>
+		public PhysicsJoint GetJoint( int index ) => native.GetJointHandle( index );
+
+		/// <summary>
 		/// Returns a <see cref="PhysicsBody"/> by its <see cref="PhysicsBody.GroupName"/> within this group.
 		/// </summary>
 		/// <param name="groupName">Name of the physics body to look up.</param>
@@ -245,6 +255,7 @@ namespace Sandbox
 
 		/// <summary>
 		/// Any and all joints that are attached to any body in this group.
+		/// WARNING: Creates Garbage. Use JointCount and GetJoint(i) for zero-allocation loops.
 		/// </summary>
 		[ActionGraphInclude]
 		public IEnumerable<PhysicsJoint> Joints

--- a/engine/Sandbox.Engine/Systems/Physics/PhysicsTrace.cs
+++ b/engine/Sandbox.Engine/Systems/Physics/PhysicsTrace.cs
@@ -10,8 +10,8 @@ internal unsafe static partial class PhysicsTrace
 	{
 		public const int NumTagFields = 8;
 
-		public IPhysicsWorld World;
-		public NativeEngine.IPhysicsBody Body;
+		public IntPtr World;
+		public IntPtr Body;
 		public Vector3 StartPos;
 		public Vector3 EndPos;
 		public fixed uint TagRequire[NumTagFields];

--- a/engine/Sandbox.Engine/Systems/Physics/PhysicsTraceBuilder.cs
+++ b/engine/Sandbox.Engine/Systems/Physics/PhysicsTraceBuilder.cs
@@ -388,11 +388,12 @@ public partial struct PhysicsTraceBuilder
 		}
 
 		var r = request;
-		r.World = targetWorld.native;
+
+		r.World = (IntPtr)targetWorld.native;
 
 		if ( targetBody.IsValid() )
 		{
-			r.Body = targetBody.native;
+			r.Body = (IntPtr)targetBody.native;
 		}
 
 		if ( filterCallback is not null )
@@ -430,11 +431,11 @@ public partial struct PhysicsTraceBuilder
 		}
 
 		var r = request;
-		r.World = targetWorld.native;
+		r.World = (IntPtr)targetWorld.native;
 
 		if ( targetBody.IsValid() )
 		{
-			r.Body = targetBody.native;
+			r.Body = (IntPtr)targetBody.native;
 		}
 
 		if ( filterCallback is not null )

--- a/engine/Sandbox.Engine/Systems/Physics/PhysicsWorld.cs
+++ b/engine/Sandbox.Engine/Systems/Physics/PhysicsWorld.cs
@@ -38,7 +38,8 @@ public sealed partial class PhysicsWorld : IHandle
 	/// <summary>
 	/// All bodies in the world
 	/// </summary>
-	public IEnumerable<PhysicsBody> Bodies => bodies.Where( x => x.IsValid() );
+	// Users should check .IsValid() inside their own loops if necessary.
+	public IEnumerable<PhysicsBody> Bodies => bodies;
 
 	//public Action<int, PhysicsBody, PhysicsBody, Vector3> Internal_OnCollision;
 


### PR DESCRIPTION
Changes focus on eliminating LINQ allocations, caching frequently accessed data, using ArrayPool for temporary buffers, and implementing lazy evaluation where appropriate.

### Synthetic Microbenchmarks;
| Category | Metric | Before | After | Improvement |
| :--- | :--- | :--- | :--- | :--- |
| **Transform** | FPS | 625 | 1106 |  +76% |
| | GC/Frame | 212 B | 119 B |  -43% |
| | Min FPS | 445 | 479 |  +8% |
| | | | | |
| **Physics** | FPS | 682 | 1223 |  +79% |
| | GC/Frame | 193 B | 86 B |  -55% |
| | Min FPS | 478 | 268 |  -43% |
| | | | | |
| **Raycast** | FPS | 1118 | 1087 |  N/A |
| | GC/Frame | 62 KB | 62 KB |  N/A |
| | Min FPS | 225 | 271 |  +20% |
| | | | | |
| **Combined** | FPS | 369 | 523 |  +41% |
| | GC/Frame | 47 KB | 47 KB |  N/A |
| | Min FPS | 180 | 207 |  +14% |

*GC provided inconsistent results, -20% to 50%
*Transform and Physics averages are up 75%, but Min FPS for Physics is -40%!! Unsure of the reason.
- **Test Scene**: 7500 GameObjects with SphereColliders arranged in a grid
- **Duration**: 15 seconds per phase

1. **Warmup**: stabilization period
2. **Transform**: Transform updates (rotation) 
3. **Physics**: Dynamic position updates - tests physics body recalculation
4. **Raycast**: 1000 physics traces per frame - tests trace performance and GC
5. **Combined**: All operations simultaneously


## Changes

### Model Loading Optimizations
- **Model.Load.cs**: Added filename sanitization helper, refactored load logic to avoid redundant string operations and improve caching checks.
- **Model.Hitbox.cs**: Cached hitbox count to avoid repeated native interop calls, initialized list with correct capacity to prevent resizing.

### Physics and Collision System Optimizations
- **Model.Physics.cs**: 
  - Cached surface array once per refresh instead of per BodyPart.
  - Set list capacities upfront to avoid resizing.
  - Replaced LINQ with typed lists for Parts (Spheres, Capsules, Hulls, Meshes).
  - Optimized Surfaces property to use yield return instead of LINQ.
- **PhysicsBody.cs**: 
  - Eliminated LINQ allocations in EnableTouchPersists and EnableSolidCollisions properties.
  - Optimized SurfaceMaterial property to avoid LINQ grouping operations.
  - Changed AddHullShape and AddMeshShape to use ReadOnlySpan parameters.
- **PhysicsGroup.cs**: Added JointCount property and GetJoint method for zero-allocation joint enumeration.
- **PhysicsTrace.cs**: Changed World and Body fields from interface types to IntPtr to reduce marshalling overhead. (Is this safe?)
- **PhysicsTraceBuilder.cs**: Cast native pointers to IntPtr in GetResult and GetResults methods.
- **PhysicsTraceResult.cs**: 
  - Implemented lazy properties for Body, Shape, Surface, and Bone with caching. (Lazy may not be preferred.)
  - Stored raw tag IDs in fixed buffer instead of allocating string arrays immediately.
  - Added HasTag methods for zero-allocation tag checking using StringToken. (There was a TODO asking for its implementation; existing code doesn't use it yet.)
  - ThreadStatic HashSet reuse for tag building.

### Component Optimizations
- **CameraComponent.cs**: 
  - Replaced LINQ FirstOrDefault with foreach loops in volumetric (?) fog and UI sorting.
  - ThreadStatic list for UI panel sorting to avoid allocations.
  - Optimized BBoxToScreenPixels to avoid array allocations.
- **CharacterController.cs**: 
  - Cached bounding box to avoid recalculation.
  - Refactored trace building to reduce allocations.
  - Used LengthSquared for velocity checks.
- **Collider.cs**: 
  - Cached hierarchy depth for descendant checks.
  - Eliminated LINQ in CalculateLocalBounds.
  - Optimized IsTrigger setter to update shapes directly.
- **CollisionEventSystem.cs**: Replaced LINQ Any() calls with foreach loops in pair existence checks.
- **HullCollider.cs**: Used ArrayPool for vertex buffers in UpdateShape and CreatePhysicsShapes.
- **ModelPhysics.cs**: Replaced LINQ Sum with foreach loop in Mass property.
- **PlaneCollider.cs**: Cached vertices buffer to avoid repeated allocations.
- **Rigidbody.cs**: Extracted collision handler lambda to method to avoid allocation.
- **SphereCollider.cs**: Used ArrayPool and Span for sphere point generation.

### Rendering and UI Optimizations
- **CubemapFog.cs**: Replaced LINQ FirstOrDefault with foreach loop. 

### General Optimizations
- **PhysicsWorld.cs (check this)**: Removed IsValid() check from Bodies enumerable to let devs handle validation as needed.

Some files above are not in use (by the engine), I was made aware too late of this.

#### PS: (I Grokked this grokgrokgrokgrokgrokgrokgrokgrok) I don't know what I am doing; I tested it via in-game scene tests, looked good to me / nothing obviously broken, works fine & helped my usecase, I recommended a heavy review.