### PR TITLE
Blender Style Rotation Gizmos

### DIFF
--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.BoundingBox.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.BoundingBox.cs
@@ -7,7 +7,7 @@ public static partial class Gizmo
 		private static bool ArrowPoint( string name, Vector3 direction, float length, Color color, out float distance, ref bool pressed )
 		{
 			distance = 0.0f;
-			var rotation = Rotation.LookAt( direction, Vector3.Up );
+			var rotation = global::Rotation.LookAt( direction, Vector3.Up );
 			using var x = Scope( name, direction * length, rotation );
 			var worldBoxScale = Transform.UniformScale;
 			using var scaler = PushFixedScale();
@@ -47,7 +47,7 @@ public static partial class Gizmo
 				Transform = Transform.ToWorld( new Transform( Vector3.Backward * (length * 2.0f) ) );
 				using ( PushFixedScale() )
 				{
-					Transform = Transform.WithRotation( Rotation.LookAt( Transform.Rotation.Forward, Camera.Rotation.Forward ) );
+					Transform = Transform.WithRotation( global::Rotation.LookAt( Transform.Rotation.Forward, Camera.Rotation.Forward ) );
 					var delta = GetMouseDelta( Vector3.Zero, Vector3.Up );
 					distance = Vector3.Forward.Dot( GetMouseDelta( Vector3.Zero, Vector3.Up ) );
 					distance /= worldBoxScale;

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Capsule.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Capsule.cs
@@ -15,7 +15,7 @@ public static partial class Gizmo
 			if ( diff.IsNearZeroLength )
 				return false;
 
-			var rot = Rotation.LookAt( diff );
+			var rot = global::Rotation.LookAt( diff );
 			var localCameraRot = Transform.RotationToLocal( Camera.Rotation );
 
 			Draw.LineThickness = 4.0f;

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Capsule.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Capsule.cs
@@ -1,4 +1,4 @@
-﻿namespace Sandbox;
+namespace Sandbox;
 
 public static partial class Gizmo
 {
@@ -35,7 +35,7 @@ public static partial class Gizmo
 				{
 					using ( Hitbox.LineScope() )
 					{
-						var delta = GetMouseDistanceDelta( 0, Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
+						var delta = GetMouseDistanceDelta( 0, global::Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
 
 						if ( Pressed.This )
 						{
@@ -50,7 +50,7 @@ public static partial class Gizmo
 				{
 					using ( Hitbox.LineScope() )
 					{
-						var delta = GetMouseDistanceDelta( 0, Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
+						var delta = GetMouseDistanceDelta( 0, global::Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
 
 						if ( Pressed.This )
 						{

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Rotation.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Rotation.cs
@@ -1,12 +1,79 @@
-﻿namespace Sandbox;
+namespace Sandbox;
 
 public static partial class Gizmo
 {
 	public sealed partial class GizmoControls
 	{
 		/// <summary>
-		/// A full 3d rotation gizmo. If rotated will return true and newValue will be the new value
+		/// A full 3d rotation gizmo. If rotated will return true and outValue will be the rotation delta.
 		/// </summary>
+		public bool Rotate( string name, out Rotation outValue )
+		{
+			using var scaler = Gizmo.GizmoControls.PushFixedScale();
+			outValue = Rotation.Identity;
+
+			bool hasValueChanged = false;
+
+			using ( Sandbox.Gizmo.Scope( name ) )
+			{
+				Sandbox.Gizmo.Draw.IgnoreDepth = true;
+
+				using ( Sandbox.Gizmo.Scope( "pitch", 0, Rotation.LookAt( Vector3.Left ) ) )
+				{
+					if ( RotateSingle( "pitch", Sandbox.Gizmo.Colors.Pitch, out var angleDelta ) )
+					{
+						outValue *= Rotation.FromAxis( Vector3.Left, angleDelta );
+						hasValueChanged = true;
+					}
+				}
+
+				using ( Sandbox.Gizmo.Scope( "yaw", 0, Rotation.LookAt( Vector3.Up ) ) )
+				{
+					if ( RotateSingle( "yaw", Sandbox.Gizmo.Colors.Yaw, out var angleDelta ) )
+					{
+						outValue *= Rotation.FromAxis( Vector3.Up, angleDelta );
+						hasValueChanged = true;
+					}
+				}
+
+				using ( Sandbox.Gizmo.Scope( "roll", 0, Rotation.LookAt( Vector3.Forward ) ) )
+				{
+					if ( RotateSingle( "roll", Sandbox.Gizmo.Colors.Roll, out var angleDelta ) )
+					{
+						outValue *= Rotation.FromAxis( Vector3.Forward, angleDelta );
+						hasValueChanged = true;
+					}
+				}
+
+				float _angleDelta;
+				bool rotateSingle;
+
+				using ( Sandbox.Gizmo.Scope( "view", 0, Gizmo.Transform.Rotation.Inverse * Gizmo.Camera.Rotation ) )
+				{
+					rotateSingle = RotateSingle( "view", Color.White, out _angleDelta, 22, false );
+				}
+
+				using ( Sandbox.Gizmo.Scope( "view", 0, Rotation.Identity ) )
+				{
+					if ( rotateSingle )
+					{
+						var camForward = Gizmo.Transform.NormalToLocal( Gizmo.CameraTransform.Rotation.Forward );
+						outValue *= Rotation.FromAxis( camForward, _angleDelta );
+						hasValueChanged = true;
+					}
+				}
+
+				if ( RotateTrackball( "trackball", Color.White, out var trackballRotation ) )
+				{
+					outValue *= trackballRotation;
+					hasValueChanged = true;
+				}
+			}
+
+			return hasValueChanged;
+		}
+
+		[Obsolete( "Use Rotate( string name, out Rotation outValue ) and WorldRotation = outValue rather than *=" )]
 		public bool Rotate( string name, out Angles outValue )
 		{
 			using var scaler = Gizmo.GizmoControls.PushFixedScale();
@@ -49,11 +116,10 @@ public static partial class Gizmo
 			return hasValueChanged;
 		}
 
-
 		/// <summary>
 		/// A single rotation axis
 		/// </summary>
-		public bool RotateSingle( string name, Color color, out float angleDelta, float size = 19.0f )
+		public bool RotateSingle( string name, Color color, out float angleDelta, float size = 19.0f, bool useHalfCircle = true )
 		{
 			angleDelta = 0;
 
@@ -77,9 +143,13 @@ public static partial class Gizmo
 				{
 					Sandbox.Gizmo.Draw.LineCircle( 0, size, sections: 64 );
 				}
-				else
+				else if ( useHalfCircle )
 				{
 					Sandbox.Gizmo.Draw.ScreenBiasedHalfCircle( 0, size );
+				}
+				else
+				{
+					Sandbox.Gizmo.Draw.LineCircle( 0, size, sections: 64 );
 				}
 			}
 
@@ -114,7 +184,7 @@ public static partial class Gizmo
 			if ( facingCamera > 0.5f )
 				dragNormal = Vector3.Forward;
 
-			var delta = Sandbox.Gizmo.GetMouseDelta( pressPoint, dragNormal );
+			var delta = Sandbox.Gizmo.GetMouseDistanceVector( pressPoint, dragNormal );
 			var angleDifference = delta.Dot( tangent ) * -4.0f;
 
 			//Gizmo.Draw.Plane( pressPoint, dragNormal );
@@ -124,9 +194,73 @@ public static partial class Gizmo
 
 			if ( angleDifference == 0.0f ) return false;
 
-			angleDelta = angleDifference;
+			angleDelta = -angleDifference;
 			return true;
 		}
 
+		/// <summary>
+		/// Trackball rotation using camera-relative axes - allows free rotation by dragging a sphere in the center
+		/// </summary>
+		private bool RotateTrackball( string name, Color color, out Rotation rotationDelta, float size = 16.0f )
+		{
+			rotationDelta = Rotation.Identity;
+			var sphere = new Sphere( Vector3.Zero, size );
+
+			using var _ = Sandbox.Gizmo.Scope( name );
+
+			Sandbox.Gizmo.Draw.Color = color.WithAlpha( 0.15f );
+
+			if ( !Sandbox.Gizmo.IsHovered )
+				Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Draw.Color.Darken( 0.33f );
+
+			if ( Sandbox.Gizmo.IsHovered )
+			{
+				Sandbox.Gizmo.Draw.Color = color.WithAlpha( 0.3f );
+			}
+
+			if ( Pressed.Any && !Pressed.This )
+			{
+				Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Draw.Color.WithAlphaMultiplied( 0.5f );
+			}
+
+			if ( Pressed.This )
+			{
+				Sandbox.Gizmo.Draw.Color = color.WithAlpha( 0.5f );
+			}
+
+			Sandbox.Gizmo.Draw.SolidSphere( Vector3.Zero, size, 24, 24 );
+
+			// Add sphere hitbox
+			Gizmo.Hitbox.Sphere( sphere );
+
+			if ( !Sandbox.Gizmo.IsHovered || !Pressed.This )
+				return false;
+
+			var localCameraRot = Gizmo.LocalCameraTransform.Rotation;
+
+			// Use the same ray transformation as RotateSingle for consistent world/local space behavior
+			Vector3 pressPoint = Vector3.Zero;
+			var plane = new Plane( 0, Vector3.Forward );
+			if ( Camera.Ortho && Camera.Rotation.Forward.Abs() != Transform.Forward.Abs() )
+			{
+				pressPoint = Pressed.Ray.ToLocal( Gizmo.Transform ).Position;
+			}
+			else if ( !plane.TryTrace( Pressed.Ray.ToLocal( Gizmo.Transform ), out pressPoint, true ) ) return false;
+
+			var delta = Sandbox.Gizmo.GetMouseDistanceVector( pressPoint, localCameraRot.Forward );
+
+			var dir = Vector3.Cross( delta, localCameraRot.Forward ).Normal;
+
+			var angleDifference = delta.Length * 1.5f;
+
+			// don't let scale affect the drag amounts
+			angleDifference /= Gizmo.Transform.UniformScale;
+
+			if ( angleDifference == 0.0f ) return false;
+
+			rotationDelta = Rotation.FromAxis( dir, angleDifference ).Inverse;
+
+			return true;
+		}
 	}
 }

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Rotation.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Rotation.cs
@@ -7,10 +7,10 @@ public static partial class Gizmo
 		/// <summary>
 		/// A full 3d rotation gizmo. If rotated will return true and outValue will be the rotation delta.
 		/// </summary>
-		public bool Rotate( string name, out Rotation outValue )
+		public bool Rotation( string name, out global::Rotation outValue )
 		{
 			using var scaler = Gizmo.GizmoControls.PushFixedScale();
-			outValue = Rotation.Identity;
+			outValue = global::Rotation.Identity;
 
 			bool hasValueChanged = false;
 
@@ -18,29 +18,29 @@ public static partial class Gizmo
 			{
 				Sandbox.Gizmo.Draw.IgnoreDepth = true;
 
-				using ( Sandbox.Gizmo.Scope( "pitch", 0, Rotation.LookAt( Vector3.Left ) ) )
+				using ( Sandbox.Gizmo.Scope( "pitch", 0, global::Rotation.LookAt( Vector3.Left ) ) )
 				{
 					if ( RotateSingle( "pitch", Sandbox.Gizmo.Colors.Pitch, out var angleDelta ) )
 					{
-						outValue *= Rotation.FromAxis( Vector3.Left, angleDelta );
+						outValue *= global::Rotation.FromAxis( Vector3.Left, angleDelta );
 						hasValueChanged = true;
 					}
 				}
 
-				using ( Sandbox.Gizmo.Scope( "yaw", 0, Rotation.LookAt( Vector3.Up ) ) )
+				using ( Sandbox.Gizmo.Scope( "yaw", 0, global::Rotation.LookAt( Vector3.Up ) ) )
 				{
 					if ( RotateSingle( "yaw", Sandbox.Gizmo.Colors.Yaw, out var angleDelta ) )
 					{
-						outValue *= Rotation.FromAxis( Vector3.Up, angleDelta );
+						outValue *= global::Rotation.FromAxis( Vector3.Up, angleDelta );
 						hasValueChanged = true;
 					}
 				}
 
-				using ( Sandbox.Gizmo.Scope( "roll", 0, Rotation.LookAt( Vector3.Forward ) ) )
+				using ( Sandbox.Gizmo.Scope( "roll", 0, global::Rotation.LookAt( Vector3.Forward ) ) )
 				{
 					if ( RotateSingle( "roll", Sandbox.Gizmo.Colors.Roll, out var angleDelta ) )
 					{
-						outValue *= Rotation.FromAxis( Vector3.Forward, angleDelta );
+						outValue *= global::Rotation.FromAxis( Vector3.Forward, angleDelta );
 						hasValueChanged = true;
 					}
 				}
@@ -53,12 +53,12 @@ public static partial class Gizmo
 					rotateSingle = RotateSingle( "view", Color.White, out _angleDelta, 22, false );
 				}
 
-				using ( Sandbox.Gizmo.Scope( "view", 0, Rotation.Identity ) )
+				using ( Sandbox.Gizmo.Scope( "view", 0, global::Rotation.Identity ) )
 				{
 					if ( rotateSingle )
 					{
 						var camForward = Gizmo.Transform.NormalToLocal( Gizmo.CameraTransform.Rotation.Forward );
-						outValue *= Rotation.FromAxis( camForward, _angleDelta );
+						outValue *= global::Rotation.FromAxis( camForward, _angleDelta );
 						hasValueChanged = true;
 					}
 				}
@@ -73,7 +73,7 @@ public static partial class Gizmo
 			return hasValueChanged;
 		}
 
-		[Obsolete( "Use Rotate( string name, out Rotation outValue ) and WorldRotation = outValue rather than *=" )]
+		[Obsolete( "Use Rotation( string name, out global::Rotation outValue ) and WorldRotation = outValue rather than *=" )]
 		public bool Rotate( string name, out Angles outValue )
 		{
 			using var scaler = Gizmo.GizmoControls.PushFixedScale();
@@ -85,7 +85,7 @@ public static partial class Gizmo
 			{
 				Sandbox.Gizmo.Draw.IgnoreDepth = true;
 
-				using ( Sandbox.Gizmo.Scope( "pitch", 0, Rotation.LookAt( Vector3.Left ) ) )
+				using ( Sandbox.Gizmo.Scope( "pitch", 0, global::Rotation.LookAt( Vector3.Left ) ) )
 				{
 					if ( RotateSingle( "pitch", Sandbox.Gizmo.Colors.Pitch, out var angleDelta ) )
 					{
@@ -94,7 +94,7 @@ public static partial class Gizmo
 					}
 				}
 
-				using ( Sandbox.Gizmo.Scope( "yaw", 0, Rotation.LookAt( Vector3.Up ) ) )
+				using ( Sandbox.Gizmo.Scope( "yaw", 0, global::Rotation.LookAt( Vector3.Up ) ) )
 				{
 					if ( RotateSingle( "yaw", Sandbox.Gizmo.Colors.Yaw, out var angleDelta ) )
 					{
@@ -103,7 +103,7 @@ public static partial class Gizmo
 					}
 				}
 
-				using ( Sandbox.Gizmo.Scope( "roll", 0, Rotation.LookAt( Vector3.Forward ) ) )
+				using ( Sandbox.Gizmo.Scope( "roll", 0, global::Rotation.LookAt( Vector3.Forward ) ) )
 				{
 					if ( RotateSingle( "roll", Sandbox.Gizmo.Colors.Roll, out var angleDelta ) )
 					{
@@ -201,9 +201,9 @@ public static partial class Gizmo
 		/// <summary>
 		/// Trackball rotation using camera-relative axes - allows free rotation by dragging a sphere in the center
 		/// </summary>
-		private bool RotateTrackball( string name, Color color, out Rotation rotationDelta, float size = 16.0f )
+		private bool RotateTrackball( string name, Color color, out global::Rotation rotationDelta, float size = 16.0f )
 		{
-			rotationDelta = Rotation.Identity;
+			rotationDelta = global::Rotation.Identity;
 			var sphere = new Sphere( Vector3.Zero, size );
 
 			using var _ = Sandbox.Gizmo.Scope( name );
@@ -258,7 +258,7 @@ public static partial class Gizmo
 
 			if ( angleDifference == 0.0f ) return false;
 
-			rotationDelta = Rotation.FromAxis( dir, angleDifference ).Inverse;
+			rotationDelta = global::Rotation.FromAxis( dir, angleDifference ).Inverse;
 
 			return true;
 		}

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Scale.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Scale.cs
@@ -54,19 +54,19 @@ public static partial class Gizmo
 		/// <summary>
 		/// A front left up position movement widget. If widget was moved then will return true and out will return the new position.
 		/// </summary>
-		public bool Scale( string name, Vector3 value, out Vector3 outValue, Rotation? axisRotation = null, float squareSize = 3.0f )
+		public bool Scale( string name, Vector3 value, out Vector3 outValue, global::Rotation? axisRotation = null, float squareSize = 3.0f )
 		{
 			using var scaler = PushFixedScale();
 
 			var screenScale = 1.0f;
 			var localRotation = Transform.Rotation;
-			var axis = axisRotation ?? Rotation.Identity;
+			var axis = axisRotation ?? global::Rotation.Identity;
 			outValue = value;
 
 			using var x = Sandbox.Gizmo.Scope( name, Vector3.Zero, axis );
 
 			if ( Settings.GlobalSpace )
-				Transform = Transform.WithRotation( Rotation.Identity );
+				Transform = Transform.WithRotation( global::Rotation.Identity );
 
 			using ( Sandbox.Gizmo.Scope( name ) )
 			{
@@ -101,7 +101,7 @@ public static partial class Gizmo
 					{
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.ToWorld( new Transform( Vector3.Zero ) );
 						Sandbox.Gizmo.Draw.Color = Color.White;
-						if ( DragBox( "center", squareSize, Rotation.Identity, out var moved ) )
+						if ( DragBox( "center", squareSize, global::Rotation.Identity, out var moved ) )
 						{
 							movement += moved;
 						}
@@ -111,7 +111,7 @@ public static partial class Gizmo
 					{
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.ToWorld( new Transform( Vector3.Up * squareOffset + Vector3.Left * squareOffset ) );
 						Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Colors.Up;
-						if ( DragSquare( "left-up", squareSize, Rotation.LookAt( Vector3.Backward, Vector3.Up ), out var moved ) )
+						if ( DragSquare( "left-up", squareSize, global::Rotation.LookAt( Vector3.Backward, Vector3.Up ), out var moved ) )
 						{
 							movement += moved;
 						}
@@ -121,7 +121,7 @@ public static partial class Gizmo
 					{
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.ToWorld( new Transform( Vector3.Forward * squareOffset + Vector3.Left * squareOffset ) );
 						Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Colors.Left;
-						if ( DragSquare( "forward-left", squareSize, Rotation.LookAt( Vector3.Up, Vector3.Forward ), out var moved ) )
+						if ( DragSquare( "forward-left", squareSize, global::Rotation.LookAt( Vector3.Up, Vector3.Forward ), out var moved ) )
 						{
 							movement += moved;
 						}
@@ -131,7 +131,7 @@ public static partial class Gizmo
 					{
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.ToWorld( new Transform( Vector3.Forward * squareOffset + Vector3.Up * squareOffset ) );
 						Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Colors.Forward;
-						if ( DragSquare( "forward-up", squareSize, Rotation.LookAt( Vector3.Left, Vector3.Down ), out var moved ) )
+						if ( DragSquare( "forward-up", squareSize, global::Rotation.LookAt( Vector3.Left, Vector3.Down ), out var moved ) )
 						{
 							movement += moved;
 						}

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Sphere.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Sphere.cs
@@ -28,7 +28,7 @@ public static partial class Gizmo
 
 				using ( Hitbox.LineScope() )
 				{
-					var delta = Sandbox.Gizmo.GetMouseDistanceDelta( 0, Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
+					var delta = Sandbox.Gizmo.GetMouseDistanceDelta( 0, global::Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
 
 					if ( Pressed.This )
 					{

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -1,4 +1,4 @@
-﻿namespace Sandbox;
+namespace Sandbox;
 
 public static partial class Gizmo
 {
@@ -22,7 +22,7 @@ public static partial class Gizmo
 		/// <summary>
 		/// A front left up position movement widget. If widget was moved then will return true and out will return the new position.
 		/// </summary>
-		public bool Position( string name, Vector3 position, out Vector3 newPos, Rotation? axisRotation = null, float squareSize = 3.0f )
+		public bool Position( string name, Vector3 position, out Vector3 newPos, global::Rotation? axisRotation = null, float squareSize = 3.0f )
 		{
 			if ( position.IsNaN )
 			{
@@ -32,7 +32,7 @@ public static partial class Gizmo
 
 			var localRotation = Transform.Rotation;
 			var localScale = Transform.UniformScale;
-			var axis = axisRotation ?? Rotation.Identity;
+			var axis = axisRotation ?? global::Rotation.Identity;
 
 			using var x = Sandbox.Gizmo.Scope( name, Vector3.Zero, axis );
 
@@ -40,7 +40,7 @@ public static partial class Gizmo
 
 			// I don't know if we should even be doing this here or leave it to the implementation
 			if ( Settings.GlobalSpace )
-				Transform = Transform.WithRotation( Rotation.Identity );
+				Transform = Transform.WithRotation( global::Rotation.Identity );
 
 			Sandbox.Gizmo.Draw.IgnoreDepth = true;
 
@@ -90,7 +90,7 @@ public static partial class Gizmo
 				{
 					Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.ToWorld( new Transform( Vector3.Up * squareOffset + Vector3.Left * squareOffset ) );
 					Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Colors.Up;
-					if ( DragSquare( "left-up", squareSize, Rotation.LookAt( Vector3.Backward, Vector3.Up ), out var moved ) )
+					if ( DragSquare( "left-up", squareSize, global::Rotation.LookAt( Vector3.Backward, Vector3.Up ), out var moved ) )
 					{
 						movement += moved;
 					}
@@ -100,7 +100,7 @@ public static partial class Gizmo
 				{
 					Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.ToWorld( new Transform( Vector3.Forward * squareOffset + Vector3.Left * squareOffset ) );
 					Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Colors.Left;
-					if ( DragSquare( "forward-left", squareSize, Rotation.LookAt( Vector3.Up, Vector3.Forward ), out var moved ) )
+					if ( DragSquare( "forward-left", squareSize, global::Rotation.LookAt( Vector3.Up, Vector3.Forward ), out var moved ) )
 					{
 						movement += moved;
 					}
@@ -110,7 +110,7 @@ public static partial class Gizmo
 				{
 					Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.ToWorld( new Transform( Vector3.Forward * squareOffset + Vector3.Up * squareOffset ) );
 					Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Colors.Forward;
-					if ( DragSquare( "forward-up", squareSize, Rotation.LookAt( Vector3.Left, Vector3.Down ), out var moved ) )
+					if ( DragSquare( "forward-up", squareSize, global::Rotation.LookAt( Vector3.Left, Vector3.Down ), out var moved ) )
 					{
 						movement += moved;
 					}
@@ -162,7 +162,7 @@ public static partial class Gizmo
 			var localCam = Transform.RotationToLocal( Camera.Rotation );
 
 			// Use the camera to provide a plane that'll work for us
-			var rot = Rotation.LookAt( axis, Vector3.Up );
+			var rot = global::Rotation.LookAt( axis, Vector3.Up );
 
 			using var x = Sandbox.Gizmo.Scope( name, axis * axisOffset, rot );
 
@@ -200,7 +200,7 @@ public static partial class Gizmo
 				return false;
 
 			// use a plane that follows the axis but that uses the camera's plane
-			Gizmo.Transform = Gizmo.Transform.WithRotation( Rotation.LookAt( Transform.Rotation.Forward, Camera.Rotation.Forward ) );
+			Gizmo.Transform = Gizmo.Transform.WithRotation( global::Rotation.LookAt( Transform.Rotation.Forward, Camera.Rotation.Forward ) );
 
 
 			//
@@ -215,7 +215,7 @@ public static partial class Gizmo
 
 		}
 
-		public bool DragBox( string name, Vector3 size, Rotation rotation, out Vector3 movement )
+		public bool DragBox( string name, Vector3 size, global::Rotation rotation, out Vector3 movement )
 		{
 			movement = default;
 			var box = new BBox( -size * 0.5f, size * 0.5f );
@@ -266,7 +266,7 @@ public static partial class Gizmo
 		/// <summary>
 		/// Manipulate a 2d value by moving on 2 axis
 		/// </summary>
-		public bool DragSquare( string name, Vector2 size, Rotation rotation, out Vector3 movement, Action drawHandle = null )
+		public bool DragSquare( string name, Vector2 size, global::Rotation rotation, out Vector3 movement, Action drawHandle = null )
 		{
 			movement = default;
 			var bbox = new BBox( new Vector3( -0.01f, -size.x, -size.y ), new Vector3( 0.01f, size.x, size.y ) );

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -244,7 +244,7 @@ public static partial class Gizmo
 
 			var localCameraRot = Transform.RotationToLocal( Camera.Rotation );
 
-			var delta = Sandbox.Gizmo.GetMouseDelta( 0, Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
+			var delta = Sandbox.Gizmo.GetMouseDelta( 0, global::Rotation.FromAxis( localCameraRot.Forward, 0 ).Forward );
 			movement = Vector3.One.Dot( delta );
 
 			// Optional: Debug drawing

--- a/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.cs
@@ -248,9 +248,9 @@ public static partial class Gizmo
 	}
 
 	/// <summary>
-	/// Get the distance from a point on a plane
+	/// Get the vector distance from a point on a plane
 	/// </summary>
-	public static float GetMouseDistance( Vector3 position, Vector3 planeNormal )
+	public static Vector3 GetMouseDistanceVector( Vector3 position, Vector3 planeNormal )
 	{
 		var plane = new Plane( position, planeNormal );
 
@@ -258,7 +258,15 @@ public static partial class Gizmo
 
 		if ( a == null ) return 0.0f;
 
-		return (position - a.Value).Length;
+		return position - a.Value;
+	}
+
+	/// <summary>
+	/// Get the distance from a point on a plane
+	/// </summary>
+	public static float GetMouseDistance( Vector3 position, Vector3 planeNormal )
+	{
+		return GetMouseDistanceVector( position, planeNormal ).Length;
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.cs
@@ -372,15 +372,15 @@ public static partial class Gizmo
 
 		// Extract axis and angle from quaternion
 		var quat = rotationDelta._quat;
-		
+
 		// Calculate angle from w component (in degrees)
 		var angle = 2.0f * MathF.Acos( quat.W ) * 180.0f / MathF.PI;
-		
+
 		var snappedAngle = angle.SnapToGrid( Settings.AngleSpacing );
-		
+
 		if ( snappedAngle.AlmostEqual( 0.0f ) )
 			return Rotation.Identity;
-		
+
 		// Calculate axis
 		var sinHalfAngle = MathF.Sqrt( 1.0f - quat.W * quat.W );
 		Vector3 axis;
@@ -393,7 +393,7 @@ public static partial class Gizmo
 			// For very small angles, default to forward axis
 			axis = Vector3.Forward;
 		}
-		
+
 		// Reconstruct rotation with snapped angle
 		return Rotation.FromAxis( axis, snappedAngle );
 	}

--- a/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Utility;
+using Sandbox.Utility;
 using System.Collections.Immutable;
 
 namespace Sandbox;
@@ -357,6 +357,45 @@ public static partial class Gizmo
 		var sz = !movement.roll.AlmostEqual( 0.0f );
 
 		return input.SnapToGrid( Settings.AngleSpacing, sx, sy, sz );
+	}
+
+	/// <summary>
+	/// Snaps a rotation delta to angle increments.
+	/// </summary>
+	/// <param name="rotationDelta">The rotation delta to snap</param>
+	/// <returns>A snapped rotation that aligns to the angle grid</returns>
+	public static Rotation Snap( Rotation rotationDelta )
+	{
+		// If control does the opposite behaviour
+		if ( Settings.SnapToAngles == IsCtrlPressed )
+			return rotationDelta;
+
+		// Extract axis and angle from quaternion
+		var quat = rotationDelta._quat;
+		
+		// Calculate angle from w component (in degrees)
+		var angle = 2.0f * MathF.Acos( quat.W ) * 180.0f / MathF.PI;
+		
+		var snappedAngle = angle.SnapToGrid( Settings.AngleSpacing );
+		
+		if ( snappedAngle.AlmostEqual( 0.0f ) )
+			return Rotation.Identity;
+		
+		// Calculate axis
+		var sinHalfAngle = MathF.Sqrt( 1.0f - quat.W * quat.W );
+		Vector3 axis;
+		if ( sinHalfAngle > 0.0001f )
+		{
+			axis = new Vector3( quat.X, quat.Y, quat.Z ) / sinHalfAngle;
+		}
+		else
+		{
+			// For very small angles, default to forward axis
+			axis = Vector3.Forward;
+		}
+		
+		// Reconstruct rotation with snapped angle
+		return Rotation.FromAxis( axis, snappedAngle );
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Resources/Model/Model.PhysicsBodyBuilder.cs
+++ b/engine/Sandbox.Engine/Resources/Model/Model.PhysicsBodyBuilder.cs
@@ -103,16 +103,16 @@ public sealed class PhysicsBodyBuilder
 	/// </summary>
 	public enum SimplifyMethod
 	{
-		/// <summary>Quadratic Error Metric – prioritizes preserving shape accuracy.</summary>
+		/// <summary>Quadratic Error Metric ï¿½ prioritizes preserving shape accuracy.</summary>
 		QEM,
 
-		/// <summary>Iterative Vertex Removal – removes vertices gradually.</summary>
+		/// <summary>Iterative Vertex Removal ï¿½ removes vertices gradually.</summary>
 		IVR,
 
-		/// <summary>No simplification – use the exact points provided.</summary>
+		/// <summary>No simplification ï¿½ use the exact points provided.</summary>
 		None,
 
-		/// <summary>Iterative Face Removal – removes faces to reduce complexity.</summary>
+		/// <summary>Iterative Face Removal ï¿½ removes faces to reduce complexity.</summary>
 		IFR
 	}
 

--- a/engine/Sandbox.System/Html/Document.cs
+++ b/engine/Sandbox.System/Html/Document.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright ï¿½ ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System.IO;
 

--- a/engine/Sandbox.System/Html/Node.cs
+++ b/engine/Sandbox.System/Html/Node.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright ï¿½ ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 
 // ReSharper disable InconsistentNaming

--- a/engine/Sandbox.System/Html/NodeType.cs
+++ b/engine/Sandbox.System/Html/NodeType.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright ï¿½ ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace Sandbox.Html
 {

--- a/engine/Sandbox.System/Html/ParseError.cs
+++ b/engine/Sandbox.System/Html/ParseError.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright ï¿½ ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace Sandbox.Html
 {

--- a/engine/Sandbox.System/Html/ParseErrorCode.cs
+++ b/engine/Sandbox.System/Html/ParseErrorCode.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright ï¿½ ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 namespace Sandbox.Html
 {

--- a/engine/Sandbox.System/Html/TextNode.cs
+++ b/engine/Sandbox.System/Html/TextNode.cs
@@ -3,7 +3,7 @@
 // Forum & Issues: https://github.com/zzzprojects/html-agility-pack
 // License: https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE
 // More projects: http://www.zzzprojects.com/
-// Copyright © ZZZ Projects Inc. 2014 - 2017. All rights reserved.
+// Copyright ï¿½ ZZZ Projects Inc. 2014 - 2017. All rights reserved.
 
 using System.Web;
 

--- a/engine/Sandbox.Test.Unit/UI/Styles/StyleSetting.cs
+++ b/engine/Sandbox.Test.Unit/UI/Styles/StyleSetting.cs
@@ -630,7 +630,7 @@ public class StyleSetting
 		Assert.AreEqual( 1, styles.Transitions.List.Count );
 		Assert.AreEqual( "width", styles.Transitions.List[0].Property );
 		Assert.AreEqual( 10, styles.Transitions.List[0].Duration );
-		// Each property has an initial value, defined in the property’s definition table
+		// Each property has an initial value, defined in the propertyï¿½s definition table
 		// https://w3c.github.io/csswg-drafts/css-transitions/#transition-timing-function-property
 		Assert.AreEqual( "ease", styles.Transitions.List[0].TimingFunction );
 		Assert.AreEqual( 0, styles.Transitions.List[0].Delay.Value );

--- a/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
+++ b/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Editor.MeshEditor;
 
 /// <summary>
@@ -12,13 +12,13 @@ namespace Editor.MeshEditor;
 [Order( 1 )]
 public sealed class RotateMode : MoveMode
 {
-	private Angles _moveDelta;
+	private Rotation _moveDelta;
 	private Vector3 _origin;
 	private Rotation _basis;
 
 	public override void OnBegin( SelectionTool tool )
 	{
-		_moveDelta = default;
+		_moveDelta = Rotation.Identity;
 		_basis = tool.CalculateSelectionBasis();
 		_origin = tool.Pivot;
 	}
@@ -30,26 +30,23 @@ public sealed class RotateMode : MoveMode
 			Gizmo.Hitbox.DepthBias = 0.01f;
 			Gizmo.Hitbox.CanInteract = CanUseGizmo;
 
-			if ( Gizmo.Control.Rotate( "rotation", out var angleDelta ) )
+			if ( Gizmo.Control.Rotate( "rotation", out var rotationDelta ) )
 			{
-				_moveDelta += angleDelta;
-
-				var snapDelta = Gizmo.Snap( _moveDelta, _moveDelta );
+				_moveDelta = rotationDelta;
 
 				tool.StartDrag();
-				tool.Rotate( _origin, _basis, snapDelta );
+				tool.Rotate( _origin, _basis, _moveDelta );
 				tool.UpdateDrag();
 			}
 		}
 
-		if ( Gizmo.Pressed.Any && (_moveDelta.pitch != 0 || _moveDelta.yaw != 0 || _moveDelta.roll != 0) )
+		if ( Gizmo.Pressed.Any && _moveDelta != Rotation.Identity )
 		{
-			var snapDelta = Gizmo.Snap( _moveDelta, _moveDelta );
-			DrawRotationAngle( _origin, snapDelta );
+			DrawRotationAngle( _origin, _moveDelta );
 		}
 	}
 
-	private void DrawRotationAngle( Vector3 origin, Angles rotation )
+	private void DrawRotationAngle( Vector3 origin, Rotation rotation )
 	{
 		using ( Gizmo.Scope( "RotationAngle" ) )
 		{
@@ -59,10 +56,11 @@ public sealed class RotateMode : MoveMode
 			var cameraDistance = Gizmo.Camera.Position.Distance( origin );
 			var scaledTextSize = textSize * (cameraDistance / 50.0f).Clamp( 0.5f, 1.0f );
 
+			var angles = rotation.Angles();
 			var angleText = "";
-			if ( rotation.pitch != 0 ) angleText += $"P:{rotation.pitch:0.##}° ";
-			if ( rotation.yaw != 0 ) angleText += $"Y:{rotation.yaw:0.##}° ";
-			if ( rotation.roll != 0 ) angleText += $"R:{rotation.roll:0.##}° ";
+			if ( angles.pitch != 0 ) angleText += $"P:{angles.pitch:0.##}° ";
+			if ( angles.yaw != 0 ) angleText += $"Y:{angles.yaw:0.##}° ";
+			if ( angles.roll != 0 ) angleText += $"R:{angles.roll:0.##}° ";
 
 			angleText = angleText.Trim();
 

--- a/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
+++ b/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
@@ -32,7 +32,7 @@ public sealed class RotateMode : MoveMode
 
 			if ( Gizmo.Control.Rotation( "rotation", out Rotation rotationDelta ) )
 			{
-				_moveDelta = rotationDelta;
+				_moveDelta = Gizmo.Snap( rotationDelta );
 
 				tool.StartDrag();
 				tool.Rotate( _origin, _basis, _moveDelta );

--- a/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
+++ b/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
@@ -30,7 +30,7 @@ public sealed class RotateMode : MoveMode
 			Gizmo.Hitbox.DepthBias = 0.01f;
 			Gizmo.Hitbox.CanInteract = CanUseGizmo;
 
-			if ( Gizmo.Control.Rotate( "rotation", out Rotation rotationDelta ) )
+			if ( Gizmo.Control.Rotation( "rotation", out Rotation rotationDelta ) )
 			{
 				_moveDelta = rotationDelta;
 

--- a/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
+++ b/game/addons/tools/Code/Scene/Mesh/MoveModes/RotateMode.cs
@@ -30,7 +30,7 @@ public sealed class RotateMode : MoveMode
 			Gizmo.Hitbox.DepthBias = 0.01f;
 			Gizmo.Hitbox.CanInteract = CanUseGizmo;
 
-			if ( Gizmo.Control.Rotate( "rotation", out var rotationDelta ) )
+			if ( Gizmo.Control.Rotate( "rotation", out Rotation rotationDelta ) )
 			{
 				_moveDelta = rotationDelta;
 

--- a/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
+++ b/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
@@ -1,4 +1,4 @@
-﻿namespace Editor;
+namespace Editor;
 
 /// <summary>
 /// Rotate selected GameObjects.<br/> <br/> 
@@ -12,7 +12,7 @@
 public class RotationEditorTool : EditorTool
 {
 	Dictionary<GameObject, Transform> startPoints = new Dictionary<GameObject, Transform>();
-	Angles moveDelta;
+	Rotation moveDelta;
 	Vector3 handlePosition;
 	Rotation handleRotation;
 
@@ -29,7 +29,7 @@ public class RotationEditorTool : EditorTool
 		{
 			startPoints.Clear();
 			moveDelta = Rotation.Identity;
-			handleRotation = nonSceneGos.FirstOrDefault().WorldRotation;
+			handleRotation = nonSceneGos.FirstOrDefault()?.WorldRotation ?? Rotation.Identity;
 			handlePosition = bbox.Center;
 			undoScope?.Dispose();
 			undoScope = null;
@@ -45,17 +45,15 @@ public class RotationEditorTool : EditorTool
 		{
 			Gizmo.Hitbox.DepthBias = 0.01f;
 
-			if ( Gizmo.Control.Rotate( "rotation", out var angleDelta ) )
+			if ( Gizmo.Control.Rotate( "rotation", out var rotationDelta ) )
 			{
 				StartDrag( nonSceneGos );
 
-				moveDelta += angleDelta;
-
-				var snapped = Gizmo.Snap( moveDelta, angleDelta );
+				moveDelta = rotationDelta;
 
 				foreach ( var entry in startPoints )
 				{
-					var rot = basis * snapped * basis.Inverse;
+					var rot = basis * moveDelta * basis.Inverse;
 					var position = entry.Value.Position - handlePosition;
 					position *= rot;
 					position += handlePosition;

--- a/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
+++ b/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
@@ -45,7 +45,7 @@ public class RotationEditorTool : EditorTool
 		{
 			Gizmo.Hitbox.DepthBias = 0.01f;
 
-			if ( Gizmo.Control.Rotate( "rotation", out var rotationDelta ) )
+			if ( Gizmo.Control.Rotate( "rotation", out Rotation rotationDelta ) )
 			{
 				StartDrag( nonSceneGos );
 

--- a/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
+++ b/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
@@ -45,7 +45,7 @@ public class RotationEditorTool : EditorTool
 		{
 			Gizmo.Hitbox.DepthBias = 0.01f;
 
-			if ( Gizmo.Control.Rotate( "rotation", out Rotation rotationDelta ) )
+			if ( Gizmo.Control.Rotation( "rotation", out Rotation rotationDelta ) )
 			{
 				StartDrag( nonSceneGos );
 

--- a/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
+++ b/game/addons/tools/Code/Scene/ObjectTool/RotationEditorTool.cs
@@ -49,7 +49,7 @@ public class RotationEditorTool : EditorTool
 			{
 				StartDrag( nonSceneGos );
 
-				moveDelta = rotationDelta;
+				moveDelta = Gizmo.Snap( rotationDelta );
 
 				foreach ( var entry in startPoints )
 				{

--- a/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
+++ b/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
@@ -12,7 +12,7 @@ internal class RotationSimple : ISceneTest
 		{
 			Gizmo.Draw.Color = Gizmo.Colors.Green;
 
-			if ( Gizmo.Control.Rotate( "my-arrow", out var rotationDelta ) )
+			if ( Gizmo.Control.Rotate( "my-arrow", out Rotation rotationDelta ) )
 			{
 				rotation = rotationDelta;
 			}

--- a/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
+++ b/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
@@ -1,10 +1,10 @@
-﻿namespace Editor.Widgets.SceneTests;
+namespace Editor.Widgets.SceneTests;
 
 [Title( "Rotation" ), Icon( "screen_rotation" )]
 [Description( "Standard rotation widget" )]
 internal class RotationSimple : ISceneTest
 {
-	Angles angles;
+	Rotation rotation = Rotation.Identity;
 
 	public void Frame()
 	{
@@ -12,18 +12,19 @@ internal class RotationSimple : ISceneTest
 		{
 			Gizmo.Draw.Color = Gizmo.Colors.Green;
 
-			if ( Gizmo.Control.Rotate( "my-arrow", out var angleDelta ) )
+			if ( Gizmo.Control.Rotate( "my-arrow", out var rotationDelta ) )
 			{
-				angles += angleDelta;
+				rotation = rotationDelta;
 			}
 
-			using ( Gizmo.Scope( "Object", new Transform( 0, angles.ToRotation() ) ) )
+			using ( Gizmo.Scope( "Object", new Transform( 0, rotation ) ) )
 			{
 				Gizmo.Draw.Color = Color.White;
 				Gizmo.Draw.Model( "models/editor/playerstart.vmdl" );
 			}
 		}
 
+		var angles = rotation.Angles();
 		Gizmo.Draw.Color = Color.Black;
 		Gizmo.Draw.Text( $"Value: {angles.pitch:n0}, {angles.yaw:n0}, {angles.roll:n0}", new Transform( Vector3.Down * 50.0f ) );
 	}

--- a/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
+++ b/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
@@ -14,7 +14,7 @@ internal class RotationSimple : ISceneTest
 
 			if ( Gizmo.Control.Rotation( "my-arrow", out Rotation rotationDelta ) )
 			{
-				rotation = rotationDelta;
+				rotation = Gizmo.Snap( rotationDelta );
 			}
 
 			using ( Gizmo.Scope( "Object", new Transform( 0, rotation ) ) )

--- a/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
+++ b/game/addons/tools/Code/WidgetGallery/Examples/Scene/Tests/RotationTest.cs
@@ -12,7 +12,7 @@ internal class RotationSimple : ISceneTest
 		{
 			Gizmo.Draw.Color = Gizmo.Colors.Green;
 
-			if ( Gizmo.Control.Rotate( "my-arrow", out Rotation rotationDelta ) )
+			if ( Gizmo.Control.Rotation( "my-arrow", out Rotation rotationDelta ) )
 			{
 				rotation = rotationDelta;
 			}


### PR DESCRIPTION
## Summary

This PR adds a trackball and view-space rotation gizmo, similar to how blender does it

## Motivation & Context

I'd like to rotate multiple axis at once, or rotate something in view-space. This is really useful for mapping in general and is part of getting feature parity with hammer and other 3D applications.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

Unfortunately to get this working I had to swap the output type of gizmocontrols.rotate to a rotation instead of angles. This is a breaking change for anything that uses this method but I have gone ahead and adjusted any engine code that uses this to reflect the change.

I've also added a gizmo method for a distance vector, the only existing method returned a float.

## Screenshots / Videos (if applicable)

[Screencast_20260206_125638.webm](https://github.com/user-attachments/assets/c530b2a6-c1aa-4454-a2ea-add9e3a66e4a)

## Checklist

- [x] Fix world vs local space rotation
- [x] Fix trackball "drifting" when continuously rotating, should use initial grab point and delta from that point instead of current delta
- [x] Potentially add blender / hammer style rotation indicators with a pie circle that gets filled
- [ ] Unit tests?