### PR TITLE
Make hi-res screenshots use MSAA value set by user instead of hardcoded 16X

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Multimedia/ScreenshotService.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Multimedia/ScreenshotService.cs
@@ -1,4 +1,5 @@
 ﻿using NativeEngine;
+using Sandbox.Engine.Settings;
 using Sandbox.UI;
 using System.Collections.Concurrent;
 using System.IO;
@@ -130,7 +131,7 @@ internal static class ScreenshotService
 
 			ResizeUI( camera, requestedSize );
 
-			renderTarget = RenderTarget.GetTemporary( width, height, ImageFormat.Default, ImageFormat.Default, MultisampleAmount.Multisample16x, 1, "HighResScreenshot" );
+			renderTarget = RenderTarget.GetTemporary( width, height, ImageFormat.Default, ImageFormat.Default, RenderSettings.Instance.AntiAliasQuality, 1, "HighResScreenshot" );
 			if ( renderTarget is null )
 			{
 				Log.Warning( "Failed to create render target for high-res screenshot." );


### PR DESCRIPTION
## Changes
Currently `screenshot_highres` will capture the image with hardcoded 16X multisampling. This is OK for some cases, but I think it would make more sense if highres screenshots would respect your current MSAA level from settings instead. 

## Why
Gives more control to user how exactly hi-res screenshots look like. 

This is coming from my experience making screenshots and other media for Rust projects, but usually high res screenshots are processed in any image editing software afterwards, and screenshots with no antialiasing are better suited for these tasks. (result is more sharper/smoother, depending on how you process it)