### PR TITLE
Fix backdrop-filter: blur generating excessive mipmap levels (#10340)

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/CommandList/CommandList.Attributes.cs
+++ b/engine/Sandbox.Engine/Systems/Render/CommandList/CommandList.Attributes.cs
@@ -313,17 +313,17 @@ public sealed partial class CommandList
 		/// <summary>
 		/// Takes a copy of the current viewport's color texture and stores it in targetName on renderAttributes.
 		/// </summary>
-		public RenderTargetHandle GrabFrameTexture( string token, Graphics.DownsampleMethod downsampleMethod )
+		public RenderTargetHandle GrabFrameTexture( string token, Graphics.DownsampleMethod downsampleMethod, int maxMips = 0 )
 		{
 			static void Execute( ref Entry entry, CommandList commandList )
 			{
 				var attrAccess = (AttributeAccess)entry.Object2;
-				var temp = Graphics.GrabFrameTexture( (string)entry.Object5, attrAccess.attributes, (Graphics.DownsampleMethod)(int)entry.Data1.x );
+				var temp = Graphics.GrabFrameTexture( (string)entry.Object5, attrAccess.attributes, (Graphics.DownsampleMethod)(int)entry.Data1.x, (int)entry.Data1.y );
 				commandList.state.renderTargets[(string)entry.Object5] = temp;
 				attrAccess._renderTargets[(string)entry.Object5] = temp;
 			}
 
-			list.AddEntry( &Execute, new Entry { Object5 = token, Object2 = this, Data1 = new Vector4( (int)downsampleMethod, 0, 0, 0 ) } );
+			list.AddEntry( &Execute, new Entry { Object5 = token, Object2 = this, Data1 = new Vector4( (int)downsampleMethod, maxMips, 0, 0 ) } );
 
 			return new RenderTargetHandle { Name = token };
 		}

--- a/engine/Sandbox.Engine/Systems/Render/Graphics.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Graphics.cs
@@ -249,14 +249,15 @@ public static partial class Graphics
 	/// <summary>
 	/// Grabs the current viewport's color texture and stores it in targetName on renderAttributes.
 	/// </summary>
-	public static RenderTarget GrabFrameTexture( string targetName = "FrameTexture", RenderAttributes renderAttributes = null, DownsampleMethod downsampleMethod = DownsampleMethod.None )
+	public static RenderTarget GrabFrameTexture( string targetName = "FrameTexture", RenderAttributes renderAttributes = null, DownsampleMethod downsampleMethod = DownsampleMethod.None, int maxMips = 0 )
 	{
 		renderAttributes ??= Attributes;
 
 		AssertRenderBlock();
 
 		bool withMips = downsampleMethod != DownsampleMethod.None;
-		var numMips = withMips ? (int)Math.Log2( Math.Max( Viewport.Width, Viewport.Height ) ) : 1;
+		var fullMips = (int)Math.Log2( Math.Max( Viewport.Width, Viewport.Height ) );
+		var numMips = withMips ? (maxMips > 0 ? Math.Min( maxMips, fullMips ) : fullMips) : 1;
 
 		// Grab a new one - which may very well be the one we just returned
 		var frameTexture = RenderTarget.GetTemporary( 1, ImageFormat.Default, ImageFormat.None, msaa: MultisampleAmount.MultisampleNone, numMips: numMips, targetName );

--- a/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.Backdrop.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.Backdrop.cs
@@ -34,11 +34,26 @@ internal partial class PanelRenderer
 		attributes.Set( "Sepia", style.BackdropFilterSepia.Value.GetPixels( 1.0f ) );
 		attributes.Set( "Invert", style.BackdropFilterInvert.Value.GetPixels( 1.0f ) );
 		attributes.Set( "HueRotate", style.BackdropFilterHueRotate.Value.GetPixels( 1.0f ) );
-		attributes.Set( "BlurScale", style.BackdropFilterBlur.Value.GetPixels( 1.0f ) );
+
+		var blurScale = style.BackdropFilterBlur.Value.GetPixels( 1.0f );
+		attributes.Set( "BlurScale", blurScale );
 
 		attributes.SetCombo( "D_BLENDMODE", OverrideBlendMode );
 
-		attributes.GrabFrameTexture( "FrameBufferCopyTexture", Graphics.DownsampleMethod.GaussianBlur );
+		if ( blurScale > 0 )
+		{
+			// Only generate the mip levels the shader will actually sample from.
+			// The shader reads at MIP level sqrt(BlurScale / 2) with trilinear filtering.
+			// Round up to even for render target pool stability.
+			int needed = (int)Math.Ceiling( Math.Sqrt( blurScale / 2.0f ) ) + 2;
+			int maxMips = ((needed + 1) / 2) * 2;
+			attributes.GrabFrameTexture( "FrameBufferCopyTexture", Graphics.DownsampleMethod.GaussianBlur, maxMips );
+		}
+		else
+		{
+			attributes.GrabFrameTexture( "FrameBufferCopyTexture", Graphics.DownsampleMethod.None );
+		}
+
 		commandList.DrawQuad( rect, Material.UI.BackdropFilter, color );
 	}
 }


### PR DESCRIPTION
## Summary

Backdrop-filter blur panels were generating the full mipmap chain (~11 levels) regardless of the actual blur amount needed. The shader only samples at MIP level `sqrt(BlurScale / 2)` (typically 2-5 for normal values), so most compute dispatches were wasted. This change limits mipmap generation to only the levels the shader will actually sample, and skips it entirely when no blur is applied (e.g. `backdrop-filter: brightness` only).

## Motivation & Context

Since version 26.04.01, panels with `backdrop-filter: blur` cause significant FPS drops around 50%. Each backdrop panel triggers a full framebuffer copy + Gaussian blur compute shader dispatch and GPU barrier for every mip level. With ~11 levels generated but only 2-5 needed

Fixes: #10340 

## Implementation Details

- Graphics.GrabFrameTexture: Added optional `maxMips` parameter (default 0 = all mips for backward compatibility). When maxMips > 0, the render target is created with fewer mip levels, so GenerateMipMaps naturally processes fewer levels.
- CommandList.Attributes.GrabFrameTexture: Threads maxMips through the deferred command system via the unused Data1.y component, following the existing float-to-int packing convention.
- PanelRenderer.Backdrop.cs: Computes needed mip count as `ceil(sqrt(blurScale / 2)) + 2` (+2 for trilinear filtering safety margin). Rounds up to even for render target pool stability. Uses `DownsampleMethod.None` when blur is 0.

Existing callers (Bloom, SSR, Highlight, BasePostProcess) are unaffected by the default maxMips = 0.

## Screenshots / Videos (if applicable)

</>

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂