### PR TITLE
Add custom texture filtering/address mode to line renderer

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Effects/BeamEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Effects/BeamEffect.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using Sandbox.Rendering;
+using System.Runtime.CompilerServices;
 
 namespace Sandbox;
 
@@ -101,6 +102,11 @@ public sealed class BeamEffect : Component, Component.ExecuteInEditor, Component
 	/// This is pretty much the same as TextureOffset - but it's seperate so you can use offset for offset, and scroll to scroll.
 	/// </summary>
 	[Property] public ParticleFloat TextureScroll { get; set; } = 0.0f;
+
+	/// <summary>
+	/// Controls texture filtering on this beam effect.
+	/// </summary>
+	[Property] public FilterMode FilterMode { get; set; } = FilterMode.Anisotropic;
 
 	/// <summary>
 	/// Color gradient of the beam over its lifetime. Defines how the color changes from birth to death.
@@ -406,7 +412,8 @@ public sealed class BeamEffect : Component, Component.ExecuteInEditor, Component
 			Material = Material ?? _defaultMaterial,
 			UnitsPerTexture = texScale,
 			Offset = offset,
-			Clamp = false,
+			FilterMode = FilterMode,
+			TextureAddressMode = Rendering.TextureAddressMode.Wrap,
 			WorldSpace = true,
 		};
 
@@ -421,7 +428,7 @@ public sealed class BeamEffect : Component, Component.ExecuteInEditor, Component
 
 			lineRenderer.Texturing = lineRenderer.Texturing with
 			{
-				Clamp = true,
+				TextureAddressMode = Rendering.TextureAddressMode.Clamp,
 				Offset = 1 + (lerp * -chunksPerLength)
 			};
 

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleTrailRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleTrailRenderer.cs
@@ -160,6 +160,7 @@ class ParticleTrail : Particle.BaseListener
 		so.Opaque = Renderer.Opaque;
 		so.BlendMode = Renderer.BlendMode;
 		so.Wireframe = Renderer.Wireframe;
+		so.SamplerState = new() { Filter = Renderer.Texturing.FilterMode, AddressModeU = Renderer.Texturing.TextureAddressMode, AddressModeV = Renderer.Texturing.TextureAddressMode };
 	}
 
 	public override void OnDisabled( Particle p )

--- a/engine/Sandbox.Engine/Scene/Components/Render/LineRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/LineRenderer.cs
@@ -165,7 +165,7 @@ public sealed class LineRenderer : Renderer, Component.ExecuteInEditor
 		_so.EndCap = EndCap;
 		_so.Face = Face;
 		_so.Wireframe = Wireframe;
-		_so.Clamped = Texturing.Clamp;
+		_so.SamplerState = new() { Filter = Texturing.FilterMode, AddressModeU = Texturing.TextureAddressMode, AddressModeV = Texturing.TextureAddressMode };
 
 		_so.RenderingEnabled = true;
 		_so.Transform = transform;

--- a/engine/Sandbox.Engine/Scene/Components/Render/TrailRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/TrailRenderer.cs
@@ -102,6 +102,7 @@ public sealed class TrailRenderer : Renderer, Component.ExecuteInEditor
 		_so.Opaque = Opaque;
 		_so.BlendMode = BlendMode;
 		_so.Face = Face;
+		_so.SamplerState = new() { Filter = Texturing.FilterMode, AddressModeU = Texturing.TextureAddressMode, AddressModeV = Texturing.TextureAddressMode };
 
 		if ( Emitting )
 		{

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SceneLineObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SceneLineObject.cs
@@ -69,6 +69,7 @@ public class SceneLineObject : SceneCustomObject
 		set => Attributes.SetCombo( "D_ENABLE_LIGHTING", value );
 	}
 
+	[Obsolete( "Use Sampler State property instead" )]
 	public bool Clamped
 	{
 		get => _clamped;
@@ -87,6 +88,18 @@ public class SceneLineObject : SceneCustomObject
 	}
 
 	private bool _clamped = false;
+
+	public SamplerState SamplerState
+	{
+		get => _samplerState;
+		set
+		{
+			_samplerState = value;
+			Attributes.Set( "SamplerIndex", SamplerState.GetBindlessIndex( _samplerState ) );
+		}
+	}
+
+	private SamplerState _samplerState = new() { Filter = FilterMode.Anisotropic, MaxAnisotropy = 8, AddressModeU = TextureAddressMode.Wrap, AddressModeV = TextureAddressMode.Wrap };
 
 	public int Smoothness
 	{

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SceneTrailObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SceneTrailObject.cs
@@ -1,4 +1,6 @@
 ﻿
+using Sandbox.Rendering;
+
 namespace Sandbox;
 
 /// <summary>
@@ -177,6 +179,8 @@ public struct TrailTextureConfig
 		Scale = 1,
 		Offset = 0,
 		Scroll = 0,
+		FilterMode = FilterMode.Anisotropic,
+		TextureAddressMode = TextureAddressMode.Wrap
 	};
 
 	[Hide, Obsolete( "Use Material property instead" )]
@@ -207,11 +211,18 @@ public struct TrailTextureConfig
 	[Property]
 	public float Scroll { get; set; }
 
+	[Group( "Texture Coordinates" )]
+	[Property]
+	public FilterMode FilterMode { get; set; } = FilterMode.Anisotropic;
+
+	[Group( "Texture Coordinates" )]
+	[Property]
+	public TextureAddressMode TextureAddressMode { get; set; } = TextureAddressMode.Wrap;
+
 	/// <summary>
 	/// If true the texture will be clamped instead of repeating
 	/// </summary>
-	[Group( "Texture Coordinates" )]
-	[Property]
+	[Hide, Obsolete( "Use Texture Address Mode property instead" )]
 	public bool Clamp { get; set; }
 
 	public bool DoesMaterialUseLineShader( Material value )


### PR DESCRIPTION
## Changes
- Allows artists to control texture filtering (point/bilinear/trilinear/anisotropic) on line and trail renderers
- Obsoletes "Clamp" in SceneTrailObject's `TrailTextureConfig` struct, use `FilterMode` and `TextureAddressMode` properties instead. Default config will set anisotropic filtering with "wrap" UV address mode.
- No changes in line.shader, it still uses bindless sampler state. It is assigned from SceneLineObject.cs in `SamplerState` property's setter
- This also adds support for changing these sampler settings on TrailRenderer, BeamEffect and ParticleTrailRenderer components. 
- One exception for BeamEffect is that allows changing only texture filtering. Clamp/wrap address mode is determined by existing logic in the component, where `Wrap` is the default option, and `Clamp` is set if "Travel" feature is enabled. This functionality is left intact because I didn't want to alter existing logic for it 

## Why 
Some other renderers (like decals) allow changing texture filtering already, so I figured that it would be beneficial for artists to have the same control for line renderer. Additionally, instead of being restricted to just "clamp" bool, you can set any address mode now. Since line renderer is used as a foundation for trail renderer and beam effects, they got support for changing texture filtering as well. 

<img width="1160" height="509" alt="image" src="https://github.com/user-attachments/assets/efb01112-51cd-43dd-b910-7abf3b10b6d8" />
<img width="1613" height="859" alt="image" src="https://github.com/user-attachments/assets/fac297a2-c762-4b6b-a26d-3766ea42f389" />
