### PR TITLE
Fix BeamEffect position with custom material

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Effects/BeamEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Effects/BeamEffect.cs
@@ -414,7 +414,7 @@ public sealed class BeamEffect : Component, Component.ExecuteInEditor, Component
 			Offset = offset,
 			FilterMode = FilterMode,
 			TextureAddressMode = Rendering.TextureAddressMode.Wrap,
-			WorldSpace = true,
+			WorldSpace = Material is null,
 		};
 
 		if ( TravelBetweenPoints )
@@ -434,7 +434,15 @@ public sealed class BeamEffect : Component, Component.ExecuteInEditor, Component
 
 		}
 
-		lineRenderer.VectorPoints.Add( beam.StartPosition );
-		lineRenderer.VectorPoints.Add( beam.EndPosition );
+		if ( Material is null )
+		{
+			lineRenderer.VectorPoints.Add( beam.StartPosition );
+			lineRenderer.VectorPoints.Add( beam.EndPosition );
+		}
+		else
+		{
+			lineRenderer.VectorPoints.Add( lineRenderer.WorldTransform.PointToLocal( beam.StartPosition ) );
+			lineRenderer.VectorPoints.Add( lineRenderer.WorldTransform.PointToLocal( beam.EndPosition ) );
+		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

BeamEffect rendered at wrong world positions when a custom Material was assigned.
Beam points were converted to local space while WorldSpace was false, causing drift.

## Motivation & Context

Forum report with video: https://sbox.game/f/gendev/1650/1/#post2

## Implementation Details

- Set WorldSpace = true unconditionally instead of Material is null
- Always use world space points regardless of material

## Screenshots / Videos (if applicable)

https://sbox.game/f/gendev/1650/1/#post2

## Checklist

- [✅] Code follows existing style and conventions
- [✅] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [✅] I’m okay with this PR being rejected or requested to change 🙂