### PR TITLE
Make JsonConvertFactory public sealed

### DIFF
--- a/engine/Sandbox.Engine/Utility/Json/IJsonConvert.cs
+++ b/engine/Sandbox.Engine/Utility/Json/IJsonConvert.cs
@@ -12,7 +12,7 @@ public interface IJsonConvert
 	public abstract static void JsonWrite( object value, Utf8JsonWriter writer );
 }
 
-class JsonConvertFactory : JsonConverterFactory
+public sealed class JsonConvertFactory : JsonConverterFactory
 {
 	public override bool CanConvert( Type typeToConvert )
 	{


### PR DESCRIPTION
## Summary

This pr simply makes the class `JsonConvertFactory` in `Utility/Json/IJsonConvert.cs` public sealed

## Motivation & Context

This change is needed so `JsonConvertFactory` can be added to to your own JsonSerializerOptions. So that you can serialize and deserialize types such as `Variant` when not using `Sandbox.Json.Serialize`

## Implementation Details

Made the class `public sealed` so that it can be used externally but not extended.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂