### PR TITLE
Fix directional light shadows in valve tools

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.Directional.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.Directional.cs
@@ -266,12 +266,12 @@ internal partial class ShadowMapper
 	/// Find or create shadow maps for a directional light (CSM).
 	/// Returns an index to the directional shadow buffer.
 	/// </summary>
-	internal unsafe void FindOrCreateDirectionalShadowMaps( SceneDirectionalLight light, ISceneView view )
+	internal unsafe void FindOrCreateDirectionalShadowMaps( SceneLight light, ISceneView view )
 	{
-		int numCascades = Math.Min( light.ShadowCascadeCount, MaxCascades );
+		int numCascades = Math.Min( light.lightNative.GetShadowCascades(), MaxCascades );
 		float farClip = CascadeDistance;
 		int shadowmapSize = MaxCascadeResolution;
-		float splitRatio = light.ShadowCascadeSplitRatio;
+		float splitRatio = light.lightNative.GetShadowCascadeSplitRatio();
 
 		// Baked lights exclude static objects from shadow maps, their static shadows come from lightmaps
 		var excludeFlags = (light.lightNative.GetLightFlags() & 32) != 0 // LIGHTTYPE_FLAGS_BAKED

--- a/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.cs
@@ -284,13 +284,7 @@ internal partial class ShadowMapper
 		if ( !CSMEnabled )
 			return 0;
 
-		if ( sceneObject is not SceneDirectionalLight directionalLight )
-		{
-			Log.Error( $"DoDirectionalLight called with non-directional light {sceneObject}" );
-			return 0;
-		}
-
-		FindOrCreateDirectionalShadowMaps( directionalLight, view );
+		FindOrCreateDirectionalShadowMaps( sceneObject, view );
 		return 0;
 	}
 


### PR DESCRIPTION
**Summary**
Directional light shadows don't work in valve tools (modeldoc, material editor) and throw a per-frame Log.Error about "DoDirectionalLight called with non-directional light". The type check was also preventing FindOrCreateDirectionalShadowMaps from running, which is likely the cause of the broken shadows.

**Motivation & Context**
Valve tools create lights natively without going through managed constructors, so they get registered as SceneLight instead of SceneDirectionalLight in HandleIndex. The DoDirectionalLight callback then rejects them on the "is not SceneDirectionalLight" type check, even though the underlying native object is a valid directional light.

Fixes: #10321

**Implementation Details**

- Changed DoDirectionalLight to pass SceneLight directly to FindOrCreateDirectionalShadowMaps instead of requiring a SceneDirectionalLight cast.

- Changed FindOrCreateDirectionalShadowMaps parameter from SceneDirectionalLight to SceneLight. The two SceneDirectionalLight-specific properties (ShadowCascadeCount, ShadowCascadeSplitRatio) were just thin wrappers around lightNative.GetShadowCascades() and lightNative.GetShadowCascadeSplitRatio(), so we call those directly instead. lightNative is on SceneLight and points to the same native object regardless of the managed wrapper type.

## Checklist

- [✓] Code follows existing style and conventions
- [✓] No unnecessary formatting or unrelated changes
- [✓] Public APIs are documented (if applicable)
- [✓] Unit tests added where applicable and all passing
- [✓] I’m okay with this PR being rejected or requested to change 🙂