### PR TITLE
Add fade-in support for Sound.Play

### DIFF
--- a/engine/Sandbox.Engine/Systems/Audio/Mixer.cs
+++ b/engine/Sandbox.Engine/Systems/Audio/Mixer.cs
@@ -344,9 +344,19 @@ public partial class Mixer
 		using var _ = _mixVoice.Start();
 		var volume = voice.Volume;
 
-		if ( voice.IsFading )
+		if ( voice.IsFadingOut )
 		{
 			volume *= voice.Fadeout.EvaluateDelta( (float)voice.TimeUntilFaded.Fraction );
+		}
+
+		if ( voice.IsFadingIn )
+		{
+			volume *= voice.Fadein.EvaluateDelta( (float)voice.TimeUntilFadedIn.Fraction );
+
+			if ( voice.TimeUntilFadedIn )
+			{
+				voice.IsFadingIn = false;
+			}
 		}
 
 		var samples = voice.sampler.GetLastReadSamples();

--- a/engine/Sandbox.Engine/Systems/Audio/MixingThread.cs
+++ b/engine/Sandbox.Engine/Systems/Audio/MixingThread.cs
@@ -140,7 +140,7 @@ static class MixingThread
 		{
 			if ( voice.sampler is null ) return;
 			if ( voice.Finished ) return;
-			if ( voice.sampler.ShouldContinueMixing && !voice.IsFading ) return;
+			if ( voice.sampler.ShouldContinueMixing && !voice.IsFadingOut ) return;
 			if ( voice.TimeUntilFaded == false ) return;
 
 			voice.Finished = true;

--- a/engine/Sandbox.Engine/Systems/Audio/SoundHandle.cs
+++ b/engine/Sandbox.Engine/Systems/Audio/SoundHandle.cs
@@ -104,6 +104,11 @@ public partial class SoundHandle : IValid, IDisposable
 	/// </summary>
 	public Curve Fadeout { get; set; } = new Curve( new( 0, 1 ), new( 1, 0 ) );
 
+	/// <summary>
+	/// The fadein curve for when the sound starts.
+	/// </summary>
+	public Curve Fadein { get; set; } = new Curve( new( 0, 0 ), new( 1, 1 ) );
+
 
 	[Obsolete( "This is not used anymore" )]
 	public float Decibels { get; set; } = 70.0f;
@@ -186,9 +191,19 @@ public partial class SoundHandle : IValid, IDisposable
 	internal RealTimeUntil TimeUntilFaded { get; set; }
 
 	/// <summary>
+	/// Time remaining until the fade-in completes
+	/// </summary>
+	internal RealTimeUntil TimeUntilFadedIn { get; set; }
+
+	/// <summary>
 	/// Have we started fading out?
 	/// </summary>
-	internal bool IsFading { get; set; }
+	internal bool IsFadingOut { get; set; }
+
+	/// <summary>
+	/// Are we currently fading in?
+	/// </summary>
+	internal bool IsFadingIn { get; set; }
 
 	/// <summary>
 	/// True if the sound has been stopped
@@ -228,12 +243,12 @@ public partial class SoundHandle : IValid, IDisposable
 
 	public void Stop( float fadeTime = 0.0f )
 	{
-		if ( Finished || IsFading ) return;
+		if ( Finished || IsFadingOut ) return;
 
 		if ( fadeTime > 0.0f )
 		{
 			TimeUntilFaded = fadeTime;
-			IsFading = true;
+			IsFadingOut = true;
 
 			return;
 		}

--- a/engine/Sandbox.Engine/Systems/Audio/SoundStream.cs
+++ b/engine/Sandbox.Engine/Systems/Audio/SoundStream.cs
@@ -99,7 +99,7 @@ public sealed partial class SoundStream : IHandle, IDisposable
 		if ( table.IsNull )
 			return default;
 
-		return Sound.PlayFile( table, volume, pitch, 0, "Sound Stream" );
+		return Sound.PlayFile( table, volume, pitch, 0, 0.0f, "Sound Stream" );
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This PR adds in the ability to fade-in a sound. This is similar to the functionality that is present in `SoundHandle.Stop(...)` where you can optionally pass in a fade-out time.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

Follows the exact same structure as `fade-out`, nothing crazy.  In the case where we are fading-in and fading-out, I made the choice of fading-out taking precedence over `fade-in`. 

My only two concerns are...
1. Are we okay with passing an extra parameter like this into `Sound.Play`? We do for `SoundHandle.Stop(...)`
2. Let's make sure we don't break any current APIs

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂