### PR TITLE
Whitelist IFormattable

### DIFF
--- a/engine/Sandbox.Access/Rules/BaseAccess.cs
+++ b/engine/Sandbox.Access/Rules/BaseAccess.cs
@@ -51,6 +51,7 @@ internal static partial class Rules
 		"System.Private.CoreLib/System.Tuple*",
 		"System.Private.CoreLib/System.Random*",
 		"System.Private.CoreLib/System.MemoryExtensions*",
+		"System.Private.CoreLib/System.IFormattable*",
 		"System.Private.CoreLib/System.IFormatProvider",
 		"System.Private.CoreLib/System.Version*",
 		"System.Private.CoreLib/System.MidpointRounding*",


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR adds System.IFormattable to the whitelist, so custom types can implemented.

## Motivation & Context

It was addressed in an issue. I don't think there's anything else to say about it.

Fixes: #10191

## Implementation Details

Added "System.Private.CoreLib/System.IFormattable*" to the base access rules. I haven't implemented any tests, since none of the whitelist candidates have done so, at least as far as I can tell from what I saw. 

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂