### PR TITLE
[CodeGen] Fix compiler warnings related to `[Sync]` when using `nullable`

### DIFF
--- a/engine/Sandbox.Compiling.Test/Tests/CodeGen.cs
+++ b/engine/Sandbox.Compiling.Test/Tests/CodeGen.cs
@@ -222,13 +222,13 @@ namespace Generator
 
 			System.Console.WriteLine( tree.GetText().ToString() );
 
-			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = null, MethodIdentity = -1168963981, MethodName = \"TestWrappedStaticCall\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap static method call" );
+			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = null !, MethodIdentity = -1168963981, MethodName = \"TestWrappedStaticCall\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap static method call" );
 			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = this, MethodIdentity = -446800946, MethodName = \"TestWrappedInstanceCall\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap instance method call" );
-			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = null, MethodIdentity = 1638661065, MethodName = \"TestWrappedStaticCallNoArg\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap static method call with no arg" );
+			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = null !, MethodIdentity = 1638661065, MethodName = \"TestWrappedStaticCallNoArg\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap static method call with no arg" );
 			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = this, MethodIdentity = -1769572979, MethodName = \"TestWrappedInstanceCallNoArg\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap instance method call with no arg" );
 			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = this, MethodIdentity = 1201362747, MethodName = \"ExpressionBodiedBroadcast\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap expression bodied method" );
 			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = this, MethodIdentity = -1316352073, MethodName = \"TestWrappedInstanceCallReturnType\", TypeName = \"TestWrapCall\"" ), "Generated code should wrap instance method call with return type" );
-			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = null, MethodIdentity = 1168636003, MethodName = \"TestAsyncTaskCall\", TypeName = \"TestWrapCall\", IsStatic = true" ), "Generated code should wrap async Task method call" );
+			Assert.IsTrue( tree.GetText().ToString().Contains( "Object = null !, MethodIdentity = 1168636003, MethodName = \"TestAsyncTaskCall\", TypeName = \"TestWrapCall\", IsStatic = true" ), "Generated code should wrap async Task method call" );
 			Assert.IsTrue( tree.GetText().ToString().Contains( "MethodName = \"MyGenericCall\", TypeName = \"TestWrapCall\", IsStatic = false, Attributes = __898531504__Attrs, GenericArguments = new[] { typeof(T) } }" ), "Generated code should include closed generic types" );
 			Assert.IsTrue( tree.GetText().ToString().Contains( "MethodName = \"MyGenericCallAsync\", TypeName = \"TestWrapCall\", IsStatic = false, Attributes = __1383690312__Attrs, GenericArguments = new[] { typeof(T) } }" ), "Generated code should include closed generic types when returning a Task" );
 		}
@@ -270,8 +270,8 @@ namespace Generator
 			var tree = compiler.SyntaxTrees.First();
 			System.Console.WriteLine( tree.GetText().ToString() );
 
-			Assert.IsTrue( tree.GetText().ToString().Contains( "WrapSet.OnWrapSetStatic(new global::Sandbox.WrappedPropertySet<bool> { Value = value, Object = null, Setter = __StaticProperty_WrapSet__CachedSetter" ), "Generated code should wrap static property set accessor" );
-			Assert.IsTrue( tree.GetText().ToString().Contains( "OnWrapSet(new global::Sandbox.WrappedPropertySet<bool> { Value = value, Object = this, Setter = __InstanceProperty_WrapSet__CachedSetter" ), "Generated code should wrap instance property set accessor" );
+			Assert.IsTrue( tree.GetText().ToString().Contains( "WrapSet.OnWrapSetStatic(new global::Sandbox.WrappedPropertySet<bool> { Value = value!, Object = null !, Setter = __StaticProperty_WrapSet__CachedSetter" ), "Generated code should wrap static property set accessor" );
+			Assert.IsTrue( tree.GetText().ToString().Contains( "OnWrapSet(new global::Sandbox.WrappedPropertySet<bool> { Value = value!, Object = this, Setter = __InstanceProperty_WrapSet__CachedSetter" ), "Generated code should wrap instance property set accessor" );
 		}
 
 		[TestMethod]


### PR DESCRIPTION
## Summary

Fixes **two distinct issues** of nullable compiler warnings in the code generator by adding null-forgiving operators (!) in several places.

**Issue 1**

If you had a sbox project with `nullables` enabled then whenever you use a `[Sync]` attribute you'd get warnings in console.

**Issue 2**

If you are using a nullable type `Type?` and `[Sync]` you will get warnings. This issue describes the initial problem https://github.com/Facepunch/sbox-public/issues/215

## Motivation & Context

For awhile now if you used a nullable type `Type?` with `[Sync]` you'd get a warning.

Since [26.01.28 update's network optimization](https://sbox.game/news/update-26-01-28#networking-optimizations) warnings appear with `nullables` enabled in project settings if you use `[Sync]`.

```
01:39:48   Compiler CS8618 Non-nullable field '__WishVelocity_SyncAttribute__CachedSetter' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
01:39:48   Compiler CS8618 Non-nullable field '__WishVelocity_SyncAttribute__CachedSetterGetter' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
01:39:48   Compiler CS8618 Non-nullable field '__WishVelocity_SyncAttribute__CachedGetter' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.
```

`Nullables` is an option in Project Settings, i personally prefer having them enabled and I think you should be able to use them without being penalized by having compiler warnings.

Fixes: #215

## Implementation Details

There were two ways this could be solved, I used the less invasive approach of essentially doing `value!` which will silence any null warnings.

The alternative way would be to properly type things as nullable `type? myVariable = etc`
This alternative though require us to wrap all generated code with `#nullable enable/disable` and would require more invasive changes.

## Tests

Some tests were updated as a result of the changes.

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂