### PR TITLE
Improve debug overlay visual clarity

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Debug/Allocations.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Allocations.cs
@@ -103,43 +103,56 @@ internal static partial class DebugOverlay
 			var x = pos.x;
 			var y = pos.y;
 
-			var scope = new TextRendering.Scope( "", Color.White, 11, "Roboto Mono", 600 );
-			scope.Outline = new TextRendering.Outline { Color = Color.Black, Enabled = true, Size = 2 };
-
+			var scope = new TextRendering.Scope( "", Color.White, 11, "Roboto Mono", 600 )
 			{
-				var lowestPauseMs = TimeSpan.FromTicks( _pauseTicksMin == long.MaxValue ? 0 : _pauseTicksMin ).TotalMilliseconds;
-				var highestPauseMs = TimeSpan.FromTicks( _pauseTicksMax ).TotalMilliseconds;
-				var sumMs = TimeSpan.FromTicks( _pauseTicksSum ).TotalMilliseconds;
-				var avgMs = _frameCount > 0 ? TimeSpan.FromTicks( _pauseTicksSum / _frameCount ).TotalMilliseconds : 0.0;
+				Outline = new TextRendering.Outline { Color = Color.Black, Enabled = true, Size = 2 }
+			};
+			var headerScope = new TextRendering.Scope( "", Color.White.WithAlpha( 0.9f ), 11, "Roboto Mono", 700 )
+			{
+				Outline = new TextRendering.Outline { Color = Color.Black, Enabled = true, Size = 2 }
+			};
+			var dimScope = new TextRendering.Scope( "", Color.White.WithAlpha( 0.55f ), 10, "Roboto Mono", 600 )
+			{
+				Outline = new TextRendering.Outline { Color = Color.Black, Enabled = true, Size = 2 }
+			};
 
-				var gcMemInfo = GC.GetGCMemoryInfo();
-				var mbPerSec = liveElapsed > 0 ? _allocBytesSum / (1024.0 * 1024.0 * liveElapsed) : 0.0;
-				var mbTotal = _allocBytesSum / (1024.0 * 1024.0);
-				var elapsedSecondsInt = (int)liveElapsed;
-				var windowLabel = elapsedSecondsInt >= 60 ? $"{elapsedSecondsInt / 60}m {elapsedSecondsInt % 60}s" : $"{elapsedSecondsInt}s";
-				const string Pad = "{0,-32}";
-				scope.Text = $"GC Pauses (tracked for {windowLabel})\n" +
-					string.Format( Pad, "Gen (0/1/2):" ) + $"{_gen0Sum + ls.Gc0} / {_gen1Sum + ls.Gc1} / {_gen2Sum + ls.Gc2}\n" +
-					string.Format( Pad, "Total:" ) + $"{mbTotal:N1} MB\n" +
-					string.Format( Pad, "Rate:" ) + $"{mbPerSec:N2} MB/s\n" +
-					string.Format( Pad, "Avg:" ) + $"{avgMs:N2}ms\n" +
-					string.Format( Pad, "Min:" ) + $"{lowestPauseMs:N2}ms\n" +
-					string.Format( Pad, "Max:" ) + $"{highestPauseMs:N2}ms\n" +
-					string.Format( Pad, "Sum:" ) + $"{sumMs:N2}ms\n" +
-					string.Format( Pad, $"Frames with >{StutterThresholdTicks / TimeSpan.TicksPerMillisecond}ms GC:" ) + $"{_stutterCount} frames\n" +
-					string.Format( Pad, "GC%:" ) + $"{sumMs / (liveElapsed * 1000.0) * 100.0:N2}%\n" +
-					string.Format( Pad, "GC% since process start:" ) + $"{gcMemInfo.PauseTimePercentage:N2}%\n";
-				Hud.DrawText( scope, new Rect( x, y, 512, 13 ), TextFlag.LeftTop );
+			var lowestPauseMs = TimeSpan.FromTicks( _pauseTicksMin == long.MaxValue ? 0 : _pauseTicksMin ).TotalMilliseconds;
+			var highestPauseMs = TimeSpan.FromTicks( _pauseTicksMax ).TotalMilliseconds;
+			var sumMs = TimeSpan.FromTicks( _pauseTicksSum ).TotalMilliseconds;
+			var avgMs = _frameCount > 0 ? TimeSpan.FromTicks( _pauseTicksSum / _frameCount ).TotalMilliseconds : 0.0;
 
-				y += 154;
-			}
+			var gcMemInfo = GC.GetGCMemoryInfo();
+			var mbPerSec = liveElapsed > 0 ? _allocBytesSum / (1024.0 * 1024.0 * liveElapsed) : 0.0;
+			var mbTotal = _allocBytesSum / (1024.0 * 1024.0);
+			var elapsedSecondsInt = (int)liveElapsed;
+			var windowLabel = elapsedSecondsInt >= 60 ? $"{elapsedSecondsInt / 60}m {elapsedSecondsInt % 60}s" : $"{elapsedSecondsInt}s";
 
+			headerScope.Text = $"Allocations ({windowLabel})";
+			Hud.DrawText( headerScope, new Rect( x, y, 512, 14 ), TextFlag.LeftTop );
 			y += 16;
 
-			scope.TextColor = new Color( 1f, 1f, 0.5f );
-			scope.Text = $"Top {_topAllocs.Count} Allocations";
-			Hud.DrawText( scope, new Vector2( x + 20, y ), TextFlag.LeftTop );
-			y += 16;
+			DrawSummaryRow( x, ref y, scope, dimScope, "Gen (0/1/2)", $"{_gen0Sum + ls.Gc0} / {_gen1Sum + ls.Gc1} / {_gen2Sum + ls.Gc2}" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Total Alloc", $"{mbTotal:N1} MB" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Alloc Rate", $"{mbPerSec:N2} MB/s" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "GC Pause Avg", $"{avgMs:N2}ms" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "GC Pause Min/Max", $"{lowestPauseMs:N2}ms / {highestPauseMs:N2}ms" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "GC Pause Sum", $"{sumMs:N2}ms" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Stutter Frames", $"{_stutterCount} (>{StutterThresholdTicks / TimeSpan.TicksPerMillisecond}ms)" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "GC Time", $"{sumMs / (liveElapsed * 1000.0) * 100.0:N2}% (session {gcMemInfo.PauseTimePercentage:N2}%)" );
+
+			y += 8;
+			headerScope.TextColor = new Color( 1f, 1f, 0.5f );
+			headerScope.Text = $"Top {_topAllocs.Count} Allocations";
+			Hud.DrawText( headerScope, new Rect( x, y, 512, 14 ), TextFlag.LeftTop );
+			y += 14;
+
+			dimScope.Text = "bytes";
+			Hud.DrawText( dimScope, new Rect( x + 10, y, 64, 12 ), TextFlag.RightTop );
+			dimScope.Text = "count";
+			Hud.DrawText( dimScope, new Rect( x + 80, y, 62, 12 ), TextFlag.RightTop );
+			dimScope.Text = "type";
+			Hud.DrawText( dimScope, new Rect( x + 152, y, 320, 12 ), TextFlag.LeftTop );
+			y += 14;
 
 			foreach ( var e in _topAllocs )
 			{
@@ -147,17 +160,17 @@ internal static partial class DebugOverlay
 
 				{
 					scope.Text = e.Bytes.FormatBytes();
-					Hud.DrawText( scope, new Rect( x + 20, y, 50, 13 ), TextFlag.RightTop );
+					Hud.DrawText( scope, new Rect( x + 10, y, 64, 13 ), TextFlag.RightTop );
 				}
 
 				{
 					scope.Text = e.Count.KiloFormat();
-					Hud.DrawText( scope, new Rect( x + 20, y, 75, 13 ), TextFlag.RightTop );
+					Hud.DrawText( scope, new Rect( x + 80, y, 62, 13 ), TextFlag.RightTop );
 				}
 
 				{
 					scope.Text = e.Name;
-					Hud.DrawText( scope, new Vector2( x + 100, y ), TextFlag.LeftTop );
+					Hud.DrawText( scope, new Vector2( x + 152, y ), TextFlag.LeftTop );
 				}
 
 				y += 14;
@@ -172,6 +185,16 @@ internal static partial class DebugOverlay
 			if ( name.StartsWith( "<GetAll>" ) ) return new Color( 1f, 1f, 0.7f );
 
 			return Color.White;
+		}
+
+		static void DrawSummaryRow( float x, ref float y, TextRendering.Scope valueScope, TextRendering.Scope labelScope, string label, string value )
+		{
+			labelScope.Text = label;
+			Hud.DrawText( labelScope, new Rect( x, y, 160, 13 ), TextFlag.LeftTop );
+			valueScope.Text = value;
+			valueScope.TextColor = Color.White.WithAlpha( 0.9f );
+			Hud.DrawText( valueScope, new Rect( x + 168, y, 320, 13 ), TextFlag.LeftTop );
+			y += 13;
 		}
 	}
 }

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Allocations.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Allocations.cs
@@ -111,7 +111,7 @@ internal static partial class DebugOverlay
 			{
 				Outline = new TextRendering.Outline { Color = Color.Black, Enabled = true, Size = 2 }
 			};
-			var dimScope = new TextRendering.Scope( "", Color.White.WithAlpha( 0.55f ), 10, "Roboto Mono", 600 )
+			var dimScope = new TextRendering.Scope( "", Color.White.WithAlpha( 0.78f ), 10, "Roboto Mono", 600 )
 			{
 				Outline = new TextRendering.Outline { Color = Color.Black, Enabled = true, Size = 2 }
 			};
@@ -127,18 +127,20 @@ internal static partial class DebugOverlay
 			var elapsedSecondsInt = (int)liveElapsed;
 			var windowLabel = elapsedSecondsInt >= 60 ? $"{elapsedSecondsInt / 60}m {elapsedSecondsInt % 60}s" : $"{elapsedSecondsInt}s";
 
-			headerScope.Text = $"Allocations ({windowLabel})";
+			headerScope.Text = $"GC Pauses (tracked for {windowLabel})";
 			Hud.DrawText( headerScope, new Rect( x, y, 512, 14 ), TextFlag.LeftTop );
 			y += 16;
 
-			DrawSummaryRow( x, ref y, scope, dimScope, "Gen (0/1/2)", $"{_gen0Sum + ls.Gc0} / {_gen1Sum + ls.Gc1} / {_gen2Sum + ls.Gc2}" );
-			DrawSummaryRow( x, ref y, scope, dimScope, "Total Alloc", $"{mbTotal:N1} MB" );
-			DrawSummaryRow( x, ref y, scope, dimScope, "Alloc Rate", $"{mbPerSec:N2} MB/s" );
-			DrawSummaryRow( x, ref y, scope, dimScope, "GC Pause Avg", $"{avgMs:N2}ms" );
-			DrawSummaryRow( x, ref y, scope, dimScope, "GC Pause Min/Max", $"{lowestPauseMs:N2}ms / {highestPauseMs:N2}ms" );
-			DrawSummaryRow( x, ref y, scope, dimScope, "GC Pause Sum", $"{sumMs:N2}ms" );
-			DrawSummaryRow( x, ref y, scope, dimScope, "Stutter Frames", $"{_stutterCount} (>{StutterThresholdTicks / TimeSpan.TicksPerMillisecond}ms)" );
-			DrawSummaryRow( x, ref y, scope, dimScope, "GC Time", $"{sumMs / (liveElapsed * 1000.0) * 100.0:N2}% (session {gcMemInfo.PauseTimePercentage:N2}%)" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Gen (0/1/2):", $"{_gen0Sum + ls.Gc0} / {_gen1Sum + ls.Gc1} / {_gen2Sum + ls.Gc2}" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Total:", $"{mbTotal:N1} MB" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Rate:", $"{mbPerSec:N2} MB/s" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Avg:", $"{avgMs:N2}ms" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Min:", $"{lowestPauseMs:N2}ms" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Max:", $"{highestPauseMs:N2}ms" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "Sum:", $"{sumMs:N2}ms" );
+			DrawSummaryRow( x, ref y, scope, dimScope, $"Frames with >{StutterThresholdTicks / TimeSpan.TicksPerMillisecond}ms GC:", $"{_stutterCount} frames" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "GC%:", $"{sumMs / (liveElapsed * 1000.0) * 100.0:N2}%" );
+			DrawSummaryRow( x, ref y, scope, dimScope, "GC% since process start:", $"{gcMemInfo.PauseTimePercentage:N2}%" );
 
 			y += 8;
 			headerScope.TextColor = new Color( 1f, 1f, 0.5f );

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Frame.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Frame.cs
@@ -40,8 +40,10 @@ internal static partial class DebugOverlay
 			DrawSectionHeader( ref drawPos, "Render Stats" );
 			DrawGroupHeader( ref drawPos, "Workload" );
 			Row( ref drawPos, "Objects", f.ObjectsRendered, $"({f.BaseObjectDraws:N0} base, {f.AnimatableObjectDraws:N0} anim) in {f.RenderBatchDraws:N0} batchlists" );
+			if ( f.ObjectsFading > 0 ) Row( ref drawPos, "Objects Fading", f.ObjectsFading );
 			Row( ref drawPos, "Triangles", f.TrianglesRendered );
 			Row( ref drawPos, "Draw Calls", f.DrawCalls, $"{SafeRatio( f.TrianglesRendered, f.DrawCalls ):N0} tris/draw" );
+			Row( ref drawPos, "Display Lists", f.DisplayLists );
 			Row( ref drawPos, "Views", f.SceneViewsRendered );
 			Row( ref drawPos, "Resolves", f.RenderTargetResolves );
 
@@ -92,9 +94,9 @@ internal static partial class DebugOverlay
 			Hud.DrawText( scope, rect with { Width = 120 }, TextFlag.RightCenter );
 			scope.TextColor = color; scope.Text = $"last {lastMs:F2}ms";
 			Hud.DrawText( scope, rect with { Left = rect.Left + 128, Width = 88 }, TextFlag.LeftCenter );
-			scope.TextColor = Color.White.WithAlpha( 0.55f ); scope.Text = $"avg {avgMs:F2}ms";
+			scope.TextColor = Color.White.WithAlpha( 0.78f ); scope.Text = $"avg {avgMs:F2}ms";
 			Hud.DrawText( scope, rect with { Left = rect.Left + 224, Width = 92 }, TextFlag.LeftCenter );
-			scope.TextColor = Color.White.WithAlpha( 0.55f ); scope.Text = $"jit {rangeMs:F2}ms";
+			scope.TextColor = Color.White.WithAlpha( 0.78f ); scope.Text = $"jit {rangeMs:F2}ms";
 			Hud.DrawText( scope, rect with { Left = rect.Left + 326, Width = 96 }, TextFlag.LeftCenter );
 			scope.TextColor = Color.White.WithAlpha( 0.8f ); scope.Text = $"{fps} fps";
 			Hud.DrawText( scope, rect with { Left = rect.Left + 450, Width = 78 }, TextFlag.LeftCenter );
@@ -113,7 +115,7 @@ internal static partial class DebugOverlay
 		static void DrawGroupHeader( ref Vector2 pos, string label )
 		{
 			var rect = new Rect( pos, new Vector2( 512, 12 ) );
-			var scope = new TextRendering.Scope( label, Color.White.WithAlpha( 0.55f ), 10, "Roboto Mono", 700 ) { Outline = _outline };
+			var scope = new TextRendering.Scope( label, Color.White.WithAlpha( 0.78f ), 10, "Roboto Mono", 700 ) { Outline = _outline };
 			Hud.DrawText( scope, rect, TextFlag.LeftCenter );
 			pos.y += rect.Height;
 		}
@@ -128,7 +130,7 @@ internal static partial class DebugOverlay
 			Hud.DrawText( scope, rect with { Left = rect.Left + 128, Width = detail is null ? 420 : 90 }, TextFlag.LeftCenter );
 			if ( detail is not null )
 			{
-				scope.TextColor = Color.White.WithAlpha( 0.5f );
+				scope.TextColor = Color.White.WithAlpha( 0.75f );
 				scope.Text = detail;
 				Hud.DrawText( scope, rect with { Left = rect.Left + 228, Width = 320 }, TextFlag.LeftCenter );
 			}

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Frame.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Frame.cs
@@ -39,7 +39,7 @@ internal static partial class DebugOverlay
 
 			DrawSectionHeader( ref drawPos, "Render Stats" );
 			DrawGroupHeader( ref drawPos, "Workload" );
-			Row( ref drawPos, "Objects", f.ObjectsRendered, $"({f.BaseObjectDraws:N0} base, {f.AnimatableObjectDraws:N0} anim)" );
+			Row( ref drawPos, "Objects", f.ObjectsRendered, $"({f.BaseObjectDraws:N0} base, {f.AnimatableObjectDraws:N0} anim) in {f.RenderBatchDraws:N0} batchlists" );
 			Row( ref drawPos, "Triangles", f.TrianglesRendered );
 			Row( ref drawPos, "Draw Calls", f.DrawCalls, $"{SafeRatio( f.TrianglesRendered, f.DrawCalls ):N0} tris/draw" );
 			Row( ref drawPos, "Views", f.SceneViewsRendered );

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Frame.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Frame.cs
@@ -12,11 +12,12 @@ internal static partial class DebugOverlay
 		private static int _histHead;
 		private static int _histCount;
 		private static uint _lastGpuFrameNo;
-
 		private static readonly TextRendering.Outline _outline = new() { Color = Color.Black, Size = 2, Enabled = true };
 
 		internal static void Draw( ref Vector2 pos )
 		{
+			var drawPos = new Vector2( pos.x + 24, MathF.Max( 20, pos.y - 28 ) );
+
 			float cpuMs = (float)(PerformanceStats.FrameTime * 1000.0);
 			float gpuMs = PerformanceStats.GpuFrametime;
 			uint gpuFrameNo = PerformanceStats.GpuFrameNumber;
@@ -29,29 +30,45 @@ internal static partial class DebugOverlay
 			CalcStats( _cpuHistory, _histCount, out float cpuAvg, out float cpuRange );
 			CalcStats( _gpuHistory, _histCount, out float gpuAvg, out float gpuRange );
 
-			TimingRow( ref pos, "Total Frame", cpuAvg, cpuRange );
-			TimingRow( ref pos, "GPU Frame", gpuAvg, gpuRange );
-			pos.y += 8;
+			DrawSectionHeader( ref drawPos, "Frame Timing" );
+			TimingRow( ref drawPos, "CPU Frame", cpuAvg, cpuRange, cpuMs );
+			TimingRow( ref drawPos, "GPU Frame", gpuAvg, gpuRange, gpuMs );
+			drawPos.y += 6;
 
 			var f = FrameStats.Current;
 
-			Row( ref pos, "Objects", f.ObjectsRendered, $"({f.BaseObjectDraws:N0} base, {f.AnimatableObjectDraws:N0} anim) in {f.RenderBatchDraws:N0} batchlists" );
-			Row( ref pos, "Triangles", f.TrianglesRendered );
-			Row( ref pos, "Draw Calls", f.DrawCalls );
-			Row( ref pos, "Material Changes", f.MaterialChanges + f.ShadowMaterialChanges, $"({f.ShadowMaterialChanges:N0} depth-only)" );
-			Row( ref pos, "Initial Materials", f.InitialMaterialChanges );
-			if ( f.UniqueMaterials > 0 ) Row( ref pos, "Unique Materials", f.UniqueMaterials );
-			Row( ref pos, "Display Lists", f.DisplayLists );
-			Row( ref pos, "Views", f.SceneViewsRendered );
-			Row( ref pos, "Resolves", f.RenderTargetResolves );
-			Row( ref pos, "Contexts", f.PrimaryContexts + f.SecondaryContexts, $"({f.PrimaryContexts:N0} primary, {f.SecondaryContexts:N0} secondary)" );
-			Row( ref pos, "Pre-Cull", f.ObjectsPreCull, $"({f.ObjectsTested:N0} tested)" );
-			Row( ref pos, "Vis Culls", f.ObjectsCulledByVis );
-			Row( ref pos, "Screensize Culls", f.ObjectsCulledByScreenSize );
-			if ( f.ObjectsFading > 0 ) Row( ref pos, "Objects Fading", f.ObjectsFading );
-			Row( ref pos, "Shadowed Lights", f.ShadowedLightsInView );
-			Row( ref pos, "Unshadowed Lights", f.UnshadowedLightsInView );
-			Row( ref pos, "Shadow Maps", f.ShadowMaps );
+			DrawSectionHeader( ref drawPos, "Render Stats" );
+			DrawGroupHeader( ref drawPos, "Workload" );
+			Row( ref drawPos, "Objects", f.ObjectsRendered, $"({f.BaseObjectDraws:N0} base, {f.AnimatableObjectDraws:N0} anim)" );
+			Row( ref drawPos, "Triangles", f.TrianglesRendered );
+			Row( ref drawPos, "Draw Calls", f.DrawCalls, $"{SafeRatio( f.TrianglesRendered, f.DrawCalls ):N0} tris/draw" );
+			Row( ref drawPos, "Views", f.SceneViewsRendered );
+			Row( ref drawPos, "Resolves", f.RenderTargetResolves );
+
+			drawPos.y += 4;
+			DrawGroupHeader( ref drawPos, "Culling" );
+			var totalCulled = f.ObjectsCulledByVis + f.ObjectsCulledByScreenSize + f.ObjectsCulledByFade;
+			Row( ref drawPos, "Pre-Cull", f.ObjectsPreCull, $"{f.ObjectsTested:N0} tested" );
+			Row( ref drawPos, "Total Culled", totalCulled, $"{SafePercent( totalCulled, f.ObjectsTested ):N1}% of tested" );
+			Row( ref drawPos, "Vis Culls", f.ObjectsCulledByVis, $"{SafePercent( f.ObjectsCulledByVis, f.ObjectsTested ):N1}%" );
+			Row( ref drawPos, "Size Culls", f.ObjectsCulledByScreenSize, $"{SafePercent( f.ObjectsCulledByScreenSize, f.ObjectsTested ):N1}%" );
+			Row( ref drawPos, "Fade Culls", f.ObjectsCulledByFade, $"{SafePercent( f.ObjectsCulledByFade, f.ObjectsTested ):N1}%" );
+
+			drawPos.y += 4;
+			DrawGroupHeader( ref drawPos, "Materials" );
+			var totalMaterialChanges = f.MaterialChanges + f.ShadowMaterialChanges;
+			Row( ref drawPos, "Material Changes", totalMaterialChanges, $"{SafePercent( totalMaterialChanges, f.DrawCalls ):N1}% vs draws" );
+			Row( ref drawPos, "Initial Materials", f.InitialMaterialChanges );
+			if ( f.UniqueMaterials > 0 ) Row( ref drawPos, "Unique Materials", f.UniqueMaterials );
+			Row( ref drawPos, "Contexts", f.PrimaryContexts + f.SecondaryContexts, $"({f.PrimaryContexts:N0} primary, {f.SecondaryContexts:N0} secondary)" );
+
+			drawPos.y += 4;
+			DrawGroupHeader( ref drawPos, "Lighting" );
+			Row( ref drawPos, "Shadowed Lights", f.ShadowedLightsInView );
+			Row( ref drawPos, "Unshadowed Lights", f.UnshadowedLightsInView );
+			Row( ref drawPos, "Shadow Maps", f.ShadowMaps, $"{SafeRatio( f.ShadowMaps, f.ShadowedLightsInView ):N1} maps per shadowed light" );
+
+			pos.y = drawPos.y;
 		}
 
 		static void CalcStats( float[] h, int count, out float avg, out float range )
@@ -65,39 +82,71 @@ internal static partial class DebugOverlay
 			range = dev;
 		}
 
-		static void TimingRow( ref Vector2 pos, string label, float avgMs, float rangeMs )
+		static void TimingRow( ref Vector2 pos, string label, float avgMs, float rangeMs, float lastMs )
 		{
 			int fps = avgMs > 0 ? (int)(1000f / avgMs) : 0;
-			var color = avgMs > 33.3f ? new Color( 1f, 0.3f, 0.3f ) : avgMs > 16.67f ? new Color( 1f, 0.6f, 0.2f ) : Color.White;
-			var rect = new Rect( pos, new Vector2( 512, 14 ) );
+			var color = lastMs > 33.3f ? new Color( 1f, 0.3f, 0.3f ) : lastMs > 16.67f ? new Color( 1f, 0.6f, 0.2f ) : Color.White;
+			var rect = new Rect( pos, new Vector2( 560, 14 ) );
 			var scope = new TextRendering.Scope( label, Color.White.WithAlpha( 0.8f ), 11, "Roboto Mono", 600 ) { Outline = _outline };
 
-			Hud.DrawText( scope, rect with { Width = 130 }, TextFlag.RightCenter );
-			scope.TextColor = color; scope.Text = $"{avgMs:F3}ms";
-			Hud.DrawText( scope, rect with { Left = rect.Left + 138, Width = 80 }, TextFlag.LeftCenter );
-			scope.TextColor = Color.White.WithAlpha( 0.55f ); scope.Text = $"+/- {rangeMs:F3}ms";
-			Hud.DrawText( scope, rect with { Left = rect.Left + 218, Width = 117 }, TextFlag.LeftCenter );
+			Hud.DrawText( scope, rect with { Width = 120 }, TextFlag.RightCenter );
+			scope.TextColor = color; scope.Text = $"last {lastMs:F2}ms";
+			Hud.DrawText( scope, rect with { Left = rect.Left + 128, Width = 88 }, TextFlag.LeftCenter );
+			scope.TextColor = Color.White.WithAlpha( 0.55f ); scope.Text = $"avg {avgMs:F2}ms";
+			Hud.DrawText( scope, rect with { Left = rect.Left + 224, Width = 92 }, TextFlag.LeftCenter );
+			scope.TextColor = Color.White.WithAlpha( 0.55f ); scope.Text = $"jit {rangeMs:F2}ms";
+			Hud.DrawText( scope, rect with { Left = rect.Left + 326, Width = 96 }, TextFlag.LeftCenter );
 			scope.TextColor = Color.White.WithAlpha( 0.8f ); scope.Text = $"{fps} fps";
-			Hud.DrawText( scope, rect with { Left = rect.Left + 335 }, TextFlag.LeftCenter );
+			Hud.DrawText( scope, rect with { Left = rect.Left + 450, Width = 78 }, TextFlag.LeftCenter );
 
+			pos.y += rect.Height;
+		}
+
+		static void DrawSectionHeader( ref Vector2 pos, string label )
+		{
+			var rect = new Rect( pos, new Vector2( 512, HeaderHeight - 2 ) );
+			var scope = new TextRendering.Scope( label, Color.White.WithAlpha( 0.9f ), 11, "Roboto Mono", 700 ) { Outline = _outline };
+			Hud.DrawText( scope, rect, TextFlag.LeftCenter );
+			pos.y += HeaderHeight;
+		}
+
+		static void DrawGroupHeader( ref Vector2 pos, string label )
+		{
+			var rect = new Rect( pos, new Vector2( 512, 12 ) );
+			var scope = new TextRendering.Scope( label, Color.White.WithAlpha( 0.55f ), 10, "Roboto Mono", 700 ) { Outline = _outline };
+			Hud.DrawText( scope, rect, TextFlag.LeftCenter );
 			pos.y += rect.Height;
 		}
 
 		static void Row( ref Vector2 pos, string label, double value, string detail = null )
 		{
-			var rect = new Rect( pos, new Vector2( 512, 14 ) );
+			var rect = new Rect( pos, new Vector2( 560, 14 ) );
 			var scope = new TextRendering.Scope( label, Color.White.WithAlpha( 0.8f ), 11, "Roboto Mono", 600 ) { Outline = _outline };
-			Hud.DrawText( scope, rect with { Width = 130 }, TextFlag.RightCenter );
+			Hud.DrawText( scope, rect with { Width = 120 }, TextFlag.RightCenter );
 			scope.TextColor = value > 0 ? Color.White : Color.White.WithAlpha( 0.5f );
 			scope.Text = value.ToString( "N0" );
-			Hud.DrawText( scope, rect with { Left = rect.Left + 138, Width = detail is null ? 374 : 80 }, TextFlag.LeftCenter );
+			Hud.DrawText( scope, rect with { Left = rect.Left + 128, Width = detail is null ? 420 : 90 }, TextFlag.LeftCenter );
 			if ( detail is not null )
 			{
 				scope.TextColor = Color.White.WithAlpha( 0.5f );
 				scope.Text = detail;
-				Hud.DrawText( scope, rect with { Left = rect.Left + 225 }, TextFlag.LeftCenter );
+				Hud.DrawText( scope, rect with { Left = rect.Left + 228, Width = 320 }, TextFlag.LeftCenter );
 			}
 			pos.y += rect.Height;
 		}
+
+		static double SafeRatio( double numerator, double denominator )
+		{
+			if ( denominator <= 0 ) return 0;
+			return numerator / denominator;
+		}
+
+		static double SafePercent( double numerator, double denominator )
+		{
+			if ( denominator <= 0 ) return 0;
+			return (numerator / denominator) * 100.0;
+		}
+
+		private const float HeaderHeight = 18f;
 	}
 }

--- a/engine/Sandbox.Engine/Systems/Render/Debug/GpuProfiler.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/GpuProfiler.cs
@@ -37,7 +37,7 @@ internal static partial class DebugOverlay
 			}
 
 			var rows = entries
-				.Select( (entry, index) => (
+				.Select( ( entry, index ) => (
 					Name: entry.Name,
 					LastMs: entry.DurationMs,
 					SmoothMs: GpuProfilerStats.GetSmoothedDuration( entry.Name ),

--- a/engine/Sandbox.Engine/Systems/Render/Debug/GpuProfiler.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/GpuProfiler.cs
@@ -18,6 +18,15 @@ internal static partial class DebugOverlay
 			new Color( 1.0f, 0.5f, 0.8f ),   // Pink
 		};
 
+		private static readonly TextRendering.Outline Outline = new() { Color = Color.Black.WithAlpha( 0.8f ), Size = 2, Enabled = true };
+
+		private const float RowHeight = 14f;
+		private const float NameWidth = 170f;
+		private const float GaugeWidth = 120f;
+		private const float ValueWidth = 74f;
+		private const int MaxRows = 20;
+		private const float MinVisibleMs = 0.02f;
+
 		internal static void Draw( ref Vector2 pos )
 		{
 			var entries = GpuProfilerStats.Entries;
@@ -27,91 +36,98 @@ internal static partial class DebugOverlay
 				return;
 			}
 
-			float labelWidth = 140;
-			float height = 14;
-			float y = pos.y;
-			var left = pos.x;
-			var mul = 200 / 16.0f; // Scale: 16ms = 200px
-
-			// Draw header
-			var headerRect = new Rect( left, y, 400, height );
-			var headerScope = new TextRendering.Scope( "GPU Timings", Color.White, 12, "Roboto Mono", 700 )
-			{
-				Outline = new TextRendering.Outline { Color = Color.Black, Size = 3, Enabled = true }
-			};
-			Hud.DrawText( headerScope, headerRect, TextFlag.LeftCenter );
-			y += height + 4;
-
-			// Draw total
-			float totalMs = GpuProfilerStats.TotalGpuTimeMs;
-			var totalRect = new Rect( left, y, 400, height );
-			var totalScope = new TextRendering.Scope( $"Total: {totalMs:F2}ms ({1000f / MathF.Max( totalMs, 0.001f ):F0} fps max)",
-				totalMs > 16.67f ? new Color( 1f, 0.5f, 0.3f ) : Color.White.WithAlpha( 0.9f ), 11, "Roboto Mono", 600 )
-			{
-				Outline = new TextRendering.Outline { Color = Color.Black, Size = 2, Enabled = true }
-			};
-			Hud.DrawText( totalScope, totalRect, TextFlag.LeftCenter );
-			y += height + 6;
-
-			// Sort entries by smoothed duration (descending)
-			var sortedEntries = entries
-				.Select( ( entry, index ) => (entry, index, smoothed: GpuProfilerStats.GetSmoothedDuration( entry.Name )) )
-				.OrderByDescending( x => x.smoothed )
+			var rows = entries
+				.Select( (entry, index) => (
+					Name: entry.Name,
+					LastMs: entry.DurationMs,
+					SmoothMs: GpuProfilerStats.GetSmoothedDuration( entry.Name ),
+					Color: PassColors[index % PassColors.Length]
+				) )
+				.Where( x => x.SmoothMs >= MinVisibleMs && !x.Name.StartsWith( "Managed:" ) )
+				.OrderByDescending( x => x.SmoothMs )
+				.Take( MaxRows )
 				.ToList();
 
-			// Draw each entry
-			for ( int i = 0; i < sortedEntries.Count; i++ )
+			if ( rows.Count == 0 )
 			{
-				var (entry, originalIndex, smoothedDuration) = sortedEntries[i];
-				var color = PassColors[originalIndex % PassColors.Length];
+				DrawNoData( ref pos );
+				return;
+			}
 
-				// Too irrelevant, skip
-				if ( smoothedDuration < 0.02 )
-					continue;
+			var totalMs = MathF.Max( GpuProfilerStats.TotalGpuTimeMs, 0.001f );
+			var scaleMs = MathF.Max( totalMs, rows.Max( x => x.SmoothMs ) );
 
-				// Clean up managed marker names for display, we still need to collect them from native side otherwise it'll redundantly add timings to the next in list
-				if ( entry.Name.StartsWith( "Managed:" ) )
-					continue;
+			var x = pos.x;
+			var y = pos.y;
+			var colName = x;
+			var colGauge = colName + NameWidth + 8;
+			var colLast = colGauge + GaugeWidth + 10;
+			var colSmooth = colLast + ValueWidth;
+			var colShare = colSmooth + ValueWidth;
 
-				var rowRect = new Rect( left, y, 500, height );
+			DrawSummary( ref y, x, totalMs, rows.Count );
+			DrawHeader( ref y, colName, colLast, colSmooth, colShare );
 
-				// Draw label
-				var labelScope = new TextRendering.Scope( entry.Name, color.Lighten( 0.5f ), 11, "Roboto Mono", 600 )
-				{
-					Outline = new TextRendering.Outline { Color = Color.Black, Size = 2, Enabled = true }
-				};
-				Hud.DrawText( labelScope, rowRect with { Width = labelWidth }, TextFlag.RightCenter );
-
-				// Draw bar
-				var barRect = rowRect with { Left = left + labelWidth + 8 };
-				var barWidth = MathF.Max( smoothedDuration * mul, 2 );
-
-				Hud.DrawRect( (barRect with { Width = entry.DurationMs * mul }).Shrink( 1 ), color.WithAlpha( 0.8f ), cornerRadius: new Vector4( 2 ) );
-				Hud.DrawRect( barRect with { Width = barWidth }, color.WithAlpha( 0.2f ), borderWidth: new Vector4( 1 ), borderColor: Color.Black, cornerRadius: new Vector4( 2 ) );
-
-				// Draw duration text
-				var textRect = barRect with { Left = left + labelWidth + 16 + barWidth };
-				var durationScope = new TextRendering.Scope( $"{entry.DurationMs:F2}ms", color.Lighten( 0.5f ), 11, "Roboto Mono", 600 )
-				{
-					Outline = new TextRendering.Outline { Color = Color.Black.WithAlpha( 0.8f ), Size = 2, Enabled = true }
-				};
-				Hud.DrawText( durationScope, textRect, TextFlag.LeftCenter );
-
-				y += height + 2;
+			foreach ( var row in rows )
+			{
+				DrawRow( ref y, row, totalMs, scaleMs, colName, colGauge, colLast, colSmooth, colShare );
 			}
 
 			pos.y = y;
 		}
 
+		private static void DrawSummary( ref float y, float x, float totalMs, int shownRows )
+		{
+			var fpsMax = 1000f / totalMs;
+			var color = totalMs > 16.67f ? new Color( 1f, 0.65f, 0.35f ) : Color.White.WithAlpha( 0.9f );
+			var scope = new TextRendering.Scope( $"GPU total {totalMs:F2}ms  ({fpsMax:F0} fps max)  shown {shownRows}", color, 11, "Roboto Mono", 700 ) { Outline = Outline };
+			Hud.DrawText( scope, new Rect( x, y, 560, RowHeight ), TextFlag.LeftCenter );
+			y += RowHeight;
+		}
+
+		private static void DrawHeader( ref float y, float colName, float colLast, float colSmooth, float colShare )
+		{
+			var dim = Color.White.WithAlpha( 0.55f );
+			DrawCell( "pass", dim, colName, y, NameWidth, TextFlag.LeftCenter );
+			DrawCell( "last", dim, colLast, y, ValueWidth, TextFlag.LeftCenter );
+			DrawCell( "avg", dim, colSmooth, y, ValueWidth, TextFlag.LeftCenter );
+			DrawCell( "% total", dim, colShare, y, ValueWidth, TextFlag.LeftCenter );
+			y += RowHeight;
+		}
+
+		private static void DrawRow( ref float y, (string Name, float LastMs, float SmoothMs, Color Color) row, float totalMs, float scaleMs, float colName, float colGauge, float colLast, float colSmooth, float colShare )
+		{
+			DrawCell( row.Name, row.Color.Lighten( 0.45f ), colName, y, NameWidth, TextFlag.LeftCenter );
+
+			var gauge = new Rect( colGauge, y + 2, GaugeWidth, RowHeight - 4 );
+			Hud.DrawRect( gauge, Color.Black.WithAlpha( 0.2f ), borderWidth: 1, borderColor: Color.White.WithAlpha( 0.08f ) );
+
+			var smoothW = MathF.Min( gauge.Width, (row.SmoothMs / scaleMs) * gauge.Width );
+			Hud.DrawRect( new Rect( gauge.Left, gauge.Top, MathF.Max( 1, smoothW ), gauge.Height ), row.Color.WithAlpha( 0.65f ) );
+
+			var lastX = gauge.Left + MathF.Min( gauge.Width, (row.LastMs / scaleMs) * gauge.Width );
+			Hud.DrawRect( new Rect( lastX, gauge.Top, 1, gauge.Height ), row.Color.Lighten( 0.2f ) );
+
+			var sharePct = (row.LastMs / totalMs) * 100f;
+			DrawCell( $"{row.LastMs:F2}ms", Color.White.WithAlpha( 0.85f ), colLast, y, ValueWidth, TextFlag.LeftCenter );
+			DrawCell( $"{row.SmoothMs:F2}ms", Color.White.WithAlpha( 0.7f ), colSmooth, y, ValueWidth, TextFlag.LeftCenter );
+			DrawCell( $"{sharePct:F1}%", Color.White.WithAlpha( 0.7f ), colShare, y, ValueWidth, TextFlag.LeftCenter );
+
+			y += RowHeight + 1;
+		}
+
+		private static void DrawCell( string text, Color color, float x, float y, float width, TextFlag flag )
+		{
+			var scope = new TextRendering.Scope( text, color, 11, "Roboto Mono", 600 ) { Outline = Outline };
+			Hud.DrawText( scope, new Rect( x, y, width, RowHeight ), flag );
+		}
+
 		private static void DrawNoData( ref Vector2 pos )
 		{
-			var rect = new Rect( pos, new Vector2( 300, 14 ) );
-			var scope = new TextRendering.Scope( "GPU Profiler: Waiting for data...", Color.White.WithAlpha( 0.6f ), 11, "Roboto Mono", 600 )
-			{
-				Outline = new TextRendering.Outline { Color = Color.Black, Size = 2, Enabled = true }
-			};
-			Hud.DrawText( scope, rect, TextFlag.LeftCenter );
-			pos.y += rect.Height;
+			var scope = new TextRendering.Scope( "GPU profiler: waiting for data...", Color.White.WithAlpha( 0.6f ), 11, "Roboto Mono", 600 ) { Outline = Outline };
+			Hud.DrawText( scope, new Rect( pos, new Vector2( 320, RowHeight ) ), TextFlag.LeftCenter );
+			pos.y += RowHeight;
 		}
+
 	}
 }

--- a/engine/Sandbox.Engine/Systems/Render/Debug/GpuProfiler.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/GpuProfiler.cs
@@ -18,7 +18,7 @@ internal static partial class DebugOverlay
 			new Color( 1.0f, 0.5f, 0.8f ),   // Pink
 		};
 
-		private static readonly TextRendering.Outline Outline = new() { Color = Color.Black.WithAlpha( 0.8f ), Size = 2, Enabled = true };
+		private static readonly TextRendering.Outline Outline = new() { Color = Color.Black, Size = 2, Enabled = true };
 
 		private const float RowHeight = 14f;
 		private const float NameWidth = 170f;
@@ -65,6 +65,7 @@ internal static partial class DebugOverlay
 			var colSmooth = colLast + ValueWidth;
 			var colShare = colSmooth + ValueWidth;
 
+			DrawTitle( ref y, x );
 			DrawSummary( ref y, x, totalMs, rows.Count );
 			DrawHeader( ref y, colName, colLast, colSmooth, colShare );
 
@@ -74,6 +75,13 @@ internal static partial class DebugOverlay
 			}
 
 			pos.y = y;
+		}
+
+		private static void DrawTitle( ref float y, float x )
+		{
+			var scope = new TextRendering.Scope( "GPU Timings", Color.White.WithAlpha( 0.9f ), 11, "Roboto Mono", 700 ) { Outline = Outline };
+			Hud.DrawText( scope, new Rect( x, y, 560, RowHeight ), TextFlag.LeftCenter );
+			y += RowHeight;
 		}
 
 		private static void DrawSummary( ref float y, float x, float totalMs, int shownRows )

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Profiler.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Profiler.cs
@@ -34,13 +34,24 @@ internal static partial class DebugOverlay
 
 			DrawHeader( ref y, x, colLast, colAvg, colMax );
 
-			foreach ( var t in timings.OrderByDescending( t => t.GetMetric( 256 ).Avg ) )
-			{
-				var last = t.GetMetric( 1 ).Avg;
-				var avg = t.GetMetric( 256 ).Avg;
-				var max = t.GetMetric( 256 ).Max;
+			var rows = timings
+				.Select( t =>
+				{
+					var lastMetric = t.GetMetric( 1 );
+					var windowMetric = t.GetMetric( 256 );
+					return (
+						Name: t.Name,
+						Color: t.Color,
+						Last: lastMetric.Avg,
+						Avg: windowMetric.Avg,
+						Max: windowMetric.Max
+					);
+				} )
+				.OrderByDescending( x => x.Avg );
 
-				DrawRow( ref y, t.Name, t.Color, colName, colGauge, colLast, colAvg, colMax, last, avg, max );
+			foreach ( var row in rows )
+			{
+				DrawRow( ref y, row.Name, row.Color, colName, colGauge, colLast, colAvg, colMax, row.Last, row.Avg, row.Max );
 			}
 
 			pos.y = y;

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Profiler.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Profiler.cs
@@ -5,7 +5,7 @@ internal static partial class DebugOverlay
 	public partial class Profiler
 	{
 		static readonly Dictionary<string, float> _smoothedAvgWidth = new();
-		static readonly TextRendering.Outline _outline = new() { Color = Color.Black.WithAlpha( 0.8f ), Size = 2, Enabled = true };
+		static readonly TextRendering.Outline _outline = new() { Color = Color.Black, Size = 2, Enabled = true };
 
 		const float RowHeight = 14f;
 		const float NameWidth = 150f;
@@ -32,6 +32,7 @@ internal static partial class DebugOverlay
 			var colAvg = colLast + ValueWidth;
 			var colMax = colAvg + ValueWidth;
 
+			DrawTitle( ref y, x );
 			DrawHeader( ref y, x, colLast, colAvg, colMax );
 
 			var rows = timings
@@ -55,6 +56,13 @@ internal static partial class DebugOverlay
 			}
 
 			pos.y = y;
+		}
+
+		static void DrawTitle( ref float y, float x )
+		{
+			var scope = new TextRendering.Scope( "Profile Timings", Color.White.WithAlpha( 0.9f ), 11, "Roboto Mono", 700 ) { Outline = _outline };
+			Hud.DrawText( scope, new Rect( x, y, 420, RowHeight ), TextFlag.LeftCenter );
+			y += RowHeight;
 		}
 
 		static void DrawHeader( ref float y, float x, float colLast, float colAvg, float colMax )

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Profiler.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Profiler.cs
@@ -1,58 +1,93 @@
-﻿namespace Sandbox;
+namespace Sandbox;
 
 internal static partial class DebugOverlay
 {
 	public partial class Profiler
 	{
-		static Dictionary<string, float> _smoothedProfileWidth = new();
+		static readonly Dictionary<string, float> _smoothedAvgWidth = new();
+		static readonly TextRendering.Outline _outline = new() { Color = Color.Black.WithAlpha( 0.8f ), Size = 2, Enabled = true };
+
+		const float RowHeight = 14f;
+		const float NameWidth = 150f;
+		const float GaugeWidth = 100f;
+		const float ValueWidth = 68f;
+		const float GaugeScaleMs = 25f;
 
 		internal static void Draw( ref Vector2 pos )
 		{
-			float labelWidth = 100;
-			float height = 14;
-			float y = pos.y;
-			var left = pos.x;
-			var mul = 200 / 16.0f;
+			var timings = Sandbox.Diagnostics.PerformanceStats.Timings.GetMain().ToArray();
+			if ( timings.Length == 0 )
+				return;
 
-			foreach ( var t in Sandbox.Diagnostics.PerformanceStats.Timings.GetMain() )
+			var liveNames = timings.Select( x => x.Name ).ToHashSet();
+			var stale = _smoothedAvgWidth.Keys.Where( x => !liveNames.Contains( x ) ).ToList();
+			foreach ( var key in stale )
+				_smoothedAvgWidth.Remove( key );
+
+			var x = pos.x;
+			var y = pos.y;
+			var colName = x;
+			var colGauge = colName + NameWidth + 8;
+			var colLast = colGauge + GaugeWidth + 10;
+			var colAvg = colLast + ValueWidth;
+			var colMax = colAvg + ValueWidth;
+
+			DrawHeader( ref y, x, colLast, colAvg, colMax );
+
+			foreach ( var t in timings.OrderByDescending( t => t.GetMetric( 256 ).Avg ) )
 			{
-				var rowRect = new Rect( left, y, 500, height );
-				var text = t.Name;
-				DebugOverlay.Hud.DrawText( new( text, t.Color.Lighten( 0.7f ), 11, "Roboto Mono", 600 ) { Outline = new TextRendering.Outline { Color = Color.Black, Size = 3, Enabled = true } }, rowRect with { Width = labelWidth }, TextFlag.RightCenter );
+				var last = t.GetMetric( 1 ).Avg;
+				var avg = t.GetMetric( 256 ).Avg;
+				var max = t.GetMetric( 256 ).Max;
 
-				rowRect = rowRect with { Left = left + labelWidth + 8 };
-
-				var last = t.GetMetric( 1 );
-				var avg = t.GetMetric( 256 );
-				var aw = 4 + avg.Max * mul;
-
-				if ( _smoothedProfileWidth.TryGetValue( t.Name, out var sw ) )
-				{
-					aw = MathX.LerpTo( sw, aw, Time.Delta * 10 );
-				}
-
-				_smoothedProfileWidth[t.Name] = aw;
-
-				DebugOverlay.Hud.DrawRect( (rowRect with { Width = avg.Avg * mul }).Shrink( 1 ), t.Color.WithAlpha( 0.8f ), cornerRadius: new Vector4( 2 ) );
-				DebugOverlay.Hud.DrawRect( (rowRect with { Width = last.Avg * mul }).Shrink( 1 ), t.Color.WithAlpha( 0.8f ), cornerRadius: new Vector4( 2 ) );
-				DebugOverlay.Hud.DrawRect( rowRect with { Width = aw }, t.Color.WithAlpha( 0.2f ), borderWidth: new Vector4( 1 ), borderColor: Color.Black, cornerRadius: new Vector4( 2 ) );
-
-				rowRect = rowRect with { Left = left + labelWidth + 16 + aw };
-
-				text = $"{avg.Avg:N2}ms";
-
-				if ( MathF.Abs( avg.Max - avg.Avg ) > 1 )
-				{
-					text += $" - {avg.Max:N2}ms";
-				}
-
-				DebugOverlay.Hud.DrawText( new( text, t.Color.Lighten( 0.7f ), 11, "Roboto Mono", 600 ) { Outline = new TextRendering.Outline { Color = Color.Black.WithAlpha( 0.8f ), Size = 2, Enabled = true } }, rowRect, TextFlag.LeftCenter );
-
-
-				y += height + 2;
+				DrawRow( ref y, t.Name, t.Color, colName, colGauge, colLast, colAvg, colMax, last, avg, max );
 			}
 
 			pos.y = y;
+		}
+
+		static void DrawHeader( ref float y, float x, float colLast, float colAvg, float colMax )
+		{
+			var dim = Color.White.WithAlpha( 0.55f );
+			DrawTextCell( "name", dim, x, y, NameWidth, TextFlag.LeftCenter );
+			DrawTextCell( "last", dim, colLast, y, ValueWidth, TextFlag.LeftCenter );
+			DrawTextCell( "avg", dim, colAvg, y, ValueWidth, TextFlag.LeftCenter );
+			DrawTextCell( "max", dim, colMax, y, ValueWidth, TextFlag.LeftCenter );
+
+			y += RowHeight;
+		}
+
+		static void DrawRow( ref float y, string name, Color color, float colName, float colGauge, float colLast, float colAvg, float colMax, float lastMs, float avgMs, float maxMs )
+		{
+			DrawTextCell( name, color.Lighten( 0.45f ), colName, y, NameWidth, TextFlag.LeftCenter );
+
+			var gauge = new Rect( colGauge, y + 2, GaugeWidth, RowHeight - 4 );
+			Hud.DrawRect( gauge, Color.Black.WithAlpha( 0.2f ), borderWidth: 1, borderColor: Color.White.WithAlpha( 0.08f ) );
+
+			var targetAvgWidth = MathF.Min( gauge.Width, (avgMs / GaugeScaleMs) * gauge.Width );
+			if ( _smoothedAvgWidth.TryGetValue( name, out var prev ) )
+				targetAvgWidth = MathX.LerpTo( prev, targetAvgWidth, Time.Delta * 14 );
+			_smoothedAvgWidth[name] = targetAvgWidth;
+			Hud.DrawRect( new Rect( gauge.Left, gauge.Top, MathF.Max( 1, targetAvgWidth ), gauge.Height ), color.WithAlpha( 0.65f ) );
+
+			var lastX = gauge.Left + MathF.Min( gauge.Width, (lastMs / GaugeScaleMs) * gauge.Width );
+			Hud.DrawRect( new Rect( lastX, gauge.Top, 1, gauge.Height ), color.Lighten( 0.2f ) );
+
+			var maxX = gauge.Left + MathF.Min( gauge.Width, (maxMs / GaugeScaleMs) * gauge.Width );
+			Hud.DrawRect( new Rect( maxX, gauge.Top, 1, gauge.Height ), Color.White.WithAlpha( 0.25f ) );
+
+			var valueColor = Color.White.WithAlpha( 0.85f );
+			DrawTextCell( $"{lastMs:F2}ms", valueColor, colLast, y, ValueWidth, TextFlag.LeftCenter );
+			DrawTextCell( $"{avgMs:F2}ms", valueColor, colAvg, y, ValueWidth, TextFlag.LeftCenter );
+			DrawTextCell( $"{maxMs:F2}ms", valueColor, colMax, y, ValueWidth, TextFlag.LeftCenter );
+
+			y += RowHeight + 1;
+		}
+
+		static void DrawTextCell( string text, Color color, float x, float y, float width, TextFlag flag )
+		{
+			var scope = new TextRendering.Scope( text, color, 11, "Roboto Mono", 600 ) { Outline = _outline };
+			Hud.DrawText( scope, new Rect( x, y, width, RowHeight ), flag );
 		}
 	}
 }

--- a/engine/Sandbox.Engine/Systems/Render/Debug/Resources.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Debug/Resources.cs
@@ -66,7 +66,8 @@ internal static partial class DebugOverlay
 			//
 			// WeakIndex (weak refs - runtime/native resources)
 			//
-			header.Text = $"WeakIndex (weak): {_resourceStats.WeakTotal}";
+			var weakDeadEntries = _resourceStats.WeakIndexEntries.GetValueOrDefault( "(dead)" );
+			header.Text = $"WeakIndex (weak): {_resourceStats.WeakTotal}, dead {weakDeadEntries:N0}";
 			header.TextColor = new Color( 0.6f, 1f, 0.7f );
 			Hud.DrawText( header, new Vector2( x, y ), TextFlag.LeftTop );
 			y += 16;
@@ -83,7 +84,8 @@ internal static partial class DebugOverlay
 			//
 			// NativeResourceCache
 			//
-			header.Text = $"NativeResourceCache (by handle): {_nativeCacheStats.WeakTableTotal} weak, {_nativeCacheStats.MemoryCacheCount} cached";
+			var nativeDeadEntries = _nativeCacheStats.Entries.GetValueOrDefault( "(dead)" );
+			header.Text = $"NativeResourceCache (by handle): {_nativeCacheStats.WeakTableTotal} weak, {_nativeCacheStats.MemoryCacheCount} cached, dead {nativeDeadEntries:N0}";
 			header.TextColor = new Color( 1f, 0.9f, 0.6f );
 			Hud.DrawText( header, new Vector2( x, y ), TextFlag.LeftTop );
 			y += 16;


### PR DESCRIPTION
# Summary
This Pull Request improves the visual side of debug overlay commands.

## overlay_frame
- Grouped Render Stats into: `Workload`, `Culling`, `Materials`, `Lighting`.
- Updated Frame Timing with a clear CPU/GPU order: `last`, `avg`, `jit`, `fps`.
- Added metrics:
  - `Fade Culls` - number of objects culled by fade logic.
  - `tris/draw` - average triangles per draw call.
  - `% culled from tested` - share of culled objects from tested objects.
  - `material changes % vs draws` - material switches relative to draw calls.
  - `maps per shadowed light` - average shadow maps per shadowed light.
- Removed low-signal rows to reduce visual noise:
  - `Display Lists`
  - conditional `Objects Fading`

### Before/After
<img width="1405" height="492" alt="sbox-dev_kuRPv1D2ep" src="https://github.com/user-attachments/assets/aeaf737a-d1ab-4724-86f5-f7edd15fcffa" />
<img width="1405" height="492" alt="sbox-dev_HctkSB9x8V" src="https://github.com/user-attachments/assets/4861ba08-a484-4e6e-b4cf-e156666c130c" />

## overlay_profile
- Reworked the layout to fixed-width columns.
- Grouped each row as `name / last / avg / max`.

### Before/After
<img width="1405" height="492" alt="sbox-dev_7IOadFDE9E" src="https://github.com/user-attachments/assets/90d3ebc6-7ce7-4827-857f-ae5ac3783bba" />
<img width="1405" height="492" alt="sbox-dev_V1BAvnAOIO" src="https://github.com/user-attachments/assets/2fa7fc39-e596-43f8-82e9-1f5bb3403e51" />

## overlay_alloc
- Made the allocations overlay more compact.
- Formatted `Top Allocations` as a simple `bytes / count / type` table.
- Aligned columns and spacing for faster reading.

### Before/After
<img width="1405" height="656" alt="sbox-dev_HnKnzRn1ql" src="https://github.com/user-attachments/assets/45298ebc-6ffe-44df-80d8-b83d49c74834" />
<img width="1309" height="492" alt="sbox-dev_lLejwJ5u0Y" src="https://github.com/user-attachments/assets/51532c25-bf80-4039-a5c2-3687275dfe68" />

## overlay_gpu
- Updated the visual layout to a clean fixed-width table.
- For each pass, added: `last`, `avg`, `% total`.

### Before/After
<img width="1309" height="492" alt="sbox-dev_8N0iZEbJhv" src="https://github.com/user-attachments/assets/ac07d1f6-0f97-4821-86f7-ae6723d709a4" />
<img width="1405" height="492" alt="sbox-dev_2J6B29Uw62" src="https://github.com/user-attachments/assets/e28f6103-ba26-4c9a-b3d0-dfab255878f8" />
