### PR TITLE
Localized Particle Velocity Fixes

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
@@ -553,7 +553,8 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		// Apply constant movement
 		if ( !ConstantMovement.IsNearlyZero() )
 		{
-			p.Position += ConstantMovement.Evaluate( p, 4395 ) * _timeDelta;
+			var constantMovement = ConstantMovement.Evaluate( p, 4395 ) * _timeDelta;
+			p.Position += constantMovement.LerpTo(_worldTx.NormalToWorld( constantMovement ) * constantMovement.Length, localSpace);
 		}
 
 		if ( Collision )
@@ -826,7 +827,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		p.Velocity = Vector3.Random.Normal * StartVelocity.Evaluate( delta, Random.Shared.Float() );
 		
 		var initialVelocity = InitialVelocity.Evaluate( delta, Random.Shared.Float(), Random.Shared.Float(), Random.Shared.Float() );
-		p.Velocity += initialVelocity.LerpTo( WorldTransform.NormalToWorld( initialVelocity.Normal ) * initialVelocity.Length, localSpace );
+		p.Velocity += initialVelocity.LerpTo( WorldTransform.NormalToWorld( initialVelocity ) * initialVelocity.Length, localSpace );
 		
 		p.BornTime += delay;
 		p.DeathTime = p.BornTime + Lifetime.Evaluate( delta, p.Rand( 145, 100 ) );

--- a/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
@@ -515,7 +515,11 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 			var localPos = lastTransform.PointToLocal( p.Position );
 			var worldPos = _worldTx.PointToWorld( localPos );
 
+			var localVelocity = lastTransform.NormalToLocal( p.Velocity.Normal );
+			var worldVelocity = _worldTx.NormalToWorld( localVelocity ) * p.Velocity.Length;
+			
 			p.Position = p.Position.LerpTo( worldPos, localSpace );
+			p.Velocity = p.Velocity.LerpTo( worldVelocity, localSpace );
 		}
 
 		p.ApplyDamping( damping * timeScale );

--- a/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
@@ -815,6 +815,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 	/// <returns>A particle, will never be null. It's up to you to obey max particles.</returns>
 	public Particle Emit( Vector3 position, float delta )
 	{
+		var localSpace = LocalSpace.Evaluate( 0, 254 ).Clamp( 0, 1 );
 		var delay = StartDelay.Evaluate( delta, Random.Shared.Float() );
 
 		var p = Particle.Create();
@@ -823,7 +824,10 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		p.StartPosition = position;
 		p.Radius = 1.0f;
 		p.Velocity = Vector3.Random.Normal * StartVelocity.Evaluate( delta, Random.Shared.Float() );
-		p.Velocity += InitialVelocity.Evaluate( delta, Random.Shared.Float(), Random.Shared.Float(), Random.Shared.Float() );
+		
+		var initialVelocity = InitialVelocity.Evaluate( delta, Random.Shared.Float(), Random.Shared.Float(), Random.Shared.Float() );
+		p.Velocity += initialVelocity.LerpTo( WorldTransform.NormalToWorld( initialVelocity.Normal ) * initialVelocity.Length, localSpace );
+		
 		p.BornTime += delay;
 		p.DeathTime = p.BornTime + Lifetime.Evaluate( delta, p.Rand( 145, 100 ) );
 

--- a/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
@@ -554,7 +554,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		if ( !ConstantMovement.IsNearlyZero() )
 		{
 			var constantMovement = ConstantMovement.Evaluate( p, 4395 ) * _timeDelta;
-			p.Position += constantMovement.LerpTo(_worldTx.NormalToWorld( constantMovement ) * constantMovement.Length, localSpace);
+			p.Position += constantMovement.LerpTo( _worldTx.NormalToWorld( constantMovement ) * constantMovement.Length, localSpace );
 		}
 
 		if ( Collision )

--- a/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
@@ -517,7 +517,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 
 			var localVelocity = lastTransform.NormalToLocal( p.Velocity.Normal );
 			var worldVelocity = _worldTx.NormalToWorld( localVelocity ) * p.Velocity.Length;
-			
+
 			p.Position = p.Position.LerpTo( worldPos, localSpace );
 			p.Velocity = p.Velocity.LerpTo( worldVelocity, localSpace );
 		}
@@ -554,7 +554,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		if ( !ConstantMovement.IsNearlyZero() )
 		{
 			var constantMovement = ConstantMovement.Evaluate( p, 4395 ) * _timeDelta;
-			p.Position += constantMovement.LerpTo(_worldTx.NormalToWorld( constantMovement ) * constantMovement.Length, localSpace);
+			p.Position += constantMovement.LerpTo( _worldTx.NormalToWorld( constantMovement ) * constantMovement.Length, localSpace );
 		}
 
 		if ( Collision )
@@ -825,10 +825,10 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		p.StartPosition = position;
 		p.Radius = 1.0f;
 		p.Velocity = Vector3.Random.Normal * StartVelocity.Evaluate( delta, Random.Shared.Float() );
-		
+
 		var initialVelocity = InitialVelocity.Evaluate( delta, Random.Shared.Float(), Random.Shared.Float(), Random.Shared.Float() );
 		p.Velocity += initialVelocity.LerpTo( WorldTransform.NormalToWorld( initialVelocity ) * initialVelocity.Length, localSpace );
-		
+
 		p.BornTime += delay;
 		p.DeathTime = p.BornTime + Lifetime.Evaluate( delta, p.Rand( 145, 100 ) );
 


### PR DESCRIPTION
This fixes [#8574](https://github.com/Facepunch/sbox-public/issues/1545) and ensures consistent behaviour with `ConstantMovement` and `InitialVelocity` as well.

I believe making these parameters consistent in how `LocalSpace` affects them is important, as they are otherwise functionally useless when trying to make particles with localized movements.

If you want world-space relative constant movement with local-space particles, then I feel a component would be a better fit, in the same vein as the `ParticleAttractor`.

Old Behaviour:

https://github.com/user-attachments/assets/893df83c-bca9-4a79-8a9c-fcfa8573a4bf

New Behaviour:

https://github.com/user-attachments/assets/b60b7c5f-9808-401e-a2ea-37a420811936

