### PR TITLE
Fix world input

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/UISystem.cs
+++ b/engine/Sandbox.Engine/Systems/UI/UISystem.cs
@@ -282,12 +282,12 @@ internal class UISystem
 	{
 		foreach ( var scene in Scene.All )
 		{
-			var rootPanels = scene.GetAllComponents<WorldPanel>();
+			var rootPanels = scene.GetAllComponents<WorldPanel>().Select( x => x.GetPanel() as RootPanel ).Where( x => x.IsValid() );
 			var worldInputs = scene.GetAllComponents<WorldInput>();
 
 			foreach ( var worldInput in worldInputs )
 			{
-				worldInput.WorldPanelInput.Tick( rootPanels.Select( x => x.GetPanel() as RootPanel ), true );
+				worldInput.WorldPanelInput.Tick( rootPanels, true );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Having the World Input component spams errors

## Motivation & Context

Stop having errors

Fixes: #168

## Implementation Details

My understanding of the problem is that `GetPanel` returns a null value because `worldPanel` is initialized when `OnEnabled` executes.

My solution is to check if the value of `GetPanel` is null.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂