### PR TITLE
Update sbox-issues links

### DIFF
--- a/engine/Launcher/SboxServer/Launcher.cs
+++ b/engine/Launcher/SboxServer/Launcher.cs
@@ -66,7 +66,7 @@ public class DedicatedServerAppSystem : AppSystem
 	void PrintHelp()
 	{
 		Log.Info( "Welcome to the s&box dedicated server. This is currently a work in progress." );
-		Log.Info( "Submit any issues to https://github.com/facepunch/sbox-issues" );
+		Log.Info( "Submit any issues to https://github.com/facepunch/sbox-public/issues" );
 		Log.Info( "" );
 		Log.Info( "game <gameident> - load a game" );
 		Log.Info( "game <gameident> <mapident> - load a game with a map" );

--- a/engine/Sandbox.Access/Rules/Async.cs
+++ b/engine/Sandbox.Access/Rules/Async.cs
@@ -47,7 +47,7 @@ internal static partial class Rules
 		"System.Private.CoreLib/System.Threading.Tasks.Task.get_IsCompletedSuccessfully()",
 		"System.Private.CoreLib/System.Threading.Tasks.Task.get_Status()",
 
-		"System.Private.CoreLib/System.Threading.Tasks.TaskExtensions.Unwrap<TResult>( System.Threading.Tasks.Task`1<System.Threading.Tasks.Task`1<TResult>> )", // https://github.com/Facepunch/sbox-issues/issues/5190
+		"System.Private.CoreLib/System.Threading.Tasks.TaskExtensions.Unwrap<TResult>( System.Threading.Tasks.Task`1<System.Threading.Tasks.Task`1<TResult>> )", // https://github.com/Facepunch/sbox-public/issues/4905
 
 		"System.Private.CoreLib/System.Threading.Tasks.TaskStatus",
 	};

--- a/engine/Sandbox.Engine/Systems/Audio/Speech/Speech.Synthesis.cs
+++ b/engine/Sandbox.Engine/Systems/Audio/Speech/Speech.Synthesis.cs
@@ -143,7 +143,7 @@ public sealed class Synthesizer
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
 		// TODO we dont do any liefecycle management on SpeechSynthesizer sounds whatsoever, this needs a complete rework to fix the diagnoser warning
-		// related: https://github.com/Facepunch/sbox-issues/issues/5922
+		// related: https://github.com/Facepunch/sbox-public/issues/4184
 		var soundStream = new SoundStream( sampleRate );
 #pragma warning restore CA2000 // Dispose objects before losing scope
 		var stream = new MemoryStream();

--- a/engine/Sandbox.Test.Unit/Editor/ControlWidgets.cs
+++ b/engine/Sandbox.Test.Unit/Editor/ControlWidgets.cs
@@ -22,7 +22,7 @@ public class ControlWidgets
 	/// Integer values should survive a round trip through <see cref="IntegerControlWidget.ValueToString"/> and <see cref="IntegerControlWidget.StringToValue"/>.
 	/// </para>
 	/// <para>
-	/// Reproduces <see href="https://github.com/Facepunch/sbox-issues/issues/6731">Facepunch/sbox-issues#6731</see>.
+	/// Reproduces <see href="https://github.com/Facepunch/sbox-public/issues/3385">Facepunch/sbox-public#3385</see>.
 	/// </para>
 	/// </summary>
 	[TestMethod]
@@ -57,7 +57,7 @@ public class ControlWidgets
 	/// Integer values should survive a round trip through <see cref="FloatControlWidget.ValueToString"/> and <see cref="FloatControlWidget.StringToValue"/>.
 	/// </para>
 	/// <para>
-	/// Reproduces <see href="https://github.com/Facepunch/sbox-issues/issues/6731">Facepunch/sbox-issues#6731</see>.
+	/// Reproduces <see href="https://github.com/Facepunch/sbox-public/issues/3385">Facepunch/sbox-public#3385</see>.
 	/// </para>
 	/// </summary>
 	[TestMethod]

--- a/engine/Sandbox.Test/Scene/GameObjects/Serialize.cs
+++ b/engine/Sandbox.Test/Scene/GameObjects/Serialize.cs
@@ -276,7 +276,7 @@ public class SerializeTest
 	/// <summary>
 	/// There was a regression when cloning a list of user defined objects, if the object had a property that was named "Prefab".
 	/// This could lead to a deserilziation issue in UpdateClonedIdsInJson when trying to rewire the GameObjectReferences.
-	/// https://github.com/Facepunch/sbox-issues/issues/7638
+	/// https://github.com/Facepunch/sbox-public/issues/2480
 	/// </summary>
 	[TestMethod]
 	public void CloneComponentWithPrefabList()
@@ -883,7 +883,7 @@ public class ComponentWithRequiredComponent : Component
 }
 
 
-// https://github.com/Facepunch/sbox-issues/issues/7638
+// https://github.com/Facepunch/sbox-public/issues/2480
 public class ComponentWithPrefabList : Component
 {
 	[Sandbox.Property] public readonly List<PrafbEntry> Decorations = new();

--- a/engine/Sandbox.Test/Scene/Prefab/Prefab.Instance.Load.cs
+++ b/engine/Sandbox.Test/Scene/Prefab/Prefab.Instance.Load.cs
@@ -10,8 +10,8 @@ public class InstanceLoadTests
 {
 	[TestMethod]
 	/// <summary>
-	/// https://github.com/Facepunch/sbox-issues/issues/9367
-	/// https://github.com/Facepunch/sbox-issues/issues/9346
+	/// https://github.com/Facepunch/sbox-public/issues/758
+	/// https://github.com/Facepunch/sbox-public/issues/779
 	/// </summary>
 	public void RepeatedAttemptToLoadMissingPrefab_ShouldNotThrowException()
 	{

--- a/engine/Sandbox.Test/Scene/Prefab/Prefabs.Instances.cs
+++ b/engine/Sandbox.Test/Scene/Prefab/Prefabs.Instances.cs
@@ -889,7 +889,7 @@ public partial class Instances
 			"Nested instance should receive updates from its prefab after parent instance broke from prefab" );
 	}
 
-	// https://github.com/Facepunch/sbox-issues/issues/9194
+	// https://github.com/Facepunch/sbox-public/issues/930
 	[TestMethod]
 	public void WriteGameObjectToPrefab_WithNestedInstance()
 	{

--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -187,7 +187,7 @@ public class EditorMainWindow : DockWindow
 
 			help.AddOption( "Open Log Folder", "source", () => EditorUtility.OpenFolder( FileSystem.Root.GetFullPath( "/logs/" ) ) );
 			help.AddOption( "Developer Documentation", "article", () => EditorUtility.OpenFolder( "https://sbox.game/dev/" ) );
-			help.AddOption( "Report a Bug", "bug_report", () => EditorUtility.OpenFolder( "https://github.com/Facepunch/sbox-issues" ) );
+			help.AddOption( "Report a Bug", "bug_report", () => EditorUtility.OpenFolder( "https://github.com/Facepunch/sbox-public/issues" ) );
 
 			help.AddSeparator();
 			help.AddOption( "About s&box editor", "info", () =>


### PR DESCRIPTION
## Summary

I was just going to fix the `Report a bug` menu item in the Editor opening the old issue tracker but I figured I might as well update all the links while I was at it.

## Motivation & Context

Well the menu item should definitely be updated. The links on the comments are arguable since it dirties the git blame and they redirect correctly anyway (for now?).
Let me know and I'll be more picky with my changes.

## Implementation Details

For all the links in the comments I clicked them and see where I was redirected, then I copied that URL back in.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] I’m okay with this PR being rejected or requested to change 🙂