### PR TITLE
Add Scene.TryGet

### DIFF
--- a/engine/Sandbox.Engine/Scene/Scene/Scene.ObjectIndex.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.ObjectIndex.cs
@@ -203,4 +203,30 @@ public partial class Scene : GameObject
 
 		return default;
 	}
+
+	/// <summary>
+	/// Gets the first object found of this type. This could be a component or a GameObjectSystem, or other stuff in the future.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="obj"></param>
+	/// <returns>true if the Scene contained a valid object; otherwise, false.</returns>
+	[Pure]
+	public bool TryGet<T>( out T obj )
+	{
+		if ( objectIndex.TryGetValue( typeof( T ), out var set ) && set.Count > 0 )
+		{
+			foreach ( var e in set.EnumerateLocked() )
+			{
+				T c = (T)e;
+				if ( c is null ) continue;
+				if ( c is IValid v && !v.IsValid ) continue;
+
+				obj = c;
+				return true;
+			}
+		}
+
+		obj = default;
+		return false;
+	}
 }

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.ObjectIndex.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.ObjectIndex.cs
@@ -220,6 +220,7 @@ public partial class Scene : GameObject
 				T c = (T)e;
 				if ( c is null ) continue;
 				if ( c is IValid v && !v.IsValid ) continue;
+				if ( c is Component co && co.GameObject.IsDestroyed ) continue;
 
 				obj = c;
 				return true;


### PR DESCRIPTION
I was writing some code like this
```cs
		foreach (var selection in Scene.GetAll<Selected>().ToList())
		{
			selection.Destroy();
		}
```
but I was irked by the fact that you have to call .ToList() to get a stable enumeration.

It would be better if I could write
```cs
		while (Scene.TryGet<Selected>(out var selection))
		{
			selection.Destroy()
		}
```

This function has other applications too. It lets you write:
```cs
if (Scene.TryGet<MyComponent>(out var c))
{
	// do something with c
}
```
instead of 
```cs
var c = Scene.Get<MyComponent>();
if (c.IsValid())
{
	// do something with c
}
```

Note that c will always be valid (IValid) after a TryGet because Scene.Get already checks validity (and so does my new addition)

Here's a quick sample project: [scenetryget.zip](https://github.com/user-attachments/files/24125825/scenetryget.zip)

Play the game and then press space to delete the modelrenderers. The disabled cube won't be deleted.
```cs
		if (Input.Pressed("Jump"))
		{
			if (Scene.TryGet<ModelRenderer>(out var box))
			{
				box.DestroyGameObject();
			} else
			{
				Log.Info( "No modelrenderers found!" );
			}
		}
		if (Input.Pressed("View")) // C by default
		{
			while (Scene.TryGet<ModelRenderer>(out var box))
			{
				box.DestroyGameObject();
			}
		}
```

Note: I had to add an extra check to my function compared to the rest to make the while example work:
```cs
				if ( c is Component co && co.GameObject.IsDestroyed ) continue;
```
Not sure what you guys think about that. I think it would be best if they all behaved the same way.
Should I add this check to the rest of the functions as well? It's technically a breaking change, but when would you want to get components on objects about to be destroyed?

I think this function has value even if the while example doesn't work, so in theory it could be merged without it.
However, then it's just a future trap for a developer who thinks the while example ought to work.

Marking this PR as a draft until that question is resolved.