### PR TITLE
Fix blank game package modal tab content

### DIFF
--- a/game/addons/menu/Code/MenuUI/Components/PortalTarget.razor.scss
+++ b/game/addons/menu/Code/MenuUI/Components/PortalTarget.razor.scss
@@ -1,6 +1,5 @@
 
 PortalTarget
 {
-    display: contents;
-    border: 1px solid red;
+    flex-direction: column;
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR fixes blank content areas in game package modals. I fixed the regression where Overview, Reviews, News, and similar sections stopped rendering their content even though the tabs and underlying data still loaded correctly.

## Motivation & Context

I traced the regression to the existing portal layout path used by the package modals. PortalTarget itself had not been changed recently, but it was still relying on an older "display: contents" setup from the existing menu implementation. That became fragile after newer UI and layout work, especially the recent menu and renderer changes in 8421496e, which included clipping, scroll-view, and command list behavior updates.

Fixes: #10418

## Implementation Details

I fixed the issue by changing PortalTarget so it no longer uses display: contents. I also removed the borders, since they would otherwise be displayed in Flex, which was only intended for debugging purposes I believe. flex-direction is mainly used for the review section, otherwise the statistics would overlap. I experimented with CSS, but this seemed to be the best solution .If there are other/better solutions or I've overlooked something, let me know.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂