### PR TITLE
Fix null TargetComponent in Doo invoke block inspector

### DIFF
--- a/game/editor/DooEditor/Code/DooEditor/BlockEditors/InvokeBlock.cs
+++ b/game/editor/DooEditor/Code/DooEditor/BlockEditors/InvokeBlock.cs
@@ -39,7 +39,8 @@ public class InvokeBlock : InspectorWidget
 
 		var invokeType = _invokeType.GetValue<Doo.InvokeType>();
 		var targetComponent = _targetComponent.GetValue<Doo.TargetComponent>();
-		var hasComponent = targetComponent.GetComponentType() != null;
+		var targetComponentType = targetComponent?.GetComponentType();
+		var hasComponent = targetComponentType != null;
 
 		var method = _memberProperty.GetCustomizable();
 		method.SetDisplayName( "Method" );
@@ -65,7 +66,7 @@ public class InvokeBlock : InspectorWidget
 			if ( hasComponent )
 			{
 				var methodSelect = cs.AddControl<ComponentMethodSelector>( method );
-				methodSelect.TargetComponentType = targetComponent.GetComponentType();
+				methodSelect.TargetComponentType = targetComponentType;
 			}
 		}
 		else
@@ -84,7 +85,7 @@ public class InvokeBlock : InspectorWidget
 		{
 			if ( targetComponent == null ) return;
 
-			if ( !methodDesc.DeclaringType.TargetType.IsAssignableFrom( targetComponent.GetComponentType() ) )
+			if ( !methodDesc.DeclaringType.TargetType.IsAssignableFrom( targetComponentType ) )
 				return;
 		}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Fixes a NullReferenceException when clicking a newly created Doo Invoke block in the editor inspector.

## Motivation & Context

A fresh Invoke block can open with TargetComponent == null, but the inspector tried to resolve its component type immediately and threw before the target component widget had a chance to initialize it.

Fixes: #10408

## Implementation Details

I think it's self-explanatory.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂