### PR TITLE
Add BaseLength

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
@@ -21,10 +21,10 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	public LineRenderer LinkedRenderer { get; set; }
 	
 	/// <summary>
-	/// Controls the rope's target length. Set to 0 for initial length when enabled.
+	/// Controls the rope's base length before <see cref="Slack"/> is applied. Set to 0 for initial length when enabled.
 	/// </summary>
 	[Property, Group( "Simulation" )]
-	public float TargetLength { get; set; } = 0f;
+	public float BaseLength { get; set; } = 0f;
 
 	/// <summary>
 	/// Additional slack, added to the rope length.
@@ -71,7 +71,7 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// <summary>
 	/// The length the rope would like to have.
 	/// </summary>
-	private float targetRopeLength => (TargetLength > 0f ? TargetLength : initialRopeLength) + Slack;
+	private float targetRopeLength => (BaseLength > 0f ? BaseLength : initialRopeLength) + Slack;
 
 	/// <summary>
 	/// Set on Initialize based on distance between attachment points and slack.

--- a/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
@@ -19,7 +19,7 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// </summary>
 	[Property, Group( "Attachment" )]
 	public LineRenderer LinkedRenderer { get; set; }
-	
+
 	/// <summary>
 	/// Controls the rope's base length before <see cref="Slack"/> is applied. Set to 0 for initial length when enabled.
 	/// </summary>

--- a/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
@@ -47,19 +47,19 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// <summary>
 	/// Rope stiffness factor. Higher values make the rope more rigid.
 	/// </summary>
-	[Property, Group( "Advanced", StartFolded = true )]
+	[Advanced, Property]
 	public float Stiffness { get; set; } = 0.7f;
 
 	/// <summary>
 	/// Dampens rope movement. Higher values make the rope settle faster.
 	/// </summary>
-	[Property, Group( "Advanced", StartFolded = true )]
+	[Advanced, Property]
 	public float DampingFactor { get; set; } = 0.2f;
 
 	/// <summary>
 	/// Controls how easily the rope bends. Lower values allow more bending, higher values make it stiffer.
 	/// </summary>
-	[Property, Group( "Advanced", StartFolded = true )]
+	[Advanced, Property]
 	public float SoftBendFactor { get; set; } = 0.3f;
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
@@ -19,6 +19,12 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// </summary>
 	[Property, Group( "Attachment" )]
 	public LineRenderer LinkedRenderer { get; set; }
+	
+	/// <summary>
+	/// Controls the rope's target length. Set to 0 for initial length when enabled.
+	/// </summary>
+	[Property, Group( "Simulation" )]
+	public float TargetLength { get; set; } = 0f;
 
 	/// <summary>
 	/// Additional slack, added to the rope length.
@@ -65,7 +71,7 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// <summary>
 	/// The length the rope would like to have.
 	/// </summary>
-	private float targetRopeLength => initialRopeLength + Slack;
+	private float targetRopeLength => (TargetLength > 0f ? TargetLength : initialRopeLength) + Slack;
 
 	/// <summary>
 	/// Set on Initialize based on distance between attachment points and slack.

--- a/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
@@ -24,13 +24,33 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// Controls the rope's base length before <see cref="Slack"/> is applied. Set to 0 for initial length when enabled.
 	/// </summary>
 	[Property, Group( "Simulation" )]
-	public float BaseLength { get; set; } = 0f;
+	public float BaseLength
+	{
+		get;
+		set
+		{
+			if ( field == value ) return;
+
+			field = MathF.Max( 0f, value );
+			isAtRest = false; // Wake up rope when length changes
+		}
+	} = 0f;
 
 	/// <summary>
 	/// Additional slack, added to the rope length.
 	/// </summary>
 	[Property, Group( "Simulation" )]
-	public float Slack { get; set; } = 0;
+	public float Slack
+	{
+		get;
+		set
+		{
+			if ( field == value ) return;
+
+			field = value;
+			isAtRest = false; // Wake up rope when slack changes
+		}
+	} = 0f;
 
 	/// <summary>
 	/// Number of segments in the rope. Higher values increase visual fidelity and collision accuracy but quickly reduce performance.


### PR DESCRIPTION
This change adds the TargetLength property, which gives developers the ability to dynamically change the length of the rope instead of relying on the initial length calculated.

Example:
Reeling in a catch with your fishing rod, the rope needs to change length depending on how much string you've got left.

