### PR TITLE
Scope last selected SceneViewportWidget to SceneViewWidget

### DIFF
--- a/game/addons/tools/Code/Extensions/SceneEditorExtensions.cs
+++ b/game/addons/tools/Code/Extensions/SceneEditorExtensions.cs
@@ -120,7 +120,7 @@ public static class SceneEditorExtensions
 					currentSpeed = Math.Clamp( currentSpeed, 0.25f, 100.0f );
 
 					EditorPreferences.CameraSpeed = currentSpeed;
-					SceneViewportWidget.LastSelected.timeSinceCameraSpeedChange = 0;
+					SceneViewWidget.Current.LastSelectedViewportWidget.timeSinceCameraSpeedChange = 0;
 				}
 
 				var sens = EditorPreferences.CameraSensitivity;

--- a/game/addons/tools/Code/Scene/Mesh/Tools/TextureTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/TextureTool.UI.cs
@@ -186,7 +186,7 @@ partial class TextureTool
 
 		private void AlignToView()
 		{
-			var sceneView = SceneViewportWidget.LastSelected;
+			var sceneView = SceneViewWidget.Current?.LastSelectedViewportWidget;
 			if ( !sceneView.IsValid() )
 				return;
 

--- a/game/addons/tools/Code/Scene/SceneEditorMenus.cs
+++ b/game/addons/tools/Code/Scene/SceneEditorMenus.cs
@@ -146,13 +146,14 @@ public static class SceneEditorMenus
 	[Shortcut( "gameObject.align-to-view", "CTRL+SHIFT+F" )]
 	public static void AlignToView()
 	{
-		if ( !SceneViewportWidget.LastSelected.IsValid() )
+		var lastSelectedViewportWidget = SceneViewWidget.Current.LastSelectedViewportWidget;
+		if ( !lastSelectedViewportWidget.IsValid() )
 			return;
 
 		if ( EditorScene.Selection.Count == 0 )
 			return;
 
-		var targetTransform = new Transform( SceneViewportWidget.LastSelected.State.CameraPosition, SceneViewportWidget.LastSelected.State.CameraRotation );
+		var targetTransform = new Transform( lastSelectedViewportWidget.State.CameraPosition, lastSelectedViewportWidget.State.CameraRotation );
 		var gos = EditorScene.Selection.OfType<GameObject>().ToArray();
 
 		gos.DispatchPreEdited( nameof( GameObject.LocalPosition ) );
@@ -331,13 +332,14 @@ public static class SceneEditorMenus
 		if ( !EditorScene.Selection.OfType<GameObject>().Any() )
 			return;
 
-		if ( !SceneViewportWidget.LastSelected.IsValid() )
+		var lastSelectedViewportWidget = SceneViewWidget.Current.LastSelectedViewportWidget;
+		if ( !lastSelectedViewportWidget.IsValid() )
 			return;
 
 		var gos = EditorScene.Selection.OfType<GameObject>();
 		using ( SceneEditorSession.Active.UndoScope( "Nudge Object(s)" ).WithGameObjectChanges( gos, GameObjectUndoFlags.Properties ).Push() )
 		{
-			var gizmoInstance = SceneViewportWidget.LastSelected.GizmoInstance;
+			var gizmoInstance = lastSelectedViewportWidget.GizmoInstance;
 
 			var rotation = Rotation.Identity;
 			if ( !gizmoInstance.Settings.GlobalSpace )

--- a/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
+++ b/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
@@ -750,7 +750,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 			if ( !EditorPreferences.CreateObjectsAtOrigin && !parent.IsValid() )
 			{
 				// I wonder if we should be tracing and placing it on the surface?
-				go.LocalPosition = SceneViewportWidget.LastSelected.State.CameraPosition + SceneViewportWidget.LastSelected.State.CameraRotation.Forward * 300;
+				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300;
 			}
 
 			afterCreate?.Invoke( go );
@@ -813,7 +813,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 			if ( !EditorPreferences.CreateObjectsAtOrigin && !parent.IsValid() )
 			{
 				// I wonder if we should be tracing and placing it on the surface?
-				go.LocalPosition = SceneViewportWidget.LastSelected.State.CameraPosition + SceneViewportWidget.LastSelected.State.CameraRotation.Forward * 300;
+				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300;
 			}
 
 			afterCreate?.Invoke( go );
@@ -891,7 +891,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 			if ( !EditorPreferences.CreateObjectsAtOrigin && !parent.IsValid() )
 			{
 				// I wonder if we should be tracing and placing it on the surface?
-				go.LocalPosition = SceneViewportWidget.LastSelected.State.CameraPosition + SceneViewportWidget.LastSelected.State.CameraRotation.Forward * 300;
+				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300;
 			}
 
 			afterCreate?.Invoke( go );

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.cs
@@ -33,6 +33,8 @@ public partial class SceneViewWidget : Widget
 
 	public static SceneViewWidget Current { get; private set; }
 
+	public SceneViewportWidget LastSelectedViewportWidget { get; set; }
+
 	public EditorToolManager Tools { get; private set; }
 
 	/// <summary>
@@ -337,6 +339,13 @@ file class ViewportToolBar : Widget
 			_sidebar.Add( scroller );
 
 			toolWidget.Focus();
+		}
+		else
+		{
+			if ( SceneViewWidget.Current?.LastSelectedViewportWidget?.IsValid() ?? false )
+			{
+				SceneViewWidget.Current.LastSelectedViewportWidget.Focus();
+			}
 		}
 
 		// Update footer

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
@@ -2,7 +2,6 @@
 
 public partial class SceneViewportWidget : Widget
 {
-	public static SceneViewportWidget LastSelected { get; private set; }
 	public static Vector2 MousePosition { get; private set; }
 
 	public int Id { get; private set; }
@@ -43,7 +42,7 @@ public partial class SceneViewportWidget : Widget
 		Id = id;
 		if ( Id == 0 )
 		{
-			LastSelected = this;
+			SceneView.LastSelectedViewportWidget = this;
 		}
 
 		if ( ProjectCookie.Get<ViewportState>( $"SceneView.Viewport{Id}.Settings", null ) is ViewportState savedSettings )
@@ -447,9 +446,9 @@ public partial class SceneViewportWidget : Widget
 		//
 
 		var hasMouseFocus = hasMouseInput;
-		if ( IsFocused )
+		if ( IsFocused && SceneViewWidget.Current.IsValid() )
 		{
-			LastSelected = this;
+			SceneViewWidget.Current.LastSelectedViewportWidget = this;
 		}
 
 		GizmoInstance.Input.IsHovered = hasMouseFocus;

--- a/game/addons/tools/Code/Scene/Tools/Component/CameraComponentTool.cs
+++ b/game/addons/tools/Code/Scene/Tools/Component/CameraComponentTool.cs
@@ -206,7 +206,7 @@ class CameraToolWindow : WidgetWindow
 	{
 		EditorToolManager.CurrentModeName = "camera.lookat";
 		// maintain focus on scene even after clicking the button
-		SceneViewportWidget.LastSelected?.Focus();
+		SceneViewWidget.Current?.LastSelectedViewportWidget?.Focus();
 	}
 
 	void CloseWindow()

--- a/game/addons/tools/Code/Scene/Tools/Component/NavMeshLinkTool.cs
+++ b/game/addons/tools/Code/Scene/Tools/Component/NavMeshLinkTool.cs
@@ -107,7 +107,7 @@ class NavMeshLinkToolWindow : WidgetWindow
 					isPickingEnd = false;
 					isAddingNewLink = false;
 					helpLabel.Text = "Pick start position for selected link. Press Ctrl or Cancel Button to cancel.";
-					SceneViewportWidget.LastSelected.Focus();
+					SceneViewWidget.Current?.LastSelectedViewportWidget?.Focus();
 				}
 			} );
 
@@ -120,7 +120,7 @@ class NavMeshLinkToolWindow : WidgetWindow
 					isPickingStart = false;
 					isAddingNewLink = false;
 					helpLabel.Text = "Pick end position for selected link. Press Ctrl or Cancel Button to cancel.";
-					SceneViewportWidget.LastSelected.Focus();
+					SceneViewWidget.Current?.LastSelectedViewportWidget?.Focus();
 				}
 			} );
 
@@ -132,7 +132,7 @@ class NavMeshLinkToolWindow : WidgetWindow
 					isAddingNewLink = true;
 					isPickingStart = true;
 					helpLabel.Text = "Pick start Position for new link. Press Ctrl or Cancel Button to cancel.";
-					SceneViewportWidget.LastSelected.Focus();
+					SceneViewWidget.Current?.LastSelectedViewportWidget?.Focus();
 				}
 			} );
 


### PR DESCRIPTION
### Summary

SceneViewportWidget had a static member `public SceneViewportWidget LastSelected`. This held a reference to the last selected viewport widget, but this reference should be scoped to the current SceneViewWidget instead.

This change allows operations on the last selected viewport widget without concern of bleeding references from other scenes.

Summary of code changes:

- Remove static LastSelected SceneViewportWidget. It should be scoped to the last selected viewport within a particular Scene view
- Add LastSelectedViewportWidget to SceneViewWidget and update all references
- Re-add focusing the last selected widget that was hotfixed in #114

cc @CarsonKompon 