### PR TITLE
Fixed OnNavigationOpen not being called on panel you switch to in NavigationHost

### DIFF
--- a/game/addons/base/code/UI/Components/NavigationHost.cs
+++ b/game/addons/base/code/UI/Components/NavigationHost.cs
@@ -452,7 +452,7 @@ public class NavigationHost : Panel
 
 		if ( Current?.Panel is INavigatorPage toNav )
 		{
-			toNav.OnNavigationClose();
+			toNav.OnNavigationOpen();
 		}
 
 		RunNavigatedEvent();


### PR DESCRIPTION
OnNavigationClose was previously being called in the panel you were switching TO. Fixed to call OnNavigationOpen instead.