### PR TITLE
Fix NRE when clearing graph on GraphView

### DIFF
--- a/game/addons/tools/Code/NodeGraph/GraphView.cs
+++ b/game/addons/tools/Code/NodeGraph/GraphView.cs
@@ -1185,12 +1185,10 @@ public class GraphView : GraphicsView, IGridSizeView
 
 		DeleteAllItems();
 
-		if ( _graph is not null )
-		{
-			BuildFromNodes( _graph.Nodes, true );
-			OnRebuild();
-		}
+		if ( _graph is not null ) BuildFromNodes( _graph.Nodes, true );
 
+		OnRebuild();
+		
 		RestoreViewFromCookie();
 	}
 

--- a/game/addons/tools/Code/NodeGraph/GraphView.cs
+++ b/game/addons/tools/Code/NodeGraph/GraphView.cs
@@ -1185,8 +1185,11 @@ public class GraphView : GraphicsView, IGridSizeView
 
 		DeleteAllItems();
 
-		BuildFromNodes( _graph.Nodes, true );
-		OnRebuild();
+		if ( _graph is not null )
+		{
+			BuildFromNodes( _graph.Nodes, true );
+			OnRebuild();
+		}
 
 		RestoreViewFromCookie();
 	}

--- a/game/addons/tools/Code/NodeGraph/GraphView.cs
+++ b/game/addons/tools/Code/NodeGraph/GraphView.cs
@@ -1188,7 +1188,6 @@ public class GraphView : GraphicsView, IGridSizeView
 		if ( _graph is not null ) BuildFromNodes( _graph.Nodes, true );
 
 		OnRebuild();
-		
 		RestoreViewFromCookie();
 	}
 


### PR DESCRIPTION
Fixes a NRE when clearing the graph in GraphView. Will now check if Graph is null before trying to build from nodes.

Allows GraphView to have more functionality when used for loading/unloading graph assets and removes the need to always have a graph loaded.