### PR TITLE
Add ShowIndicator property to Voice Transmitter component

### DIFF
--- a/engine/Sandbox.Engine/Application.cs
+++ b/engine/Sandbox.Engine/Application.cs
@@ -162,6 +162,12 @@ public static class Application
 #endif
 
 	/// <summary>
+	/// If set to false, the built-in microphone indicator overlay will be hidden.
+	/// Games can set this to false when they provide their own voice chat UI.
+	/// </summary>
+	public static bool ShowMicrophoneIndicator { get; set; } = true;
+
+	/// <summary>
 	/// Returns true if the microphone is currently listening
 	/// </summary>
 	public static bool IsMicrophoneListening => VoiceManager.IsListening;

--- a/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
@@ -38,6 +38,9 @@ public class Voice : Component
 	[Description( "Play the sound of your own voice" )]
 	[Property] public bool Loopback { get; set; } = false;
 
+	[Description( "Show the built-in microphone indicator overlay. Disable this if your game provides its own voice chat UI." )]
+	[Property] public bool ShowIndicator { get; set; } = true;
+
 	[Property, ToggleGroup( "LipSync", Label = "Lip Sync" )]
 	public bool LipSync { get; set; } = true;
 
@@ -148,6 +151,8 @@ public class Voice : Component
 
 	internal override void OnEnabledInternal()
 	{
+		Application.ShowMicrophoneIndicator = ShowIndicator;
+
 		VoiceManager.OnCompressedVoiceData += OnVoice;
 
 		soundStream = new SoundStream( VoiceManager.SampleRate );
@@ -163,6 +168,8 @@ public class Voice : Component
 	internal override void OnDisabledInternal()
 	{
 		base.OnDisabledInternal();
+
+		Application.ShowMicrophoneIndicator = true;
 
 		VoiceManager.OnCompressedVoiceData -= OnVoice;
 

--- a/game/addons/menu/Code/Overlay/Overlays/MicOverlay.razor
+++ b/game/addons/menu/Code/Overlay/Overlays/MicOverlay.razor
@@ -9,6 +9,7 @@
     {
         get
         {
+            if (!Application.ShowMicrophoneIndicator) return "inactive";
 
             if (Application.IsMicrophoneRecording) return "active recording";
             if (Application.IsMicrophoneListening) return "active";
@@ -17,6 +18,6 @@
         }
     }
 
-    protected override int BuildHash() => System.HashCode.Combine( Application.IsMicrophoneListening , Application.IsMicrophoneRecording );
+    protected override int BuildHash() => System.HashCode.Combine( Application.IsMicrophoneListening, Application.IsMicrophoneRecording, Application.ShowMicrophoneIndicator );
 
 }


### PR DESCRIPTION
## Summary

Adds a `ShowIndicator` property to the **Voice Transmitter** component and a corresponding `Application.ShowMicrophoneIndicator` API, allowing games to hide the built-in microphone indicator overlay when they provide their own voice chat UI.

## Motivation & Context

Games that implement custom voice chat UI (e.g. proximity voice with custom HUD indicators, overhead speaker icons) end up with two overlapping mic indicators — their own and the engine's built-in `MicOverlay`. There is currently no way to disable the default overlay from game code.

## Implementation Details

- **`Application.ShowMicrophoneIndicator`** — new `public static bool` property (defaults to `true`). Games can also set this directly via code.
- **`Voice.ShowIndicator`** — new `[Property]` on the Voice Transmitter component, exposed as a checkbox in the editor. Sets `Application.ShowMicrophoneIndicator` on enable, resets to `true` on disable.
- **`MicOverlay.razor`** — checks `Application.ShowMicrophoneIndicator` and returns `"inactive"` when `false`, effectively hiding the overlay. Added to `BuildHash` for proper reactivity.

## Screenshots / Videos (if applicable)

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/a1f50f46-5b91-444c-92f1-cf503173a494" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂