### PR TITLE
Fix TGA file preview exception by correcting mip level mismatch

### DIFF
--- a/engine/Sandbox.Engine/Resources/Textures/Loader/ImageLoader.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Loader/ImageLoader.cs
@@ -84,7 +84,6 @@ internal static class Image
 
 			int width = bm.Width();
 			int height = bm.Height();
-			int numMips = (int)Math.Log2( Math.Min( width, height ) ) + 1;
 			var format = ImageFormat.RGBA8888;
 			var dataSize = ImageLoader.GetMemRequired( width, height, 1, 1, format );
 			var data = new byte[dataSize];
@@ -102,7 +101,7 @@ internal static class Image
 			var texture = Texture.Create( width, height, format )
 				.WithName( filename )
 				.WithData( data, dataSize )
-				.WithMips( numMips )
+				.WithMips( 1 )
 				.Finish();
 
 			return texture;
@@ -123,12 +122,10 @@ internal static class Image
 			_ => throw new System.Exception( $"bitmap.ColorType is {bitmap.ColorType} - unsupported" ),
 		};
 
-		int numMips = (int)Math.Log2( Math.Min( bitmap.Width, bitmap.Height ) ) + 1;
-
 		var texture = Texture.Create( bitmap.Width, bitmap.Height, format )
 			.WithName( name )
 			.WithData( bitmap.GetPixels(), bitmap.ByteCount )
-			.WithMips( numMips )
+			.WithMips( 1 )
 			.Finish();
 
 		return texture;


### PR DESCRIPTION
Fixes a exception when trying to preview a `tga` file in the inspector

Here's the exception that this fixes
```
2026/01/12 19:40:28.2861    [Generic] Image.Load: thirdparty/sci_fi_character_03/textures/character/sci_fi_character_03_albedo_01.tga: 67108864 is wrong for this texture! 89,478,484 bytes are required (or 89,478,484 with mips)! You sent 67,108,864 bytes!    System.Exception: 67108864 is wrong for this texture! 89,478,484 bytes are required (or 89,478,484 with mips)! You sent 67,108,864 bytes!
   at Sandbox.TextureBuilder.Create(String name, Boolean anonymous, ReadOnlySpan`1 data, Int32 dataLength)
   at Sandbox.Texture2DBuilder.Finish()
   at Sandbox.TextureLoader.Image.Load(BaseFileSystem filesystem, String filename)
   at Sandbox.TextureLoader.Image.Load(BaseFileSystem filesystem, String filename, Boolean warnOnMissing)
```