### PR TITLE
Fix inconsistent core mesh editing hotkeys

### DIFF
--- a/game/addons/tools/Code/Scene/Mesh/Tools/EdgeTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/EdgeTool.UI.cs
@@ -147,7 +147,7 @@ partial class EdgeTool
 			return _edges.Length != 0;
 		}
 
-		[Shortcut( "mesh.edge-bevel", "ALT+F", typeof( SceneViewportWidget ) )]
+		[Shortcut( "mesh.edge-bevel", "F", typeof( SceneViewportWidget ) )]
 		private void Bevel()
 		{
 			if ( !CanBevel() )
@@ -386,7 +386,7 @@ partial class EdgeTool
 			}
 		}
 
-		[Shortcut( "mesh.bridge-edges", "ALT+B", typeof( SceneViewportWidget ) )]
+		[Shortcut( "mesh.bridge-edges", "B", typeof( SceneViewportWidget ) )]
 		private void BridgeEdges()
 		{
 			if ( !CanBridgeEdges() )

--- a/game/addons/tools/Code/Scene/Mesh/Tools/MoveModeToolBar.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/MoveModeToolBar.cs
@@ -24,16 +24,16 @@ class MoveModeToolBar : Widget
 		Update();
 	}
 
-	[Shortcut( "mesh.position.mode", "w", typeof( SceneDock ) )]
+	[Shortcut( "mesh.position.mode", "t", typeof( SceneDock ) )]
 	public void ActivatePositionMode() => SetMode( "mesh.position.mode" );
 
-	[Shortcut( "mesh.rotate.mode", "e", typeof( SceneDock ) )]
+	[Shortcut( "mesh.rotate.mode", "r", typeof( SceneDock ) )]
 	public void ActivateRotateMode() => SetMode( "mesh.rotate.mode" );
 
-	[Shortcut( "mesh.scale.mode", "r", typeof( SceneDock ) )]
+	[Shortcut( "mesh.scale.mode", "e", typeof( SceneDock ) )]
 	public void ActivateScaleMode() => SetMode( "mesh.scale.mode" );
 
-	[Shortcut( "mesh.pivot.mode", "t", typeof( SceneDock ) )]
+	[Shortcut( "mesh.pivot.mode", "d", typeof( SceneDock ) )]
 	public void ActivatePivotMode() => SetMode( "mesh.pivot.mode" );
 }
 


### PR DESCRIPTION
This is a very small PR. I only changed two shortcut strings in the EdgeTool to make the hotkeys a bit more consistent with the rest of the mesh editor and with how users expect these operations to behave.

Changes
Bevel (edges): Alt+F -> F
Matches vertex bevel

Bridge Edges: Alt+B -> B
Move Mode -> t
Rotate Mode -> r
Scale Mode -> e
Pivot Mode -> d
All other core mesh editing operations use single key presses.

There is an ALT+B keybinding in hammer for BridgeTool Mode, but that creates an arch.

