### PR TITLE
gitignore compiled menu content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ engine/TestResults/
 /game/tools
 /game/aftermath_dumps
 /game/gamecache
+/game/addons/menu/Transients
+/game/core/maps/editor/_bakeresourcecache


### PR DESCRIPTION
Update gitignore to exclude the compiled menu assets that get downloaded by bootstrap, not sure if there's a reason those paths weren't already in gitignore. Seems easier than everyone having their own local gitignore floating around between branches.