### PR TITLE
Fix BaseBrushTool trying to dispatch a shader with 0 thread size

### DIFF
--- a/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
@@ -122,8 +122,9 @@ public abstract class BaseBrushTool : EditorTool
 
 	protected virtual void OnPaint( Terrain terrain, TerrainPaintParameters paint )
 	{
-		// stupid?
 		int size = (int)Math.Floor( paint.BrushSettings.Size / terrain.Storage.TerrainSize * terrain.Storage.Resolution );
+		size = Math.Max( size, 1 );
+
 		var opacity = paint.BrushSettings.Opacity * (AllowBrushInvert && Gizmo.IsCtrlPressed ? -1.0f : 1.0f);
 
 		var cs = new ComputeShader( "terrain/cs_terrain_sculpt" );


### PR DESCRIPTION
## Summary

This is a very small fix for an error when BaseBrushTool attempts to dispatch a compute shader with a thread size of 0, caused by a very small brush size.  

## Motivation & Context

Hole/Noise tools will throw an error and won't work if your brush size is very small. When this value is too small, dispatch thread size may get floored to 0 in `BaseBrushTool.OnPaint()`

<img width="819" height="87" alt="image" src="https://github.com/user-attachments/assets/22182f3d-210e-4204-8b25-fbafbe226034" />

I am able to consistently replicate this error on my scene with following conditions:
- 4096x4096 terrain resolution 
- Physical terrain size is 176000 units
- Set hole/noise brush size to 64 or below

## Implementation Details

BaseBrushTool now sets minimum dispatch thread size to 1, similar to how it's done in `PaintTextureTool` already. This will prevent dispatching the shader with 0 threads. 

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂