### PR TITLE
Show resource generator descriptions as menu option tooltips

### DIFF
--- a/game/addons/tools/Code/Widgets/ControlWidgets/ResourceWrapperControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/ResourceWrapperControlWidget.cs
@@ -158,7 +158,14 @@ public sealed class ResourceWrapperControlWidget : ControlWidget
 		{
 			if ( generator.TargetType.IsAbstract ) continue;
 
-			AddOption( menu, generator.Title, generator.Icon, generator.ClassName );
+			var option = AddOption( menu, generator.Title, generator.Icon, generator.ClassName );
+			var description = generator.Description;
+
+			if ( !string.IsNullOrEmpty( description ) )
+			{
+				menu.ToolTipsVisible = true;
+				option.ToolTip = description;
+			}
 		}
 
 		menu.OpenNextTo( Button, WidgetAnchor.BottomEnd with { AdjustSize = true, ConstrainToScreen = true } );


### PR DESCRIPTION
Allow users to explain what resource generators do if they have a description.

<img width="432" height="340" alt="image" src="https://github.com/user-attachments/assets/e9e4ab3b-de7e-44c9-9e2b-08efa60481ec" />
<img width="552" height="183" alt="image" src="https://github.com/user-attachments/assets/b81a89da-451f-4644-9fef-7732d5c578e2" />

Adds tooltips to resource generator menu entries in ResourceWrapperControlWidget
Tooltips are shown only if the generator type has its own DescriptionAttribute (not inherited): this avoids showing a parent-class description for derived types.


