### PR TITLE
 EdgeCutTool snapping and visualization

### DIFF
--- a/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.Gizmo.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.Gizmo.cs
@@ -15,6 +15,32 @@ partial class EdgeCutTool
 				Gizmo.Draw.Color = new Color( 0.3137f, 0.7843f, 1.0f, 1f );
 				for ( int i = 1; i < _cutPoints.Count; i++ )
 				{
+					var color = new Color( 0.3137f, 0.7843f, 1.0f, 1f );
+					var prev = _cutPoints[i - 1];
+					var curr = _cutPoints[i];
+
+					if ( prev.Edge.IsValid() && curr.Edge.IsValid() && prev.Component == curr.Component )
+					{
+						var meshObj = prev.Component.Mesh;
+						meshObj.GetVerticesConnectedToEdge( prev.Edge.Handle, out var pvA, out var pvB );
+						meshObj.GetVertexPosition( pvA, prev.Component.WorldTransform, out var pp0 );
+						meshObj.GetVertexPosition( pvB, prev.Component.WorldTransform, out var pp1 );
+
+						meshObj.GetVerticesConnectedToEdge( curr.Edge.Handle, out var cvA, out var cvB );
+						meshObj.GetVertexPosition( cvA, curr.Component.WorldTransform, out var cp0 );
+						meshObj.GetVertexPosition( cvB, curr.Component.WorldTransform, out var cp1 );
+
+						var prevDir = (pp1 - pp0).Normal;
+						var currDir = (cp1 - cp0).Normal;
+						var angle = MathF.Acos( Vector3.Dot( prevDir, currDir ) ) * (180f / MathF.PI);
+
+						if ( MathF.Abs( angle - 90f ) < 1f ) // Close to 90 degrees
+						{
+							color = Color.Orange;
+						}
+					}
+
+					Gizmo.Draw.Color = color;
 					Gizmo.Draw.Line( _cutPoints[i - 1].WorldPosition, _cutPoints[i].WorldPosition );
 				}
 			}
@@ -36,14 +62,44 @@ partial class EdgeCutTool
 		if ( _hoveredMesh != mesh ) _hoveredMesh = mesh;
 
 		var edge = _previewCutPoint.Edge;
+		var component = _previewCutPoint.Component;
+		var meshObj = component.Mesh;
+		Vector3 p0 = default, p1 = default;
 		if ( edge.IsValid() )
 		{
+			meshObj.GetVerticesConnectedToEdge( edge.Handle, out var vA, out var vB );
+			meshObj.GetVertexPosition( vA, component.WorldTransform, out p0 );
+			meshObj.GetVertexPosition( vB, component.WorldTransform, out p1 );
+
+			// Determine color based on angle if previous cut exists
+			var lineColor = Color.Green;
+
 			using ( Gizmo.Scope( "Edge Hover", _previewCutPoint.Edge.Transform ) )
 			{
 				Gizmo.Draw.IgnoreDepth = true;
-				Gizmo.Draw.Color = Color.Green;
+				Gizmo.Draw.Color = lineColor;
 				Gizmo.Draw.LineThickness = 4;
 				Gizmo.Draw.Line( edge.Line );
+			}
+
+			// Add snapping feedback
+			var edgeLength = p0.Distance( p1 );
+			var cutPos = _previewCutPoint.WorldPosition;
+			var distFromA = p0.Distance( cutPos );
+			var ratio = distFromA / edgeLength;
+
+			var unitsText = $"{distFromA:F2} units";
+			var ratioText = $"{ratio:P0}";
+
+			var textColor = Color.White;
+
+			// Draw text near the cut point
+			var textPos = cutPos + Vector3.Up * 10f; // Offset above
+			if ( _showSnappingInfo )
+			{
+				Gizmo.Draw.Color = textColor;
+				Gizmo.Draw.Text( unitsText, new Transform( textPos ), "default", 12f );
+				Gizmo.Draw.Text( ratioText, new Transform( textPos + Vector3.Up * 15f ), "default", 12f );
 			}
 		}
 
@@ -55,7 +111,23 @@ partial class EdgeCutTool
 			{
 				var lastCutPoint = _cutPoints.Last();
 				Gizmo.Draw.LineThickness = 4;
-				Gizmo.Draw.Color = Color.White;
+				var previewLineColor = Color.White;
+				if ( lastCutPoint.Edge.IsValid() && edge.IsValid() && lastCutPoint.Component == component )
+				{
+					meshObj.GetVerticesConnectedToEdge( lastCutPoint.Edge.Handle, out var lvA, out var lvB );
+					meshObj.GetVertexPosition( lvA, component.WorldTransform, out var lp0 );
+					meshObj.GetVertexPosition( lvB, component.WorldTransform, out var lp1 );
+
+					var lastDir = (lp1 - lp0).Normal;
+					var currentDir = (p1 - p0).Normal;
+					var angle = MathF.Acos( Vector3.Dot( lastDir, currentDir ) ) * (180f / MathF.PI);
+
+					if ( MathF.Abs( angle - 90f ) < 5f ) // Close to 90 degrees
+					{
+						previewLineColor = Color.Orange;
+					}
+				}
+				Gizmo.Draw.Color = previewLineColor;
 				Gizmo.Draw.Line( _previewCutPoint.WorldPosition, lastCutPoint.WorldPosition );
 			}
 

--- a/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.Snapping.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.Snapping.cs
@@ -133,6 +133,14 @@ partial class EdgeCutTool
 			{
 				snaps.Add( new SnapPoint( edge, hit, EdgeCutAlignment.Perpendicular ) );
 			}
+
+			// Add fine-tuned ratio snap points
+			var ratios = new[] { 1f / 3f, 1f / 4f, 1f / 5f, 1f / 6f, 1f / 7f, 1f / 9f, 1f / 17f, 1f / 33f, 1f / 65f };
+			foreach ( var r in ratios )
+			{
+				var pos = p0.LerpTo( p1, r );
+				snaps.Add( new SnapPoint( edge, pos, EdgeCutAlignment.None ) );
+			}
 		}
 	}
 

--- a/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.UI.cs
@@ -22,6 +22,27 @@ partial class EdgeCutTool
 				var row = Layout.AddRow();
 				row.Spacing = 4;
 
+				var snapping = new IconButton( "grid_on", null );
+				snapping.IsToggle = true;
+				snapping.IsActive = _tool._snappingEnabled;
+				snapping.OnToggled = ( e ) => { _tool._snappingEnabled = e; EditorCookie.Set( "edgecut_snapping", e ); };
+				snapping.ToolTip = "Toggle snapping for edge cuts";
+				row.Add( snapping );
+
+				var showInfo = new IconButton( "info", null );
+				showInfo.IsToggle = true;
+				showInfo.IsActive = _tool._showSnappingInfo;
+				showInfo.OnToggled = ( e ) => { _tool._showSnappingInfo = e; EditorCookie.Set( "edgecut_showinfo", e ); };
+				showInfo.ToolTip = "Toggle display of snapping info";
+				row.Add( showInfo );
+			}
+
+			Layout.AddSpacingCell( 8 );
+
+			{
+				var row = Layout.AddRow();
+				row.Spacing = 4;
+
 				var apply = new Button( "Apply", "done" );
 				apply.Clicked = Apply;
 				apply.ToolTip = "[Apply " + EditorShortcuts.GetKeys( "mesh.edge-cut-apply" ) + "]";

--- a/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/EdgeCutTool.cs
@@ -97,6 +97,8 @@ public partial class EdgeCutTool( string tool ) : EditorTool
 
 	readonly string _tool = tool;
 	bool _cancel;
+	bool _snappingEnabled = EditorCookie.Get( "edgecut_snapping", true );
+	bool _showSnappingInfo = EditorCookie.Get( "edgecut_showinfo", true );
 
 	public override void OnDisabled()
 	{
@@ -109,7 +111,7 @@ public partial class EdgeCutTool( string tool ) : EditorTool
 		if ( escape && !_cancel ) Cancel();
 		_cancel = escape;
 
-		_previewCutPoint = ShouldSnap() ? FindSnappedCutPoint() : FindCutPoint();
+		_previewCutPoint = _snappingEnabled ? FindSnappedCutPoint() : FindCutPoint();
 
 		MeshCutPoint previousCutPoint = default;
 		if ( _cutPoints.Count > 0 )


### PR DESCRIPTION
Added  ratio snap points for edge cuts and improved visual feedback, snapping info overlays.


https://github.com/user-attachments/assets/5331e936-dce7-4dfb-b5e4-422c14480be9

https://github.com/user-attachments/assets/1fb8a1f6-03a5-4dcf-99f2-747b5be2d930


