### PR TITLE
Nicer bounds for IndirectLightVolume "Fit to Scene Bounds" button

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
+++ b/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
@@ -225,7 +225,7 @@ public sealed partial class IndirectLightVolume : Component, Component.ExecuteIn
 				continue;
 			sceneBounds = sceneBounds.AddBBox( model.RenderBounds.Transform( mesh.WorldTransform ) );
 		}
-		sceneBounds = sceneBounds.Grow( 16 );
+		sceneBounds = sceneBounds.Translate( -WorldPosition ).Grow( 16 );
 
 		Bounds = sceneBounds;
 	}

--- a/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
+++ b/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
@@ -210,11 +210,19 @@ public sealed partial class IndirectLightVolume : Component, Component.ExecuteIn
 		}
 		foreach ( var terrain in Scene.GetAll<Terrain>() )
 		{
-			terrain.UpdateShape();
+			var collision = terrain.EnableCollision; // isnt great but poking around in the heightmap is worse
+			terrain.EnableCollision = true;
 			sceneBounds = sceneBounds.AddBBox( terrain.GetWorldBounds() );
+			if ( !collision )
+				terrain.EnableCollision = false;
 		}
 		foreach ( var mesh in Scene.GetAll<MeshComponent>() )
-			sceneBounds = sceneBounds.AddBBox( mesh.GetWorldBounds() );
+		{
+			var model = mesh.Model;
+			if (model is null)
+				continue;
+			sceneBounds = sceneBounds.AddBBox( model.RenderBounds.Transform( mesh.WorldTransform ) );
+		}
 
 		Bounds = sceneBounds;
 	}

--- a/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
+++ b/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
@@ -202,11 +202,11 @@ public sealed partial class IndirectLightVolume : Component, Component.ExecuteIn
 
 		var sceneBounds = BBox.FromPositionAndSize( WorldPosition );
 
-		foreach ( var hasBounds in Scene.GetAll<IHasBounds>() )
+		foreach ( var renderer in Scene.GetAll<Renderer>() )
 		{
-			if ( hasBounds is not Renderer component )
+			if ( renderer is not IHasBounds bounds )
 				continue;
-			sceneBounds = sceneBounds.AddBBox( hasBounds.LocalBounds.Transform( component.WorldTransform ) );
+			sceneBounds = sceneBounds.AddBBox( bounds.LocalBounds.Transform( renderer.WorldTransform ) );
 		}
 		foreach ( var terrain in Scene.GetAll<Terrain>() )
 		{

--- a/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
+++ b/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
@@ -219,7 +219,7 @@ public sealed partial class IndirectLightVolume : Component, Component.ExecuteIn
 		foreach ( var mesh in Scene.GetAll<MeshComponent>() )
 		{
 			var model = mesh.Model;
-			if (model is null)
+			if ( model is null )
 				continue;
 			sceneBounds = sceneBounds.AddBBox( model.RenderBounds.Transform( mesh.WorldTransform ) );
 		}

--- a/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
+++ b/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
@@ -200,6 +200,8 @@ public sealed partial class IndirectLightVolume : Component, Component.ExecuteIn
 		if ( Scene is null )
 			return;
 
+		WorldScale = 1;
+		WorldRotation = Rotation.Identity;
 		var sceneBounds = BBox.FromPositionAndSize( WorldPosition );
 
 		foreach ( var renderer in Scene.GetAll<Renderer>() )
@@ -223,6 +225,7 @@ public sealed partial class IndirectLightVolume : Component, Component.ExecuteIn
 				continue;
 			sceneBounds = sceneBounds.AddBBox( model.RenderBounds.Transform( mesh.WorldTransform ) );
 		}
+		sceneBounds = sceneBounds.Grow( 16 );
 
 		Bounds = sceneBounds;
 	}


### PR DESCRIPTION
# Pull Request
## Summary

Changes the logic for determining the bounds of the scene in `IndirectLightVolume.ExtendToSceneBounds`, which previously seemed to skip most of the scene.

## Implementation Details

`SceneObject.Bounds` seems to not work for a lot of stuf (at least in the editor) so rather than loop through scene objects it now targets the specific component types `Renderer` `Terrain` and `MeshComponent` and retrieves bounds from them in a more direct way.

## Screenshots
Before
<img width="1597" height="746" alt="image" src="https://github.com/user-attachments/assets/b561ecaa-6e8a-4267-8a9b-d7952289f777" />

After
<img width="1134" height="629" alt="image" src="https://github.com/user-attachments/assets/4c3d239f-62a1-4d70-b380-b4216736f4a4" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂