### PR TITLE
switch icons for the pin button in camera preview window

### DIFF
--- a/game/addons/tools/Code/Scene/Tools/Component/CameraComponentTool.cs
+++ b/game/addons/tools/Code/Scene/Tools/Component/CameraComponentTool.cs
@@ -136,7 +136,7 @@ class CameraToolWindow : WidgetWindow
 		var headerRow = Layout.AddRow();
 		headerRow.AddStretchCell();
 
-		_pinButton = new IconButton( IsPinned ? "lock_open" : "lock", TogglePinned )
+		_pinButton = new IconButton( IsPinned ? "lock" : "lock_open", TogglePinned )
 		{
 			ToolTip = IsPinned ? "Unpin" : "Pin",
 			FixedHeight = HeaderHeight,
@@ -173,7 +173,7 @@ class CameraToolWindow : WidgetWindow
 
 		IsPinned = isPinned;
 
-		_pinButton.Icon = isPinned ? "lock_open" : "lock";
+		_pinButton.Icon = isPinned ? "lock" : "lock_open";
 		_pinButton.ToolTip = isPinned ? "Unpin" : "Pin";
 		_pinButton.Update();
 


### PR DESCRIPTION
Low effort pr fixing an entirely subjective non-issue, but I've always felt like the icons used for the pin button in the camera preview are backwards. It feels better in my mind to have the filled in icon represent the feature being enabled, especially with the dropper icon next to it not being filled.

icon previously shown while not pinned, now shown when pinned
<img width="102" height="81" alt="image" src="https://github.com/user-attachments/assets/505710c1-5aa0-41b1-8a85-6e00b229861c" />

icon previously shown while pinned, now shown while not pinned
<img width="112" height="84" alt="image" src="https://github.com/user-attachments/assets/bd303f79-eb6b-432a-b2e8-9db5d927c200" />