### PR TITLE
Enforce FriendsOnly lobby privacy during handshake

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
@@ -144,6 +144,24 @@ internal partial class NetworkSystem
 
 		Log.Info( $"{msg.DisplayName} [{msg.SteamId}] is connecting" );
 
+		//
+		// If the lobby is set to FriendsOnly,
+		// only allow players who are Steam friends with the host.
+		//
+		if ( Config.Privacy == LobbyPrivacy.FriendsOnly && msg.SteamId != 0 )
+		{
+			var hostSteamId = Utility.Steam.SteamId;
+
+			// Host is always allowed
+			if ( msg.SteamId != hostSteamId.Value && !new Friend( msg.SteamId ).IsFriend )
+			{
+				Log.Info( $"Kicked {msg.DisplayName} [{msg.SteamId}] - not friends with host [{hostSteamId}]" );
+				source.Kick( "This lobby is Friends Only." );
+				return Task.CompletedTask;
+			}
+		}
+
+
 		var denialReason = "";
 
 		source.PreInfo = new ConnectionInfo( null )


### PR DESCRIPTION
## Summary

Adds server-side enforcement for `LobbyPrivacy.FriendsOnly` lobbies during the handshake phase. When a lobby is set to FriendsOnly, the host now validates the joining player's SteamId against its own Steam friend list and kicks non-friends with the message "This lobby is Friends Only."

Previously, non-friends could connect and remain in the lobby.
## Motivation & Context
Players expect that setting their lobby to "Friends Only" actually prevents non-friends from joining. This change closes that gap at the engine level so game code doesn't need to reimplement it.

## Implementation Details
- The check runs in `On_Handshake_ClientInfo` after the SteamId is resolved from the trusted `SteamLobbyConnection`, using `Friend.IsFriend` against the host's local friend list.
- The host always bypasses the check. Steam API failures fail closed (deny access).

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂