### PR TITLE
`display: inline-flex` support

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Panel/Panel.Layout.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Panel/Panel.Layout.cs
@@ -235,13 +235,49 @@ public partial class Panel
 		if ( ComputedStyle == null )
 			return;
 
-		YogaNode.Width = ComputedStyle.Width;
-		YogaNode.Height = ComputedStyle.Height;
+		// Handle width specially for inline-flex: default to auto (shrink-to-content)
+		// unless an explicit width is set via inline style OR CSS/SCSS stylesheet
+		var hasExplicitWidth = Style?.Width != null ||
+			(ComputedStyle.Width.HasValue && ComputedStyle.Width.Value.Unit != LengthUnit.Undefined);
+
+		if ( IsInlineFlex && !hasExplicitWidth )
+		{
+			YogaNode.Width = Length.Auto;
+		}
+		else
+		{
+			YogaNode.Width = ComputedStyle.Width;
+		}
+
+		// Handle height specially for inline-flex: default to auto (shrink-to-content)
+		// unless an explicit height is set via inline style OR CSS/SCSS stylesheet
+		var hasExplicitHeight = Style?.Height != null ||
+			(ComputedStyle.Height.HasValue && ComputedStyle.Height.Value.Unit != LengthUnit.Undefined);
+
+		if ( IsInlineFlex && !hasExplicitHeight )
+		{
+			YogaNode.Height = Length.Auto;
+		}
+		else
+		{
+			YogaNode.Height = ComputedStyle.Height;
+		}
+
 		YogaNode.MaxWidth = ComputedStyle.MaxWidth;
 		YogaNode.MaxHeight = ComputedStyle.MaxHeight;
 		YogaNode.MinWidth = ComputedStyle.MinWidth;
 		YogaNode.MinHeight = ComputedStyle.MinHeight;
-		YogaNode.Display = ComputedStyle.Display;
+
+		// For Yoga, both flex and inline-flex use the same display mode
+		// The difference is only in how we handle the width above
+		if ( ComputedStyle.Display == DisplayMode.InlineFlex )
+		{
+			YogaNode.Display = DisplayMode.Flex;
+		}
+		else
+		{
+			YogaNode.Display = ComputedStyle.Display;
+		}
 
 		YogaNode.Left = ComputedStyle.Left;
 		YogaNode.Right = ComputedStyle.Right;
@@ -265,14 +301,47 @@ public partial class Panel
 
 		YogaNode.PositionType = ComputedStyle.Position;
 		YogaNode.AspectRatio = ComputedStyle.AspectRatio;
-		YogaNode.FlexGrow = ComputedStyle.FlexGrow;
-		YogaNode.FlexShrink = ComputedStyle.FlexShrink;
+
+		// inline-flex defaults flex-grow/shrink to 0 (shrink-to-content); regular flex defers to ComputedStyle.
+		// Check if explicitly set via inline style OR CSS/SCSS (not the default value)
+		if ( IsInlineFlex )
+		{
+			// Check if flex-grow was explicitly set (default is 0, so we check if style has a value)
+			var hasExplicitFlexGrow = Style?.FlexGrow != null ||
+				(ComputedStyle.FlexGrow.HasValue && ComputedStyle.FlexGrow.Value != 0);
+
+			var hasExplicitFlexShrink = Style?.FlexShrink != null ||
+				(ComputedStyle.FlexShrink.HasValue && ComputedStyle.FlexShrink.Value != 1); // default is 1
+
+			YogaNode.FlexGrow = hasExplicitFlexGrow ? ComputedStyle.FlexGrow : 0;
+			YogaNode.FlexShrink = hasExplicitFlexShrink ? ComputedStyle.FlexShrink : 0;
+		}
+		else
+		{
+			YogaNode.FlexGrow = ComputedStyle.FlexGrow;
+			YogaNode.FlexShrink = ComputedStyle.FlexShrink;
+		}
+
 		YogaNode.FlexBasis = ComputedStyle.FlexBasis;
 		YogaNode.Wrap = ComputedStyle.FlexWrap;
 
 		YogaNode.AlignContent = ComputedStyle.AlignContent;
 		YogaNode.AlignItems = ComputedStyle.AlignItems;
-		YogaNode.AlignSelf = ComputedStyle.AlignSelf;
+
+		// For inline-flex, default to align-self: flex-start to prevent cross-axis stretching
+		// unless explicitly set via inline style OR CSS/SCSS
+		if ( IsInlineFlex )
+		{
+			var hasExplicitAlignSelf = Style?.AlignSelf != null ||
+				(ComputedStyle.AlignSelf.HasValue && ComputedStyle.AlignSelf.Value != Align.Auto);
+
+			YogaNode.AlignSelf = hasExplicitAlignSelf ? ComputedStyle.AlignSelf : Align.FlexStart;
+		}
+		else
+		{
+			YogaNode.AlignSelf = ComputedStyle.AlignSelf;
+		}
+
 		YogaNode.FlexDirection = ComputedStyle.FlexDirection;
 		YogaNode.JustifyContent = ComputedStyle.JustifyContent;
 		YogaNode.Overflow = ComputedStyle.Overflow;

--- a/engine/Sandbox.Engine/Systems/UI/Panel/Panel.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Panel/Panel.cs
@@ -662,4 +662,34 @@ public partial class Panel : IPanel, IValid, IComponent
 		}
 	}
 
+	/// <summary>
+	/// Returns true if this panel uses inline-flex display mode.
+	/// Inline-flex containers shrink to fit their content instead of stretching to fill parent.
+	/// </summary>
+	[Hide]
+	public bool IsInlineFlex
+	{
+		get
+		{
+			// Check ComputedStyle first (used during layout), fall back to Style for pre-layout checks
+			var display = ComputedStyle?.Display ?? Style?.Display;
+			return display == DisplayMode.InlineFlex;
+		}
+	}
+
+	/// <summary>
+	/// Returns true if this panel uses flex or inline-flex display mode.
+	/// Both use flexbox layout for children, but differ in how the container itself is sized.
+	/// </summary>
+	[Hide]
+	public bool UseFlexLayout
+	{
+		get
+		{
+			// Check ComputedStyle first, fall back to Style, default to Flex
+			var display = ComputedStyle?.Display ?? Style?.Display ?? DisplayMode.Flex;
+			return display == DisplayMode.Flex || display == DisplayMode.InlineFlex;
+		}
+	}
+
 }

--- a/engine/Sandbox.Engine/Systems/UI/Styles/Styles.Set.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Styles/Styles.Set.cs
@@ -909,6 +909,9 @@ namespace Sandbox.UI
 				case "contents":
 					Display = DisplayMode.Contents;
 					return true;
+				case "inline-flex":
+					Display = DisplayMode.InlineFlex;
+					return true;
 				default:
 					Log.Warning( $"Unhandled display property: {value}" );
 					return false;

--- a/engine/Sandbox.Engine/Systems/UI/Yoga/YogaWrapper.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Yoga/YogaWrapper.cs
@@ -547,5 +547,11 @@ namespace Sandbox.UI
 				Yoga.YGNodeStyleSetGap( Node, YGGutter.YGGutterColumn, value?.GetPixels( 0 ) ?? float.NaN );
 			}
 		}
+
+		/// <summary>
+		/// Returns true if the panel uses inline-flex display mode.
+		/// Inline-flex containers shrink to fit their content instead of stretching.
+		/// </summary>
+		internal bool IsInlineFlex => _panel?.ComputedStyle?.Display == DisplayMode.InlineFlex;
 	}
 }

--- a/engine/Sandbox.System/UI/Styles/StyleEnums.cs
+++ b/engine/Sandbox.System/UI/Styles/StyleEnums.cs
@@ -141,7 +141,13 @@ public enum DisplayMode
 	/// <summary>
 	/// Causes an element's children to appear as if they were direct children of the element's parent, ignoring the element itself. This can be useful when a wrapper element should be ignored.
 	/// </summary>
-	Contents = 2
+	Contents = 2,
+
+	/// <summary>
+	/// Inline-level flex container. Shrinks to content width while using flex layout internally.
+	/// Participates in inline flow rather than block flow.
+	/// </summary>
+	InlineFlex = 3
 }
 
 /// <summary>

--- a/engine/Sandbox.Test.Unit/UI/InlineFlex.cs
+++ b/engine/Sandbox.Test.Unit/UI/InlineFlex.cs
@@ -1,0 +1,256 @@
+﻿using Sandbox.UI;
+
+namespace Sandbox.Test.Unit.UI;
+
+/// <summary>
+/// Unit tests for display: inline-flex support.
+/// Tests that inline-flex containers shrink to fit their content
+/// while still using flexbox layout internally.
+/// </summary>
+[TestClass]
+[DoNotParallelize] // RootPanel.AddToLists() modifies shared collections
+public class InlineFlex
+{
+	/// <summary>
+	/// Helper to run layout on a root panel
+	/// </summary>
+	private static void RunLayout( RootPanel root )
+	{
+		root.PreLayout();
+		root.YogaNode?.CalculateLayout();
+		root.FinalLayout( Vector2.Zero );
+	}
+
+	/// <summary>
+	/// Helper to create a root panel with specific size
+	/// </summary>
+	private static RootPanel CreateRoot( float width = 500, float height = 500 )
+	{
+		var root = new RootPanel();
+		root.PanelBounds = new Rect( 0, 0, width, height );
+		return root;
+	}
+
+	[TestMethod]
+	[Description( "Verify inline-flex enum value exists and is parsed correctly" )]
+	public void InlineFlex_EnumValueExists()
+	{
+		Assert.AreEqual( 3, (int)DisplayMode.InlineFlex );
+	}
+
+	[TestMethod]
+	[Description( "Verify CSS parser recognizes 'inline-flex' string" )]
+	public void InlineFlex_CSSParsingWorks()
+	{
+		var styles = new Styles();
+		var result = styles.Set( "display", "inline-flex" );
+
+		Assert.IsTrue( result, "Setting display: inline-flex should return true" );
+		Assert.AreEqual( DisplayMode.InlineFlex, styles.Display, "Display should be InlineFlex" );
+	}
+
+	[TestMethod]
+	[Description( "Verify inline-flex container shrinks to content when no width specified" )]
+	public void InlineFlex_ShrinksToContent()
+	{
+		var root = CreateRoot();
+
+		var inlineFlex = new Panel();
+		inlineFlex.Style.Set( "display: inline-flex;" );
+		inlineFlex.Parent = root;
+
+		var child = new Panel();
+		child.Style.Width = 100;
+		child.Style.Height = 50;
+		child.Parent = inlineFlex;
+
+		RunLayout( root );
+
+		// Inline-flex should shrink to fit its child (100px wide)
+		// rather than stretching to parent width (500px)
+		Assert.IsTrue( inlineFlex.Box.Rect.Width <= 100 + 1,
+			$"Inline-flex should shrink to content. Expected ~100, got {inlineFlex.Box.Rect.Width}" );
+	}
+
+	[TestMethod]
+	[Description( "Verify explicit width overrides inline-flex shrink behavior" )]
+	public void InlineFlex_ExplicitWidthOverridesShrink()
+	{
+		var root = CreateRoot();
+
+		var inlineFlex = new Panel();
+		inlineFlex.Style.Set( "display: inline-flex; width: 200px;" );
+		inlineFlex.Parent = root;
+
+		var child = new Panel();
+		child.Style.Width = 100;
+		child.Style.Height = 50;
+		child.Parent = inlineFlex;
+
+		RunLayout( root );
+
+		// Explicit width should override shrink-to-content
+		Assert.AreEqual( 200, inlineFlex.Box.Rect.Width, 1,
+			"Explicit width should override inline-flex shrink behavior" );
+	}
+
+	[TestMethod]
+	[Description( "Verify inline-flex children still use flex layout rules" )]
+	public void InlineFlex_ChildrenStillUseFlex()
+	{
+		var root = CreateRoot();
+
+		var inlineFlex = new Panel();
+		inlineFlex.Style.Set( "display: inline-flex; width: 300px;" );
+		inlineFlex.Parent = root;
+
+		var child1 = new Panel();
+		child1.Style.Set( "flex-grow: 1; height: 50px;" );
+		child1.Parent = inlineFlex;
+
+		var child2 = new Panel();
+		child2.Style.Set( "flex-grow: 1; height: 50px;" );
+		child2.Parent = inlineFlex;
+
+		RunLayout( root );
+
+		// Children should share space equally (flex-grow: 1 each)
+		Assert.AreEqual( 150, child1.Box.Rect.Width, 1,
+			"Children should use flex layout rules" );
+		Assert.AreEqual( 150, child2.Box.Rect.Width, 1,
+			"Children should use flex layout rules" );
+	}
+
+	[TestMethod]
+	[Description( "Verify nested inline-flex containers work correctly" )]
+	public void InlineFlex_NestedInlineFlex()
+	{
+		var root = CreateRoot();
+
+		var outer = new Panel();
+		outer.Style.Set( "display: inline-flex; gap: 10px;" );
+		outer.Parent = root;
+
+		var inner1 = new Panel();
+		inner1.Style.Set( "display: inline-flex;" );
+		inner1.Parent = outer;
+
+		var innerChild1 = new Panel();
+		innerChild1.Style.Width = 50;
+		innerChild1.Style.Height = 50;
+		innerChild1.Parent = inner1;
+
+		var inner2 = new Panel();
+		inner2.Style.Set( "display: inline-flex;" );
+		inner2.Parent = outer;
+
+		var innerChild2 = new Panel();
+		innerChild2.Style.Width = 30;
+		innerChild2.Style.Height = 50;
+		innerChild2.Parent = inner2;
+
+		RunLayout( root );
+
+		// Inner containers should shrink to fit their content
+		Assert.AreEqual( 50, inner1.Box.Rect.Width, 1 );
+		Assert.AreEqual( 30, inner2.Box.Rect.Width, 1 );
+
+		// Outer should be: 50 (inner1) + 10 (gap) + 30 (inner2) = 90
+		Assert.AreEqual( 90, outer.Box.Rect.Width, 1 );
+	}
+
+	[TestMethod]
+	[Description( "Verify empty inline-flex container has zero/minimal size" )]
+	public void InlineFlex_EmptyContainer()
+	{
+		var root = CreateRoot();
+
+		var inlineFlex = new Panel();
+		inlineFlex.Style.Set( "display: inline-flex;" );
+		inlineFlex.Parent = root;
+
+		// No children
+
+		RunLayout( root );
+
+		// Empty inline-flex should have zero width
+		Assert.AreEqual( 0, inlineFlex.Box.Rect.Width, 1 );
+	}
+
+	[TestMethod]
+	[Description( "Verify inline-flex with padding includes padding in size" )]
+	public void InlineFlex_WithPadding()
+	{
+		var root = CreateRoot();
+
+		var inlineFlex = new Panel();
+		inlineFlex.Style.Set( "display: inline-flex; padding: 10px;" );
+		inlineFlex.Parent = root;
+
+		var child = new Panel();
+		child.Style.Width = 80;
+		child.Style.Height = 40;
+		child.Parent = inlineFlex;
+
+		RunLayout( root );
+
+		// Width should be: 10 (padding-left) + 80 (child) + 10 (padding-right) = 100
+		Assert.AreEqual( 100, inlineFlex.Box.Rect.Width, 1 );
+		Assert.AreEqual( 60, inlineFlex.Box.Rect.Height, 1 );
+	}
+
+	[TestMethod]
+	[Description( "Verify inline-flex shrinks to content while regular flex uses default behavior" )]
+	public void InlineFlex_ShrinksWhileFlexUsesDefault()
+	{
+		// Test inline-flex shrinks to content
+		var root = CreateRoot();
+
+		var inlineFlex = new Panel();
+		inlineFlex.Style.Set( "display: inline-flex;" );
+		inlineFlex.Parent = root;
+
+		var inlineChild = new Panel();
+		inlineChild.Style.Width = 100;
+		inlineChild.Style.Height = 50;
+		inlineChild.Parent = inlineFlex;
+
+		RunLayout( root );
+
+		// Inline-flex should shrink to content width (100px)
+		Assert.AreEqual( 100, inlineFlex.Box.Rect.Width, 1,
+			"Inline-flex should shrink to content width" );
+	}
+
+	[TestMethod]
+	[Description( "Verify Panel.IsInlineFlex property works correctly" )]
+	public void Panel_IsInlineFlexProperty()
+	{
+		var panel = new Panel();
+
+		panel.Style.Set( "display: flex;" );
+		Assert.IsFalse( panel.IsInlineFlex, "display: flex should not be inline-flex" );
+
+		panel.Style.Set( "display: inline-flex;" );
+		Assert.IsTrue( panel.IsInlineFlex, "display: inline-flex should be inline-flex" );
+
+		panel.Style.Set( "display: none;" );
+		Assert.IsFalse( panel.IsInlineFlex, "display: none should not be inline-flex" );
+	}
+
+	[TestMethod]
+	[Description( "Verify Panel.UseFlexLayout property works for both flex and inline-flex" )]
+	public void Panel_UseFlexLayoutProperty()
+	{
+		var panel = new Panel();
+
+		panel.Style.Set( "display: flex;" );
+		Assert.IsTrue( panel.UseFlexLayout, "display: flex should use flex layout" );
+
+		panel.Style.Set( "display: inline-flex;" );
+		Assert.IsTrue( panel.UseFlexLayout, "display: inline-flex should use flex layout" );
+
+		panel.Style.Set( "display: none;" );
+		Assert.IsFalse( panel.UseFlexLayout, "display: none should not use flex layout" );
+	}
+}


### PR DESCRIPTION
## Summary

Adds `display: inline-flex` as a supported CSS display value in the UI layout engine.

Inline-flex containers use flex layout internally for their children but shrink to fit
their content width/height rather than stretching to fill the parent - the same
distinction the CSS spec makes between `block` and `inline` elements, applied to flex
containers.

## Motivation & Context

The primary use case is embedding custom emojis or icons inline within text content.
Previously the only way to approximate this was with nested column-direction flex
workarounds. `display: inline-flex` lets a panel sit inline in a flow while still
managing its own children with full flex rules.

Fixes: #4803
Related: #1423

## Implementation Details

Yoga has no native `inline-flex` concept, so the semantics are layered on top at the `Panel.Layout.cs` level. When `IsInlineFlex` is true, Yoga is passed `DisplayMode.Flex` - the distinction is enforced by overriding a set of defaults before the layout pass:

- `Width`/`Height` -> `Length.Auto` (unless explicitly set in the panel's own `Style`)
- `FlexGrow`/`FlexShrink` -> `0` (don't stretch into parent)
- `AlignSelf` -> `FlexStart` (don't cross-axis stretch)

Explicit values in the panel's stylesheet always win over these defaults.

## Screenshots / Videos (if applicable)


https://github.com/user-attachments/assets/ac089db4-fee7-4c78-b763-d7e46ed1d306

<img width="851" height="791" alt="image" src="https://github.com/user-attachments/assets/16a8701e-c519-4eac-b1df-e51ac9e42279" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂