### PR TITLE
[Shadergraph] check for description attribute in pluginfo to assign a description to a node port

### DIFF
--- a/game/addons/tools/Code/ShaderGraph/BaseNode.cs
+++ b/game/addons/tools/Code/ShaderGraph/BaseNode.cs
@@ -371,6 +371,11 @@ public class PlugInfo
 		{
 			info.Name = titleAttr.Value;
 		}
+		var descriptionAttr = property.GetCustomAttribute<DescriptionAttribute>();
+		if ( descriptionAttr is not null )
+		{
+			info.Description = descriptionAttr.Value;
+		}
 		DisplayInfo = info;
 		Property = property;
 	}


### PR DESCRIPTION
## Summary

A small tweak so that `PlugInfo` checks for the `DescriptionAttribute`

## Motivation & Context

Lets users define descriptions for `NodeInput` and `NodeResult` properties of a node class so that when
hovering over the respective ports on the node the assigned description is shown.

## Implementation Details

Just a simple attribute check in the PlugInfo class contructor.

## Screenshots / Videos (if applicable)

In-Graph test  :

<img width="392" height="267" alt="sbox-dev_hjHyaprEyq" src="https://github.com/user-attachments/assets/728b038a-5b01-493b-9116-56457eabbc50" />
<img width="589" height="386" alt="sbox-dev_6WWYs5BomJ" src="https://github.com/user-attachments/assets/517c6aec-6a3d-4421-8785-12ea1c32d5ef" />

Example Definition in a node class :

<img width="528" height="169" alt="devenv_Sjg5RZ2Qcj" src="https://github.com/user-attachments/assets/97617db4-a822-4bc2-aec6-e81c6fb7e8f1" />

<img width="713" height="180" alt="devenv_Il6kvIoKDb" src="https://github.com/user-attachments/assets/4b1f66dd-2c69-4fb2-902b-3fc503171d52" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂