### PR TITLE
Fix: Properly destroy Scene in MapWorld to prevent memory leak

### DIFF
--- a/engine/Sandbox.Tools/MapEditor/MapDoc/Nodes/MapWorld.cs
+++ b/engine/Sandbox.Tools/MapEditor/MapDoc/Nodes/MapWorld.cs
@@ -111,7 +111,11 @@ public sealed class MapWorld : MapNode
 		base.OnNativeDestroy();
 
 		worldNative = default;
-		Scene = default; // FIXME: Dispose
+		if ( Scene.IsValid() )
+		{
+			Scene.Destroy();
+			Scene = null;
+		}
 
 		EditorSession?.Destroy();
 		EditorSession = null;


### PR DESCRIPTION
Fixes a `FIXME` in [MapWorld.cs](cci:7://file:///t:/sbox-public/engine/Sandbox.Tools/MapEditor/MapDoc/Nodes/MapWorld.cs:0:0-0:0) where the [Scene](cci:1://file:///t:/sbox-public/engine/Sandbox.Engine/Scene/Scene/Scene.cs:80:1-80:35) wasn't being properly destroyed.

Previously, the reference was set to `null`, which meant the Scene (and its native resources) hung around until the GC decided to run. This change ensures `Scene.Destroy()` is called immediately when the MapWorld is destroyed.