### PR TITLE
Don't show Max Player slider if Min players == Max players

### DIFF
--- a/game/addons/menu/Code/Modals/CreateGameModal/CreateGameModal.razor
+++ b/game/addons/menu/Code/Modals/CreateGameModal/CreateGameModal.razor
@@ -53,12 +53,15 @@
                             </div>
                         </div>
 
-                        <div class="entry">
-                            <div class="is-label">Max Players</div>
-                            <div class="control">
-                                <SliderControl class="glass with-grow" Value:bind=@Players Min=@MinPlayers Max=@MaxPlayers Step=@(1) ShowTextEntry=@true />
+                        @if ( MinPlayers != MaxPlayers )
+                        {
+                            <div class="entry">
+                                <div class="is-label">Max Players</div>
+                                <div class="control">
+                                    <SliderControl class="glass with-grow" Value:bind=@Players Min=@MinPlayers Max=@MaxPlayers Step=@(1) ShowTextEntry=@true />
+                                </div>
                             </div>
-                        </div>
+                        }
                     }
 
                     if ( NeedsMap() )


### PR DESCRIPTION
## Summary

This PR modifies the Create Game modal to only show the Max players slider if it's meaningful.

## Motivation & Context

One of my games, [Quality Riichi Mahjong](https://sbox.game/quality/riichi_mahjong) has a minimum players of 4 *and* a maximum players of 4.
When you get the Create Game popup for this game, you get a Max players slider where both the min and max is 4, and so it does not move.
I feel it's appropriate that if you've set up your project settings so that min and max players are the same, then you should always use that number as the player count.

## Screenshots / Videos (if applicable)

Before:

https://github.com/user-attachments/assets/30869246-3370-49eb-bee6-b393c752189d

After:
![2026-01-29_16-01-48](https://github.com/user-attachments/assets/f3b8c5bd-afe0-4356-a9b0-edf362ccd819)

Other games remain unaffected:
![2026-01-29_16-02-04](https://github.com/user-attachments/assets/0e02b028-d2bc-495a-b9f8-d11f45af489f)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂