### PR TITLE
Support Nullable<> as ConCmd argument

### DIFF
--- a/engine/Sandbox.System/Extend/StringExtensions.cs
+++ b/engine/Sandbox.System/Extend/StringExtensions.cs
@@ -614,6 +614,7 @@ public static partial class SandboxSystemExtensions
 	{
 		Value = null;
 
+		t = Nullable.GetUnderlyingType( t ) ?? t;
 		if ( t == typeof( decimal ) ) { Value = str.ToDecimal(); return true; }
 		if ( t == typeof( float ) ) { Value = str.ToFloat(); return true; }
 		if ( t == typeof( double ) ) { Value = (double)str.ToFloat(); return true; }


### PR DESCRIPTION
A command cannot have a nullable argument. My PR checks whether the type is nullable and, if so, uses the internal type of the nullable and continues the same processing as with a classic type.

Resolves https://github.com/Facepunch/sbox-public/issues/1729