### PR TITLE
Show volume tooltip in settings as a percentage rather than a decimal

### DIFF
--- a/engine/Sandbox.Engine/Game/Preferences.cs
+++ b/engine/Sandbox.Engine/Game/Preferences.cs
@@ -15,13 +15,13 @@ public static class Preferences
 	/// <summary>
 	/// The user's preferred Music volume, as set in the options, clamped between 0 and 1
 	/// </summary>
-	[ConVar( "music_volume", ConVarFlags.Protected, Help = "Music volume", Min = 0.0f, Max = 1.0f, Saved = true )]
+	[ConVar( "music_volume", ConVarFlags.Protected, Help = "Music volume", Min = 0.0f, Saved = true )]
 	public static float MusicVolume { get; internal set; } = 1.0f;
 
 	/// <summary>
 	/// The user's preferred VOIP volume, as set in the options, clamped between 0 and 1
 	/// </summary>
-	[ConVar( "voip_volume", ConVarFlags.Protected, Help = "Voice chat volume", Min = 0.0f, Max = 1.0f, Saved = true )]
+	[ConVar( "voip_volume", ConVarFlags.Protected, Help = "Voice chat volume", Min = 0.0f, Saved = true )]
 	public static float VoipVolume { get; internal set; } = 1.0f;
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Systems/Audio/Sound.cs
+++ b/engine/Sandbox.Engine/Systems/Audio/Sound.cs
@@ -22,9 +22,9 @@ public static partial class Sound
 	}
 
 	/// <summary>
-	/// The user's preference for their field of view
+	/// The user's preference for their master volume.
 	/// </summary>
-	[ConVar( "volume", ConVarFlags.Protected | ConVarFlags.Saved, Help = "Global volume output", Min = 0.0f, Max = 1.0f )]
+	[ConVar( "volume", ConVarFlags.Protected | ConVarFlags.Saved, Help = "Global volume output", Min = 0.0f )]
 	public static float MasterVolume { get; internal set; } = 1.0f;
 
 	[System.Obsolete]

--- a/game/addons/menu/Code/Modals/Settings/AudioSettings.razor
+++ b/game/addons/menu/Code/Modals/Settings/AudioSettings.razor
@@ -23,21 +23,21 @@
             <cell class="glass with-padding is-label">
                 Master
             </cell>
-            <SliderControl Value:bind=@GlobalVolume class="glass with-grow" Min="@(0)" Max="@(1)" Step="@(0.01f)"></SliderControl>
+            <SliderControl Value:bind=@GlobalVolume class="glass with-grow" Min="@(0)" Max="@(1)" Step="@(0.01f)" NumberFormat="0.##%"></SliderControl>
         </row>
 
         <row class="with-gaps">
             <cell class="glass with-padding is-label">
                 Music
             </cell>
-            <SliderControl Value:bind=@MusicVolume class="glass with-grow" Min="@(0)" Max="@(1)" Step="@(0.01f)"></SliderControl>
+            <SliderControl Value:bind=@MusicVolume class="glass with-grow" Min="@(0)" Max="@(1)" Step="@(0.01f)" NumberFormat="0.##%"></SliderControl>
         </row>
 
         <row class="with-gaps">
             <cell class="glass with-padding is-label">
                 Voice
             </cell>
-            <SliderControl Value:bind=@VoiceVolume class="glass with-grow" Min="@(0)" Max="@(1)" Step="@(0.01f)"></SliderControl>
+            <SliderControl Value:bind=@VoiceVolume class="glass with-grow" Min="@(0)" Max="@(1)" Step="@(0.01f)" NumberFormat="0.##%"></SliderControl>
         </row>
 
     </div>


### PR DESCRIPTION
Also increases the max volume from 100% to 200% because 100% is quieter than everything else on my pc and it's nice to have