### PR TITLE
Fix `GameObjectSystem` `SceneLoaded` listeners not being called for clients

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -468,6 +468,8 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 
 		if ( Game.ActiveScene.IsValid() )
 		{
+			Game.ActiveScene.Signal( GameObjectSystem.Stage.SceneLoaded );
+
 			Game.ActiveScene.RunEvent<ISceneStartup>( x => x.OnClientInitialize() );
 		}
 

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -56,7 +56,7 @@ public partial class Scene
 	/// <summary>
 	/// Signal a hook stage
 	/// </summary>
-	private void Signal( in GameObjectSystem.Stage stage )
+	internal void Signal( in GameObjectSystem.Stage stage )
 	{
 		GetCallbacks( stage ).Run();
 	}


### PR DESCRIPTION
Issue: https://github.com/Facepunch/sbox-public/issues/2737

### Changes

- Added a call to Signal after the client has loaded the scene.