### PR TITLE
Clean up editor tools when entering play mode

### DIFF
--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.Game.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.Game.cs
@@ -40,6 +40,7 @@ public partial class SceneViewportWidget
 	public void SetGameView()
 	{
 		GameMode.SetPlayWidget( Renderer );
+		Tools.ClearScreen();
 		IsGameView = true;
 	}
 
@@ -82,6 +83,7 @@ public partial class SceneViewportWidget
 	public void OnPossessGame()
 	{
 		GameMode.SetPlayWidget( Renderer );
+		Tools.ClearScreen();
 		IsGameView = true;
 	}
 }

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.Game.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.Game.cs
@@ -40,8 +40,8 @@ public partial class SceneViewportWidget
 	public void SetGameView()
 	{
 		GameMode.SetPlayWidget( Renderer );
-		Tools.ClearScreen();
 		IsGameView = true;
+		Tools.DisposeAll();
 	}
 
 	/// <summary>
@@ -83,7 +83,7 @@ public partial class SceneViewportWidget
 	public void OnPossessGame()
 	{
 		GameMode.SetPlayWidget( Renderer );
-		Tools.ClearScreen();
 		IsGameView = true;
+		Tools.DisposeAll();
 	}
 }

--- a/game/addons/tools/Code/Scene/Tools/EditorToolManager.cs
+++ b/game/addons/tools/Code/Scene/Tools/EditorToolManager.cs
@@ -188,6 +188,14 @@ public class EditorToolManager
 		}
 	}
 
+	public void ClearScreen()
+	{
+		foreach ( var tool in ComponentTools )
+			tool?.Dispose();
+		ComponentTools.Clear();
+		previousHash = -1;
+	}
+
 	/// <summary>
 	/// Switches to the named tool type next editor frame.
 	/// </summary>

--- a/game/addons/tools/Code/Scene/Tools/EditorToolManager.cs
+++ b/game/addons/tools/Code/Scene/Tools/EditorToolManager.cs
@@ -188,12 +188,12 @@ public class EditorToolManager
 		}
 	}
 
-	public void ClearScreen()
+	public void DisposeAll()
 	{
+		previousHash = -1;
 		foreach ( var tool in ComponentTools )
 			tool?.Dispose();
 		ComponentTools.Clear();
-		previousHash = -1;
 	}
 
 	/// <summary>


### PR DESCRIPTION
When entering play mode editor tools would stop updating but wouldn't be deleted, leaving them in a non-functional state taking up space on the screen (specifically camera preview and the particle controls). This disposes of editor tools when entering play mode so any connected widgets can be properly removed. Upon exiting play mode or ejecting the editor tools reappear.