### PR TITLE
Select the implementation without parameters

### DIFF
--- a/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
@@ -159,7 +159,7 @@ public class GenericControlWidget : ControlObjectWidget
 		string labelText = displayInfo.Name;
 
 		// If the type has a custom ToString(), use that instead of the type name.
-		if ( type.GetMethod( "ToString" ).DeclaringType != typeof( object ) )
+		if ( type.GetMethod( "ToString", Type.EmptyTypes ).DeclaringType != typeof( object ) )
 		{
 			labelText = value?.ToString() ?? labelText;
 		}


### PR DESCRIPTION
## Summary

This PR eliminates errors if a structure has multiple implementations of ToString.

## Motivation & Context

The editor generates an error if there are multiple implementations of ToString.

```csharp
struct Test
{
	public override string ToString()
	{
		return "ekip";
	}
	
	public string ToString(int test)
	{
		return "ekip";
	}
}
```

Fixes: #222

## Implementation Details

Instead of using the `GetMethod` method, I use `GetMethods` and then search for ToString implementations and then implementations with no parameters.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂