### PR TITLE
Allow all assemblies when whitelist is false

### DIFF
--- a/engine/Sandbox.Compiling/CompilerConfiguration.cs
+++ b/engine/Sandbox.Compiling/CompilerConfiguration.cs
@@ -69,8 +69,11 @@ partial class Compiler
 		/// </summary>
 		public HashSet<string> IgnoreFolders { get; set; } = new HashSet<string>();
 
-		static bool IsPermittedAssemblyReference( string assemblyName )
+		bool IsPermittedAssemblyReference( string assemblyName )
 		{
+			if ( !Whitelist )
+				return true;
+
 			return assemblyName.StartsWith( "Sandbox.", StringComparison.OrdinalIgnoreCase )
 				|| assemblyName.StartsWith( "Facepunch.", StringComparison.OrdinalIgnoreCase )
 				|| assemblyName == "Microsoft.AspNetCore.Components";


### PR DESCRIPTION
## Summary

This PR will remove the check for the assembly, If the whitelist is disabled.

## Motivation & Context

[issue](https://github.com/Facepunch/sbox-public/issues/3068)

## Problem

I managed to use MySqlConnector, by adding the full path without the extension ".dll" at the end, to AssemblyReferences in the *.sbproj file. Although it works, you have to modify the *.csproj file  for your editor to recongize the assembly,  because the path will be `{ManagedRoot}/{entry}`. I don't know how to resolve this. I thinks it's [here](https://github.com/Facepunch/sbox-public/blob/997c0cb069fc292a210e0c874f00e3926168fd50/engine/Sandbox.SolutionGenerator/Templates/Project.cs#L88).