### PR TITLE
Fix BBox gizmos after Hitbox.Sphere change

### DIFF
--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.BoundingBox.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.BoundingBox.cs
@@ -25,11 +25,11 @@ public static partial class Gizmo
 			var db = Gizmo.Hitbox.DepthBias;
 			Gizmo.Hitbox.DepthBias = 0.01f;
 
-			Hitbox.Sphere( new Sphere( 0, hoverSphereRadius * Transform.UniformScale ) );
+			Hitbox.Sphere( new Sphere( 0, hoverSphereRadius ) );
 
 			Vector3 arrowFrom = Vector3.Forward * -(actualArrowHeadLength + actualSphereRadius);
 			Vector3 arrowTo = Vector3.Forward * -actualSphereRadius;
-			Hitbox.Sphere( new Sphere( arrowFrom / 2, hoverArrowHeadRadius * Transform.UniformScale ) );
+			Hitbox.Sphere( new Sphere( arrowFrom / 2, hoverArrowHeadRadius ) );
 
 			Gizmo.Hitbox.DepthBias = db;
 			color = IsHovered || Pressed.This ? Colors.Active : color;


### PR DESCRIPTION
## Summary

When I changed the behaviour of Gizmo.Hitbox.Sphere with #10080, this had an adverse effect on BBox gizmos.
It seems like whoever wrote that code implemented their own one-time for for this translation issue, which now results in a compounding effect where the handle hitboxes get too big when you zoom out.

## Implementation Details

I simply removed the adjustment and things seem to work fine.

## Screenshots / Videos (if applicable)

Here are a pair of videos with Gizmo hitboxes enabled:

Current state:

https://github.com/user-attachments/assets/962facd4-0443-4866-9a58-6d70ba968167

With this PR:

https://github.com/user-attachments/assets/96aa8a26-c609-4c3a-a64d-7aeb14f62a15


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂