### PR TITLE
Fix `DebugOverlay.Text` being culled when looking away from the scene origin

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/DebugOverlay/DebugOverlaySystem.DrawText.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/DebugOverlay/DebugOverlaySystem.DrawText.cs
@@ -22,9 +22,10 @@ public partial class DebugOverlaySystem
 	/// </summary>
 	public void Text( Vector3 position, TextRendering.Scope scope, TextFlag flags = TextFlag.Center, float duration = 0, bool overlay = false )
 	{
-		Add( duration, new DebugTextSceneObject( Scene.SceneWorld, position, scope, flags )
+		Add( duration, new DebugTextSceneObject( Scene.SceneWorld, scope, flags )
 		{
 			RenderLayer = overlay ? SceneRenderLayer.OverlayWithoutDepth : SceneRenderLayer.OverlayWithDepth,
+			Transform = new Transform( position ),
 			LocalBounds = BBox.FromPositionAndSize( 0, 256 )
 		} );
 	}
@@ -34,14 +35,12 @@ file class DebugTextSceneObject : SceneCustomObject
 {
 	private readonly TextRendering.Scope _scope;
 	private readonly TextFlag _flags;
-	private readonly Vector3 _position;
 	private readonly float _scale;
 
-	public DebugTextSceneObject( SceneWorld sceneWorld, Vector3 position, TextRendering.Scope scope, TextFlag flags ) : base( sceneWorld )
+	public DebugTextSceneObject( SceneWorld sceneWorld, TextRendering.Scope scope, TextFlag flags ) : base( sceneWorld )
 	{
 		_scope = scope;
 		_flags = flags;
-		_position = position;
 
 		var fontSize = _scope.FontSize;
 		var scaleFactor = fontSize < 32 ? fontSize.Remap( 0, 32, 0, 1 ) : 1.0f;
@@ -53,7 +52,7 @@ file class DebugTextSceneObject : SceneCustomObject
 	public override void RenderSceneObject()
 	{
 		var rotation = Graphics.CameraRotation;
-		Graphics.Attributes.Set( "WorldMat", Matrix.CreateScale( _scale ) * Matrix.CreateWorld( _position, rotation.Forward, rotation.Up ) );
+		Graphics.Attributes.Set( "WorldMat", Matrix.CreateScale( _scale ) * Matrix.CreateWorld( Vector3.Zero, rotation.Forward, rotation.Up ) );
 		Graphics.Attributes.SetCombo( "D_WORLDPANEL", 1 );
 		Graphics.DrawText( new Rect( 0 ), _scope, _flags );
 	}

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SceneCustomObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SceneCustomObject.cs
@@ -26,9 +26,6 @@ public class SceneCustomObject : SceneObject
 				// if the user forgets/doesn't need bounds.
 				native.SetBoundsInfinite();
 			}
-
-			// Initialize Transform so it will render (default Transform has scale 0)
-			Transform = Transform.Zero;
 		}
 	}
 


### PR DESCRIPTION
Issue: https://github.com/Facepunch/sbox-public/issues/699#issuecomment-3638646507

The fix I did for `DebugOverlay.Text` was crap. It rendered the text but it was still broken. It spawned the `DebugTextSceneObject` at the scene origin every time, even though the position the text was rendered was often different. When you looked away from the origin, the object would be outside the camera frustum and so it would cull it from rendering.

@K3rhos helpfully posted a video of the issue: 

https://private-user-images.githubusercontent.com/30273537/525006285-7e77e739-4384-4f31-8de2-be2255f9a30c.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjU0NjcxMTQsIm5iZiI6MTc2NTQ2NjgxNCwicGF0aCI6Ii8zMDI3MzUzNy81MjUwMDYyODUtN2U3N2U3MzktNDM4NC00ZjMxLThkZTItYmUyMjU1ZjlhMzBjLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEyMTElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMjExVDE1MjY1NFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTQ3MGU1YTQ0MmI2ODU3NjY3ODg1NWZlYmQ5MmJkN2FjMDlkMzIzZGJhZTBhZWVjN2UyYjQyZWE3Zjg3Yzg1YjkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.g2vYVjtCEp7835Ri-AXS-4nOnnjCInkAcSSEeIxcpWM

I didn't notice this when testing because I was using the minimal scene and always looking towards the origin to see the text.

This PR changes it so that the `Transform` of the the `DebugTextSceneObject` is set to the position passed in to the function rather than the origin. 

