### PR TITLE
Prevent a crash when accessing the title property of a music track that is not playing

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Multimedia/MusicPlayer.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Multimedia/MusicPlayer.cs
@@ -143,6 +143,9 @@ public sealed class MusicPlayer : IDisposable
 	{
 		get
 		{
+			if ( native is not { HasAudio: true } )
+				return null;
+
 			var title = GetMeta( "title" );
 			return string.IsNullOrWhiteSpace( title ) ? GetMeta( "StreamTitle" ) : title;
 		}


### PR DESCRIPTION
# Pull Request

## Summary

Do not fetch the title metadata from the playing music track if there is no audio.

## Motivation & Context

I think I must have experienced this before, but it was seemingly random and just dismissed it. Looking back on it though, it was likely this crash.
Fixes: https://github.com/Facepunch/sbox-public/issues/10385

## Implementation Details

I put this logic here since the Title property is the only thing that exposes GetMeta outside of the MusicPlayer class and I wanted to keep that clean. I didn't want to change it on VideoPlayer since you could have metadata for a video that isn't playing audio (obviously that is not the case here).

To me, this was the most effective fix. I did also consider moving around the logic for validating URLs, but I wasn't sure about that. I didn't want to change how PlayUrl worked (though adding an exception to some of the conditions in there could be good).

You guys might determine that a fix to GetMetadata at the native level might be better than this. The fact that a video player can get in a situation where this is possible is a bit strange.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂