### PR TITLE
Fix for buttons with no gameobject

### DIFF
--- a/game/addons/tools/Code/Widgets/ControlWidgets/ButtonControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/ButtonControlWidget.cs
@@ -48,9 +48,12 @@ public class ButtonControlWidget : ControlWidget
 				}
 				else
 				{
-					foreach ( var prop in props )
+					using ( SceneEditorSession.Scope() )
 					{
-						prop.Invoke();
+						foreach ( var prop in props )
+						{
+							prop.Invoke();
+						}
 					}
 				}
 			};

--- a/game/addons/tools/Code/Widgets/ControlWidgets/ButtonControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/ButtonControlWidget.cs
@@ -41,9 +41,7 @@ public class ButtonControlWidget : ControlWidget
 					using ( session.Scene.Push() )
 					{
 						foreach ( var prop in props )
-						{
 							prop.Invoke();
-						}
 					}
 				}
 				else
@@ -51,9 +49,7 @@ public class ButtonControlWidget : ControlWidget
 					using ( SceneEditorSession.Scope() )
 					{
 						foreach ( var prop in props )
-						{
 							prop.Invoke();
-						}
 					}
 				}
 			};

--- a/game/addons/tools/Code/Widgets/ControlWidgets/ButtonControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/ButtonControlWidget.cs
@@ -34,8 +34,19 @@ public class ButtonControlWidget : ControlWidget
 
 			button.Clicked += () =>
 			{
-				var session = SceneEditorSession.Resolve( property.GetContainingGameObject() );
-				using ( session.Scene.Push() )
+				var go = property.GetContainingGameObject();
+				if ( go is not null )
+				{
+					var session = SceneEditorSession.Resolve( go );
+					using ( session.Scene.Push() )
+					{
+						foreach ( var prop in props )
+						{
+							prop.Invoke();
+						}
+					}
+				}
+				else
 				{
 					foreach ( var prop in props )
 					{


### PR DESCRIPTION
https://github.com/Facepunch/sbox-public/commit/c8d27185483a9c9e3d5f242de750ca17a47bbb16 broke control sheet buttons that don't have an associated gameobject (e.g. adding a control sheet in an editor tool), this uses the previous `SceneEditorSession.Scope()` method if `GetContainingGameObject()` is null.