### PR TITLE
Prevent package closed toast from being dismissed on click

### DIFF
--- a/game/addons/menu/Code/MenuSystem.cs
+++ b/game/addons/menu/Code/MenuSystem.cs
@@ -168,7 +168,7 @@ public partial class MenuSystem : IMenuSystem
 	void IMenuSystem.OnPackageClosed( Package package )
 	{
 		var panel = new GameClosedToast() { Package = package };
-		MenuOverlay.Instance.BottomRight.Queue( panel, duration: 0 );
+		MenuOverlay.Instance.BottomRight.Queue( panel, duration: 0, clickToDismiss: false );
 	}
 
 	[MenuConCmd( "menu_packageclosed" )]


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Prevent the post-game info popup from dismissing itself on mouse down so its actions can actually be clicked. This fixes the case where the popup can handle input.

## Motivation & Context

The popup shown after closing a game is meant to be interactive, but it was being queued with the toast area's default click-to-dismiss behavior. The default value for clickToDismiss has changed I guess, but I haven't spent much time analysing it. I only saw the issue and thought it must be something easy with the panel -.-

Fixes: #10342

## Implementation Details

I think it's self-explanatory.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->
-/-

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂