### PR TITLE
Allow [ShowIf] and [HideIf] to check for null

### DIFF
--- a/engine/Sandbox.Engine/Editor/Hammer/ConditionalVisibilityAttributes.cs
+++ b/engine/Sandbox.Engine/Editor/Hammer/ConditionalVisibilityAttributes.cs
@@ -59,7 +59,7 @@ public class HideIfAttribute : ConditionalVisibilityAttribute
 	{
 		if ( so.TryGetProperty( PropertyName, out var property ) )
 		{
-			var value = property.GetValue<object>( so );
+			var value = property.GetValue<object>();
 			return Equals( value, Value );
 		}
 


### PR DESCRIPTION
## Summary
HideIfAttribute (and by extension ShowIfAttribute) previously wouldn't function when using null as the value, now they do.

<img width="534" height="54" alt="image" src="https://github.com/user-attachments/assets/3d1314a6-0072-4bb4-a104-e2868448c4d6" />

## Motivation & Context
slight annoyance, easy fix

## Implementation Details
The entire SerializedObject was being passed into `SerializedProperty.GetValue(object defaultValue)` as the default (such that if the properties value was null it would check against the serialized object rather than the property and always return false). I'm assuming this to be unintentional.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂