### PR TITLE
Fix hammer entity selection

### DIFF
--- a/game/editor/Hammer/Code/Tools/EntityTool/EntityTreeView.cs
+++ b/game/editor/Hammer/Code/Tools/EntityTool/EntityTreeView.cs
@@ -22,10 +22,16 @@ public class EntityTreeView : TreeView
 
 	protected void OnItemClicked( object value )
 	{
-		if ( value is not EntityDataNode entityNode )
+		if ( value is MapClass mapClass )
+		{
+			OnItemSelected?.Invoke( mapClass.Name );
 			return;
+		}
 
-		OnItemSelected.Invoke( entityNode.Value.Name );
+		if ( value is EntityDataNode entityNode )
+		{
+			OnItemSelected?.Invoke( entityNode.Value.Name );
+		}
 	}
 
 	protected override void OnPaint()


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

instead of always placing info_player_start, it now places the correct entity

## Motivation & Context

As a hammer user, this as been a really annoying bug and has been here for like a month at least now, so I decided to fix it.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)


https://github.com/user-attachments/assets/63830ef6-2d29-48a5-907e-57e54c6f575b



## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂