### PR TITLE
Fix scene switching by not focusing LastSelected when switching tools

### DIFF
--- a/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.cs
@@ -338,10 +338,6 @@ file class ViewportToolBar : Widget
 
 			toolWidget.Focus();
 		}
-		else
-		{
-			SceneViewportWidget.LastSelected?.Focus();
-		}
 
 		// Update footer
 		var footerWidget = subTool?.CreateToolFooter() ?? rootTool?.CreateToolFooter();


### PR DESCRIPTION
### Summary of the hotfix
LastSelected may belong to another SceneView and completely locks up tabs in some scenarios. This is a hotfix - there are cases where we want to re-focus the last selected widget.

This was introduced 2 days ago: https://github.com/Facepunch/sbox-public/commit/c2398b349976e831e0aae3e9bb9dc055f0e9313e#diff-cd9bee7a3175dd65092db020fb57a8bb8784c559023f1b64f334ae1a4426c85d

Video showing the issue that will be fixed:

https://github.com/user-attachments/assets/bf154cfd-ed59-4077-a98e-466a9be169b2

### Hacky "Solution"

See: https://github.com/Facepunch/sbox-public/compare/master...aidencurtis:sbox-public:focus-last-selected-fix

If the Viewport is not within our Current SceneView, then we do not try to focus it.

### Better Solution

Stop using static SceneViewportWidget LastSelected - each SceneView should likely have its own reference to its LastSelected widget. This is a larger refactor that I wanted to chat about before attempting.

cc @CarsonKompon 