### PR TITLE
Fix package visibility overlay

### DIFF
--- a/game/addons/base/code/UI/Components/PackageCard.razor
+++ b/game/addons/base/code/UI/Components/PackageCard.razor
@@ -23,25 +23,26 @@
 
         @if ( Decorated )
         {
-            if (Package.Public == false)
-            {
-                <div class="card-decorator-hidden" tooltip="This is hidden from the public">Hidden</div>
-            }
-
-            if ( UsersNow > 0 )
-            {
-                <div class="card-decorator-users" tooltip="This many users are playing now">
-                    <i>sports_esports</i>
-                    <span> @UsersNow.KiloFormat() </span>
-                </div>
-            }
-            else if ( Package.Usage.UsersNow > 0 )
-            {
-                <div class="card-decorator-users" tooltip="This many users are playing now">
-                    <i>sports_esports</i>
-                    <span> @Package.Usage.UsersNow.KiloFormat() </span>
-                </div>
-            }
+            <div class="card-decorator">
+                @if ( Package.Public == false )
+                {
+                    <i tooltip="This package is hidden from the public">visibility_off</i>
+                }
+                @if ( UsersNow > 0 )
+                {   
+                    <div class="player-count" tooltip="This many users are playing now">
+                        <i>sports_esports</i>
+                        <span> @UsersNow.KiloFormat() </span>
+                    </div>
+                }
+                else if ( Package.Usage.UsersNow > 0 )
+                {
+                    <div class="player-count tooltip="This many users are playing now">
+                        <i>sports_esports</i>
+                        <span> @Package.Usage.UsersNow.KiloFormat() </span>
+                    </div>
+                }
+            </div>
         }
 
     </div>

--- a/game/addons/base/code/UI/Components/PackageCard.razor.scss
+++ b/game/addons/base/code/UI/Components/PackageCard.razor.scss
@@ -100,21 +100,7 @@ $highlight: #5c5;
 	transition: all 0.3s ease-out;
 }
 
-.card-decorator-hidden
-{
-	position: absolute;
-	background-color: #0009;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	color: white;
-	padding: 10px;
-	text-transform: uppercase;
-	font-size: 12px;
-	z-index: 5;
-}
-
-.card-decorator-users
+.card-decorator
 {
 	background-color: darken( rgba( $highlight, 0.7 ), 0.66 );
 	color: lighten( $highlight, 0.5 );
@@ -123,15 +109,25 @@ $highlight: #5c5;
 	top: 5px;
 	padding: 3px 8px;
 	border-radius: 200px;
-	aspect-ratio: 1;
 	box-shadow: 2px 2px 16px #0002;
 	font-size: 12px;
 	font-weight: bold;
-	gap: 3px;
+	gap: 6px;
 	align-items: center;
+	justify-content: space-between;
 
 	i
 	{
 		font-size: 16px;
 	}
+
+	&:empty
+	{
+		display: none;
+	}
+}
+
+.player-count
+{
+	gap: 3px;
 }


### PR DESCRIPTION
Before:
<img width="296" height="197" alt="image" src="https://github.com/user-attachments/assets/9f1ea159-dcbb-476d-be72-b5c90caa5e35" />

After:
<img width="310" height="202" alt="image" src="https://github.com/user-attachments/assets/c242d3bc-bf54-4b6f-a66d-17493a509437" />

I noticed the little "hidden" text displayed off screen so I went ahead and merged it with the player count overlay. This works perfectly with multiple icons and can be expanded on in the future
<img width="413" height="263" alt="image" src="https://github.com/user-attachments/assets/f801cadf-3fb2-4aa9-abcd-944b5dbd718c" />
