### PR TITLE
Fix NRE in Input.GetGlyph with unset input action bind

### DIFF
--- a/engine/Sandbox.Engine/Systems/Input/Input.Glyphs.cs
+++ b/engine/Sandbox.Engine/Systems/Input/Input.Glyphs.cs
@@ -85,9 +85,14 @@ public static partial class Input
 		{
 			return LoadGlyphTexture( "unknown", size, outline );
 		}
-		var key = GetButtonOrigin( action ).ToLowerInvariant();
 
-		key = GetButtonName( key );
+		var key = GetButtonOrigin( action );
+		if ( key is null )
+		{
+			return LoadGlyphTexture( "unknown", size, outline );
+		}
+
+		key = GetButtonName( key.ToLowerInvariant() );
 
 		if ( string.IsNullOrEmpty( key ) ) key = "UNBOUND";
 

--- a/engine/Sandbox.Engine/Systems/Input/Input.cs
+++ b/engine/Sandbox.Engine/Systems/Input/Input.cs
@@ -139,6 +139,9 @@ public static partial class Input
 	public static InputMotionData MotionData { get; internal set; }
 
 	/// <inheritdoc cref="GetButtonOrigin( string, bool )"/>
+	/// <remarks>
+	/// This will return <see langword="null"/> if no button was set in the action.
+	/// </remarks>
 	internal static string GetButtonOrigin( InputAction action, bool ignoreController = false )
 	{
 		if ( UsingController )


### PR DESCRIPTION
## Summary

This PR adds a null guard to `Input.GetGlyph( string, InputGlyphSize, bool )` against an input action having no bind set in the project settings.
Additionally, I've added a remark to `Input.GetButtonOrigin( InputAction, bool )` to notify consumers of this possibility.

Fixes: #10017

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂