### PR TITLE
Fix gizmo selection crash when TypeLibrary lacks a component type

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
@@ -227,7 +227,7 @@ public partial class GameObject
 	/// </summary>
 	GameObject FindSelectionBase()
 	{
-		var isSelectionBase = IsNetworkRoot || IsOutermostPrefabInstanceRoot || Components.GetAll().Any( x => Game.TypeLibrary.GetType( x.GetType() ).HasAttribute<SelectionBaseAttribute>() );
+		var isSelectionBase = IsNetworkRoot || IsOutermostPrefabInstanceRoot || Components.GetAll().Any( x => Game.TypeLibrary.GetType( x?.GetType() )?.HasAttribute<SelectionBaseAttribute>() == true );
 
 		if ( isSelectionBase ) return this;
 


### PR DESCRIPTION
Prevents a NullReferenceException during gizmo selection when a component entry is null or its type is not present in the TypeLibrary.