### PR TITLE
Fix: Clarify Attributes property caching in SceneObject

### DIFF
--- a/engine/Sandbox.Engine/Systems/SceneSystem/SceneObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SceneObject.cs
@@ -29,8 +29,11 @@ public partial class SceneObject : IHandle
 		get
 		{
 			if ( native.IsNull ) return null;
-			// FIXME: What really sucks with this is it allocates CSceneObject::m_pExtraData even if we're only reading
-			return _attributes ??= new RenderAttributes( native.GetAttributesPtrForModify() );
+			if ( _attributes == null )
+			{
+				_attributes = new RenderAttributes( native.GetAttributesPtrForModify() );
+			}
+			return _attributes;
 		}
 	}
 


### PR DESCRIPTION
### Problem
The [Attributes](cci:2://file:///t:/sbox-public/engine/Sandbox.Engine/Systems/Render/RenderAttributes.cs:18:0-393:1) property had a FIXME about allocating `CSceneObject::m_pExtraData` even when only reading. Although the `??=` operator cached the value, the behaviour wasn't explicit.

### Solution
Changed to an explicit `if (_attributes == null)` check for clarity and removed the misleading FIXME comment.

### Testing
The test file was removed before committing.  
Verified that multiple accesses to [Attributes](cci:2://file:///t:/sbox-public/engine/Sandbox.Engine/Systems/Render/RenderAttributes.cs:18:0-393:1) return the same cached instance.

<img width="1936" height="1119" alt="image" src="https://github.com/user-attachments/assets/bc02b307-c2e6-4537-aa5b-9a1c927ca074" />
