### PR TITLE
Add VS Code fork detection & manual .exe selection to "Code Editor" Selection

### DIFF
--- a/game/addons/tools/Code/CodeEditors/CodeEditor.Rider.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditor.Rider.cs
@@ -34,10 +34,10 @@ public class Rider : ICodeEditor
 	}
 
 	public bool IsInstalled() => !string.IsNullOrEmpty( FindRider() );
-	
+
 	public bool MatchesExecutable( string fileName )
 	{
-		return fileName.Equals( "rider64.exe", StringComparison.OrdinalIgnoreCase ) || 
+		return fileName.Equals( "rider64.exe", StringComparison.OrdinalIgnoreCase ) ||
 			   fileName.Equals( "rider.exe", StringComparison.OrdinalIgnoreCase );
 	}
 

--- a/game/addons/tools/Code/CodeEditors/CodeEditor.Rider.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditor.Rider.cs
@@ -34,6 +34,12 @@ public class Rider : ICodeEditor
 	}
 
 	public bool IsInstalled() => !string.IsNullOrEmpty( FindRider() );
+	
+	public bool MatchesExecutable( string fileName )
+	{
+		return fileName.Equals( "rider64.exe", StringComparison.OrdinalIgnoreCase ) || 
+			   fileName.Equals( "rider.exe", StringComparison.OrdinalIgnoreCase );
+	}
 
 	private static void Launch( string arguments )
 	{
@@ -57,7 +63,15 @@ public class Rider : ICodeEditor
 			return RiderPath;
 		}
 
-		// Always use whatever the user has open first as you can have multiple Rider installations
+		// check manual override cookie
+		var cookiePath = EditorCookie.Get( "CodeEditor.Rider.Path", "" );
+		if ( !string.IsNullOrEmpty( cookiePath ) && System.IO.File.Exists( cookiePath ) )
+		{
+			RiderPath = cookiePath;
+			return RiderPath;
+		}
+
+		// Always use whatever the user has open first as you can have multiple rider installations
 		foreach ( var p in System.Diagnostics.Process.GetProcessesByName( "rider64" ) )
 		{
 			RiderPath = p.MainModule.FileName;

--- a/game/addons/tools/Code/CodeEditors/CodeEditor.VSCode.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditor.VSCode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.Win32;
@@ -59,8 +60,9 @@ public abstract class VSCodeBase : ICodeEditor
 		{
 			FileName = location,
 			Arguments = arguments,
-			CreateNoWindow = true,
-			WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden
+			// CreateNoWindow avoids spawning a console window for GUI processes; do not set WindowStyle.Hidden
+			// so the editor UI can appear or be reused normally.
+			CreateNoWindow = true
 		};
 
 		try
@@ -74,7 +76,7 @@ public abstract class VSCodeBase : ICodeEditor
 	}
 
 	// Static cache to avoid hitting the registry on every frame/widget update
-	private static Dictionary<string, string> _cachedLocations = new Dictionary<string, string>();
+	private static readonly Dictionary<string, string> _cachedLocations = new Dictionary<string, string>();
 	private static readonly Regex _commandRegex = new Regex( "\"([^\"]+)\"", RegexOptions.IgnoreCase );
 
 	[System.Diagnostics.CodeAnalysis.SuppressMessage( "Interoperability", "CA1416:Validate platform compatibility", Justification = "Windows Registry required" )]
@@ -128,17 +130,8 @@ public abstract class VSCodeBase : ICodeEditor
 
 		// extracts the executable path from the registry command string
 		var match = _commandRegex.Match( value );
-		string path;
-
-		if ( match.Success )
-		{
-			path = match.Groups[1].Value;
-		}
-		else
-		{
-			// If Regex fails (no quotes?), assume the whole string is the path
-			path = value;
-		}
+		// Use a conditional expression to clearly express the two possible values
+		string path = match.Success ? match.Groups[1].Value : value;
 
 		// validate that the file actually exists
 		if ( !File.Exists( path ) )
@@ -191,7 +184,7 @@ public class VSCodiumEditor : VSCodeBase
 	public override string RegistryKey => "codium.exe";
 }
 
-[Title( "VSCodium" )]
+[Title( "VSCodium (Alt)" )]
 public class VSCodiumEditorAlt : VSCodeBase
 {
 	public override string RegistryKey => "VSCodium.exe";

--- a/game/addons/tools/Code/CodeEditors/CodeEditor.VSCode.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditor.VSCode.cs
@@ -6,11 +6,10 @@ using Microsoft.Win32;
 
 namespace Editor.CodeEditors;
 
-/// <summary></summary>
-public abstract class VSCodeBase : ICodeEditor
+[Title( "Visual Studio Code" )]
+public class VisualStudioCode : ICodeEditor
 {
-	public abstract string RegistryKey { get; }
-	public virtual bool IsPrimary => false;
+	public string RegistryKey => "Code.exe";
 
 	public void OpenFile( string path, int? line, int? column )
 	{
@@ -145,65 +144,4 @@ public abstract class VSCodeBase : ICodeEditor
 	{
 		return string.Equals( RegistryKey, fileName, StringComparison.OrdinalIgnoreCase );
 	}
-}
-
-[Title( "Visual Studio Code" )]
-public class VisualStudioCode : VSCodeBase
-{
-	public override string RegistryKey => "Code.exe";
-	public override bool IsPrimary => true;
-}
-
-[Title( "VS Code Insiders" )]
-public class VSCodeInsidersEditor : VSCodeBase
-{
-	public override string RegistryKey => "Code - Insiders.exe";
-}
-
-[Title( "Cursor" )]
-public class CursorEditor : VSCodeBase
-{
-	public override string RegistryKey => "Cursor.exe";
-}
-
-[Title( "Windsurf" )]
-public class WindsurfEditor : VSCodeBase
-{
-	public override string RegistryKey => "Windsurf.exe";
-}
-
-[Title( "Trae" )]
-public class TraeEditor : VSCodeBase
-{
-	public override string RegistryKey => "Trae.exe";
-}
-
-[Title( "VSCodium" )]
-public class VSCodiumEditor : VSCodeBase
-{
-	public override string RegistryKey => "codium.exe";
-}
-
-[Title( "VSCodium (Alt)" )]
-public class VSCodiumEditorAlt : VSCodeBase
-{
-	public override string RegistryKey => "VSCodium.exe";
-}
-
-[Title( "Void" )]
-public class VoidEditor : VSCodeBase
-{
-	public override string RegistryKey => "Void.exe";
-}
-
-[Title( "PearAI" )]
-public class PearAIEditor : VSCodeBase
-{
-	public override string RegistryKey => "PearAI.exe";
-}
-
-[Title( "Antigravity" )]
-public class AntigravityEditor : VSCodeBase
-{
-	public override string RegistryKey => "Antigravity.exe";
 }

--- a/game/addons/tools/Code/CodeEditors/CodeEditor.VisualStudio.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditor.VisualStudio.cs
@@ -23,6 +23,11 @@ public class VisualStudio : ICodeEditor
 
 	public bool IsInstalled() => !string.IsNullOrEmpty( FindVisualStudio() );
 
+	public bool MatchesExecutable( string fileName )
+	{
+		return fileName.Equals( "devenv.exe", StringComparison.OrdinalIgnoreCase );
+	}
+
 	/// <summary>
 	/// Uses vsopen to open the file in a currently running instance of Visual Studio.
 	/// Failing that it will launch it.

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -135,7 +135,7 @@ public class CodeEditorControlWidget : ControlWidget
 			var fd = new FileDialog( null );
 			fd.Title = $"Locate editor executable";
 			fd.DefaultSuffix = "exe";
-			fd.SetNameFilter( "Executable Files (*.exe)" );
+			fd.SetNameFilter( "Executable Files (*.exe);;All Files (*)" );
 			if ( fd.Execute() )
 			{
 				var selectedFile = fd.SelectedFile;

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -86,7 +86,7 @@ public class CodeEditorControlWidget : ControlWidget
 				},
 				codeEditor.Description,
 				isSelected,
-				isInstalled 
+				isInstalled
 			);
 
 			// add the custom path entry separately if it exists
@@ -181,7 +181,7 @@ public class CodeEditorControlWidget : ControlWidget
 				if ( targetType != null )
 				{
 					EditorCookie.Set( $"CodeEditor.{targetType.Name}.Path", selectedFile );
-					
+
 					// Change current editor to the one we just mapped
 					CodeEditor.Current = EditorTypeLibrary.Create<ICodeEditor>( targetType );
 

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -1,4 +1,5 @@
-﻿
+using Editor.CodeEditors;
+
 namespace Editor;
 
 [CustomEditor( typeof( ICodeEditor ) )]
@@ -7,40 +8,186 @@ public class CodeEditorControlWidget : ControlWidget
 	public CodeEditorControlWidget( SerializedProperty property ) : base( property )
 	{
 		Layout = Layout.Row();
+		BuildUIImmediate();
+	}
+
+	bool _needsRebuild;
+
+	[EditorEvent.Frame]
+	public void OnFrame()
+	{
+		if ( _needsRebuild )
+		{
+			_needsRebuild = false;
+			BuildUIImmediate();
+		}
+	}
+
+	void BuildUI()
+	{
+		_needsRebuild = true;
+	}
+
+	void BuildUIImmediate()
+	{
+		Layout.Clear( true );
 
 		var comboBox = new ComboBox( this );
-
 		var codeEditors = EditorTypeLibrary.GetTypes<ICodeEditor>()
-			.Where( x => !x.IsInterface )
-			.OrderBy( x => x.Name );
+			.Where( x => !x.IsInterface && !x.IsAbstract )
+			.Select( x =>
+			{
+				var instance = x.Create<ICodeEditor>();
+				return new { Type = x, Instance = instance, IsInstalled = instance?.IsInstalled() ?? false };
+			} )
+			.OrderByDescending( x => x.IsInstalled )
+			.ThenBy( x => x.Type.Name );
 
-		// If we have no code editors, the combobox will end up defaulting to a code editor we don't have installed.
 		if ( !codeEditors.Any() )
 		{
 			comboBox.AddItem( "None - install one!", "error" );
 		}
 
-		foreach ( var codeEditor in codeEditors.OrderByDescending( x => x.Create<ICodeEditor>()?.IsInstalled() ) )
+		foreach ( var entry in codeEditors )
 		{
+			var codeEditor = entry.Type;
+			var instance = entry.Instance;
+			var isInstalled = entry.IsInstalled;
+
 			if ( codeEditor.TargetType == typeof( ICodeEditor ) ) continue;
 
-			var instance = codeEditor.Create<ICodeEditor>();
+			var pathKey = $"CodeEditor.{codeEditor.Name}.Path";
+			var customPath = EditorCookie.Get( pathKey, "" );
+			bool isUsingCustom = !string.IsNullOrEmpty( customPath );
+
+			bool isSelected = CodeEditor.Current?.GetType() == instance?.GetType() && !isUsingCustom;
+
+			// hide forks if they aren't installed (unless it's the main vs code or currently selected)
+			if ( !isInstalled && !isSelected && instance is VSCodeBase vsCode && !vsCode.IsPrimary )
+			{
+				continue;
+			}
 
 			comboBox.AddItem(
 				codeEditor.Title,
 				codeEditor.Icon,
-				() => property.SetValue( codeEditor.Create<ICodeEditor>() ),
+				() =>
+				{
+					if ( !string.IsNullOrEmpty( EditorCookie.Get( pathKey, "" ) ) )
+					{
+						EditorCookie.Set( pathKey, "" ); // Clear any override
+						CodeEditor.Current = codeEditor.Create<ICodeEditor>();
+						BuildUI(); // rebuild because we changed a cookie/item list
+					}
+					else
+					{
+						CodeEditor.Current = codeEditor.Create<ICodeEditor>();
+					}
+				},
 				codeEditor.Description,
-				false,
-				instance.IsInstalled()
+				isSelected,
+				isInstalled 
 			);
+
+			// add the custom path entry separately if it exists
+			if ( isUsingCustom )
+			{
+				bool isCustomSelected = CodeEditor.Current?.GetType() == instance?.GetType() && isUsingCustom;
+
+				comboBox.AddItem(
+					customPath,
+					"folder",
+					() =>
+					{
+						// cookie is already set, so just select it
+						CodeEditor.Current = codeEditor.Create<ICodeEditor>();
+					},
+					$"Manual override for {codeEditor.Title}",
+					isCustomSelected,
+					true // always considered "installed" if path is set
+				);
+			}
 		}
 
+		// selection logic for the combobox itself to show the right text
 		if ( CodeEditor.Current is not null )
 		{
-			comboBox.TrySelectNamed( DisplayInfo.ForType( CodeEditor.Current.GetType() ).Name );
+			var type = EditorTypeLibrary.GetType( CodeEditor.Current.GetType() );
+			var pathKey = $"CodeEditor.{type.Name}.Path";
+			var customPath = EditorCookie.Get( pathKey, "" );
+
+			if ( !string.IsNullOrEmpty( customPath ) )
+			{
+				comboBox.TrySelectNamed( customPath );
+			}
+			else
+			{
+				comboBox.TrySelectNamed( type.Title );
+			}
 		}
 
 		Layout.Add( comboBox );
+
+		var browseBtn = new IconButton( "folder_open" );
+		browseBtn.ToolTip = "Manually locate executable (if auto-detection fails)";
+		browseBtn.OnClick += () =>
+		{
+			var fd = new FileDialog( null );
+			fd.Title = $"Locate editor executable";
+			fd.DefaultSuffix = "exe";
+			if ( fd.Execute() )
+			{
+				var selectedFile = fd.SelectedFile;
+				var fileName = System.IO.Path.GetFileName( selectedFile );
+				var targetType = CodeEditor.Current?.GetType();
+
+				// see if this exe belongs to a known editor class
+				var editorTypes = EditorTypeLibrary.GetTypes<ICodeEditor>()
+					.Where( x => !x.IsInterface && !x.IsAbstract );
+
+				foreach ( var type in editorTypes )
+				{
+					var instance = type.Create<ICodeEditor>();
+					if ( instance == null ) continue;
+
+					bool isMatch = false;
+					if ( instance is VSCodeBase vsCode )
+					{
+						isMatch = vsCode.MatchesExecutable( fileName );
+					}
+					else if ( instance is Rider rider )
+					{
+						isMatch = rider.MatchesExecutable( fileName );
+					}
+					else if ( instance is VisualStudio vs )
+					{
+						isMatch = vs.MatchesExecutable( fileName );
+					}
+
+					if ( isMatch )
+					{
+						targetType = type.TargetType;
+						break;
+					}
+				}
+
+				if ( targetType == null )
+				{
+					// If we couldn't smart-match the name, default to main VS Code
+					targetType = typeof( VisualStudioCode );
+				}
+
+				if ( targetType != null )
+				{
+					EditorCookie.Set( $"CodeEditor.{targetType.Name}.Path", selectedFile );
+					
+					// Change current editor to the one we just mapped
+					CodeEditor.Current = EditorTypeLibrary.Create<ICodeEditor>( targetType );
+
+					BuildUI();
+				}
+			}
+		};
+		Layout.Add( browseBtn );
 	}
 }

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -135,6 +135,7 @@ public class CodeEditorControlWidget : ControlWidget
 			var fd = new FileDialog( null );
 			fd.Title = $"Locate editor executable";
 			fd.DefaultSuffix = "exe";
+			fd.SetNameFilter( "Executable Files (*.exe)" );
 			if ( fd.Execute() )
 			{
 				var selectedFile = fd.SelectedFile;

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -191,6 +191,8 @@ public class CodeEditorControlWidget : ControlWidget
 				}
 			}
 		};
+		Layout.AddSpacingCell(3);
 		Layout.Add( browseBtn );
+		Layout.AddSpacingCell(3);
 	}
 }

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -185,8 +185,8 @@ public class CodeEditorControlWidget : ControlWidget
 				}
 			}
 		};
-		Layout.AddSpacingCell(3);
+		Layout.AddSpacingCell( 3 );
 		Layout.Add( browseBtn );
-		Layout.AddSpacingCell(3);
+		Layout.AddSpacingCell( 3 );
 	}
 }

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -64,12 +64,6 @@ public class CodeEditorControlWidget : ControlWidget
 
 			bool isSelected = CodeEditor.Current?.GetType() == instance?.GetType() && !isUsingCustom;
 
-			// hide forks if they aren't installed (unless it's the main vs code or currently selected)
-			if ( !isInstalled && !isSelected && instance is VSCodeBase vsCode && !vsCode.IsPrimary )
-			{
-				continue;
-			}
-
 			comboBox.AddItem(
 					codeEditor.Title,
 					codeEditor.Icon,
@@ -131,7 +125,7 @@ public class CodeEditorControlWidget : ControlWidget
 		Layout.Add( comboBox );
 
 		var browseBtn = new IconButton( "folder_open" );
-		browseBtn.ToolTip = "Manually locate executable (if auto-detection fails)";
+		browseBtn.ToolTip = "Manually locate executable (if auto-detection fails, or to use a VS Code derivative)";
 		browseBtn.OnClick += () =>
 		{
 			var fd = new FileDialog( null );
@@ -154,7 +148,7 @@ public class CodeEditorControlWidget : ControlWidget
 					if ( instance == null ) continue;
 
 					bool isMatch = false;
-					if ( instance is VSCodeBase vsCode )
+					if ( instance is VisualStudioCode vsCode )
 					{
 						isMatch = vsCode.MatchesExecutable( fileName );
 					}


### PR DESCRIPTION
## Summary

This PR overhauls the code editor selection system to support manual .exe selection, detection of VSC forks, and improving discovery.

## Motivation & Context

Many users now prefer specialized vibe-coding slop generators like the one I am currently using and **Cursor**, **Windsurf**, or **Trae**, there is no user-friendly way to add them and PRs to do so cause more bloat (like 192).
Sometimes people will have random issues and unable to use their existing IDE, letting them choose an .exe is very flexible because of this. 
Additionally, portable or user-only installations of these editors often fail auto-detection because they don't register in the standard HKLM registry keys.

*   Satisfies: https://github.com/Facepunch/sbox-public/pull/192
*   Fixes: https://github.com/Facepunch/sbox-public/issues/936
*   Fixes: https://github.com/Facepunch/sbox-public/issues/3833
*   Fixes: https://github.com/Facepunch/sbox-public/issues/9997

## Implementation Details

*   **Polymorphic editor sensing**: Replaces hardcoded string checks in the UI with a method where editor implementations identify if they match a given executable. This makes the system extensible for adding new editors without modifying the core UI widget.
*   **Tiered installation discovery**: Overhauls the location sensing to check manual overrides, application registrations, and both machine-wide (`HKLM`) and per-user (`HKCU`) registry entries, improves auto-detection for portable or user-only installations.
*   **ux & bloat**: 
    *   Manual override appears as an item in the dropdown and disappears when the user unselects it. (see screenshots)
    *   To avoid list bloat VSC forks are automatically hidden from the main list unless they are detected.
*   **Unified VS Code integration**: Consolidates the launch and detection logic for VS Code-based editors into a shared base class, enabling support for diverse forks (Cursor, Windsurf, Trae, etc.) in just 3 lines with consistent argument handling.
*  **Browse for .exe**: Assumes VS Code fork (or same format as it) if it can't find a name match. 
[I guess we don't "need" handling for VSC forks if they can just browse for it? nah good UX nevertheless]

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->
<img width="516" height="175" alt="image" src="https://github.com/user-attachments/assets/5185a7a2-f0c0-4196-8350-dcfc1dc31ee0" />

<img width="497" height="193" alt="image" src="https://github.com/user-attachments/assets/164e23e0-db6b-473e-a881-6117ccf317cd" />



## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂
- [x] Add padding to the button
