### PR TITLE
Expose faster way to loop over lights

### DIFF
--- a/game/addons/base/Assets/shaders/common/classes/Light.hlsl
+++ b/game/addons/base/Assets/shaders/common/classes/Light.hlsl
@@ -7,6 +7,11 @@
 #include "light_probe_volume.fxc"
 #include "baked_lighting_constants.fxc"
 
+struct LightQuery {
+    ClusterRange Range;
+    uint Count;
+};
+
 //-----------------------------------------------------------------------------
 // Light structure
 //-----------------------------------------------------------------------------
@@ -34,7 +39,15 @@ struct Light
     // 1.0.
     float Visibility;
 
-    // Gets the light structure given the world position and the light index.
+    // Collect a range of lights to loop over. Use the result with Light::From
+    // to avoid calling Cluster::Query a bunch of extra times.
+    static LightQuery Query( float4 vPositionSs );
+
+    // Gets the light structure using cached information from Light::Query.
+    static Light From( float3 vPositionWs, LightQuery query, uint index, float2 vLightMapUV = 0.0f );
+
+    // Gets the light structure given the world position and the light index
+    // without cached information from LightQuery (slower).
     static Light From( float3 vPositionWs, float4 vPositionSs, uint nLightIndex, float2 vLightMapUV = 0.0f );
 
     // Number of lights in the current fragment.
@@ -259,6 +272,29 @@ class StaticLight : Light
 };
 
 //-----------------------------------------------------------------------------
+
+static LightQuery Light::Query( float4 vPositionSs )
+{
+    ClusterRange range = Cluster::Query( ClusterItemType_Light, vPositionSs );
+    LightQuery query;
+    query.Range = range;
+    query.Count = range.Count + StaticLight::Count();
+    return query;
+}
+
+static Light Light::From( float3 vPositionWs, LightQuery query, uint index, float2 vLightMapUV )
+{
+    uint dynamicCount = query.Range.Count;
+
+    if ( index < dynamicCount )
+    {
+        DynamicLight light = (DynamicLight)0;
+        light.Init( vPositionWs, DynamicLightConstantByIndex( Cluster::LoadItem( query.Range, index ) ) );
+        return light;
+    }
+
+    return StaticLight::From( vPositionWs, vLightMapUV, index - dynamicCount);
+}
 
 static Light Light::From( float3 vPositionWs, float4 vPositionSs, uint nLightIndex, float2 vLightMapUV )
 {

--- a/game/addons/base/Assets/shaders/common/classes/Light.hlsl
+++ b/game/addons/base/Assets/shaders/common/classes/Light.hlsl
@@ -7,7 +7,8 @@
 #include "light_probe_volume.fxc"
 #include "baked_lighting_constants.fxc"
 
-struct LightQuery {
+struct LightQuery
+{
     ClusterRange Range;
     uint Count;
 };
@@ -293,7 +294,7 @@ static Light Light::From( float3 vPositionWs, LightQuery query, uint index, floa
         return light;
     }
 
-    return StaticLight::From( vPositionWs, vLightMapUV, index - dynamicCount);
+    return StaticLight::From( vPositionWs, vLightMapUV, index - dynamicCount );
 }
 
 static Light Light::From( float3 vPositionWs, float4 vPositionSs, uint nLightIndex, float2 vLightMapUV )


### PR DESCRIPTION
## Summary
Light::From was calling Cluster::Query twice. With it generally being in a loop this was apparently not great for performance (as pointed out by @rzkid). This pr provides a way to loop over lights while keeping the ClusterRange cached, fairly drastically improving performance for games with custom shading models to the tune of dynamic opaque forward ms cut in half.

## Motivation & Context
free perf

## Implementation Details
```hlsl
Light::Query( float4 vPositionSs )
```
returns a `LightQuery` struct (similar to `Cluster::Query`) that contains the cached `ClusterRange` and a Count of dynamic + static lights to use in the for loop.

```hlsl
Light::From( float3 vPositionWs, LightQuery query, uint index, float2 vLightMapUV = 0.0f )
```
returns a `Light` using the cached `ClusterRange` inside the `LightQuery`, and as such can avoid additional calls to `Cluster::Query`.

Looping through lights would now look like
```hlsl
LightQuery query = Light::Query(i.vPositionSs);
for (int x = 0; x < query.Count; x++) {
    Light l = Light::From(pos, query, x);

}
```

I left the existing Light::From and Light::Count methods in place to avoid breaking things but it might be better to remove them, seems like any place theyre getting used should probably be using the 'double your framerate' version? Idk though.

## Screenshots
On my machine the previous method pulls around 40ms on a scene with a stupid number of lights, and around 4ms in a more reasonable scenario.
```hlsl
for (int x = 0; x < Light::Count(i.vPositionSs); x++) {
    Light l = Light::From(pos, i.vPositionSs, x);
}
```
<img width="2560" height="1301" alt="image" src="https://github.com/user-attachments/assets/dd313c99-ae62-49a1-8ea0-dae6a15d9042" />
<img width="2560" height="1298" alt="image" src="https://github.com/user-attachments/assets/d7281dce-b60a-4adf-b3d3-a69c3db12923" />

---

New method runs at 16ms on the heavy scene and 2ms on the reasonable one, roughly matching the performance of default shading model.
```hlsl
LightQuery query = Light::Query(i.vPositionSs);
for (int x = 0; x < query.Count; x++) {
    Light l = Light::From(pos, query, x);
}
```
<img width="2560" height="1297" alt="image" src="https://github.com/user-attachments/assets/a94bf451-ffc3-4822-8cc2-5c945929cd86" />
<img width="2560" height="1297" alt="image" src="https://github.com/user-attachments/assets/ac242c1e-8461-41ea-8f13-31724b437eef" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂