### PR TITLE
fix spacing of lines in DirectionalLight gizmo

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Light/DirectionalLight.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/DirectionalLight.cs
@@ -53,18 +53,12 @@ public class DirectionalLight : Light
 
 		Gizmo.Draw.Color = LightColor;
 
-		for ( float f = 0; f < MathF.PI * 2; f += 0.5f )
+		var segments = 12;
+		for ( var i = 0; i < segments; i++ )
 		{
-			var x = MathF.Sin( f );
-			var y = MathF.Cos( f );
-
-			var off = (x * Vector3.Left + y * Vector3.Up) * 5.0f;
-
-			Gizmo.Draw.Line( off, off + fwd * 30 );
+			var angle = MathF.PI * 2 * i / segments;
+			var off = (MathF.Sin( angle ) * Vector3.Left + MathF.Cos( angle ) * Vector3.Up) * 5.0f;
+			Gizmo.Draw.Line( off, off + Vector3.Forward * 30 );
 		}
-
-		//	Gizmo.Transform = Transform.Zero;
-		//	Gizmo.Draw.Sprite( GameObject.Transform.Position, 10, Texture.Load( FileSystem.Mounted, "/editor/directional_light.png" ) );
-
 	}
 }

--- a/engine/Sandbox.Engine/Scene/Components/Light/DirectionalLight.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/DirectionalLight.cs
@@ -48,9 +48,6 @@ public class DirectionalLight : Light
 	protected override void DrawGizmos()
 	{
 		using var scope = Gizmo.Scope( $"light-{GetHashCode()}" );
-
-		var fwd = Vector3.Forward;
-
 		Gizmo.Draw.Color = LightColor;
 
 		var segments = 12;


### PR DESCRIPTION
## Summary
The lines in the DirectionalLight gizmo aren't evenly spaced, this pr makes the lines evenly spaced.

## Motivation & Context
bothered me slightly

## Screenshots
Before:
<img width="912" height="757" alt="image" src="https://github.com/user-attachments/assets/6dff4de1-8337-4c62-8e9d-03bdbccde334" />

After:
<img width="935" height="798" alt="image" src="https://github.com/user-attachments/assets/7c13e30b-942f-411f-9a00-2567123c6516" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂