### PR TITLE
Fix ComponentSheet null reference when hotloading

### DIFF
--- a/engine/Sandbox.Tools/Inspector/ComponentEditorWidget.cs
+++ b/engine/Sandbox.Tools/Inspector/ComponentEditorWidget.cs
@@ -19,7 +19,8 @@ public abstract class ComponentEditorWidget : Widget
 
 	public static ComponentEditorWidget Create( SerializedObject obj )
 	{
-		var componentType = TypeLibrary.GetType( obj.TypeName ).TargetType;
+		var componentType = TypeLibrary.GetType( obj.TypeName )?.TargetType;
+		if ( componentType == null ) return null;
 
 		var editor = EditorTypeLibrary.GetTypesWithAttribute<CustomEditorAttribute>( false )
 					.Where( x => x.Type.TargetType.IsAssignableTo( typeof( ComponentEditorWidget ) ) )


### PR DESCRIPTION
## Summary

Hotloading after adding/removing functions with the inspector opened to a gameobject has been throwing the following exception. This pr adds a null check to avoid that.
<img width="467" height="318" alt="image" src="https://github.com/user-attachments/assets/5f70a1e8-6118-497c-bb13-a91e4e3848da" />


## Motivation & Context

Seemed easier to fix than to write an issue for.

## Implementation Details

It appears that when hotloading the inspector gets rebuilt several times. On some of these tries TypeLibrary.GetType fails to find some of the component types, by the end it all works fine. Guessing theres a period of time mid hotload where type libraries library of types isn't up to date? In any case returning null here the first time doesnt seem to have any adverse effects.

I also found while I was testing, EditorEvent.Hotload is invoked quite a few times during hotloads, e.g. anywhere from 8 to 150 times. As best as I can tell the whole inspector gets rebuilt for each of these calls. Seems like a bad thing?

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂