### PR TITLE
Fix glass shader tint not blending through multiple layers (#10364)

### DIFF
--- a/game/addons/base/Assets/shaders/glass.shader
+++ b/game/addons/base/Assets/shaders/glass.shader
@@ -78,10 +78,18 @@ PS
     // Attributes ------------------------------------------------------------------------------------------
 
     // Transparency
+    RenderState(BlendEnable, true);
     #if (S_CHEAP_GLASS)
-        RenderState(BlendEnable, true);
         RenderState(SrcBlend, SRC_ALPHA);
         RenderState(DstBlend, INV_SRC_ALPHA);
+    #else
+        // Premultiplied alpha: refraction is pre-scaled by alpha, reflections stay additive.
+        // This allows multiple glass layers to composite their tints correctly.
+        RenderState(SrcBlend, ONE);
+        RenderState(DstBlend, INV_SRC_ALPHA);
+        RenderState(SrcBlendAlpha, ONE);
+        RenderState(DstBlendAlpha, INV_SRC_ALPHA);
+        RenderState(BlendOpAlpha, ADD);
     #endif
 
     // Hate this
@@ -181,7 +189,8 @@ PS
         float3 vViewRayWs = bOrtho ? g_vCameraDirWs : normalize(i.vPositionWithOffsetWs.xyz);
         float flNDotV = saturate(dot(-m.Normal, vViewRayWs));
         float3 vEnvBRDF = CalcBRDFReflectionFactor(flNDotV, m.Roughness, 0.04);
-        
+        float3 vOriginalAlbedo = m.Albedo;
+
         #if !S_CHEAP_GLASS
         {
             float4 vRefractionColor = 0;
@@ -239,6 +248,18 @@ PS
                 m.Albedo *= m.Roughness * AlbedoAbsorption;
             }
 
+            // Multi-layer glass compositing
+            // Scale emission for premultiplied alpha blend so previously
+            // rendered glass layers can show through this one
+            {
+                float flAvgFresnel = ( vEnvBRDF.x + vEnvBRDF.y + vEnvBRDF.z ) * ( 1.0 / 3.0 );
+                float flAlbedoLum = dot( vOriginalAlbedo, float3( 0.2126, 0.7152, 0.0722 ) );
+                float flGlassAlpha = saturate( flAvgFresnel + ( 1.0 - flAvgFresnel ) * sqrt( flAlbedoLum ) );
+
+                m.Emission *= flGlassAlpha;
+                m.Opacity = flGlassAlpha;
+            }
+
             if( ToolsVis::WantsToolsVis() )
             {
                 m.Albedo = m.Emission;
@@ -256,9 +277,6 @@ PS
         #endif
 
         float4 output = ShadingModelStandard::Shade( m );
-
-        if( !S_CHEAP_GLASS )
-            output.a = 1.0f; // FBCopy Glass shouldn't write to alpha
 
         return output;
     }


### PR DESCRIPTION
## Summary

Quality glass (refractive mode) writes fully opaque with no blend state, so the front glass pane completely overwrites the back glass pixels. This means only the front glass tint is ever visible when looking through multiple layers.

This PR enables premultiplied alpha blending for quality glass and computes a physically-based alpha from Fresnel reflectance and albedo luminance. Back glass layers now partially show through the front glass, blending their tints together. Clear glass (white albedo) is unaffected (alpha ≈ 1.0). Reflections remain at full strength due to premultiplied alpha.

## Motivation & Context

Fixes: #10364 

## Implementation Details

- **Premultiplied alpha** (`SrcBlend=ONE, DstBlend=INV_SRC_ALPHA`) instead of standard alpha blend — this keeps specular reflections additive at full strength while only the refraction (emission) is pre-scaled by alpha.
- **Alpha formula**: `saturate(avgFresnel + (1 - avgFresnel) * sqrt(albedoLuminance))`. At grazing angles Fresnel pushes alpha to 1.0 (glass is reflective/opaque). At normal incidence, darker tints get lower alpha so more of the back glass shows through. Clear glass gets alpha ≈ 1.0 (no visual change).
- The original albedo is saved before the quality glass path modifies it, so the luminance calculation uses the unmodified tint color.
- Cheap glass path is unchanged.
- Single-pane tinted glass will appear slightly less saturated since emission is scaled by alpha. This is a trade-off to enable multi-layer blending.

## Screenshots / Videos (if applicable)

-/-

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂