### PR TITLE
Fix editor camera sticking in place at very low speeds

### DIFF
--- a/game/addons/tools/Code/Extensions/SceneEditorExtensions.cs
+++ b/game/addons/tools/Code/Extensions/SceneEditorExtensions.cs
@@ -226,8 +226,9 @@ public static class SceneEditorExtensions
 			camera.WorldPosition = Vector3.SmoothDamp( camera.WorldPosition, cameraTarget.Value, ref vel, EditorPreferences.CameraMovementSmoothing.Clamp( 0.0f, 1.0f ), RealTime.Delta );
 			cameraVelocity = vel;
 
-			if ( camera.WorldPosition.AlmostEqual( cameraTarget.Value, 0.1f ) )
+			if ( camera.WorldPosition.AlmostEqual( cameraTarget.Value, 0.01f ) )
 			{
+				camera.WorldPosition = cameraTarget.Value;
 				cameraTarget = default;
 				cameraVelocity = default;
 			}


### PR DESCRIPTION
The editor camera would previously get stuck in place or move very slowly when trying to move it at low speed (e.g. 0.25 speed with ctrl held down). This was due to an overzealous AlmostEqual repeatedly clearing the camera target. This lowers that threshold from 0.1 to 0.01 and also snaps the camera to the target position before clearing it.