### PR TITLE
Save launcher geometry when using 'Close On Launch'

### DIFF
--- a/engine/Launcher/StandaloneTest/Widgets/StartupWindow.cs
+++ b/engine/Launcher/StandaloneTest/Widgets/StartupWindow.cs
@@ -109,6 +109,8 @@ public partial class StartupWindow : Window
 	{
 		if ( !CloseOnLaunch.Value ) return;
 
+		LauncherPreferences.Cookie.Set( "startscreen.geometry", SaveGeometry() );
+
 		Destroy();
 	}
 }


### PR DESCRIPTION
## Summary

The cookie for the launcher geometry was being saved when manually closing the window, but not when the window was automatically closed (e.g. when opening an addon with close on launch enabled), this saves the geometry for both cases.

## Motivation & Context

Annoyed me, sometimes the launcher would get stuck in weird places for weeks on end.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂