### PR TITLE
Remove unnecessary log when removing component

### DIFF
--- a/game/addons/tools/Code/Scene/GameObjectInspector/ComponentListWidget.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/ComponentListWidget.cs
@@ -270,7 +270,6 @@ public class ComponentListWidget : Widget
 			using var scene = session.Scene.Push();
 			using ( session.UndoScope( $"Remove {component.GetType().Name} Component" ).WithComponentDestructions( component ).Push() )
 			{
-				Log.Info( Game.ActiveScene.Name );
 				component.Destroy();
 			}
 		} );


### PR DESCRIPTION
It logged the current scene every time you removed a component.

Tony told me to make a PR. He says it's not used for anything.
<img width="401" height="119" alt="image" src="https://github.com/user-attachments/assets/b0b73a5d-92df-45ee-bcf0-aa72fac61ada" />
