### PR TITLE
Fix cloud assets not persisting between sessions

### DIFF
--- a/engine/Sandbox.Tools/Assets/CloudAssetDirectory.cs
+++ b/engine/Sandbox.Tools/Assets/CloudAssetDirectory.cs
@@ -104,8 +104,6 @@ internal class CloudAssetDirectory : IDisposable
 
 		packages.Insert( package );
 
-		// Force checkpoint to ensure data is persisted to disk
-		db.Checkpoint();
 
 		packageCache[package.FullIdent] = package;
 	}


### PR DESCRIPTION
- Clean up stale file entries from old package revisions to prevent validation failures on restart
- Fix ValidatePackage to only validate files matching the current package revision

This fixes Hammer cloud asset faulty persistence too, before some assets could go missing after restarting s&box.