### PR TITLE
Fix editor crash when importing WAV files into assets

### DIFF
--- a/engine/Sandbox.Tools/Assets/AssetSystem.cs
+++ b/engine/Sandbox.Tools/Assets/AssetSystem.cs
@@ -173,7 +173,7 @@ public static partial class AssetSystem
 				asset.RebuildThumbnail( true );
 			}
 
-			if ( !asset.IsCompiled && asset.AssetType.IsGameResource )
+			if ( !asset.IsCompiled && asset.AssetType is not null && asset.AssetType.IsGameResource )
 			{
 				asset.Compile( false );
 			}

--- a/engine/Sandbox.Tools/Assets/AssetType.cs
+++ b/engine/Sandbox.Tools/Assets/AssetType.cs
@@ -284,13 +284,23 @@ public class AssetType
 		if ( extension.EndsWith( "_c" ) )
 			extension = extension.Substring( 0, extension.Length - 2 );
 
-		return string.Equals( extension, FileExtension, StringComparison.InvariantCultureIgnoreCase );
+		if ( string.Equals( extension, FileExtension, StringComparison.InvariantCultureIgnoreCase ) )
+			return true;
+
+		for ( int i = 0; i < AllFileExtensions.Count; i++ )
+		{
+			if ( string.Equals( extension, AllFileExtensions[i], StringComparison.InvariantCultureIgnoreCase ) )
+				return true;
+		}
+
+		return false;
 	}
 
 	internal bool CouldBeIdentifiedAs( string name, bool fuzzy = false )
 	{
 		if ( string.Equals( FriendlyName, name, System.StringComparison.OrdinalIgnoreCase ) ) return true;
 		if ( string.Equals( FileExtension, name, System.StringComparison.OrdinalIgnoreCase ) ) return true;
+		if ( HasExtension( name ) ) return true;
 
 		if ( fuzzy )
 		{

--- a/engine/Sandbox.Tools/Assets/NativeAsset/NativeAsset.cs
+++ b/engine/Sandbox.Tools/Assets/NativeAsset/NativeAsset.cs
@@ -16,7 +16,8 @@ internal class NativeAsset : Asset
 		if ( AssetType.AssetTypeCache.TryGetValue( native.GetAssetTypeId(), out var type ) )
 			AssetType = type;
 
-		Assert.NotNull( AssetType ); // agh? Maybe we mock up an unknown type type?
+		if ( AssetType is null )
+			return;
 
 		AssetId = native.GetAssetIndexInt();
 		Name = native.GetFriendlyName_Transient().NormalizeFilename( false );

--- a/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
+++ b/game/addons/tools/Code/Assets/PreviewSoundFIle.cs
@@ -23,6 +23,10 @@ class PreviewSoundFile : AssetPreview
 	public override Widget CreateWidget( Widget parent )
 	{
 		previewWidget = new SoundPlayer( parent );
+
+		if ( soundFile is null )
+			return previewWidget;
+
 		previewWidget.SetSamples( samples, soundFile.Duration, soundFile.ResourcePath );
 
 		if ( AutoPlay )
@@ -44,6 +48,9 @@ class PreviewSoundFile : AssetPreview
 
 	public override async Task InitializeAsset()
 	{
+		if ( soundFile is null )
+			return;
+
 		await soundFile.LoadAsync();
 
 		samples = await soundFile.GetSamplesAsync();


### PR DESCRIPTION
## Summary

Fixes #10299 — Editor crashes when a `.wav` file is placed in `assets/sounds` and clicked.

## Root Cause

`AssetType.HasExtension()` only checked the primary `FileExtension` (`vsnd`), completely ignoring the `AllFileExtensions` list populated by the native engine during `RegisterAssetType()`. This meant `AssetType.Find("wav")` and `AssetType.FromExtension("wav")` returned `null` despite `.wav` being a registered additional extension for the SoundFile type.

**Crash path**: User clicks `.wav` file → `PreviewSoundFile` constructor calls `SoundFile.Load(asset.Path)` with a `.vsnd` path for an uncompiled asset → returns `null` → `InitializeAsset()` calls `null.LoadAsync()` → `NullReferenceException`.

## Changes

- **`AssetType.HasExtension()`** — Now iterates `AllFileExtensions` after checking the primary extension, so source format extensions (`.wav`, `.mp3`, `.ogg`) correctly resolve to their asset type
- **`AssetType.CouldBeIdentifiedAs()`** — Delegates to `HasExtension()` for extension matching, enabling `AssetType.Find()` to resolve source extensions
- **`PreviewSoundFile`** — Null guards in `CreateWidget()` and `InitializeAsset()` to handle failed `SoundFile.Load()` gracefully instead of crashing
- **`NativeAsset.UpdateInternals()`** — Replaced `Assert.NotNull(AssetType)` with a proper null guard (early return) for unrecognized asset types
- **`AssetSystem.Tick()`** — Added null-check on `AssetType` before accessing `IsGameResource` during parallel asset processing