### PR TITLE
Add MODES section to compute shader template

### DIFF
--- a/game/templates/compute.shader
+++ b/game/templates/compute.shader
@@ -1,3 +1,8 @@
+MODES
+{
+	Default();
+}
+
 CS
 {
 	#include "system.fxc"


### PR DESCRIPTION
## Summary
Compute shaders don't work without
```hlsl
MODES
{
	Default();
}
```
I believe this is an issue with whatever preprocessing step is supposed to add the default modes section to shaders that don't contain it, if a newline is added to the top of the file the shader starts working. That's all native (afaik) though, and seems easier just to add it to the template.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: https://github.com/Facepunch/sbox-public/issues/1890

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂