### PR TITLE
Update ModelDropObject gizmo model

### DIFF
--- a/game/addons/tools/Code/Scene/SceneView/DropObjects/ModelDropObject.cs
+++ b/game/addons/tools/Code/Scene/SceneView/DropObjects/ModelDropObject.cs
@@ -43,6 +43,7 @@ partial class ModelDropObject : BaseDropObject
 			if ( so.IsValid() )
 			{
 				so.Flags.CastShadows = true;
+				so.UpdateToBindPose();
 			}
 		}
 


### PR DESCRIPTION
relating to https://github.com/Facepunch/sbox-public/pull/175

Skinned models would previously get stuck in place when dragging them into the viewport, now they don't. Fixes the only instance of a facepunch component using a potentially skinned model in Gizmo.Draw.Model() without updating it.