### PR TITLE
Shadergraph: Don't generate TextureAttributes for albedo if its dynamic

### DIFF
--- a/game/addons/tools/Code/ShaderGraph/Compiler/GraphCompiler.cs
+++ b/game/addons/tools/Code/ShaderGraph/Compiler/GraphCompiler.cs
@@ -191,7 +191,7 @@ public sealed partial class GraphCompiler
 
 		result.TextureInputs.Add( id, input );
 
-		if ( CurrentResultInput == "Albedo" )
+		if ( CurrentResultInput == "Albedo" && !input.IsAttribute )
 		{
 			result.RepresentativeTexture = $"g_t{id}";
 		}


### PR DESCRIPTION
## Summary
This PR fixes a problem where a shadergraph shader will not compile if the Texture2D node connected to the Albedo input of the shader output is marked as an attribute.

## Motivation & Context
Fixes: #536 

## Implementation Details
Makes the shadergraph compiler no longer generate shader code which tries to use a TextureAttribute on the albedo if it is marked as an attrribute.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂