### PR TITLE
Make sure we only create or update the nav mesh area if we're active

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Navigation/NavMeshArea.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Navigation/NavMeshArea.cs
@@ -59,6 +59,8 @@ public class NavMeshArea : VolumeComponent, Component.ExecuteInEditor
 
 	protected override void OnDirty()
 	{
+		if ( !Active ) return;
+
 		UpdateNavMeshArea();
 	}
 


### PR DESCRIPTION
## Summary

The NavMeshArea component has a private little object it creates and destroys in OnEnabled and OnDisabled.
However, due to a mistake, it can also be created while the Component is disabled and some properties change.

## Motivation & Context

Fixes: #10009 

## Implementation Details

This also fixes the issue where the blocker stays around after the component gets deleted, because there is no way to create a blocker while the component is disabled, so the ondisabled function always destroys any area that exists.

## Other

I have a quick sample project: [navareasticky.zip](https://github.com/user-attachments/files/25238473/navareasticky.zip)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂