### PR TITLE
compile with STANDALONE constant when exporting game

### DIFF
--- a/engine/Sandbox.Compiling/CompilerConfiguration.cs
+++ b/engine/Sandbox.Compiling/CompilerConfiguration.cs
@@ -37,12 +37,6 @@ partial class Compiler
 		public bool Whitelist { get; set; } = true;
 
 		/// <summary>
-		/// Game is being compiled for standalone export, the STANDALONE constant is enabled.
-		/// </summary>
-		[JsonIgnore]
-		public bool Standalone { get; set; } = false;
-
-		/// <summary>
 		/// If true, we'll compile with /unsafe. This means that the package won't be able to
 		/// be published on the platform.
 		/// </summary>
@@ -124,14 +118,13 @@ partial class Compiler
 							.ToHashSet();
 
 			if ( ReleaseMode == ReleaseMode.Debug )
+			{
 				symbols.Add( "DEBUG" );
+			}
 			else
+			{
 				symbols.Remove( "DEBUG" );
-
-			if ( Standalone )
-				symbols.Add( "STANDALONE" );
-			else
-				symbols.Remove( "STANDALONE" );
+			}
 
 			return symbols;
 		}

--- a/engine/Sandbox.Compiling/CompilerConfiguration.cs
+++ b/engine/Sandbox.Compiling/CompilerConfiguration.cs
@@ -37,6 +37,12 @@ partial class Compiler
 		public bool Whitelist { get; set; } = true;
 
 		/// <summary>
+		/// Game is being compiled for standalone export, the STANDALONE constant is enabled.
+		/// </summary>
+		[JsonIgnore]
+		public bool Standalone { get; set; } = false;
+
+		/// <summary>
 		/// If true, we'll compile with /unsafe. This means that the package won't be able to
 		/// be published on the platform.
 		/// </summary>
@@ -118,13 +124,14 @@ partial class Compiler
 							.ToHashSet();
 
 			if ( ReleaseMode == ReleaseMode.Debug )
-			{
 				symbols.Add( "DEBUG" );
-			}
 			else
-			{
 				symbols.Remove( "DEBUG" );
-			}
+
+			if ( Standalone )
+				symbols.Add( "STANDALONE" );
+			else
+				symbols.Remove( "STANDALONE" );
 
 			return symbols;
 		}

--- a/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.Compile.cs
+++ b/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.Compile.cs
@@ -8,6 +8,7 @@ partial class StandaloneExporter
 	{
 		var compilerSettings = Project.Config.GetCompileSettings();
 		compilerSettings.Whitelist = false;
+		compilerSettings.Standalone = true;
 
 		var generated = await EditorUtility.Projects.Compile( Project, compilerSettings, ( s ) => Logger.Info( $"[Compiler] {s}" ) );
 		if ( generated == null )

--- a/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.Compile.cs
+++ b/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.Compile.cs
@@ -8,7 +8,8 @@ partial class StandaloneExporter
 	{
 		var compilerSettings = Project.Config.GetCompileSettings();
 		compilerSettings.Whitelist = false;
-		compilerSettings.Standalone = true;
+		if ( !compilerSettings.GetPreprocessorSymbols().Contains( "STANDALONE" ) )
+			compilerSettings.DefineConstants += ";STANDALONE";
 
 		var generated = await EditorUtility.Projects.Compile( Project, compilerSettings, ( s ) => Logger.Info( $"[Compiler] {s}" ) );
 		if ( generated == null )


### PR DESCRIPTION
## Summary
When developing a game for both platform and standalone at the same time (in this case the plan is demo on platform, full game on steam) there is inevitably code that should run in the standalone export but not on platform, different pause menu or stuff that breaks whitelist or whatever. This adds an extra constant when doing the compile for game export.
<img width="579" height="72" alt="image" src="https://github.com/user-attachments/assets/2cc21509-066c-4a81-9325-32beb45f2ef9" />


## Motivation & Context
Needed for my own project, seemed rude not to share.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂