### PR TITLE
Sound preview misc fixes

### DIFF
--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.Scrubber.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.Scrubber.cs
@@ -14,6 +14,7 @@ public partial class SoundPlayer
 			Cursor = CursorShape.SizeH;
 			Movable = true;
 			Selectable = true;
+			HandlePosition = new( 0.5f, 0f );
 		}
 
 		protected override void OnPaint()
@@ -41,7 +42,7 @@ public partial class SoundPlayer
 		protected override void OnMouseReleased( GraphicsMouseEvent e )
 		{
 			base.OnMouseReleased( e );
-			TimelineView.MoveScrubber( Position.x + 4 );
+			TimelineView.MoveScrubber( Position.x );
 			TimelineView.Scrubbing = false;
 		}
 
@@ -50,7 +51,7 @@ public partial class SoundPlayer
 			base.OnMoved();
 
 			TimelineView.Scrubbing = true;
-			TimelineView.MoveScrubber( Position.x + 4, false );
+			TimelineView.MoveScrubber( Position.x, false );
 		}
 	}
 

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.Scrubber.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.Scrubber.cs
@@ -41,6 +41,7 @@ public partial class SoundPlayer
 		protected override void OnMouseReleased( GraphicsMouseEvent e )
 		{
 			base.OnMouseReleased( e );
+			TimelineView.MoveScrubber( Position.x + 4 );
 			TimelineView.Scrubbing = false;
 		}
 
@@ -49,7 +50,7 @@ public partial class SoundPlayer
 			base.OnMoved();
 
 			TimelineView.Scrubbing = true;
-			TimelineView.MoveScrubber( Position.x, false );
+			TimelineView.MoveScrubber( Position.x + 4, false );
 		}
 	}
 

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.Scrubber.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.Scrubber.cs
@@ -51,7 +51,7 @@ public partial class SoundPlayer
 			base.OnMoved();
 
 			TimelineView.Scrubbing = true;
-			TimelineView.MoveScrubber( Position.x, false );
+			TimelineView.MoveScrubber( Position.x + 0.5f, false );
 		}
 	}
 

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -235,6 +235,7 @@ public partial class SoundPlayer : Widget
 
 			if ( Scrubbing || Timeline.Playing )
 			{
+				Translate( 1 );
 				CenterOn( Scrubber.Position );
 			}
 

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -262,7 +262,7 @@ public partial class SoundPlayer : Widget
 
 		public void MoveScrubber( float position, bool centreOn = true )
 		{
-			Scrubber.Position = Vector2.Right * (position - 4).SnapToGrid( 1.0f );
+			Scrubber.Position = Vector2.Right * (position - 4).SnapToGrid( 1.0f ).Clamp( -4, ContentRect.Width );
 			Time = TimeFromPosition( Scrubber.Position.x + 4 );
 
 			if ( SoundHandle.IsValid() )

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -152,7 +152,8 @@ public partial class SoundPlayer : Widget
 
 			var size = Size;
 			size.x = MathF.Max( Size.x, PositionFromTime( Duration ) );
-			SceneRect = new( 0, size - ( Width - ContentRect.Width ) );
+			size.x -= Width - ContentRect.Width;
+			SceneRect = new( 0, size );
 			TimeAxis.Size = new Vector2( size.x, Theme.RowHeight );
 			Scrubber.Size = new Vector2( 9, size.y );
 
@@ -234,13 +235,14 @@ public partial class SoundPlayer : Widget
 				SoundHandle.Paused = Scrubbing;
 			}
 
-			TimeAxis.Update();
-			WaveForm.Update();
-
 			if ( Scrubbing || Timeline.Playing )
 			{
 				CenterOn( Scrubber.Position );
+				VisibleRect = Rect.FromPoints( ToScene( LocalRect.TopLeft ), ToScene( LocalRect.BottomRight ) );
 			}
+
+			TimeAxis.Update();
+			WaveForm.Update();
 		}
 
 		public float PositionFromTime( float time )

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -264,7 +264,7 @@ public partial class SoundPlayer : Widget
 
 		public void MoveScrubber( float position, bool centreOn = true )
 		{
-			Scrubber.Position = Vector2.Right * position.SnapToGrid( 1.0f ).Clamp( 0, SceneRect.Width + 4 );
+			Scrubber.Position = Vector2.Right * position.Clamp( 0, SceneRect.Width + 4 ).SnapToGrid( 1.0f );
 			Time = TimeFromPosition( Scrubber.Position.x );
 
 			if ( SoundHandle.IsValid() )

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -163,7 +163,7 @@ public partial class SoundPlayer : Widget
 			WaveForm.SceneRect = r;
 			WaveForm.Analyse();
 
-			Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) - 4 ).SnapToGrid( 1.0f );
+			Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) ).SnapToGrid( 1.0f );
 		}
 
 		protected override void OnResize()
@@ -223,7 +223,7 @@ public partial class SoundPlayer : Widget
 					SoundHandle.DistanceAttenuation = false;
 				}
 
-				Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) - 4 ).SnapToGrid( 1.0f );
+				Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) ).SnapToGrid( 1.0f );
 				if ( Timeline.Playing )
 					Time += RealTime.SmoothDelta;
 			}
@@ -264,8 +264,8 @@ public partial class SoundPlayer : Widget
 
 		public void MoveScrubber( float position, bool centreOn = true )
 		{
-			Scrubber.Position = Vector2.Right * (position - 4).SnapToGrid( 1.0f ).Clamp( -4, SceneRect.Width );
-			Time = TimeFromPosition( Scrubber.Position.x + 4 );
+			Scrubber.Position = Vector2.Right * position.SnapToGrid( 1.0f ).Clamp( 0, SceneRect.Width + 4 );
+			Time = TimeFromPosition( Scrubber.Position.x );
 
 			if ( SoundHandle.IsValid() )
 			{
@@ -287,6 +287,8 @@ public partial class SoundPlayer : Widget
 			ZoomLevel = ZoomLevel.Clamp( 1.0f, 20.0f );
 
 			DoLayout();
+
+			VisibleRect = Rect.FromPoints( ToScene( LocalRect.TopLeft ), ToScene( LocalRect.BottomRight ) );
 
 			TimeAxis.Update();
 			WaveForm.Update();

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -264,7 +264,7 @@ public partial class SoundPlayer : Widget
 
 		public void MoveScrubber( float position, bool centreOn = true )
 		{
-			Scrubber.Position = Vector2.Right * (position - 4).SnapToGrid( 1.0f ).Clamp( -4, ContentRect.Width );
+			Scrubber.Position = Vector2.Right * (position - 4).SnapToGrid( 1.0f ).Clamp( -4, SceneRect.Width );
 			Time = TimeFromPosition( Scrubber.Position.x + 4 );
 
 			if ( SoundHandle.IsValid() )

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -163,7 +163,7 @@ public partial class SoundPlayer : Widget
 			WaveForm.SceneRect = r;
 			WaveForm.Analyse();
 
-			Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) - 3 ).SnapToGrid( 1.0f );
+			Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) - 4 ).SnapToGrid( 1.0f );
 		}
 
 		protected override void OnResize()

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -219,13 +219,14 @@ public partial class SoundPlayer : Widget
 				if ( Timeline.Playing && !SoundHandle.IsValid() )
 				{
 					SoundHandle = EditorUtility.PlaySound( Sound, Time );
-					SoundHandle.Time = 0;
+					SoundHandle.Time = Time;
 					SoundHandle.Occlusion = false;
 					SoundHandle.DistanceAttenuation = false;
 				}
 
 				Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) - 3 ).SnapToGrid( 1.0f );
-				Time += RealTime.SmoothDelta;
+				if ( Timeline.Playing )
+					Time += RealTime.SmoothDelta;
 			}
 
 			if ( SoundHandle.IsValid() )

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -192,8 +192,6 @@ public partial class SoundPlayer : Widget
 				SoundHandle = null;
 			}
 
-			VisibleRect = Rect.FromPoints( ToScene( LocalRect.TopLeft ), ToScene( LocalRect.BottomRight ) );
-
 			if ( Timeline.Playing && !Scrubbing )
 			{
 				var time = Time % Duration;
@@ -238,8 +236,9 @@ public partial class SoundPlayer : Widget
 			if ( Scrubbing || Timeline.Playing )
 			{
 				CenterOn( Scrubber.Position );
-				VisibleRect = Rect.FromPoints( ToScene( LocalRect.TopLeft ), ToScene( LocalRect.BottomRight ) );
 			}
+
+			VisibleRect = Rect.FromPoints( ToScene( LocalRect.TopLeft ), ToScene( LocalRect.BottomRight ) );
 
 			TimeAxis.Update();
 			WaveForm.Update();

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -129,7 +129,7 @@ public partial class SoundPlayer : Widget
 		{
 			Timeline = parent;
 			SceneRect = new( 0, Size );
-			HorizontalScrollbar = ScrollbarMode.On;
+			HorizontalScrollbar = ScrollbarMode.Auto;
 			VerticalScrollbar = ScrollbarMode.Off;
 			Scale = 1;
 			Time = 0;
@@ -152,7 +152,7 @@ public partial class SoundPlayer : Widget
 
 			var size = Size;
 			size.x = MathF.Max( Size.x, PositionFromTime( Duration ) );
-			SceneRect = new( 0, size );
+			SceneRect = new( 0, size - ( Width - ContentRect.Width ) );
 			TimeAxis.Size = new Vector2( size.x, Theme.RowHeight );
 			Scrubber.Size = new Vector2( 9, size.y );
 

--- a/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
+++ b/game/addons/tools/Code/Widgets/SoundPlayer/SoundPlayer.cs
@@ -224,7 +224,7 @@ public partial class SoundPlayer : Widget
 					SoundHandle.DistanceAttenuation = false;
 				}
 
-				Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) - 3 ).SnapToGrid( 1.0f );
+				Scrubber.Position = Scrubber.Position.WithX( PositionFromTime( Time ) - 4 ).SnapToGrid( 1.0f );
 				if ( Timeline.Playing )
 					Time += RealTime.SmoothDelta;
 			}


### PR DESCRIPTION
Sound preview playback previously always started at 0, now it starts at the playhead position.

https://github.com/user-attachments/assets/93caa3f9-9b90-49da-88d2-45b297059b07

Also added a check to only increment time while actually playing, previously upon reaching the end of a file with looping disabled it would reset the playhead position then add an extra RealTime.SmoothDelta. When playing the file again the start would be cut off slightly. Now it correctly parks itself at 0.