### PR TITLE
Support font-variant-numeric style property with tabular-nums

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/TextRendering/TextRendering.Scope.cs
+++ b/engine/Sandbox.Engine/Systems/Render/TextRendering/TextRendering.Scope.cs
@@ -26,6 +26,7 @@ public static partial class TextRendering
 		[JsonInclude] public int FontWeight;
 
 		[JsonInclude] public bool FontItalic;
+		[JsonInclude] public UI.FontVariantNumeric FontVariantNumeric;
 
 		[Range( 0, 5 )]
 		[JsonInclude] public float LineHeight;
@@ -60,6 +61,7 @@ public static partial class TextRendering
 			hc.Add( FontSize );
 			hc.Add( FontWeight );
 			hc.Add( FontItalic );
+			hc.Add( FontVariantNumeric );
 			hc.Add( LineHeight );
 			hc.Add( LetterSpacing );
 			hc.Add( WordSpacing );
@@ -83,6 +85,7 @@ public static partial class TextRendering
 			FontName = "Roboto",
 			FontSize = 64,
 			FontWeight = 400,
+			FontVariantNumeric = UI.FontVariantNumeric.Normal,
 			LineHeight = 1,
 			Shadow = new Shadow() { Color = Color.Black },
 			ShadowUnder = new Shadow() { Color = Color.Black },
@@ -99,6 +102,7 @@ public static partial class TextRendering
 			FontSize = size;
 			FontName = font;
 			FontWeight = weight;
+			FontVariantNumeric = UI.FontVariantNumeric.Normal;
 			LineHeight = 1;
 			Shadow = new Shadow() { Color = Color.Black };
 			ShadowUnder = new Shadow() { Color = Color.Black };
@@ -126,6 +130,7 @@ public static partial class TextRendering
 			style.FontSize = FontSize;
 			style.FontWeight = FontWeight;
 			style.FontItalic = FontItalic;
+			style.FontVariantNumeric = FontVariantNumeric;
 			style.TextColor = TextColor.ToSk();
 			style.Underline = Topten.RichTextKit.UnderlineStyle.None;
 			style.StrikeThrough = Topten.RichTextKit.StrikeThroughStyle.None;

--- a/engine/Sandbox.Engine/Systems/UI/Engine/TextBlock.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Engine/TextBlock.cs
@@ -74,6 +74,7 @@ internal sealed class TextBlock : IDisposable
 	FilterMode TextFilter;
 	TextDecoration TextDecoration;
 	FontStyle FontStyle;
+	FontVariantNumeric? FontVariantNumeric;
 	WordBreak WordBreak;
 	TextTransform? TextTransform;
 	Length? LetterSpacing;
@@ -223,6 +224,7 @@ internal sealed class TextBlock : IDisposable
 		TextAlign = style.TextAlign.Value;
 		TextDecoration = style.TextDecorationLine.Value;
 		FontStyle = style.FontStyle.Value;
+		FontVariantNumeric = style.FontVariantNumeric;
 		AlignItems = style.AlignItems.Value;
 		LetterSpacing = style.LetterSpacing;
 		WordSpacing = style.WordSpacing;
@@ -240,7 +242,7 @@ internal sealed class TextBlock : IDisposable
 		hash = HashCode.Combine( hash, style.TextStrokeWidth, style.TextStrokeColor, style.TextDecorationColor, style.TextDecorationThickness, style.TextDecorationSkipInk, style.TextDecorationStyle );
 		hash = HashCode.Combine( hash, style.TextUnderlineOffset, style.TextOverlineOffset, style.TextLineThroughOffset, style.TextGradient, style.TextOverflow, style.WordBreak, style.LineHeight );
 		hash = HashCode.Combine( hash, style.WordSpacing );
-		hash = HashCode.Combine( hash, Smooth );
+		hash = HashCode.Combine( hash, Smooth, FontVariantNumeric );
 
 		if ( FontHash == hash && Block != null )
 			return false;
@@ -257,6 +259,7 @@ internal sealed class TextBlock : IDisposable
 		Style.FontSize = FontSize;
 		Style.FontWeight = FontWeight ?? 400;
 		Style.FontItalic = FontStyle != FontStyle.None;
+		Style.FontVariantNumeric = FontVariantNumeric ?? UI.FontVariantNumeric.Normal;
 		Style.TextColor = fontColor.ToSk();
 		Style.Underline = UnderlineStyle.None;
 		Style.StrokeInkSkip = style.TextDecorationSkipInk == TextSkipInk.All;
@@ -390,6 +393,7 @@ internal sealed class TextBlock : IDisposable
 						sty.BackgroundColor = s.BackgroundColor?.ToSk() ?? sty.BackgroundColor;
 						sty.FontWeight = s.FontWeight ?? sty.FontWeight;
 						sty.FontItalic = s.FontStyle == FontStyle.Italic;
+						sty.FontVariantNumeric = s.FontVariantNumeric ?? sty.FontVariantNumeric;
 						sty.Underline = s.TextDecorationLine == UI.TextDecoration.Underline ? UnderlineStyle.Solid : UnderlineStyle.None;
 						sty.UnderlineColor = sty.TextColor;
 						sty.LetterSpacing = s.LetterSpacing?.GetPixels( 1000.0f ) ?? sty.LetterSpacing;

--- a/engine/Sandbox.Engine/Systems/UI/Styles/BaseStyles.Generated.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Styles/BaseStyles.Generated.cs
@@ -1126,6 +1126,22 @@ public abstract partial class BaseStyles
 			Dirty();
 		}
 	}
+
+	internal FontVariantNumeric? _fontvariantnumeric;
+
+	/// <summary>
+	/// Represents the <c>font-variant-numeric</c> CSS property.
+	/// </summary>
+	public FontVariantNumeric? FontVariantNumeric
+	{
+		get => _fontvariantnumeric;
+		set
+		{
+			if ( _fontvariantnumeric == value ) return;
+			_fontvariantnumeric = value;
+			Dirty();
+		}
+	}
 	
 	internal PanelTransform? _transform;
 	
@@ -2339,6 +2355,7 @@ public abstract partial class BaseStyles
 		if ( a._textoverlineoffset != null ) _textoverlineoffset = a._textoverlineoffset;
 		if ( a._textlinethroughoffset != null ) _textlinethroughoffset = a._textlinethroughoffset;
 		if ( a._fontstyle != null ) _fontstyle = a._fontstyle;
+		if ( a._fontvariantnumeric != null ) _fontvariantnumeric = a._fontvariantnumeric;
 		if ( a._transform != null ) _transform = a._transform;
 		if ( a._texttransform != null ) _texttransform = a._texttransform;
 		if ( a._transformoriginx != null ) _transformoriginx = a._transformoriginx;
@@ -2487,6 +2504,7 @@ public abstract partial class BaseStyles
 		_textoverlineoffset = a._textoverlineoffset;
 		_textlinethroughoffset = a._textlinethroughoffset;
 		_fontstyle = a._fontstyle;
+		_fontvariantnumeric = a._fontvariantnumeric;
 		_transform = a._transform;
 		_texttransform = a._texttransform;
 		_transformoriginx = a._transformoriginx;
@@ -2976,6 +2994,7 @@ public abstract partial class BaseStyles
 			hash = HashCode.Combine( hash, _textoverlineoffset );
 			hash = HashCode.Combine( hash, _textlinethroughoffset );
 			hash = HashCode.Combine( hash, _fontstyle );
+			hash = HashCode.Combine( hash, _fontvariantnumeric );
 			hash = HashCode.Combine( hash, _transform );
 			hash = HashCode.Combine( hash, _texttransform );
 			hash = HashCode.Combine( hash, _transformoriginx );
@@ -3528,6 +3547,7 @@ public abstract partial class BaseStyles
 		copy._textoverlineoffset = _textoverlineoffset;
 		copy._textlinethroughoffset = _textlinethroughoffset;
 		copy._fontstyle = _fontstyle;
+		copy._fontvariantnumeric = _fontvariantnumeric;
 		copy._transform = _transform;
 		copy._texttransform = _texttransform;
 		copy._transformoriginx = _transformoriginx;
@@ -3624,6 +3644,7 @@ public abstract partial class BaseStyles
 		if ( _textoverlineoffset == null ) _textoverlineoffset = parent._textoverlineoffset;
 		if ( _textlinethroughoffset == null ) _textlinethroughoffset = parent._textlinethroughoffset;
 		if ( _fontstyle == null ) _fontstyle = parent._fontstyle;
+		if ( _fontvariantnumeric == null ) _fontvariantnumeric = parent._fontvariantnumeric;
 		if ( _texttransform == null ) _texttransform = parent._texttransform;
 		if ( _letterspacing == null ) _letterspacing = parent._letterspacing;
 		if ( _lineheight == null ) _lineheight = parent._lineheight;
@@ -3702,6 +3723,7 @@ public abstract partial class BaseStyles
 		if ( !_textoverlineoffset.HasValue ) _textoverlineoffset = 0;
 		if ( !_textlinethroughoffset.HasValue ) _textlinethroughoffset = 0;
 		if ( !_fontstyle.HasValue ) _fontstyle = UI.FontStyle.None;
+		if ( !_fontvariantnumeric.HasValue ) _fontvariantnumeric = UI.FontVariantNumeric.Normal;
 		if ( !_transform.HasValue ) _transform = new UI.PanelTransform();
 		if ( !_texttransform.HasValue ) _texttransform = UI.TextTransform.None;
 		if ( !_transformoriginx.HasValue ) _transformoriginx = Length.Percent( 50 ).Value;
@@ -3839,6 +3861,7 @@ public abstract partial class BaseStyles
 			case "text-overline-offset": return (_textoverlineoffset == 0);
 			case "text-line-through-offset": return (_textlinethroughoffset == 0);
 			case "font-style": return (_fontstyle == UI.FontStyle.None);
+			case "font-variant-numeric": return (_fontvariantnumeric == UI.FontVariantNumeric.Normal);
 			case "transform": return (_transform == new UI.PanelTransform());
 			case "text-transform": return (_texttransform == UI.TextTransform.None);
 			case "transform-origin-x": return (_transformoriginx == Length.Percent( 50 ).Value);

--- a/engine/Sandbox.Engine/Systems/UI/Styles/BaseStyles.Generated.tt
+++ b/engine/Sandbox.Engine/Systems/UI/Styles/BaseStyles.Generated.tt
@@ -81,6 +81,7 @@ var Members = new Dictionary<string, (string TypeName, string DefaultValue, bool
 	{ "TextOverlineOffset",			("Length?",				"0",							true)},
 	{ "TextLineThroughOffset",		("Length?",				"0",							true)},
 	{ "FontStyle",					("FontStyle?",			"UI.FontStyle.None",			true)},
+	{ "FontVariantNumeric",			("FontVariantNumeric?",	"UI.FontVariantNumeric.Normal",	true)},
 	{ "Transform",					("PanelTransform?",		"new UI.PanelTransform()",		false)},
 	{ "TextTransform",				("TextTransform?",		"UI.TextTransform.None",		true)},
 	{ "TransformOriginX",			("Length?",				"Length.Percent( 50 ).Value",	false)},

--- a/engine/Sandbox.Engine/Systems/UI/Styles/Styles.Set.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Styles/Styles.Set.cs
@@ -143,6 +143,9 @@ namespace Sandbox.UI
 				case "font-style":
 					return SetFontStyle( value );
 
+				case "font-variant-numeric":
+					return SetFontVariantNumeric( value );
+
 				case "white-space":
 					return SetWhiteSpace( value );
 
@@ -1257,6 +1260,22 @@ namespace Sandbox.UI
 
 			FontStyle = fs;
 			return true;
+		}
+
+		bool SetFontVariantNumeric( string value )
+		{
+			switch ( value.Trim().ToLowerInvariant() )
+			{
+				case "normal":
+					FontVariantNumeric = UI.FontVariantNumeric.Normal;
+					return true;
+				case "tabular-nums":
+					FontVariantNumeric = UI.FontVariantNumeric.TabularNums;
+					return true;
+				default:
+					Log.Warning( $"Unhandled font-variant-numeric property: {value}" );
+					return false;
+			}
 		}
 
 		bool SetWhiteSpace( string value )

--- a/engine/Sandbox.System/UI/Styles/StyleEnums.cs
+++ b/engine/Sandbox.System/UI/Styles/StyleEnums.cs
@@ -395,6 +395,22 @@ public enum FontStyle
 }
 
 /// <summary>
+/// Possible values for <c>font-variant-numeric</c> CSS property.
+/// </summary>
+public enum FontVariantNumeric
+{
+	/// <summary>
+	/// Default numeric glyph behavior.
+	/// </summary>
+	Normal = 0,
+
+	/// <summary>
+	/// Use tabular-width digits if the font provides them.
+	/// </summary>
+	TabularNums = 1,
+}
+
+/// <summary>
 /// Possible values for <c>image-rendering</c> CSS property.
 /// </summary>
 public enum ImageRendering

--- a/engine/Sandbox.Test.Unit/System/TextRenderingScopeTests.cs
+++ b/engine/Sandbox.Test.Unit/System/TextRenderingScopeTests.cs
@@ -1,0 +1,31 @@
+using Sandbox.UI;
+
+namespace SystemTest;
+
+[TestClass]
+public class TextRenderingScopeTests
+{
+	[TestMethod]
+	public void HashCodeIncludesFontVariantNumeric()
+	{
+		var normal = TextRendering.Scope.Default;
+		normal.FontVariantNumeric = FontVariantNumeric.Normal;
+
+		var tabular = normal;
+		tabular.FontVariantNumeric = FontVariantNumeric.TabularNums;
+
+		Assert.AreNotEqual( normal.GetHashCode(), tabular.GetHashCode() );
+	}
+
+	[TestMethod]
+	public void ToStyleCopiesFontVariantNumeric()
+	{
+		var scope = TextRendering.Scope.Default;
+		scope.FontVariantNumeric = FontVariantNumeric.TabularNums;
+
+		var style = new Topten.RichTextKit.Style();
+		scope.ToStyle( style );
+
+		Assert.AreEqual( FontVariantNumeric.TabularNums, style.FontVariantNumeric );
+	}
+}

--- a/engine/Sandbox.Test.Unit/UI/Styles/StyleSetting.cs
+++ b/engine/Sandbox.Test.Unit/UI/Styles/StyleSetting.cs
@@ -1,4 +1,4 @@
-using Sandbox.UI;
+ï»¿using Sandbox.UI;
 
 namespace UITest;
 
@@ -630,7 +630,7 @@ public class StyleSetting
 		Assert.AreEqual( 1, styles.Transitions.List.Count );
 		Assert.AreEqual( "width", styles.Transitions.List[0].Property );
 		Assert.AreEqual( 10, styles.Transitions.List[0].Duration );
-		// Each property has an initial value, defined in the property’s definition table
+		// Each property has an initial value, defined in the property's definition table
 		// https://w3c.github.io/csswg-drafts/css-transitions/#transition-timing-function-property
 		Assert.AreEqual( "ease", styles.Transitions.List[0].TimingFunction );
 		Assert.AreEqual( 0, styles.Transitions.List[0].Delay.Value );
@@ -1191,5 +1191,27 @@ public class StyleSetting
 		Assert.IsTrue( styles.BackdropFilterInvert.HasValue );
 		Assert.AreEqual( LengthUnit.Percentage, styles.BackdropFilterInvert.Value.Unit );
 		Assert.AreEqual( 70.0f, styles.BackdropFilterInvert.Value.Value );
+	}
+
+	[TestMethod]
+	public void SetFontVariantNumeric()
+	{
+		{
+			var styles = new Styles();
+			Assert.IsTrue( styles.Set( "font-variant-numeric", "tabular-nums" ) );
+			Assert.AreEqual( FontVariantNumeric.TabularNums, styles.FontVariantNumeric );
+		}
+
+		{
+			var styles = new Styles();
+			Assert.IsTrue( styles.Set( "font-variant-numeric", "normal" ) );
+			Assert.AreEqual( FontVariantNumeric.Normal, styles.FontVariantNumeric );
+		}
+
+		{
+			var styles = new Styles();
+			Assert.IsFalse( styles.Set( "font-variant-numeric", "lining-nums" ) );
+			Assert.IsNull( styles.FontVariantNumeric );
+		}
 	}
 }

--- a/engine/ThirdParty/Topten.RichTextKit/IStyle.cs
+++ b/engine/ThirdParty/Topten.RichTextKit/IStyle.cs
@@ -120,6 +120,11 @@ namespace Topten.RichTextKit
 		FontVariant FontVariant { get; }
 
 		/// <summary>
+		/// Numeric variant selection (eg: tabular-width numerals).
+		/// </summary>
+		FontVariantNumeric FontVariantNumeric { get; }
+
+		/// <summary>
 		/// Text direction override for this span
 		/// </summary>
 		TextDirection TextDirection { get; }

--- a/engine/ThirdParty/Topten.RichTextKit/Style.cs
+++ b/engine/ThirdParty/Topten.RichTextKit/Style.cs
@@ -14,6 +14,7 @@
 // under the License.
 
 using SkiaSharp;
+using Sandbox.UI;
 
 namespace Topten.RichTextKit
 {
@@ -45,6 +46,7 @@ namespace Topten.RichTextKit
 			s.LetterSpacing = LetterSpacing;
 			s.WordSpacing = WordSpacing;
 			s.FontVariant = FontVariant;
+			s.FontVariantNumeric = FontVariantNumeric;
 			s.TextDirection = TextDirection;
 			s.ReplacementCharacter = ReplacementCharacter;
 			s._textEffects = _textEffects?.ToList();
@@ -146,6 +148,11 @@ namespace Topten.RichTextKit
 		/// The font variant (ie: super/sub-script) for text in this run.
 		/// </summary>
 		public FontVariant FontVariant { get; set; } = FontVariant.Normal;
+
+		/// <summary>
+		/// Numeric variant selection (eg: tabular-width numerals).
+		/// </summary>
+		public FontVariantNumeric FontVariantNumeric { get; set; } = FontVariantNumeric.Normal;
 
 		/// <summary>
 		/// Text direction override for this span

--- a/engine/ThirdParty/Topten.RichTextKit/TextShaping/TextShaper.cs
+++ b/engine/ThirdParty/Topten.RichTextKit/TextShaping/TextShaper.cs
@@ -14,6 +14,7 @@
 // under the License.
 
 using HarfBuzzSharp;
+using Sandbox.UI;
 using SkiaSharp;
 using System.Runtime.InteropServices;
 using Topten.RichTextKit.Utils;
@@ -204,6 +205,11 @@ namespace Topten.RichTextKit
 		/// </summary>
 		const int overScale = 512;
 
+		static readonly Feature[] _tabularNumbersFeature = new[]
+		{
+			new Feature( new Tag( 't', 'n', 'u', 'm' ), 1 )
+		};
+
 
 
 		/// <summary>
@@ -324,7 +330,14 @@ namespace Topten.RichTextKit
 				buffer.GuessSegmentProperties();
 
 				// Shape it
-				_font.Shape( buffer );
+				if ( style.FontVariantNumeric == FontVariantNumeric.TabularNums )
+				{
+					_font.Shape( buffer, _tabularNumbersFeature );
+				}
+				else
+				{
+					_font.Shape( buffer );
+				}
 
 				// RTL?
 				bool rtl = buffer.Direction == Direction.RightToLeft;


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

- Adds `font-variant-numeric: tabular-nums` support in s&box, enabling developers to use [tabular nums](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-variant-numeric#numeric-spacing-values) on fonts that support it (via tnum)
- Applying this property on a font that does not support tnum is a no-op (no warnings or errors, fonts still behave as expected), which is consistent across s&box font properties at the moment.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

I had a use-case and decided to open a quick PR for it. No issue.

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

Standard CSS property implementation. The RichTextKit supports this out of the box.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

| font-variant-numeric: normal | font-variant-numeric: tabular-nums |
|--------|--------|
| <img width="529" height="199" alt="sbox-dev_BsfVNhAQSW" src="https://github.com/user-attachments/assets/679284db-80e1-4416-9594-42c19258a018" /> | <img width="529" height="199" alt="sbox-dev_lK3sD2inRd" src="https://github.com/user-attachments/assets/af779933-f2f9-4712-8bd1-da0f6d305048" /> |

You may need to click into the images to see the differences, which are applied in the timestamp in the chat panel.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂