### PR TITLE
Clamp FOV/Field Of View slider in game settings to an integer

### DIFF
--- a/game/addons/menu/Code/Modals/Settings/GameSettings.razor
+++ b/game/addons/menu/Code/Modals/Settings/GameSettings.razor
@@ -23,7 +23,7 @@
             <cell class="glass with-padding is-label">
                 Field Of View
             </cell>
-            <SliderControl Min="@(45)" Max="@(120)" Value:bind=@FieldOfView />
+            <SliderControl Min="@(45)" Max="@(120)" Step="@(1f)" Value:bind=@FieldOfView />
 
             <TextEntry Numeric=@true class="glass" Value:bind=@FieldOfView style="min-width: 50px;"></TextEntry>
         </row>


### PR DESCRIPTION
## Summary

Currently, the slider in the game settings for FOV doesn't clamp itself to an integer and will display as a float until the settings tab is opened again.

## Motivation & Context

Seemed more straight forward to fix instead of creating an issue.

## Screenshots

Before ->

<img width="938" height="103" alt="image" src="https://github.com/user-attachments/assets/e9b7f90d-7a8e-4854-8dca-0cbb33c0cd9f" />

After ->

<img width="943" height="106" alt="image" src="https://github.com/user-attachments/assets/77e90310-4d6b-47f9-afbd-90ced4be3ef0" />