### PR TITLE
Make custom font loading recursive

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/TextRendering/FontManager.cs
+++ b/engine/Sandbox.Engine/Systems/Render/TextRendering/FontManager.cs
@@ -51,8 +51,8 @@ internal class FontManager : FontMapper
 		// If we're loading new fonts, we may have cached it already
 		Cache.Clear();
 
-		var fontFiles = fileSystem.FindFile( "/fonts/", "*.ttf" )
-			.Union( fileSystem.FindFile( "/fonts/", "*.otf" ) );
+		var fontFiles = fileSystem.FindFile( "/fonts/", "*.ttf", true )
+			.Union( fileSystem.FindFile( "/fonts/", "*.otf", true ) );
 
 		Parallel.ForEach( fontFiles, ( string font ) =>
 		{


### PR DESCRIPTION
# Pull Request

## Summary

Right now, fonts are only loaded in the /fonts/ top directory. 
This PR Makes FontManager load fonts in subfolders in /fonts/ asset folder recursively.

## Motivation & Context

It doesnt really make sense for it to only consider the top folder, since this means all organisation in case of fonts with multiple files is impossible.

## Implementation Details

N/A 

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂