### PR TITLE
Fix Asset Inspector showing "2 Assets" when creating a new Asset

### DIFF
--- a/game/addons/tools/Code/Editor/AssetList/Entries/AssetEntry.cs
+++ b/game/addons/tools/Code/Editor/AssetList/Entries/AssetEntry.cs
@@ -8,6 +8,14 @@ public class AssetEntry : IAssetListEntry
 {
 	private readonly Color TypeColor;
 
+	/// <summary>
+	/// Cached path used for identity (Equals/GetHashCode). This is set once at construction
+	/// and never changes, even if the file is renamed. This is critical because AssetEntry
+	/// is used as a key in hash-based collections (like SelectionSystem), and changing the
+	/// hash code after insertion would corrupt the collection's state.
+	/// </summary>
+	private readonly string _identityPath;
+
 	public readonly FileInfo FileInfo;
 	public readonly string TypeName;
 	public Asset Asset { get; private set; }
@@ -45,6 +53,7 @@ public class AssetEntry : IAssetListEntry
 	public AssetEntry( FileInfo fileInfo, Asset asset )
 	{
 		FileInfo = fileInfo;
+		_identityPath = fileInfo.FullName;
 
 		var fileExtension = Path.GetExtension( fileInfo.Name );
 
@@ -237,12 +246,14 @@ public class AssetEntry : IAssetListEntry
 			return false;
 		}
 
-		return FileInfo.FullName.Equals( ae.FileInfo.FullName );
+		var thisPath = _identityPath ?? FileInfo.FullName;
+		var otherPath = ae._identityPath ?? ae.FileInfo.FullName;
+		return thisPath.Equals( otherPath );
 	}
 
 	public override int GetHashCode()
 	{
-		return FileInfo.FullName.GetHashCode();
+		return (_identityPath ?? FileInfo.FullName).GetHashCode();
 	}
 }
 


### PR DESCRIPTION
# Fix
- Fixes a bug where creating a new non-engine resource (like a GameResource) and then clicking on it would cause the Inspector to incorrectly show "2 Assets selected"

# How did I get to this hypothesis?

I started by tracing the selection flow from Asset Browser to the Inspector:
1. AssetList.OnSelectionChanged fires with selected items
2. AssetBrowser extracts Asset objects and calls OnAssetHighlight (single) or OnAssetsHighlight (multiple)
3. EditorUtility.InspectorObject is set
4. AssetInspector reads so.Targets to get the asset count

The Inspector showing "2 Assets" meant so.Targets had 2 items, which meant Selection contained 2 entries.
The hash code was being mutated. 
```cs
  public void Rename( string newName )
  {
      FileInfo.MoveTo( FileInfo.GetNewPath( newName ) );  // Changes FileInfo.FullName
      Asset = AssetSystem.RegisterFile( FileInfo.FullName );
  }
```

This changes the object's hash code because FileInfo.FullName was being changed, while it's a key in SelectionSystem's dictionary.

It was relying on old behavior from the Asset Browser unnecessarily clearing the AssetList when SetItems already handled it.