### PR TITLE
Verify CreateGameResults cookie before use

### DIFF
--- a/game/addons/menu/Code/Modals/CreateGameModal/CreateGameModal.razor
+++ b/game/addons/menu/Code/Modals/CreateGameModal/CreateGameModal.razor
@@ -149,6 +149,18 @@
         } );
 
         //
+        // Verify cookie data
+        //
+        if ( Output.MaxPlayers < MinPlayers )
+        {
+            Output.MaxPlayers = MinPlayers;
+        }
+        if ( string.IsNullOrEmpty( Output.ServerName ) )
+        {
+            ServerName = $"{Sandbox.Utility.Steam.PersonaName}'s game";
+        }
+
+        //
         // Apply config / defaults
         //
         Players = Output.MaxPlayers;

--- a/game/addons/menu/Code/Modals/CreateGameModal/CreateGameModal.razor
+++ b/game/addons/menu/Code/Modals/CreateGameModal/CreateGameModal.razor
@@ -149,23 +149,23 @@
         } );
 
         //
-        // Verify cookie data
-        //
-        if ( Output.MaxPlayers < MinPlayers )
-        {
-            Output.MaxPlayers = MinPlayers;
-        }
-        if ( string.IsNullOrEmpty( Output.ServerName ) )
-        {
-            ServerName = $"{Sandbox.Utility.Steam.PersonaName}'s game";
-        }
-
-        //
         // Apply config / defaults
         //
         Players = Output.MaxPlayers;
         ServerName = Output.ServerName;
         Settings = Package.GetMeta( "GameSettings", new List<GameSetting>() );
+
+        //
+        // Verify cookie data
+        //
+        if ( Players < MinPlayers )
+        {
+            Players = MinPlayers;
+        }
+        if ( string.IsNullOrEmpty( ServerName ) )
+        {
+            ServerName = $"{Sandbox.Utility.Steam.PersonaName}'s game";
+        }
 
         //
         // Initialize GameSettings dictionary with defaults if missing


### PR DESCRIPTION
## Summary

This PR verifies the data stored in the CreateGameResults cookie before use.

## Motivation & Context

Copilot made a comment on my other PR #9929. It follows:
> Conditionally hiding the Max Players slider when `MinPlayers == MaxPlayers` solves the UI issue, but it doesn’t actually enforce that fixed player count in the data that gets saved and passed to `CreateGameResults`. If a user has an existing cookie from when `MinPlayers` and `MaxPlayers` differed, `Output.MaxPlayers` (and thus `Players`) can still hold an out-of-range value even though the slider is now hidden, which contradicts the intent of always using the fixed player count for these games. Consider explicitly forcing `Players` to `MinPlayers` when `MinPlayers == MaxPlayers` (e.g. on initialization and/or in `OnSave`) so that stale cookie values cannot override the package’s fixed player count.

I figured that would be a separate change, so I made a separate PR.

## Implementation Details

If either value in the cookie has a now-invalid value, they are replaced with the default value.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂