### PR TITLE
Reset Game.IsPaused when scene is stopped, tint pause button when scene is paused

### DIFF
--- a/engine/Sandbox.Tools/Scene/EditorScene.cs
+++ b/engine/Sandbox.Tools/Scene/EditorScene.cs
@@ -300,6 +300,7 @@ public static class EditorScene
 		SceneEditorSession.Active.StopPlaying();
 
 		Game.IsPlaying = false;
+		Game.IsPaused = false;
 
 		// Immediately stop active recordings so we don't get any black frames
 		ScreenRecorder.StopRecording();

--- a/game/addons/tools/Code/Scene/SceneView/ViewportTools.Center.cs
+++ b/game/addons/tools/Code/Scene/SceneView/ViewportTools.Center.cs
@@ -69,6 +69,7 @@ partial class ViewportTools
 	{
 		// What the fuck, why isnt this a method
 		Game.IsPaused = !Game.IsPaused;
+		PauseButton.Color = Game.IsPaused ? Theme.Blue : Theme.TextLight;
 	}
 
 	[Shortcut( "editor.eject", "F8", ShortcutType.Window )]


### PR DESCRIPTION
**Summary**
- Resets Game.IsPaused when the active scene is stopped
- Reimplements the missing tint on the pause button when the scene is paused 

<img width="109" height="44" alt="image" src="https://github.com/user-attachments/assets/d8bd7f13-f027-4a05-9a66-0f5147e0e2f1" />
