### PR TITLE
Validate CanRefreshObjects for new network refresh messages

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -884,6 +884,10 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 
 	private void OnObjectRefreshDescendant( ObjectRefreshDescendantMsg message, Connection source )
 	{
+		// Is this a request from someone? If so, check if they can refresh objects.
+		if ( source is not null && !source.CanRefreshObjects )
+			return;
+
 		var scene = Game.ActiveScene;
 		if ( !scene.IsValid() )
 			return;
@@ -936,6 +940,10 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 
 	private void OnObjectRefreshComponent( ObjectRefreshComponentMsg message, Connection source )
 	{
+		// Is this a request from someone? If so, check if they can refresh objects.
+		if ( source is not null && !source.CanRefreshObjects )
+			return;
+
 		var scene = Game.ActiveScene;
 		if ( !scene.IsValid() )
 			return;


### PR DESCRIPTION
## Pull Request: Secure Object Refresh Permission Checks

### Summary
This PR addresses a security vulnerability where `OnObjectRefreshComponent` and `OnObjectRefreshDescendant` message handlers lacked server-side permission validation. We have now implemented `CanRefreshObjects` checks in these handlers to maintain parity with the existing `OnObjectRefresh` logic.

---

### Motivation & Context
While `OnObjectRefresh` correctly validates `source.CanRefreshObjects` before processing client requests, the newer component and descendant handlers were missing this restriction. This oversight allowed clients to bypass "Default Client Permissions" by sending forged `ObjectRefreshComponentMsg` or `ObjectRefreshDescendantMsg` packets.

This vulnerability is currently being exploited via DLL injection. Malicious users are sending crafted messages to spawn unauthorized objects or components (such as `MoneyEntity`), effectively bypassing host-only variable restrictions.

### Implementation Details
The identical permission check used in `OnObjectRefresh` has been integrated into both handlers:

```csharp
// Validate client permissions
if ( source is not null && !source.CanRefreshObjects )
    return;
```

**Key Improvements:**
* **Early Rejection:** The check is positioned at the top of each handler to reject unauthorized requests before any scene lookups or object resolution occur.
* **Layered Security:** Existing ownership and host checks (`HasControl` / `IsHost`) remain intact. The permission check acts as the primary gate for the action itself, while ownership checks continue to regulate which specific objects can be targeted.

---

### Checklist
* Code adheres to existing project style and conventions.
* No unnecessary formatting or unrelated code changes.
* Permission checks are applied consistently across all refresh-related handlers.
* All existing unit tests pass.