### PR TITLE
Obsolete [MakeDirty]

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Collider/Rigidbody.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/Rigidbody.cs
@@ -125,11 +125,29 @@ sealed public partial class Rigidbody : Component, Component.ExecuteInEditor, IG
 	[Property, ReadOnly, Group( "Mass" ), JsonIgnore]
 	public float Mass => _body.IsValid() ? _body.Mass : default;
 
-	[Property, Group( "Mass" ), MakeDirty]
-	public bool OverrideMassCenter { get; set; }
+	[Property, Group( "Mass" )]
+	public bool OverrideMassCenter
+	{
+		get;
+		set
+		{
+			field = value;
 
-	[Property, Title( "Mass Center Override" ), Group( "Mass" ), ShowIf( nameof( OverrideMassCenter ), true ), MakeDirty]
-	public Vector3 MassCenterOverride { get; set; }
+			OnPropertyDirty();
+		}
+	}
+
+	[Property, Title( "Mass Center Override" ), Group( "Mass" ), ShowIf( nameof( OverrideMassCenter ), true )]
+	public Vector3 MassCenterOverride
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Center of mass for this rigidbody in local space coordinates.
@@ -137,14 +155,32 @@ sealed public partial class Rigidbody : Component, Component.ExecuteInEditor, IG
 	[Property, ReadOnly, Group( "Mass" ), JsonIgnore]
 	public Vector3 MassCenter => _body.IsValid() ? _body.LocalMassCenter : default;
 
-	[Property, MakeDirty]
-	public PhysicsLock Locking { get; set; }
+	[Property]
+	public PhysicsLock Locking
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	[Property]
 	public bool StartAsleep { get; set; }
 
-	[Property, MakeDirty]
-	public RigidbodyFlags RigidbodyFlags { get; set; }
+	[Property]
+	public RigidbodyFlags RigidbodyFlags
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Whether this rigidbody can deal damage to damageable objects on high-speed impacts.
@@ -238,8 +274,17 @@ sealed public partial class Rigidbody : Component, Component.ExecuteInEditor, IG
 		}
 	}
 
-	[Property, MakeDirty]
-	public bool MotionEnabled { get; set; } = true;
+	[Property]
+	public bool MotionEnabled
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = true;
 
 
 	bool _collisionEventsEnabled = true;

--- a/engine/Sandbox.Engine/Scene/Components/Component.Dirty.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Component.Dirty.cs
@@ -13,6 +13,9 @@ public abstract partial class Component
 		OnPropertyDirty();
 	}
 
+	/// <summary>
+	/// Marks the component as dirty
+	/// </summary>
 	protected void OnPropertyDirty()
 	{
 		if ( _dirty ) return;
@@ -48,6 +51,7 @@ public abstract partial class Component
 
 [AttributeUsage( AttributeTargets.Property )]
 [CodeGenerator( CodeGeneratorFlags.WrapPropertySet | CodeGeneratorFlags.Instance, "OnPropertyDirty" )]
+[Obsolete( "Call OnPropertyDirty in your property setter" )]
 public class MakeDirtyAttribute : Attribute
 {
 

--- a/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/VerletRope.cs
@@ -11,8 +11,17 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// <summary>
 	/// The GameObject the end of the rope attaches to.
 	/// </summary>
-	[Property, Group( "Attachment" ), MakeDirty]
-	public GameObject Attachment { get; set; }
+	[Property, Group( "Attachment" )]
+	public GameObject Attachment
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// The LineRenderer used to visualize the rope.
@@ -37,8 +46,17 @@ public class VerletRope : Component, Component.ExecuteInEditor
 	/// <summary>
 	/// Number of segments in the rope. Higher values increase visual fidelity and collision accuracy but quickly reduce performance.
 	/// </summary>
-	[Property, Group( "Simulation" ), MakeDirty, Range( 1, 64 ), Step( 1 )]
-	public int SegmentCount { get; set; } = 16;
+	[Property, Group( "Simulation" ), Range( 1, 64 ), Step( 1 )]
+	public int SegmentCount
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 16;
 
 	/// <summary>
 	/// Radius of the rope for collision detection.

--- a/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
+++ b/engine/Sandbox.Engine/Scene/Components/IndirectLighting/IndirectLightVolume.cs
@@ -58,29 +58,65 @@ public sealed partial class IndirectLightVolume : Component, Component.ExecuteIn
 	/// <summary>
 	/// World-space bounding box that defines the volume coverage area.
 	/// </summary>
-	[Property, MakeDirty]
-	public BBox Bounds { get; set; } = BBox.FromPositionAndSize( Vector3.Zero, new Vector3( 512.0f ) );
+	[Property]
+	public BBox Bounds
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = BBox.FromPositionAndSize( Vector3.Zero, new Vector3( 512.0f ) );
 
 	/// <summary>
 	/// Number of probes per 1024 world units. Higher values increase probe resolution.
 	/// </summary>
-	[Property, Range( 1, 15 ), MakeDirty]
-	public int ProbeDensity { get; set; } = 8;
+	[Property, Range( 1, 15 )]
+	public int ProbeDensity
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 8;
 
 	/// <summary>
 	/// Bias applied along surface normals to prevent self-occlusion artifacts.
 	/// </summary>
 	[Group( "Advanced Settings" )]
-	[Property, Range( -0.0f, 50.0f ), MakeDirty]
-	public float NormalBias { get; set; } = 5.0f;
+	[Property, Range( -0.0f, 50.0f )]
+	public float NormalBias
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 5.0f;
 
 	/// <summary>
 	/// Controls how much less energy to conserve during probe integration.
 	/// Higher values give a harsher, more contrasty look.
 	/// </summary>
-	[Property, Range( 1.0f, 2.0f ), MakeDirty]
+	[Property, Range( 1.0f, 2.0f )]
 	[Group( "Advanced Settings" )]
-	public float Contrast { get; set; } = 1.0f;
+	public float Contrast
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
 
 	/// <summary>
 	/// Calculated probe count along each axis based on bounds and density.

--- a/engine/Sandbox.Engine/Scene/Components/Joint/BallJoint.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Joint/BallJoint.cs
@@ -32,74 +32,173 @@ public sealed class BallJoint : Joint
 	/// Motor mode
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty]
-	public MotorMode Motor { get; set; }
+	[Property]
+	public MotorMode Motor
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Enables or disables the swing limit.
 	/// </summary>
-	[Property, MakeDirty]
-	public bool SwingLimitEnabled { get; set; } = false;
+	[Property]
+	public bool SwingLimitEnabled
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = false;
 
 	/// <summary>
 	/// The minimum and maximum swing angles allowed by the joint in degrees.
 	/// </summary>
-	[Property, MakeDirty]
-	public Vector2 SwingLimit { get; set; } = new Vector2( 0, 90 );
+	[Property]
+	public Vector2 SwingLimit
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = new Vector2( 0, 90 );
 
 	/// <summary>
 	/// Enables or disables the twist limit.
 	/// </summary>
-	[Property, MakeDirty]
-	public bool TwistLimitEnabled { get; set; } = false;
+	[Property]
+	public bool TwistLimitEnabled
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = false;
 
 	/// <summary>
 	/// The minimum and maximum twist angles allowed by the joint in degrees.
 	/// </summary>
-	[Property, MakeDirty]
-	public Vector2 TwistLimit { get; set; } = new Vector2( -15, 15 );
+	[Property]
+	public Vector2 TwistLimit
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = new Vector2( -15, 15 );
 
 	/// <summary>
 	/// Joint friction.
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.Disabled )]
-	public float Friction { get; set; } = 0.5f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.Disabled )]
+	public float Friction
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 0.5f;
 
 	/// <summary>
 	/// Target angle of motor.
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetRotation )]
-	public Rotation TargetRotation { get; set; }
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetRotation )]
+	public Rotation TargetRotation
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Frequency of motor.
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetRotation )]
-	public float Frequency { get; set; } = 1.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetRotation )]
+	public float Frequency
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
 
 	/// <summary>
 	/// Damping of motor.
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetRotation )]
-	public float DampingRatio { get; set; } = 1.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetRotation )]
+	public float DampingRatio
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
 
 	/// <summary>
 	/// Target angular velocity of the motor.
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
-	public Vector3 TargetVelocity { get; set; } = 0.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
+	public Vector3 TargetVelocity
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 0.0f;
 
 	/// <summary>
 	/// Maximum torque the motor can apply when in velocity mode.
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
-	public float MaxTorque { get; set; } = 0.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
+	public float MaxTorque
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 0.0f;
 
 	BallSocketJoint _joint;
 

--- a/engine/Sandbox.Engine/Scene/Components/Joint/HingeJoint.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Joint/HingeJoint.cs
@@ -24,36 +24,81 @@ public sealed class HingeJoint : Joint
 	/// Minimum angle it should be allowed to go
 	/// </summary>
 	[Title( "Min" ), Group( "Limit" )]
-	[Property, MakeDirty]
-	public float MinAngle { get; set; }
+	[Property]
+	public float MinAngle
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Maximum angle it should be allowed to go
 	/// </summary>
 	[Title( "Max" ), Group( "Limit" )]
-	[Property, MakeDirty]
-	public float MaxAngle { get; set; }
+	[Property]
+	public float MaxAngle
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Motor mode
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty]
-	public MotorMode Motor { get; set; }
+	[Property]
+	public MotorMode Motor
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Hinge friction
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.Disabled )]
-	public float Friction { get; set; }
+	[Property, ShowIf( nameof( Motor ), MotorMode.Disabled )]
+	public float Friction
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Target angle of motor
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetAngle )]
-	public float TargetAngle { get; set; }
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetAngle )]
+	public float TargetAngle
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	[Obsolete( $"Use {nameof( Frequency )}" )]
 	public float Fequency { get => Frequency; set => Frequency = value; }
@@ -62,29 +107,65 @@ public sealed class HingeJoint : Joint
 	/// Frequency of motor
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetAngle )]
-	public float Frequency { get; set; } = 1.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetAngle )]
+	public float Frequency
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
 
 	/// <summary>
 	/// Damping of motor
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetAngle )]
-	public float DampingRatio { get; set; } = 1.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetAngle )]
+	public float DampingRatio
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
 
 	/// <summary>
 	/// Target velocity of motor
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
-	public float TargetVelocity { get; set; } = 0.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
+	public float TargetVelocity
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 0.0f;
 
 	/// <summary>
 	/// Max torque of motor
 	/// </summary>
 	[Group( "Motor" )]
-	[Property, MakeDirty, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
-	public float MaxTorque { get; set; } = 0.0f;
+	[Property, ShowIf( nameof( Motor ), MotorMode.TargetVelocity )]
+	public float MaxTorque
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 0.0f;
 
 	[Group( "State" )]
 	[Property, JsonIgnore]

--- a/engine/Sandbox.Engine/Scene/Components/Light/EnvmapProbe.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/EnvmapProbe.cs
@@ -87,12 +87,52 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 	}
 
 	[Space]
-	[Property, MakeDirty] public SceneCubemap.ProjectionMode Projection { get; set; }
-	[Property, MakeDirty] public Color TintColor { get; set; } = Color.White;
-	[Property, MakeDirty] public BBox Bounds { get; set; } = BBox.FromPositionAndSize( 0, 1024 );
+	[Property]
+	public SceneCubemap.ProjectionMode Projection
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
+	[Property]
+	public Color TintColor
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = Color.White;
+	[Property]
+	public BBox Bounds
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = BBox.FromPositionAndSize( 0, 1024 );
 
 
-	[Property, Range( -32.0f, 32.0f ), MakeDirty] public float Feathering { get; set; } = 8.0f;
+	[Property, Range( -32.0f, 32.0f )]
+	public float Feathering
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 8.0f;
 
 	/// <summary>
 	/// Gets or sets the priority level for the object.
@@ -117,9 +157,18 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 	/// <summary>
 	/// If this is set, the EnvmapProbe will use a custom cubemap texture instead of rendering dynamically
 	/// </summary>
-	[Property, MakeDirty]
+	[Property]
 	[ShowIf( nameof( Mode ), EnvmapProbeMode.CustomTexture )]
-	public Texture Texture { get; set; }
+	public Texture Texture
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// The texture that was baked for this envmap probe
@@ -139,22 +188,58 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 	/// </summary>
 	[Header( "Rendering" )]
 	[HideIf( nameof( Mode ), EnvmapProbeMode.CustomTexture )]
-	[Property, MakeDirty]
+	[Property]
 	[EnumButtonGroup]
-	public CubemapResolution Resolution { get; set; } = CubemapResolution.Small;
+	public CubemapResolution Resolution
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = CubemapResolution.Small;
 
 	[HideIf( nameof( Mode ), EnvmapProbeMode.CustomTexture )]
-	[Property, MakeDirty]
-	public float ZNear { get; set; } = 16;
+	[Property]
+	public float ZNear
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 16;
 
 	[HideIf( nameof( Mode ), EnvmapProbeMode.CustomTexture )]
-	[Property, MakeDirty]
-	public float ZFar { get; set; } = 4096;
+	[Property]
+	public float ZFar
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 4096;
 
 	[Header( "Realtime Updates" )]
 	[ShowIf( nameof( Mode ), EnvmapProbeMode.Realtime )]
-	[Property, MakeDirty]
-	public CubemapDynamicUpdate UpdateStrategy { get; set; }
+	[Property]
+	public CubemapDynamicUpdate UpdateStrategy
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	/// <summary>
 	/// Only update dynamically if we're this close to it
@@ -179,8 +264,17 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 	/// </summary>
 	[HideIf( nameof( Mode ), EnvmapProbeMode.CustomTexture )]
 	[ShowIf( nameof( UpdateStrategy ), CubemapDynamicUpdate.OnEnabled )]
-	[Property, MakeDirty]
-	public bool MultiBounce { get; set; } = false;
+	[Property]
+	public bool MultiBounce
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = false;
 
 	protected override void OnEnabled()
 	{

--- a/engine/Sandbox.Engine/Scene/Components/Light/Light.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/Light.cs
@@ -10,16 +10,56 @@ public abstract class Light : Component, IColorProvider, ExecuteInEditor, ITinta
 	/// <summary>
 	/// The main color of the light
 	/// </summary>
-	[Property, MakeDirty] public Color LightColor { get; set; } = "#E9FAFF";
+	[Property]
+	public Color LightColor
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = "#E9FAFF";
 
 	/// <summary>
 	/// Should this light cast shadows?
 	/// </summary>
-	[Property, MakeDirty] public bool Shadows { get; set; } = true;
+	[Property]
+	public bool Shadows
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = true;
 
 
-	[Property, MakeDirty, Category( "Fog Settings" )] public FogInfluence FogMode { get; set; } = FogInfluence.Enabled;
-	[Property, MakeDirty, Range( 0, 1 ), Category( "Fog Settings" )] public float FogStrength { get; set; } = 1.0f;
+	[Property, Category( "Fog Settings" )]
+	public FogInfluence FogMode
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = FogInfluence.Enabled;
+	[Property, Range( 0, 1 ), Category( "Fog Settings" )]
+	public float FogStrength
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
 
 
 	Color IColorProvider.ComponentColor => LightColor;

--- a/engine/Sandbox.Engine/Scene/Components/Light/PointLight.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/PointLight.cs
@@ -11,8 +11,28 @@
 [Alias( "PointLightComponent" )]
 public class PointLight : Light
 {
-	[Property, MakeDirty] public float Radius { get; set; } = 400;
-	[Property, MakeDirty, Range( 0, 10 )] public float Attenuation { get; set; } = 1.0f;
+	[Property]
+	public float Radius
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 400;
+	[Property, Range( 0, 10 )]
+	public float Attenuation
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
 	//	[Property, MakeDirty] public Texture Cookie { get; set; }
 
 	protected override SceneLight CreateSceneObject()

--- a/engine/Sandbox.Engine/Scene/Components/Light/SpotLight.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/SpotLight.cs
@@ -11,16 +11,66 @@
 [Alias( "SpotLightComponent" )]
 public class SpotLight : Light
 {
-	[Property, MakeDirty] public float Radius { get; set; } = 500;
+	[Property]
+	public float Radius
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 500;
 
 	[Range( 0, 90 )]
-	[Property, MakeDirty] public float ConeOuter { get; set; } = 45;
+	[Property]
+	public float ConeOuter
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 45;
 
 	[Range( 0, 90 )]
-	[Property, MakeDirty] public float ConeInner { get; set; } = 15;
+	[Property]
+	public float ConeInner
+	{
+		get;
+		set
+		{
+			field = value;
 
-	[Property, MakeDirty, Range( 0, 10 )] public float Attenuation { get; set; } = 1.0f;
-	[Property, MakeDirty] public Texture Cookie { get; set; }
+			OnPropertyDirty();
+		}
+	} = 15;
+
+	[Property, Range( 0, 10 )]
+	public float Attenuation
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1.0f;
+	[Property]
+	public Texture Cookie
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	public SpotLight()
 	{

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -21,7 +21,17 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 	[Property] public bool UseMapFromLaunch { get; set; }
 
-	[Property, MakeDirty] public bool EnableCollision { get; set; } = true;
+	[Property]
+	public bool EnableCollision
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = true;
 
 	/// <summary>
 	/// True if the map is loaded

--- a/engine/Sandbox.Engine/Scene/Components/Navigation/NavMeshAgent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Navigation/NavMeshAgent.cs
@@ -18,24 +18,60 @@ namespace Sandbox;
 public sealed class NavMeshAgent : Component
 {
 	[Group( "Physical Properties" )]
-	[Property, MakeDirty]
-	public float Height { get; set; } = 64;
+	[Property]
+	public float Height
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 64;
 
 	[Group( "Physical Properties" )]
-	[Property, MakeDirty]
-	public float Radius { get; set; } = 16;
+	[Property]
+	public float Radius
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 16;
 
 	[Group( "Movement" )]
-	[Property, MakeDirty]
-	public float MaxSpeed { get; set; } = 120f;
+	[Property]
+	public float MaxSpeed
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 120f;
 
 	/// <summary>
 	/// The maximum acceleration a agent can have. This is how fast the agent can change its velocity.
 	/// If you want snappy movement this should be as high or higher than <see cref="MaxSpeed"/>.
 	/// </summary>
 	[Group( "Movement" )]
-	[Property, MakeDirty]
-	public float Acceleration { get; set; } = 120f;
+	[Property]
+	public float Acceleration
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 120f;
 
 	/// <summary>
 	/// Set the Position of the GameObject to the agent position every frame. You can turn this off and handle it yourself by using the AgentPosition property.
@@ -76,15 +112,33 @@ public sealed class NavMeshAgent : Component
 	/// Should the agent automatically traverse links when it reaches them? Or do you want to implement your own link traversal logic?
 	/// </summary>
 	[Group( "Constraints" )]
-	[Property, MakeDirty]
-	public bool AutoTraverseLinks { get; set; } = true;
+	[Property]
+	public bool AutoTraverseLinks
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = true;
 
 	/// <summary>
 	/// Gets or sets the separation factor used to control how strongly agents avoid crowding each other.
 	/// </summary>
 	[Group( "Avoidance" )]
-	[Property, MakeDirty, Range( 0, 1 )]
-	public float Separation { get; set; } = 0.25f;
+	[Property, Range( 0, 1 )]
+	public float Separation
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 0.25f;
 
 	/// <summary>
 	/// Updated  with the agent's position, even if UpdatePosition is false

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
@@ -50,10 +50,30 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 	/// <summary>
 	/// Which tonemapping algorithm to use for color grading.
 	/// </summary>
-	[Property, MakeDirty] public TonemappingMode Mode { get; set; } = TonemappingMode.HableFilmic;
+	[Property]
+	public TonemappingMode Mode
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = TonemappingMode.HableFilmic;
 
 	[ShowIf( nameof( Mode ), TonemappingMode.HableFilmic )]
-	[Property, MakeDirty] public ExposureColorSpaceEnum ExposureMethod { get; set; } = ExposureColorSpaceEnum.RGB;
+	[Property]
+	public ExposureColorSpaceEnum ExposureMethod
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = ExposureColorSpaceEnum.RGB;
 
 	private static Material Shader = Material.FromShader( "shaders/tonemapping/tonemapping.shader" );
 

--- a/engine/Sandbox.Engine/Scene/Components/Render/ModelRenderer.Materials.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/ModelRenderer.Materials.cs
@@ -12,8 +12,17 @@ using Sandbox.Engine;
 public partial class ModelRenderer : MaterialAccessor.ITarget
 {
 
-	[Property, MakeDirty]
-	public Material MaterialOverride { get; set; }
+	[Property]
+	public Material MaterialOverride
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	Dictionary<string, Material> taggedMaterialOverrides;
 

--- a/engine/Sandbox.Engine/Scene/Components/Render/ModelRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/ModelRenderer.cs
@@ -71,20 +71,47 @@ public partial class ModelRenderer : Renderer, ExecuteInEditor, ITintable, IMate
 		}
 	}
 
-	[Property, Model.BodyGroupMask, MakeDirty, ShowIf( nameof( HasBodyGroups ), true )]
+	[Property, Model.BodyGroupMask, ShowIf( nameof( HasBodyGroups ), true )]
 	[DefaultValue( ulong.MaxValue )]
-	public ulong BodyGroups { get => _bodyGroups; set => _bodyGroups = value; }
+	public ulong BodyGroups
+	{
+		get => _bodyGroups;
+		set
+		{
+			_bodyGroups = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	public bool HasBodyGroups => Model?.Parts.All.Sum( x => x.Choices.Count ) > 1;
 
-	[Property, Model.MaterialGroup, MakeDirty, ShowIf( nameof( HasMaterialGroups ), true )]
+	[Property, Model.MaterialGroup, ShowIf( nameof( HasMaterialGroups ), true )]
 	[DefaultValue( default )]
-	public string MaterialGroup { get; set; }
+	public string MaterialGroup
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	}
 
 	public bool HasMaterialGroups => Model?.MaterialGroupCount > 0 && MaterialOverride is null;
 
-	[Title( "Cast Shadows" ), Property, Category( "Lighting" ), MakeDirty]
-	public ShadowRenderType RenderType { get; set; } = ShadowRenderType.On;
+	[Title( "Cast Shadows" ), Property, Category( "Lighting" )]
+	public ShadowRenderType RenderType
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = ShadowRenderType.On;
 
 	private int? _lodOverride;
 

--- a/engine/Sandbox.Engine/Scene/Components/Render/Renderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/Renderer.cs
@@ -9,7 +9,7 @@ public abstract class Renderer : Component, SceneObjectCallbacks
 	RenderOptions _renderOptions;
 	SceneObject _sceneObject;
 
-	[Property, MakeDirty, Order( -100 ), InlineEditor( Label = false ), Group( "Advanced Rendering", StartFolded = true )]
+	[Property, Order( -100 ), InlineEditor( Label = false ), Group( "Advanced Rendering", StartFolded = true )]
 	public RenderOptions RenderOptions
 	{
 		get

--- a/engine/Sandbox.Engine/Scene/Components/Render/SkyBox2D.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/SkyBox2D.cs
@@ -34,8 +34,17 @@ public class SkyBox2D : Component, Component.ExecuteInEditor
 		}
 	}
 
-	[Property, Description( "Whether to use the skybox for lighting as an envmap probe" ), MakeDirty, DefaultValue( true )]
-	public bool SkyIndirectLighting { get; set; } = true;
+	[Property, Description( "Whether to use the skybox for lighting as an envmap probe" ), DefaultValue( true )]
+	public bool SkyIndirectLighting
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = true;
 
 	Material _material = Material.Load( "materials/skybox/skybox_day_01.vmat" ); // todo - better default
 

--- a/engine/Sandbox.Engine/Scene/Components/UI/WorldPanel.cs
+++ b/engine/Sandbox.Engine/Scene/Components/UI/WorldPanel.cs
@@ -24,7 +24,17 @@ public sealed class WorldPanel : Renderer, IRootPanelComponent
 	/// <summary>
 	/// How far can we interact with this world panel?
 	/// </summary>
-	[Property, MakeDirty] public float InteractionRange { get; set; } = 1000.0f;
+	[Property]
+	public float InteractionRange
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = 1000.0f;
 
 	public enum HAlignment
 	{

--- a/engine/Sandbox.Engine/Scene/Components/Utility/VolumeSystem/VolumeComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Utility/VolumeSystem/VolumeComponent.cs
@@ -2,8 +2,17 @@
 
 public abstract class VolumeComponent : Component, VolumeSystem.IVolume
 {
-	[InlineEditor, Property, MakeDirty]
-	public SceneVolume SceneVolume { get; set; } = new SceneVolume();
+	[InlineEditor, Property]
+	public SceneVolume SceneVolume
+	{
+		get;
+		set
+		{
+			field = value;
+
+			OnPropertyDirty();
+		}
+	} = new SceneVolume();
 
 	/// <summary>
 	/// True if SceneVolume.Type == SceneVolume.VolumeTypes.Infinite


### PR DESCRIPTION
## Summary

This PR obsoletes the MakeDirty attribute. The rest of the Dirty code seems to be pretty useful, batching successive property sets into a single OnDirty call (hopefully), so I left that intact.

## Motivation & Context

It seems to be the consensus at Facepunch that Change and MakeDirty was a mistake, and in my opinion, if something is discouraged it should actually be marked Obsolete.

## Implementation Details

The actual code of the MakeDirty attribute is 
```cs
		p.Setter( p.Value );
		OnPropertyDirty();
```
So that is what I put in every setter as a replacement.

I did not make new unit tests for this since it was a lot of components, but I jumped into the editor and changed some stuff and things seem to be fine.

## Notes

Sandbox.Renderer.RenderOptions had a MakeDirty applied to it but it doesn't have a setter, so it was never called.

The name `Component.OnPropertyDirty` is not especially great. Perhaps it should be called `Component.MarkDirty` now?

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂