### PR TITLE
Fix clamped does nothing

### DIFF
--- a/engine/Sandbox.Tools/ControlWidget/FloatControlWidget.cs
+++ b/engine/Sandbox.Tools/ControlWidget/FloatControlWidget.cs
@@ -245,7 +245,7 @@ public class FloatControlWidget : StringControlWidget
 			if ( e.ButtonState.Contains( MouseButtons.Right ) ) delta *= 0.1f;
 
 			dragValue += delta;
-			if ( HasRange ) dragValue = dragValue.Clamp( Range.x, Range.y );
+			if ( HasRange && RangeClamped ) dragValue = dragValue.Clamp( Range.x, Range.y );
 
 			var steppedValue = (RangeStep != 0.0f) ? dragValue.SnapToGrid( RangeStep ) : dragValue;
 			SerializedProperty.As.Float = steppedValue;


### PR DESCRIPTION
The `clamped` parameter of the `FloatControlWidget.MakeRanged()` function does nothing. My PR fixes this by checking the value of the variable before clamping the value.

Resolves https://github.com/Facepunch/sbox-public/issues/933