### PR TITLE
Add formatting to indicate state of sound preview toggle buttons

### DIFF
--- a/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
+++ b/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
@@ -31,8 +31,18 @@ class PreviewSoundFile : AssetPreview
 		}
 
 		var autoPlay = previewWidget.ToolBar.AddOption( "Auto-Play", "slideshow" );
+		autoPlay.Toggled = ( value ) =>
+		{
+			var icon = new Bitmap( 64, 64 );
+			icon.SetFill( Theme.Blue );
+			if ( value )
+				icon.DrawRoundRect( new( 0, 64 ), 8f );
+			icon.DrawText( new ( "slideshow", Theme.Text, 56, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
+			autoPlay.SetIcon( Pixmap.FromBitmap( icon ) );
+		};
 		autoPlay.Checkable = true;
 		autoPlay.Bind( "Checked" ).From( this, nameof( AutoPlay ) );
+		autoPlay.Toggled.Invoke( AutoPlay );
 
 		return previewWidget;
 	}

--- a/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
+++ b/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
@@ -30,19 +30,14 @@ class PreviewSoundFile : AssetPreview
 			previewWidget.Play();
 		}
 
-		var autoPlay = previewWidget.ToolBar.AddOption( "Auto-Play", "slideshow" );
-		autoPlay.Toggled = ( value ) =>
+		previewWidget.ToolBar.AddWidget( new IconButton( "slideshow" )
 		{
-			var icon = new Bitmap( 64, 64 );
-			icon.SetFill( Theme.Blue );
-			if ( value )
-				icon.DrawRoundRect( new( 0, 64 ), 8f );
-			icon.DrawText( new( "slideshow", Theme.Text, 56, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
-			autoPlay.SetIcon( Pixmap.FromBitmap( icon ) );
-		};
-		autoPlay.Checkable = true;
-		autoPlay.Bind( "Checked" ).From( this, nameof( AutoPlay ) );
-		autoPlay.Toggled.Invoke( AutoPlay );
+			ToolTip = "Auto-Play",
+			IconSize = 18,
+			IsToggle = true,
+			IsActive = AutoPlay,
+			OnToggled = ( value ) => AutoPlay = value
+		} );
 
 		return previewWidget;
 	}

--- a/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
+++ b/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
@@ -37,7 +37,7 @@ class PreviewSoundFile : AssetPreview
 			icon.SetFill( Theme.Blue );
 			if ( value )
 				icon.DrawRoundRect( new( 0, 64 ), 8f );
-			icon.DrawText( new ( "slideshow", Theme.Text, 56, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
+			icon.DrawText( new( "slideshow", Theme.Text, 56, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
 			autoPlay.SetIcon( Pixmap.FromBitmap( icon ) );
 		};
 		autoPlay.Checkable = true;

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -10,7 +10,7 @@ public partial class SoundPlayer : Widget
 
 	public ToolBar ToolBar { get; private set; }
 
-	private readonly Option PlayOption;
+	private readonly IconButton PlayOption;
 
 	private bool _prevPlay = false;
 
@@ -27,7 +27,12 @@ public partial class SoundPlayer : Widget
 		ToolBar = header.Add( new ToolBar( this ) );
 		ToolBar.NoSystemBackground = false;
 		ToolBar.SetIconSize( 18 );
-		PlayOption = ToolBar.AddOption( "Play", "play_arrow", () => Playing = !Playing );
+		PlayOption = ToolBar.AddWidget( new IconButton( "play_arrow" )
+		{
+			ToolTip = "Play",
+			IconSize = 18,
+			OnClick = () => Playing = !Playing
+		} );
 
 		var timecode = header.Add( new Label( this ) );
 		timecode.Bind( "Text" ).ReadOnly().From( () =>
@@ -38,21 +43,21 @@ public partial class SoundPlayer : Widget
 		}, null );
 		timecode.Alignment = TextFlag.RightCenter;
 
-		var skipStart = ToolBar.AddOption( "Skip to Start", "skip_previous", () => Timeline.MoveScrubber( 0 ) );
-		ToolBar.AddSeparator();
-		var loop = ToolBar.AddOption( "Loop", "repeat" );
-		loop.Toggled = ( value ) =>
+		ToolBar.AddWidget( new IconButton( "skip_previous" )
 		{
-			var icon = new Bitmap( 64, 64 );
-			icon.SetFill( Theme.Blue );
-			if ( value )
-				icon.DrawRoundRect( new( 0, 64 ), 8f );
-			icon.DrawText( new( "repeat", Theme.Text, 64, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
-			loop.SetIcon( Pixmap.FromBitmap( icon ) );
-		};
-		loop.Bind( "Checked" ).From( this, nameof( Repeating ) );
-		loop.Checkable = true;
-		loop.Toggled.Invoke( Repeating );
+			ToolTip = "Skip to Start",
+			IconSize = 18,
+			OnClick = () => Timeline.MoveScrubber( 0 )
+		} );
+		ToolBar.AddSeparator();
+		ToolBar.AddWidget( new IconButton( "repeat" )
+		{
+			ToolTip = "Loop",
+			IconSize = 18,
+			IsToggle = true,
+			IsActive = Repeating,
+			OnToggled = ( value ) => Repeating = value
+		} );
 
 		Timeline = Layout.Add( new TimelineView( this ), 1 );
 	}
@@ -89,7 +94,7 @@ public partial class SoundPlayer : Widget
 		Timeline.OnFrame();
 		Time = Timeline.Time;
 
-		PlayOption.Text = Playing ? "Pause" : "Play";
+		PlayOption.ToolTip = Playing ? "Pause" : "Play";
 		PlayOption.Icon = Playing ? "pause" : "play_arrow";
 
 		if ( Application.FocusWidget.IsValid() )

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -47,7 +47,7 @@ public partial class SoundPlayer : Widget
 			icon.SetFill( Theme.Blue );
 			if ( value )
 				icon.DrawRoundRect( new( 0, 64 ), 8f );
-			icon.DrawText( new ( "repeat", Theme.Text, 64, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
+			icon.DrawText( new( "repeat", Theme.Text, 64, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
 			loop.SetIcon( Pixmap.FromBitmap( icon ) );
 		};
 		loop.Bind( "Checked" ).From( this, nameof( Repeating ) );

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -41,8 +41,18 @@ public partial class SoundPlayer : Widget
 		var skipStart = ToolBar.AddOption( "Skip to Start", "skip_previous", () => Timeline.MoveScrubber( 0 ) );
 		ToolBar.AddSeparator();
 		var loop = ToolBar.AddOption( "Loop", "repeat" );
+		loop.Toggled = ( value ) =>
+		{
+			var icon = new Bitmap( 64, 64 );
+			icon.SetFill( Theme.Blue );
+			if ( value )
+				icon.DrawRoundRect( new( 0, 64 ), 8f );
+			icon.DrawText( new ( "repeat", Theme.Text, 64, "Material Icons" ), new( 0, 64 ), TextFlag.Center | TextFlag.DontClip );
+			loop.SetIcon( Pixmap.FromBitmap( icon ) );
+		};
 		loop.Bind( "Checked" ).From( this, nameof( Repeating ) );
 		loop.Checkable = true;
+		loop.Toggled.Invoke( Repeating );
 
 		Timeline = Layout.Add( new TimelineView( this ), 1 );
 	}


### PR DESCRIPTION
fixes https://github.com/Facepunch/sbox-public/issues/918

Loop and Auto-Play buttons in sound preview previously had no indication as to their state, this adds a stylish blue background to those buttons when they are enabled
<img width="159" height="90" alt="image" src="https://github.com/user-attachments/assets/91409a26-5ac1-4601-9229-7856d1ab0c70" />