### PR TITLE
Add Collision Rules to NavMeshAgent Ground Trace

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/NavMeshAgentSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/NavMeshAgentSystem.cs
@@ -66,6 +66,7 @@ internal sealed class NavMeshGameSystem : GameObjectSystem
 				.IgnoreDynamic()
 				.IgnoreGameObjectHierarchy( agent.GameObject )
 				.WithAnyTags( Scene.NavMesh.IncludedBodies )
+				.WithCollisionRules(agent.Tags)
 				.WithoutTags( Scene.NavMesh.ExcludedBodies );
 
 		if ( !Scene.NavMesh.IncludeStaticBodies )

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/NavMeshAgentSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/NavMeshAgentSystem.cs
@@ -66,7 +66,7 @@ internal sealed class NavMeshGameSystem : GameObjectSystem
 				.IgnoreDynamic()
 				.IgnoreGameObjectHierarchy( agent.GameObject )
 				.WithAnyTags( Scene.NavMesh.IncludedBodies )
-				.WithCollisionRules(agent.Tags)
+				.WithCollisionRules( agent.Tags )
 				.WithoutTags( Scene.NavMesh.ExcludedBodies );
 
 		if ( !Scene.NavMesh.IncludeStaticBodies )


### PR DESCRIPTION
Changes The FindPhysicsGroundZ function on NavMeshAgentSystem so it includes the collision rules of the agent.