### PR TITLE
Fix incorrect DamageTags comment

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/TriggerHurt.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/TriggerHurt.cs
@@ -7,7 +7,7 @@
 public sealed class TriggerHurt : Component
 {
 	/// <summary>
-	/// If not empty, the target must have one of these tags
+	/// These tags will be applied to the emitted <see cref="DamageInfo"/>
 	/// </summary>
 	[Property, Group( "Damage" )] public TagSet DamageTags { get; set; } = new();
 


### PR DESCRIPTION
## Summary

I was just reading this code and noticed that the comment here was likely copied from Include or Exclude.

## Motivation & Context

Incorrect comments are bad.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂