### PR TITLE
Fix ComponentEditorWidget ignoring derived types

### DIFF
--- a/engine/Sandbox.System/SerializedObject/CustomEditorAttribute.cs
+++ b/engine/Sandbox.System/SerializedObject/CustomEditorAttribute.cs
@@ -59,7 +59,7 @@ public class CustomEditorAttribute : Attribute
 		if ( TargetType is not null && !ForMethod )
 		{
 			//
-			// Order by derived classes so we get the most relevent editor
+			// Order by derived classes so we get the most relevant editor
 			//
 			Type baseType = TargetType;
 			while ( baseType.BaseType != null )

--- a/engine/Sandbox.Tools/Inspector/ComponentEditorWidget.cs
+++ b/engine/Sandbox.Tools/Inspector/ComponentEditorWidget.cs
@@ -37,7 +37,7 @@ public abstract class ComponentEditorWidget : Widget
 		int score = 0;
 
 		//
-		// Order by derived classes so we get the most relevent editor
+		// Order by derived classes so we get the most relevant editor
 		//
 		Type baseType = componentType;
 		while ( targetType.IsAssignableFrom( baseType ) )

--- a/engine/Sandbox.Tools/Inspector/ComponentEditorWidget.cs
+++ b/engine/Sandbox.Tools/Inspector/ComponentEditorWidget.cs
@@ -19,13 +19,34 @@ public abstract class ComponentEditorWidget : Widget
 
 	public static ComponentEditorWidget Create( SerializedObject obj )
 	{
+		var componentType = TypeLibrary.GetType( obj.TypeName ).TargetType;
+
 		var editor = EditorTypeLibrary.GetTypesWithAttribute<CustomEditorAttribute>( false )
 					.Where( x => x.Type.TargetType.IsAssignableTo( typeof( ComponentEditorWidget ) ) )
-					.Where( x => x.Attribute.TargetType.Name == obj.TypeName )
+					.Select( x => (score: GetEditorScore( x.Attribute.TargetType, componentType ), x.Type) )
+					.Where( x => x.score > 0 )
+					.OrderBy( x => x.score )
 					.FirstOrDefault();
 
 		if ( editor.Type == null ) return null;
 		return editor.Type.Create<ComponentEditorWidget>( new object[] { obj } );
+	}
+
+	private static int GetEditorScore( Type targetType, Type componentType )
+	{
+		int score = 0;
+
+		//
+		// Order by derived classes so we get the most relevent editor
+		//
+		Type baseType = componentType;
+		while ( targetType.IsAssignableFrom( baseType ) )
+		{
+			score++;
+			baseType = baseType.BaseType;
+		}
+
+		return score;
 	}
 
 	public virtual void OnHeaderContextMenu( Menu menu )


### PR DESCRIPTION
# Bug
Custom component editors only work if the type is an exact match. It has no support for derived component types.

https://github.com/Facepunch/sbox-public/issues/305

# Fix
I've made it use a simple scoring system to find the best editor.

The score given is based on the inheritance distance with exact matches being the best.

It also now supports interfaces as targets.

