### PR TITLE
hide and rename _d files with same logic as _c files

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
@@ -464,18 +464,27 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 				if ( file.Exists && file.Attributes.HasFlag( FileAttributes.Hidden ) )
 					continue;
 
-				var asset = AssetSystem.FindByPath( file.ToString() );
+				var path = file.ToString();
+				// pretend blobs are real assets for a moment so we can filter them out if they have a source file
+				var blob = file.Name.EndsWith( "_d" );
+				if ( blob )
+					path = path[..^2];
+				var asset = AssetSystem.FindByPath( path );
 
 				//
 				// Filter out compiled assets if we have a source asset
 				//
 				string sourcePath = asset?.GetSourceFile();
-				if ( file.Name.EndsWith( "_c" ) && !string.IsNullOrEmpty( sourcePath ) )
+				if ( (file.Name.EndsWith( "_c" ) || blob) && !string.IsNullOrEmpty( sourcePath ) )
 				{
 					// ( but only if the extensions are similar and would both be shown in this filter, eg so we don't hide .sounds because we have a .wav etc )
 					if ( Search.AssetTypes.ActiveTags.Count == 0 || file.Extension.Contains( System.IO.Path.GetExtension( sourcePath ) ) )
 						continue;
 				}
+
+				// can't load an asset or show the inspector from a blob
+				if ( blob )
+					asset = null;
 
 				if ( asset == null && HideNonAssets )
 					continue;

--- a/game/addons/tools/Code/Editor/AssetList/Entries/AssetEntry.cs
+++ b/game/addons/tools/Code/Editor/AssetList/Entries/AssetEntry.cs
@@ -194,8 +194,11 @@ public class AssetEntry : IAssetListEntry
 		if ( !string.IsNullOrEmpty( compiledPath ) )
 		{
 			var compiled = new FileInfo( compiledPath );
-
 			compiled.MoveTo( compiled.GetNewPath( $"{newName}_c" ) );
+
+			var blob = new FileInfo( $"{compiledPath[..^2]}_d" );
+			if ( blob.Exists )
+				blob.MoveTo( compiled.GetNewPath( $"{newName}_d" ) );
 		}
 
 		FileInfo.MoveTo( FileInfo.GetNewPath( newName ) );


### PR DESCRIPTION
## Summary
Hides blob data files if a source file is present, if the source file is renamed it will rename the blob data in addition to the compiled file.

## Motivation & Context
Seemed messy to have them all out in the open like that.

<img width="402" height="244" alt="image" src="https://github.com/user-attachments/assets/3fbe4ebb-d189-4836-b5ba-a7ce80b55bf3" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂