### PR TITLE
Make GameObjectSource public

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Collider/Rigidbody.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/Rigidbody.cs
@@ -171,7 +171,7 @@ sealed public partial class Rigidbody : Component, Component.ExecuteInEditor, IG
 	/// <summary>
 	/// The game object source for finding collision listeners.
 	/// </summary>
-	internal GameObject GameObjectSource;
+	public GameObject GameObjectSource { get; set; }
 
 	Vector3 _lastVelocity;
 	Vector3 _lastAngularVelocity;


### PR DESCRIPTION
This is set on each child body of ModelPhysics to report collision events to the main component.
No reason to have it internal as we also need it for features such as car doors or other child objects without having to create a new component on each for the sole purpose of listening to collision events.