### PR TITLE
Fix GameObjects in GameObjectSystem NetLists being null on clients

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -418,18 +418,6 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		Time.Now = (float)msg.Time;
 		Game.ActiveScene.UpdateTimeFromHost( msg.Time );
 
-		foreach ( var s in msg.GameObjectSystems )
-		{
-			var type = Game.TypeLibrary.GetTypeByIdent( s.Type );
-			var system = Game.ActiveScene.GetSystemByType( type );
-
-			if ( system is null )
-				continue;
-
-			system.Id = s.Id;
-			system.ReadDataTable( s.TableData );
-		}
-
 		{
 			using var batchGroup = CallbackBatch.Batch();
 
@@ -455,6 +443,18 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 			{
 				go.NetworkSpawnRemote( oc );
 			}
+		}
+
+		foreach ( var s in msg.GameObjectSystems )
+		{
+			var type = Game.TypeLibrary.GetTypeByIdent( s.Type );
+			var system = Game.ActiveScene.GetSystemByType( type );
+
+			if ( system is null )
+				continue;
+
+			system.Id = s.Id;
+			system.ReadDataTable( s.TableData );
 		}
 
 		MountedVPKs?.Dispose();

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
@@ -60,7 +60,7 @@ public partial class Scene : GameObject
 			objects = objects.Concat( systems );
 
 		system.DeltaSnapshots.Send( objects, connectionsArray );
-		
+
 		system.DeltaSnapshots.Tick();
 	}
 

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
@@ -53,17 +53,14 @@ public partial class Scene : GameObject
 		var connections = system.GetFilteredConnections( Connection.ChannelState.Connected );
 		var connectionsArray = connections as Connection[] ?? connections.ToArray();
 
-		if ( connectionsArray.Length != 0 )
-		{
-			var objects = networkedObjects.OfType<IDeltaSnapshot>();
+		var objects = networkedObjects.OfType<IDeltaSnapshot>();
 
-			// If we're the host, include any GameObjectSystems.
-			if ( Networking.IsHost )
-				objects = objects.Concat( systems );
+		// If we're the host, include any GameObjectSystems.
+		if ( Networking.IsHost )
+			objects = objects.Concat( systems );
 
-			system.DeltaSnapshots.Send( objects, connectionsArray );
-		}
-
+		system.DeltaSnapshots.Send( objects, connectionsArray );
+		
 		system.DeltaSnapshots.Tick();
 	}
 


### PR DESCRIPTION
### Fix GameObjects in GameObjectSystem NetLists / NetDictionaries being null on clients.

Issue: https://github.com/Facepunch/sbox-public/issues/432

### Changes

**SceneNetworkSystem.cs:** 
- Moved `GameObjectSystem` data table reading to after `GameObject` spawning

**Scene.Network.cs:**
- Removed connection count check to ensure network table `isDirty` flags are cleared every network update

### Notes

When `GameObjectSystem` data tables were read before `GameObjects` spawned, `GameObjects` in `NetList`/`NetDictionaries` were `null` because lookup by `GUID` failed.

There was a second issue that meant that the first client to connect would not experience the first bug. When the `NetList` is changed on the host, it's entry within the `NetworkTable` is marked as `isDirty`. This is only ever toggled when a network update is sent. Since there are no connections at first, no network update is sent and so `isDirty` remains true until the first client connects. 

When the first client connects, it encounters the first bug, but immediately after it receives an additional delta snapshot which fixes it. This then toggles `isDirty` to `false` for that entry on the server, so every other client that connects now develops the first bug with no correction snapshot afterwards.

I found this really confusing. It took me ages to understand why the first client was being treated differently from all the rest. I think the code should be changed so that even when no clients are connected `isDirty` will still be set to `false` when the `SceneNetworkUpdate`ticks. This way, every client will run the same code regardless of if they are the first to connect to the server or not. The change I made to `Scene.Network.cs` does this. I don't think it will have a big performance impact because when there are no changes it just returns early. It might not affect anything else outside of the first bug but I still think it's better to not have some clients running different code from the rest. It could end up masking other bugs that you wouldn't notice while testing if you only connected with one client.

If you want to avoid the extra work when there are no clients connected, other than the host, it should be done in another way, so that `isDirty` is still set to `false` each `SceneNetworkUpdate` regardless of whether an update was sent to anyone or not.