### PR TITLE
Save Play in Game Mode with cookie project

### DIFF
--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -104,6 +104,7 @@ public class EditorMainWindow : DockWindow
 	private Option discard;
 	private Option undoOption;
 	private Option redoOption;
+	private Option gameMode;
 
 	internal EditorMainWindow()
 	{
@@ -155,10 +156,9 @@ public class EditorMainWindow : DockWindow
 			var gameMenu = MenuBar.AddMenu( "Game" );
 			gameMenu.AddOption( "Play", "play_arrow", EditorScene.TogglePlay, "editor.toggle-play" );
 
-			gameMenu.AddOption( new Option()
+			gameMode = gameMenu.AddOption( new Option()
 			{
 				Checkable = true,
-				Checked = EditorScene.PlayMode,
 				Toggled = ( b ) => EditorScene.PlayMode = b,
 				Text = "Play in Game Mode",
 				Icon = "sports_esports"
@@ -308,6 +308,9 @@ public class EditorMainWindow : DockWindow
 	{
 		// Load gizmo settings
 		EditorScene.RestoreState();
+
+		// Load game mode value
+		gameMode.Checked = EditorScene.PlayMode;
 
 		// Register our menu bar and dock options, doesn't open anything
 		MenuBar.RegisterNamed( "Editor", MenuBar );

--- a/engine/Sandbox.Tools/Scene/EditorScene.cs
+++ b/engine/Sandbox.Tools/Scene/EditorScene.cs
@@ -10,7 +10,11 @@ public static class EditorScene
 	/// <summary>
 	/// Should the game start in play mode when hitting play, instead of playing the active scene.
 	/// </summary>
-	public static bool PlayMode { get; set; } = false;
+	public static bool PlayMode
+	{
+		get => ProjectCookie?.Get( "editor.playmode", false ) ?? false;
+		set => ProjectCookie?.Set( "editor.playmode", value );
+	}
 
 	public static Gizmo.SceneSettings GizmoSettings { get; private set; } = new Gizmo.SceneSettings();
 


### PR DESCRIPTION
## Summary

This PR allows you to save the `Play in Game Mode` option depending on the project.

## Motivation & Context

Fixes: #1166

## Implementation Details

I modified the implementation of the setter and getter for the `PlayMode` variable. I changed the initialization of the checkbox value because we have to wait until `ProjectCookie` is not null.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂