### PR TITLE
Fix crash under Proton due to case-sensitivity

### DIFF
--- a/engine/Sandbox.Filesystem/LocalFileSystem.cs
+++ b/engine/Sandbox.Filesystem/LocalFileSystem.cs
@@ -11,7 +11,7 @@ internal class LocalFileSystem : BaseFileSystem
 	{
 		Physical = new Zio.FileSystems.PhysicalFileSystem();
 
-		var rootPath = Physical.ConvertPathFromInternal( rootFolder.ToLowerInvariant() );
+		var rootPath = Physical.ConvertPathFromInternal( rootFolder );
 		system = new Zio.FileSystems.SubFileSystem( Physical, rootPath );
 
 		if ( makereadonly )


### PR DESCRIPTION
For some God forsaken reason, forcing the path to be lowercase here under Proton causes a `System.IO.DirectoryNotFoundException` due to case-sensitivity. Removing `ToLowerInvariant()` in the creation of the `LocalFileSystem` fixes the issue and allows the game to boot under Proton again.