### PR TITLE
Calculate splash screen height using image aspect ratio

### DIFF
--- a/engine/Sandbox.Tools/Editor/EditorSplashScreen.cs
+++ b/engine/Sandbox.Tools/Editor/EditorSplashScreen.cs
@@ -23,7 +23,8 @@ namespace Editor
 			string geometryCookie = EditorCookie.GetString( "splash.geometry", null );
 			RestoreGeometry( geometryCookie );
 
-			Size = new( 700, 400 + InfoAreaHeight );
+			var aspect = (float)BackgroundImage.Height / BackgroundImage.Width;
+			Size = new( 700, (700 * aspect).FloorToInt() + InfoAreaHeight );
 
 			if ( geometryCookie is null )
 			{


### PR DESCRIPTION
## Summary

Rather than stretching the splash screen background image to fit a hard coded 700x400, height is now determined using the aspect ratio of the image while width remains at 700.

## Motivation & Context

Seemed like it'd be cool

## Screenshots

<img width="905" height="483" alt="image" src="https://github.com/user-attachments/assets/2033c177-2df7-49fd-9a99-d18174a60a1d" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂