### PR TITLE
Make Gizmo.Hitbox.Sphere use same behaviour as other hitboxes

### DIFF
--- a/engine/Sandbox.Engine/Editor/Gizmos/Hitbox/Hitbox.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Hitbox/Hitbox.cs
@@ -90,10 +90,10 @@ public static partial class Gizmo
 				Sandbox.Gizmo.Draw.LineSphere( sphere );
 			}
 
-			var transformedSphere = sphere;
-			transformedSphere.Center = Transform.PointToWorld( transformedSphere.Center );
+			// convert ray to local to the sphere
+			var ray = CurrentRay.ToLocal( Transform );
 
-			if ( !transformedSphere.Trace( CurrentRay, float.MaxValue, out float hitDistance ) )
+			if ( !sphere.Trace( ray, float.MaxValue, out float hitDistance ) )
 				return;
 
 			// too close


### PR DESCRIPTION
## Summary

For some reason, Gizmo.Hitbox.Sphere works differently than every other function in this file. I made it to the same thing as the other functions and now things look better.

## Motivation & Context

The newly added rotation gizmo has an issue where it takes priority over the small lines when you're zoomed in, and being hard to click when zoomed out.

This PR fixes that issue by changing the Gizmo.Hitbox.Sphere code.

For some reason, fixing the sphere hitbox was enough to fix the lines not being clickable, so two birds killed with one stone.

## Implementation Details

I am not sure why Gizmo.Hitbox.Sphere was doing things in this manner. The git blame does not go back far enough on the public repo.

Please make sure I am not breaking anything by making this change.

Of note: The debug code in the function shows the hitboxes that *currently* work. So it seems that the function was simply broken before, and now it matches the behaviour the debug drawing shows.

## Screenshots / Videos (if applicable)

Before:

https://github.com/user-attachments/assets/3b2adf0b-e832-4e70-b0c7-b8da4522d5a9

After:

https://github.com/user-attachments/assets/729d7a91-2075-4b0b-bdf5-fc9ad15fef05

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂