### PR TITLE
Fix editor command line argument parsing

### DIFF
--- a/game/addons/tools/Code/Scene/SceneView/ViewportTools.Network.cs
+++ b/game/addons/tools/Code/Scene/SceneView/ViewportTools.Network.cs
@@ -86,15 +86,30 @@ partial class ViewportTools
 		window.SwitchPage<PageNetworking>();
 	}
 
+	static void AddUserCommandLineArgs( ProcessStartInfo startInfo, string argumentString )
+	{
+		if ( string.IsNullOrWhiteSpace( argumentString ) )
+			return;
+
+		var args = argumentString.Split( ' ',
+			StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries );
+
+		foreach ( var arg in args )
+		{
+			startInfo.ArgumentList.Add( arg );
+		}
+	}
+
 	void SpawnDedicatedServer()
 	{
 		var p = new Process();
 		p.StartInfo.FileName = "sbox-server.exe";
 		p.StartInfo.WorkingDirectory = Environment.CurrentDirectory;
-		p.StartInfo.ArgumentList.Add( EditorPreferences.DedicatedServerCommandLineArgs );
 
 		p.StartInfo.ArgumentList.Add( "+game" );
 		p.StartInfo.ArgumentList.Add( Project.Current.GetProjectPath() );
+
+		AddUserCommandLineArgs( p.StartInfo, EditorPreferences.DedicatedServerCommandLineArgs );
 
 		p.Start();
 	}
@@ -110,13 +125,14 @@ partial class ViewportTools
 		p.StartInfo.UseShellExecute = false;
 
 		p.StartInfo.ArgumentList.Add( "-joinlocal" );
-		p.StartInfo.ArgumentList.Add( EditorPreferences.NewInstanceCommandLineArgs );
 
 		if ( EditorPreferences.WindowedLocalInstances )
 		{
 			p.StartInfo.ArgumentList.Add( "-sw" );
 			p.StartInfo.ArgumentList.Add( "-720" );
 		}
+
+		AddUserCommandLineArgs( p.StartInfo, EditorPreferences.NewInstanceCommandLineArgs );
 
 		p.Start();
 	}


### PR DESCRIPTION
### Changes

- Add each argument individually rather than one large string.

### Notes

At the moment, setting command line arguments in the editor settings window doesn't work right. If you add a command line argument with a value like this `+volume 0` it will not be parsed correctly. The current implementation treats all arguments as one large string. This passes `"+volume 0"` as one argument, instead of 2. It fails and the volume is not changed. 

This PR fixes this by adding each argument individually.