### PR TITLE
[ShaderGraph] Make use of NodeResultType in NodeResult struct instead of just an int to define the result type

### DIFF
--- a/game/addons/tools/Code/ShaderGraph/Compiler/GraphCompiler.cs
+++ b/game/addons/tools/Code/ShaderGraph/Compiler/GraphCompiler.cs
@@ -433,7 +433,7 @@ public sealed partial class GraphCompiler
 
 			var id = ShaderResult.InputResults.Count;
 			var varName = $"l_{id}";
-			var localResult = new NodeResult( funcResult.Components, varName );
+			var localResult = new NodeResult( funcResult.ResultType, varName );
 
 			ShaderResult.InputResults.Add( input, localResult );
 			ShaderResult.Results.Add( (localResult, funcResult) );
@@ -464,9 +464,9 @@ public sealed partial class GraphCompiler
 			return (resultA, resultB);
 
 		if ( resultA.Components < resultB.Components )
-			return (new( resultB.Components, resultA.Cast( resultB.Components ) ), resultB);
+			return (new( resultB.ResultType, resultA.Cast( resultB.Components ) ), resultB);
 
-		return (resultA, new( resultA.Components, resultB.Cast( resultA.Components ) ));
+		return (resultA, new( resultA.ResultType, resultB.Cast( resultA.Components ) ));
 	}
 
 	/// <summary>
@@ -561,12 +561,12 @@ public sealed partial class GraphCompiler
 
 		return value switch
 		{
-			float v => isNamed ? new NodeResult( 1, $"{name}" ) : new NodeResult( 1, $"{v}", true ),
-			Vector2 v => isNamed ? new NodeResult( 2, $"{name}" ) : new NodeResult( 2, $"float2( {v.x}, {v.y} )" ),
-			Vector3 v => isNamed ? new NodeResult( 3, $"{name}" ) : new NodeResult( 3, $"float3( {v.x}, {v.y}, {v.z} )" ),
-			Vector4 v => isNamed ? new NodeResult( 4, $"{name}" ) : new NodeResult( 4, $"float4( {v.x}, {v.y}, {v.z}, {v.w} )" ),
-			Color v => isNamed ? new NodeResult( 4, $"{name}" ) : new NodeResult( 4, $"float4( {v.r}, {v.g}, {v.b}, {v.a} )" ),
-			bool v => isNamed ? new NodeResult( 0, $"{name}" ) : new NodeResult( 0, $"{v}" ),
+			float v => isNamed ? new NodeResult( NodeResultType.Float, $"{name}" ) : new NodeResult( NodeResultType.Float, $"{v}", true ),
+			Vector2 v => isNamed ? new NodeResult( NodeResultType.Vector2, $"{name}" ) : new NodeResult( NodeResultType.Vector2, $"float2( {v.x}, {v.y} )" ),
+			Vector3 v => isNamed ? new NodeResult( NodeResultType.Vector3, $"{name}" ) : new NodeResult( NodeResultType.Vector3, $"float3( {v.x}, {v.y}, {v.z} )" ),
+			Vector4 v => isNamed ? new NodeResult( NodeResultType.Vector4, $"{name}" ) : new NodeResult( NodeResultType.Vector4, $"float4( {v.x}, {v.y}, {v.z}, {v.w} )" ),
+			Color v => isNamed ? new NodeResult( NodeResultType.Vector4, $"{name}" ) : new NodeResult( NodeResultType.Vector4, $"float4( {v.r}, {v.g}, {v.b}, {v.a} )" ),
+			bool v => isNamed ? new NodeResult( NodeResultType.Bool, $"{name}" ) : new NodeResult( NodeResultType.Bool, $"{v}" ),
 			_ => throw new ArgumentException( "Unsupported attribute type", nameof( value ) )
 		};
 	}

--- a/game/addons/tools/Code/ShaderGraph/Compiler/NodeResult.cs
+++ b/game/addons/tools/Code/ShaderGraph/Compiler/NodeResult.cs
@@ -6,49 +6,69 @@ public enum NodeResultType
 	Float,
 	Vector2,
 	Vector3,
-	Color
+	Vector4,
+	[Obsolete( "Use NodeResultType.Vector4 instead", false )]
+	Color,
+	Invalid,
 }
 
 public struct NodeResult : IValid
 {
 	public delegate NodeResult Func( GraphCompiler compiler );
-
+	public NodeResultType ResultType { get; private set; } = NodeResultType.Invalid;
 	public string Code { get; private set; }
-	public int Components { get; private set; }
 	public bool Constant { get; set; }
 	public string[] Errors { get; private init; }
+	public readonly bool IsValid => ResultType != NodeResultType.Invalid && !string.IsNullOrWhiteSpace( Code );
 
-	public readonly bool IsValid => Components > 0 && !string.IsNullOrWhiteSpace( Code );
-
-	public readonly string TypeName => Components > 1 ? $"float{Components}" : Components == 0 ? "bool" : "float";
-
-	public readonly Type ComponentType => Components switch
+	public readonly string TypeName => ResultType switch
 	{
-		1 => typeof( float ),
-		2 => typeof( Vector2 ),
-		3 => typeof( Vector3 ),
-		4 => typeof( Color ),
+		NodeResultType.Bool => "bool",
+		NodeResultType.Float => "float",
+		NodeResultType.Vector2 => "float2",
+		NodeResultType.Vector3 => "float3",
+		NodeResultType.Vector4 => "float4",
+		_ => null
+	};
+
+	public int Components => ResultType switch
+	{
+		NodeResultType.Bool => 1,
+		NodeResultType.Float => 1,
+		NodeResultType.Vector2 => 2,
+		NodeResultType.Vector3 => 3,
+		NodeResultType.Vector4 => 4,
+		_ => 1
+	};
+
+	public readonly Type ComponentType => ResultType switch
+	{
+		NodeResultType.Float => typeof( float ),
+		NodeResultType.Vector2 => typeof( Vector2 ),
+		NodeResultType.Vector3 => typeof( Vector3 ),
+		NodeResultType.Vector4 => typeof( Vector4 ),
 		_ => null,
 	};
 
+	[Obsolete( "Use NodeResult( NodeResultType resultType, string code, bool constant = false ) instead", false )]
 	public NodeResult( int components, string code, bool constant = false )
 	{
-		Components = components;
+		ResultType = components switch
+		{
+			1 => NodeResultType.Float,
+			2 => NodeResultType.Vector2,
+			3 => NodeResultType.Vector3,
+			4 => NodeResultType.Vector4,
+			_ => NodeResultType.Invalid,
+		};
+
 		Code = code;
 		Constant = constant;
 	}
 
-	public NodeResult( NodeResultType type, string code, bool constant = false )
+	public NodeResult( NodeResultType resultType, string code, bool constant = false )
 	{
-		Components = type switch
-		{
-			NodeResultType.Bool => 1,
-			NodeResultType.Float => 1,
-			NodeResultType.Vector2 => 2,
-			NodeResultType.Vector3 => 3,
-			NodeResultType.Color => 4,
-			_ => 1
-		};
+		ResultType = resultType;
 		Code = code;
 		Constant = constant;
 	}
@@ -62,6 +82,11 @@ public struct NodeResult : IValid
 	/// </summary>
 	public string Cast( int components, float defaultValue = 0.0f )
 	{
+		if ( ResultType == NodeResultType.Bool || ResultType == NodeResultType.Invalid )
+		{
+			throw new Exception( $"ResultType `{ResultType}` cannot be cast." );
+		}
+
 		if ( Components == components )
 			return Code;
 

--- a/game/addons/tools/Code/ShaderGraph/ParameterNode.cs
+++ b/game/addons/tools/Code/ShaderGraph/ParameterNode.cs
@@ -59,7 +59,7 @@ public abstract class ParameterNode<T> : ShaderNode, IParameterNode, IErroringNo
 			return compiler.ResultValue( value );
 
 		var result = compiler.Result( new NodeInput { Identifier = Identifier, Output = nameof( Result ) } );
-		return new( 1, $"{result}.{component}", true );
+		return new( NodeResultType.Float, $"{result}.{component}", true );
 	}
 
 	public virtual object GetDefaultValue()

--- a/game/editor/ShaderGraph/Code/Nodes/Binary.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Binary.cs
@@ -40,7 +40,7 @@ public abstract class Binary : ShaderNode
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var results = compiler.Result( A, B, DefaultA, DefaultB );
-		return new NodeResult( results.Item1.Components, $"{results.Item1} {Op} {results.Item2}" );
+		return new NodeResult( results.Item1.ResultType, $"{results.Item1} {Op} {results.Item2}" );
 	};
 
 	[JsonIgnore, Hide, Browsable( false )]
@@ -148,7 +148,7 @@ public sealed class Lerp : ShaderNode
 		var results = compiler.Result( A, B, DefaultA, DefaultB );
 		var fraction = compiler.Result( C );
 		var fractionType = fraction.IsValid && fraction.Components > 1 ? Math.Max( results.Item1.Components, results.Item2.Components ) : 1;
-		return new NodeResult( results.Item1.Components, $"lerp( {results.Item1}, {results.Item2}," +
+		return new NodeResult( results.Item1.ResultType, $"lerp( {results.Item1}, {results.Item2}," +
 			$" {(fraction.IsValid ? fraction.Cast( fractionType ) : compiler.ResultValue( Fraction ))} )" );
 	};
 }
@@ -194,7 +194,7 @@ public sealed class CrossProduct : ShaderNode
 	{
 		var a = compiler.ResultOrDefault( A, DefaultA ).Cast( 3 );
 		var b = compiler.ResultOrDefault( B, DefaultB ).Cast( 3 );
-		return new NodeResult( 3, $"cross( {a}, {b} )" );
+		return new NodeResult( NodeResultType.Vector3, $"cross( {a}, {b} )" );
 	};
 }
 
@@ -328,7 +328,16 @@ public sealed class RemapValue : ShaderNode
 		// Remap the normalized value to the output range
 		var remappedOutput = $"{normalizedInValue} * ( {outMaxValue} - {outMinValue} ) + {outMinValue}";
 
-		return new NodeResult( maxComponents, remappedOutput );
+		NodeResultType resultType = maxComponents switch
+		{
+			1 => NodeResultType.Float,
+			2 => NodeResultType.Vector2,
+			3 => NodeResultType.Vector3,
+			4 => NodeResultType.Vector4,
+			_ => NodeResultType.Invalid,
+		};
+
+		return new NodeResult( resultType, remappedOutput );
 	};
 }
 
@@ -362,7 +371,7 @@ public sealed class Arctan2 : ShaderNode
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var results = compiler.Result( Y, X, DefaultY, DefaultX );
-		return new NodeResult( results.Item1.Components, $"atan2( {results.Item1}, {results.Item2} )" );
+		return new NodeResult( results.Item1.ResultType, $"atan2( {results.Item1}, {results.Item2} )" );
 	};
 }
 
@@ -408,7 +417,7 @@ public sealed class Power : ShaderNode
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var results = compiler.Result( A, B, DefaultA, DefaultB );
-		return new NodeResult( results.Item1.Components, $"pow( {results.Item1}, {results.Item2} )" );
+		return new NodeResult( results.Item1.ResultType, $"pow( {results.Item1}, {results.Item2} )" );
 	};
 
 	public override void OnPaint( Rect rect )

--- a/game/editor/ShaderGraph/Code/Nodes/Branch.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Branch.cs
@@ -79,7 +79,7 @@ public sealed class Branch : ShaderNode
 		var resultA = useCondition ? compiler.ResultOrDefault( A, 0.0f ) : default;
 		var resultB = useCondition ? compiler.ResultOrDefault( B, 0.0f ) : default;
 
-		return new NodeResult( results.Item1.Components, $"{(useCondition ?
+		return new NodeResult( results.Item1.ResultType, $"{(useCondition ?
 			$"{resultA.Cast( 1 )} {Op} {resultB.Cast( 1 )}" : compiler.ResultParameter( Name, Enabled, default, default, false, IsAttribute, UI ))} ?" +
 			$" {results.Item1} :" +
 			$" {results.Item2}" );

--- a/game/editor/ShaderGraph/Code/Nodes/Camera.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Camera.cs
@@ -9,19 +9,19 @@ public sealed class Camera : ShaderNode
 {
 	[Output( typeof( Vector3 ) ), Title( "Position" )]
 	[Hide]
-	public static NodeResult.Func WorldPosition => ( GraphCompiler compiler ) => new( 3, "g_vCameraPositionWs" );
+	public static NodeResult.Func WorldPosition => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "g_vCameraPositionWs" );
 
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func Direction => ( GraphCompiler compiler ) => new( 3, "g_vCameraDirWs" );
+	public static NodeResult.Func Direction => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "g_vCameraDirWs" );
 
 	[Output( typeof( float ) )]
 	[Hide]
-	public static NodeResult.Func NearPlane => ( GraphCompiler compiler ) => new( 1, "g_flNearPlane" );
+	public static NodeResult.Func NearPlane => ( GraphCompiler compiler ) => new( NodeResultType.Float, "g_flNearPlane" );
 
 	[Output( typeof( float ) )]
 	[Hide]
-	public static NodeResult.Func FarPlane => ( GraphCompiler compiler ) => new( 1, "g_flFarPlane" );
+	public static NodeResult.Func FarPlane => ( GraphCompiler compiler ) => new( NodeResultType.Float, "g_flFarPlane" );
 }
 
 /// <summary>
@@ -39,7 +39,7 @@ public sealed class Depth : ShaderNode
 		var result = UV.IsValid() ? compiler.Result( UV ).Cast( 2 ) :
 			compiler.IsVs ? "i.vPositionPs.xy" : "i.vPositionSs.xy";
 
-		return new NodeResult( 1, $"Depth::Get( {result} )" );
+		return new NodeResult( NodeResultType.Float, $"Depth::Get( {result} )" );
 	};
 }
 
@@ -58,6 +58,6 @@ public sealed class LinearDepth : ShaderNode
 		var result = UV.IsValid() ? compiler.Result( UV ).Cast( 2 ) :
 			compiler.IsVs ? "i.vPositionPs.xy" : "i.vPositionSs.xy";
 
-		return new NodeResult( 1, $"Depth::GetLinear( {result} )" );
+		return new NodeResult( NodeResultType.Float, $"Depth::GetLinear( {result} )" );
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Channel.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Channel.cs
@@ -22,32 +22,32 @@ public sealed class SplitVector : ShaderNode
 	public NodeResult.Func X => ( GraphCompiler compiler ) =>
 	{
 		var result = compiler.Result( Input );
-		if ( result.IsValid && result.Components > 0 ) return new NodeResult( 1, $"{result}.x" );
-		return new NodeResult( 1, "0.0f" );
+		if ( result.IsValid && result.Components > 0 ) return new NodeResult( NodeResultType.Float, $"{result}.x" );
+		return new NodeResult( NodeResultType.Float, "0.0f" );
 	};
 
 	[Output( typeof( float ) ), Hide]
 	public NodeResult.Func Y => ( GraphCompiler compiler ) =>
 	{
 		var result = compiler.Result( Input );
-		if ( result.IsValid && result.Components > 1 ) return new NodeResult( 1, $"{result}.y" );
-		return new NodeResult( 1, "0.0f" );
+		if ( result.IsValid && result.Components > 1 ) return new NodeResult( NodeResultType.Float, $"{result}.y" );
+		return new NodeResult( NodeResultType.Float, "0.0f" );
 	};
 
 	[Output( typeof( float ) ), Hide]
 	public NodeResult.Func Z => ( GraphCompiler compiler ) =>
 	{
 		var result = compiler.Result( Input );
-		if ( result.IsValid && result.Components > 2 ) return new NodeResult( 1, $"{result}.z" );
-		return new NodeResult( 1, "0.0f" );
+		if ( result.IsValid && result.Components > 2 ) return new NodeResult( NodeResultType.Float, $"{result}.z" );
+		return new NodeResult( NodeResultType.Float, "0.0f" );
 	};
 
 	[Output( typeof( float ) ), Hide]
 	public NodeResult.Func W => ( GraphCompiler compiler ) =>
 	{
 		var result = compiler.Result( Input );
-		if ( result.IsValid && result.Components > 3 ) return new NodeResult( 1, $"{result}.w" );
-		return new NodeResult( 1, "0.0f" );
+		if ( result.IsValid && result.Components > 3 ) return new NodeResult( NodeResultType.Float, $"{result}.w" );
+		return new NodeResult( NodeResultType.Float, "0.0f" );
 	};
 }
 
@@ -92,7 +92,7 @@ public sealed class CombineVector : ShaderNode
 		var z = compiler.ResultOrDefault( Z, DefaultZ ).Cast( 1 );
 		var w = compiler.ResultOrDefault( W, DefaultW ).Cast( 1 );
 
-		return new NodeResult( 4, $"float4( {x}, {y}, {z}, {w} )" );
+		return new NodeResult( NodeResultType.Vector4, $"float4( {x}, {y}, {z}, {w} )" );
 	};
 
 	[Output( typeof( Vector3 ) )]
@@ -103,7 +103,7 @@ public sealed class CombineVector : ShaderNode
 		var y = compiler.ResultOrDefault( Y, DefaultY ).Cast( 1 );
 		var z = compiler.ResultOrDefault( Z, DefaultZ ).Cast( 1 );
 
-		return new NodeResult( 3, $"float3( {x}, {y}, {z} )" );
+		return new NodeResult( NodeResultType.Vector3, $"float3( {x}, {y}, {z} )" );
 	};
 
 	[Output( typeof( Vector2 ) )]
@@ -113,7 +113,7 @@ public sealed class CombineVector : ShaderNode
 		var x = compiler.ResultOrDefault( X, DefaultX ).Cast( 1 );
 		var y = compiler.ResultOrDefault( Y, DefaultY ).Cast( 1 );
 
-		return new NodeResult( 2, $"float2( {x}, {y})" );
+		return new NodeResult( NodeResultType.Vector2, $"float2( {x}, {y})" );
 	};
 }
 
@@ -155,7 +155,7 @@ public sealed class SwizzleVector : ShaderNode
 		swizzle += SwizzleToChannel( BlueOut );
 		swizzle += SwizzleToChannel( AlphaOut );
 
-		return new NodeResult( 4, $"{input.Cast( 4 )}{swizzle}" );
+		return new NodeResult( NodeResultType.Vector4, $"{input.Cast( 4 )}{swizzle}" );
 	};
 }
 
@@ -181,6 +181,15 @@ public sealed class AppendVector : ShaderNode
 		if ( components < 1 || components > 4 )
 			return NodeResult.Error( $"Can't append {resultB.TypeName} to {resultA.TypeName}" );
 
-		return new NodeResult( components, $"float{components}( {resultA}, {resultB} )" );
+		NodeResultType resultType = components switch
+		{
+			1 => NodeResultType.Float,
+			2 => NodeResultType.Vector2,
+			3 => NodeResultType.Vector3,
+			4 => NodeResultType.Vector4,
+			_ => NodeResultType.Invalid,
+		};
+
+		return new NodeResult( resultType, $"float{components}( {resultA}, {resultB} )" );
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Effects.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Effects.cs
@@ -43,6 +43,6 @@ public sealed class Fresnel : ShaderNode
 		var direction = Direction.IsValid ? compiler.Result( Direction ).Cast( 3 ) :
 			$"CalculatePositionToCameraDirWs( {(compiler.IsVs ? "i.vPositionWs.xyz" : "i.vPositionWithOffsetWs.xyz + g_vHighPrecisionLightingOffsetWs.xyz")} )";
 
-		return new( 3, $"pow( 1.0 - dot( normalize( {normal} ), normalize( {direction} ) ), {power} )" );
+		return new( NodeResultType.Vector3, $"pow( 1.0 - dot( normalize( {normal} ), normalize( {direction} ) ), {power} )" );
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Geometry.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Geometry.cs
@@ -9,7 +9,7 @@ public sealed class WorldNormal : ShaderNode
 {
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func Result => ( GraphCompiler compiler ) => new( 3, "i.vNormalWs", compiler.IsNotPreview );
+	public static NodeResult.Func Result => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "i.vNormalWs", compiler.IsNotPreview );
 }
 
 /// <summary>
@@ -20,11 +20,11 @@ public sealed class WorldTangent : ShaderNode
 {
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func U => ( GraphCompiler compiler ) => new( 3, "i.vTangentUWs", compiler.IsNotPreview );
+	public static NodeResult.Func U => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "i.vTangentUWs", compiler.IsNotPreview );
 
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func V => ( GraphCompiler compiler ) => new( 3, "i.vTangentVWs", compiler.IsNotPreview );
+	public static NodeResult.Func V => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "i.vTangentVWs", compiler.IsNotPreview );
 }
 
 /// <summary>
@@ -37,7 +37,7 @@ public sealed class IsFrontFace : ShaderNode
 	[Hide]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
-		return new NodeResult( 1, compiler.IsPs ? "i.vFrontFacing" : "0", compiler.IsNotPreview );
+		return new NodeResult( NodeResultType.Float, compiler.IsPs ? "i.vFrontFacing" : "0", compiler.IsNotPreview );
 	};
 }
 
@@ -50,7 +50,7 @@ public sealed class ObjectSpaceNormal : ShaderNode
 {
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func Result => ( GraphCompiler compiler ) => new( 3, "i.vNormalOs", compiler.IsNotPreview );
+	public static NodeResult.Func Result => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "i.vNormalOs", compiler.IsNotPreview );
 }
 
 /// <summary>
@@ -64,19 +64,19 @@ public sealed class ScreenPosition : ShaderNode
 
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func XYZ => ( GraphCompiler compiler ) => compiler.IsVs ? new( 3, "i.vPositionPs.xyz" ) : new( 3, "i.vPositionSs.xyz" );
+	public static NodeResult.Func XYZ => ( GraphCompiler compiler ) => compiler.IsVs ? new( NodeResultType.Vector3, "i.vPositionPs.xyz" ) : new( NodeResultType.Vector3, "i.vPositionSs.xyz" );
 
 	[Output( typeof( Vector2 ) )]
 	[Hide]
-	public static NodeResult.Func XY => ( GraphCompiler compiler ) => compiler.IsVs ? new( 2, "i.vPositionPs.xy" ) : new( 2, "i.vPositionSs.xy" );
+	public static NodeResult.Func XY => ( GraphCompiler compiler ) => compiler.IsVs ? new( NodeResultType.Vector2, "i.vPositionPs.xy" ) : new( NodeResultType.Vector2, "i.vPositionSs.xy" );
 
 	[Output( typeof( float ) )]
 	[Hide]
-	public static NodeResult.Func Z => ( GraphCompiler compiler ) => compiler.IsVs ? new( 1, "i.vPositionPs.z" ) : new( 1, "i.vPositionSs.z" );
+	public static NodeResult.Func Z => ( GraphCompiler compiler ) => compiler.IsVs ? new( NodeResultType.Float, "i.vPositionPs.z" ) : new( NodeResultType.Float, "i.vPositionSs.z" );
 
 	[Output( typeof( float ) )]
 	[Hide]
-	public static NodeResult.Func W => ( GraphCompiler compiler ) => compiler.IsVs ? new( 1, "i.vPositionPs.w" ) : new( 1, "i.vPositionSs.w" );
+	public static NodeResult.Func W => ( GraphCompiler compiler ) => compiler.IsVs ? new( NodeResultType.Float, "i.vPositionPs.w" ) : new( NodeResultType.Float, "i.vPositionSs.w" );
 }
 
 /// <summary>
@@ -89,8 +89,8 @@ public sealed class ScreenCoordinate : ShaderNode
 	[Hide]
 	public static NodeResult.Func Result => ( GraphCompiler compiler ) =>
 		compiler.IsVs ?
-		new( 2, "CalculateViewportUv( i.vPositionPs.xy )" ) :
-		new( 2, "CalculateViewportUv( i.vPositionSs.xy )" );
+		new( NodeResultType.Vector2, "CalculateViewportUv( i.vPositionPs.xy )" ) :
+		new( NodeResultType.Vector2, "CalculateViewportUv( i.vPositionSs.xy )" );
 }
 
 /// <summary>
@@ -103,8 +103,8 @@ public sealed class WorldPosition : ShaderNode
 	[Hide]
 	public static NodeResult.Func Result => ( GraphCompiler compiler ) =>
 		compiler.IsVs ?
-		new( 3, "i.vPositionWs" ) :
-		new( 3, "i.vPositionWithOffsetWs.xyz + g_vHighPrecisionLightingOffsetWs.xyz" );
+		new( NodeResultType.Vector3, "i.vPositionWs" ) :
+		new( NodeResultType.Vector3, "i.vPositionWithOffsetWs.xyz + g_vHighPrecisionLightingOffsetWs.xyz" );
 }
 
 /// <summary>
@@ -115,7 +115,7 @@ public sealed class ObjectPosition : ShaderNode
 {
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func Result => ( GraphCompiler compiler ) => new( 3, "i.vPositionOs" );
+	public static NodeResult.Func Result => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "i.vPositionOs" );
 }
 
 /// <summary>
@@ -128,8 +128,8 @@ public sealed class ViewDirection : ShaderNode
 	[Hide]
 	public static NodeResult.Func Result => ( GraphCompiler compiler ) =>
 		compiler.IsVs ?
-		new( 3, "CalculatePositionToCameraDirWs( i.vPositionWs )" ) :
-		new( 3, "CalculatePositionToCameraDirWs( i.vPositionWithOffsetWs.xyz + g_vHighPrecisionLightingOffsetWs.xyz )" );
+		new( NodeResultType.Vector3, "CalculatePositionToCameraDirWs( i.vPositionWs )" ) :
+		new( NodeResultType.Vector3, "CalculatePositionToCameraDirWs( i.vPositionWithOffsetWs.xyz + g_vHighPrecisionLightingOffsetWs.xyz )" );
 }
 
 /// <summary>
@@ -140,11 +140,11 @@ public sealed class VertexColor : ShaderNode
 {
 	[Output( typeof( Vector3 ) )]
 	[Hide]
-	public static NodeResult.Func RGB => ( GraphCompiler compiler ) => new( 3, "i.vColor.rgb" );
+	public static NodeResult.Func RGB => ( GraphCompiler compiler ) => new( NodeResultType.Vector3, "i.vColor.rgb" );
 
 	[Output( typeof( float ) )]
 	[Hide]
-	public static NodeResult.Func Alpha => ( GraphCompiler compiler ) => new( 1, "i.vColor.a" );
+	public static NodeResult.Func Alpha => ( GraphCompiler compiler ) => new( NodeResultType.Float, "i.vColor.a" );
 }
 
 /// <summary>
@@ -154,5 +154,5 @@ public sealed class VertexColor : ShaderNode
 public sealed class Tint : ShaderNode
 {
 	[Hide, Output( typeof( Color ) )]
-	public static NodeResult.Func RGBA => ( GraphCompiler compiler ) => new( 4, "i.vTintColor" );
+	public static NodeResult.Func RGBA => ( GraphCompiler compiler ) => new( NodeResultType.Vector4, "i.vTintColor" );
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Geometry.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Geometry.cs
@@ -153,6 +153,6 @@ public sealed class VertexColor : ShaderNode
 [Title( "Tint" ), Category( "Variables" ), Icon( "palette" )]
 public sealed class Tint : ShaderNode
 {
-	[Hide, Output( typeof( Color ) )]
+	[Hide, Output( typeof( Vector4 ) )]
 	public static NodeResult.Func RGBA => ( GraphCompiler compiler ) => new( NodeResultType.Vector4, "i.vTintColor" );
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Noise.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Noise.cs
@@ -14,7 +14,7 @@ public abstract class NoiseNode : ShaderNode
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var result = compiler.Result( Coords );
-		return new( 1, $"{Func}( {(result.IsValid ? $"{result.Cast( 2 )}" : "i.vTextureCoords.xy")} )" );
+		return new( NodeResultType.Float, $"{Func}( {(result.IsValid ? $"{result.Cast( 2 )}" : "i.vTextureCoords.xy")} )" );
 	};
 }
 
@@ -94,6 +94,6 @@ public sealed class VoronoiNoise : ShaderNode
 		string angleStr = $"{(angleOffset.IsValid ? angleOffset.Cast( 1 ) : compiler.ResultValue( AngleOffset ))}";
 		string densityStr = $"{(cellDensity.IsValid ? cellDensity.Cast( 1 ) : compiler.ResultValue( CellDensity ))}";
 
-		return new( 1, $"{(Worley ? "1.0f - " : string.Empty)}VoronoiNoise( {(result.IsValid ? $"{result.Cast( 2 )}" : "i.vTextureCoords.xy")}, {angleStr}, {densityStr} )" );
+		return new( NodeResultType.Float, $"{(Worley ? "1.0f - " : string.Empty)}VoronoiNoise( {(result.IsValid ? $"{result.Cast( 2 )}" : "i.vTextureCoords.xy")}, {angleStr}, {densityStr} )" );
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Parameter.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Parameter.cs
@@ -192,7 +192,7 @@ public sealed class Float3 : ParameterNode<Vector3>
 [Title( "Color" ), Category( "Constants" ), Icon( "palette" )]
 public sealed class Float4 : ParameterNode<Color>
 {
-	[Output( typeof( Vector4 ) ), Title( "RGBA" )]
+	[Output( typeof( Color ) ), Title( "RGBA" )]
 	[Hide, Editor( nameof( Value ) )]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{

--- a/game/editor/ShaderGraph/Code/Nodes/Parameter.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Parameter.cs
@@ -192,7 +192,7 @@ public sealed class Float3 : ParameterNode<Vector3>
 [Title( "Color" ), Category( "Constants" ), Icon( "palette" )]
 public sealed class Float4 : ParameterNode<Color>
 {
-	[Output( typeof( Color ) ), Title( "RGBA" )]
+	[Output( typeof( Vector4 ) ), Title( "RGBA" )]
 	[Hide, Editor( nameof( Value ) )]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{

--- a/game/editor/ShaderGraph/Code/Nodes/SceneColor.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/SceneColor.cs
@@ -113,7 +113,7 @@ float2 MapSceneColorCoords( float2 vInput, float2 modes )
 
 		if ( graph.Domain is ShaderDomain.PostProcess )
 		{
-			return new NodeResult( 3, $"g_tColorBuffer.Sample( g_sAniso, {(
+			return new NodeResult( NodeResultType.Vector3, $"g_tColorBuffer.Sample( g_sAniso, {(
 				coords.IsValid
 				? $"{compiler.ResultFunction( func, coords.Cast( 2 ), uvModes )}"
 				: $"CalculateViewportUv( {compiler.ResultFunction( func, "i.vPositionSs.xy", uvModes )} )"

--- a/game/editor/ShaderGraph/Code/Nodes/Texture.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Texture.cs
@@ -160,7 +160,7 @@ public sealed class TextureSampler : TextureSamplerBase
 	/// RGBA color result
 	/// </summary>
 	[Hide]
-	[Output( typeof( Color ) ), Title( "RGBA" )]
+	[Output( typeof( Vector4 ) ), Title( "RGBA" )]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var input = UI;
@@ -279,7 +279,7 @@ public sealed class TextureCube : ShaderNode
 	/// RGBA color result
 	/// </summary>
 	[Hide]
-	[Output( typeof( Color ) ), Title( "RGBA" )]
+	[Output( typeof( Vector4 ) ), Title( "RGBA" )]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var input = UI;
@@ -350,7 +350,7 @@ public sealed class TextureTriplanar : TextureSamplerBase
 	/// RGBA color result
 	/// </summary>
 	[Hide]
-	[Output( typeof( Color ) ), Title( "RGBA" )]
+	[Output( typeof( Vector4 ) ), Title( "RGBA" )]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var input = UI;

--- a/game/editor/ShaderGraph/Code/Nodes/Texture.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Texture.cs
@@ -115,7 +115,7 @@ public abstract class TextureSamplerBase : ShaderNode, ITextureParameterNode, IE
 	protected NodeResult Component( string component, GraphCompiler compiler )
 	{
 		var result = compiler.Result( new NodeInput { Identifier = Identifier, Output = nameof( Result ) } );
-		return result.IsValid ? new( 1, $"{result}.{component}", true ) : new( 1, "0.0f", true );
+		return result.IsValid ? new( NodeResultType.Float, $"{result}.{component}", true ) : new( NodeResultType.Float, "0.0f", true );
 	}
 
 	public List<string> GetErrors()
@@ -176,13 +176,13 @@ public sealed class TextureSampler : TextureSamplerBase
 
 		if ( compiler.Stage == GraphCompiler.ShaderStage.Vertex )
 		{
-			return new NodeResult( 4, $"{result.Item1}.SampleLevel(" +
+			return new NodeResult( NodeResultType.Vector4, $"{result.Item1}.SampleLevel(" +
 				$" g_sSampler{result.Item2}," +
 				$" {(coords.IsValid ? $"{coords.Cast( 2 )}" : "i.vTextureCoords.xy")}, 0 )" );
 		}
 		else
 		{
-			return new NodeResult( 4, $"Tex2DS( {result.Item1}," +
+			return new NodeResult( NodeResultType.Vector4, $"Tex2DS( {result.Item1}," +
 				$" g_sSampler{result.Item2}," +
 				$" {(coords.IsValid ? $"{coords.Cast( 2 )}" : "i.vTextureCoords.xy")} )" );
 		}
@@ -288,7 +288,7 @@ public sealed class TextureCube : ShaderNode
 		var result = compiler.ResultTexture( Sampler, input, Sandbox.Texture.Load( Texture ) );
 		var coords = compiler.Result( Coords );
 
-		return new NodeResult( 4, $"TexCubeS( {result.Item1}," +
+		return new NodeResult( NodeResultType.Vector4, $"TexCubeS( {result.Item1}," +
 			$" g_sSampler{result.Item2}," +
 			$" {(coords.IsValid ? $"{coords.Cast( 3 )}" : ViewDirection.Result.Invoke( compiler ))} )" );
 	};
@@ -296,7 +296,7 @@ public sealed class TextureCube : ShaderNode
 	private NodeResult Component( string component, GraphCompiler compiler )
 	{
 		var result = compiler.Result( new NodeInput { Identifier = Identifier, Output = nameof( Result ) } );
-		return result.IsValid ? new( 1, $"{result}.{component}", true ) : new( 1, "0.0f", true );
+		return result.IsValid ? new( NodeResultType.Float, $"{result}.{component}", true ) : new( NodeResultType.Float, "0.0f", true );
 	}
 
 	/// <summary>
@@ -371,7 +371,7 @@ public sealed class TextureTriplanar : TextureSamplerBase
 			coords.IsValid ? coords.Cast( 3 ) : "(i.vPositionWithOffsetWs.xyz + g_vHighPrecisionLightingOffsetWs.xyz) / 39.3701",
 			normal.IsValid ? normal.Cast( 3 ) : "normalize( i.vNormalWs.xyz )" );
 
-		return new NodeResult( 4, result );
+		return new NodeResult( NodeResultType.Vector4, result );
 	};
 
 	/// <summary>
@@ -461,7 +461,7 @@ public sealed class NormapMapTriplanar : TextureSamplerBase
 			coords.IsValid ? coords.Cast( 3 ) : "(i.vPositionWithOffsetWs.xyz + g_vHighPrecisionLightingOffsetWs.xyz) / 39.3701",
 			normal.IsValid ? normal.Cast( 3 ) : "normalize( i.vNormalWs.xyz )" );
 
-		return new NodeResult( 3, result );
+		return new NodeResult( NodeResultType.Vector3, result );
 	};
 }
 
@@ -494,12 +494,12 @@ public sealed class TextureCoord : ShaderNode
 		if ( compiler.IsPreview )
 		{
 			var result = $"{compiler.ResultValue( UseSecondaryCoord )} ? i.vTextureCoords.zw : i.vTextureCoords.xy";
-			return new( 2, $"{compiler.ResultValue( Tiling.IsNearZeroLength )} ? {result} : ({result}) * {compiler.ResultValue( Tiling )}" );
+			return new( NodeResultType.Vector2, $"{compiler.ResultValue( Tiling.IsNearZeroLength )} ? {result} : ({result}) * {compiler.ResultValue( Tiling )}" );
 		}
 		else
 		{
 			var result = UseSecondaryCoord ? "i.vTextureCoords.zw" : "i.vTextureCoords.xy";
-			return Tiling.IsNearZeroLength ? new( 2, result ) : new( 2, $"{result} * {compiler.ResultValue( Tiling )}" );
+			return Tiling.IsNearZeroLength ? new( NodeResultType.Vector2, result ) : new( NodeResultType.Vector2, $"{result} * {compiler.ResultValue( Tiling )}" );
 		}
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Time.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Time.cs
@@ -14,6 +14,6 @@ public sealed class Time : ShaderNode
 	[Hide]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
-		return new NodeResult( 1, compiler.IsPreview ? "g_flPreviewTime" : "g_flTime", compiler.IsNotPreview );
+		return new NodeResult( NodeResultType.Float, compiler.IsPreview ? "g_flPreviewTime" : "g_flTime", compiler.IsNotPreview );
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Transform.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Transform.cs
@@ -76,7 +76,7 @@ public sealed class TransformNormal : ShaderNode
 	/// </summary>
 	public bool DecodeNormal { get; set; } = true;
 
-	[Output]
+	[Output( typeof( Vector3 ) )]
 	[Hide]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
@@ -85,7 +85,7 @@ public sealed class TransformNormal : ShaderNode
 		if ( !result.IsValid )
 		{
 			// No input, just return the vertex normal in worldspace or a default tangent space output.
-			return OutputSpace == OutputNormalSpace.World ? new NodeResult( 3, "i.vNormalWs.xyz" ) : new NodeResult( 3, "float3( 0, 0, 1 )" );
+			return OutputSpace == OutputNormalSpace.World ? new NodeResult( NodeResultType.Vector3, "i.vNormalWs.xyz" ) : new NodeResult( NodeResultType.Vector3, "float3( 0, 0, 1 )" );
 		}
 
 		// Cast the result to a float3
@@ -116,7 +116,7 @@ public sealed class TransformNormal : ShaderNode
 			inputNormal = $"Vec3WsToTs( {inputNormal}, i.vNormalWs, i.vTangentUWs, i.vTangentVWs )";
 		}
 
-		return OutputSpace == OutputNormalSpace.World ? new NodeResult( 3, $"TransformNormal( {inputNormal}, i.vNormalWs, i.vTangentUWs, i.vTangentVWs )" ) : new NodeResult( 3, $"{inputNormal}" );
+		return OutputSpace == OutputNormalSpace.World ? new NodeResult( NodeResultType.Vector3, $"TransformNormal( {inputNormal}, i.vNormalWs, i.vTangentUWs, i.vTangentVWs )" ) : new NodeResult( NodeResultType.Vector3, $"{inputNormal}" );
 	};
 }
 
@@ -171,7 +171,7 @@ public sealed class ApplyTrs : ShaderNode
 
 		if ( compiler.Result( Rotation ) is { IsValid: true } rotationResult )
 		{
-			rotation = new NodeResult( 4, compiler.ResultFunction( "Quaternion_FromAngles", rotationResult.Code ) );
+			rotation = new NodeResult( NodeResultType.Vector4, compiler.ResultFunction( "Quaternion_FromAngles", rotationResult.Code ) );
 		}
 		else
 		{
@@ -184,7 +184,7 @@ public sealed class ApplyTrs : ShaderNode
 		if ( rotation.IsValid ) ApplyMatrix( ref matrix, compiler.ResultFunction( "Matrix_FromQuaternion", rotation.Code ) );
 		if ( translation.IsValid ) ApplyMatrix( ref matrix, compiler.ResultFunction( "Matrix_FromTranslation", translation.Code ) );
 
-		return matrix is null ? vector : new NodeResult( 3, $"mul( {matrix}, float4( {vector.Code}, 1.0 ) ).xyz" );
+		return matrix is null ? vector : new NodeResult( NodeResultType.Vector3, $"mul( {matrix}, float4( {vector.Code}, 1.0 ) ).xyz" );
 	};
 
 	private static void ApplyMatrix( ref string lhs, string rhs )
@@ -222,7 +222,7 @@ public sealed class PolarCoordinates : ShaderNode
 	[InputDefault( nameof( LengthScale ) )]
 	public float DefaultLengthScale { get; set; } = 1.0f;
 
-	[Output]
+	[Output( typeof( Vector2 ) )]
 	[Hide]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
@@ -231,7 +231,7 @@ public sealed class PolarCoordinates : ShaderNode
 		var radialScale = compiler.ResultOrDefault( RadialScale, DefaultRadialScale );
 		var lengthScale = compiler.ResultOrDefault( LengthScale, DefaultLengthScale );
 
-		return new NodeResult( 2, $"PolarCoordinates( ( {(coords.IsValid ? coords : "i.vTextureCoords.xy")} ) - ( {(center.IsValid ? center : "0.0f")} ), {(radialScale.IsValid ? radialScale : "1.0f")}, {(lengthScale.IsValid ? lengthScale : "1.0f")} )" );
+		return new NodeResult( NodeResultType.Vector2, $"PolarCoordinates( ( {(coords.IsValid ? coords : "i.vTextureCoords.xy")} ) - ( {(center.IsValid ? center : "0.0f")} ), {(radialScale.IsValid ? radialScale : "1.0f")}, {(lengthScale.IsValid ? lengthScale : "1.0f")} )" );
 	};
 }
 
@@ -282,7 +282,7 @@ public sealed class TileAndOffset : ShaderNode
 			resultCode = $"frac( {resultCode} )";
 		}
 
-		return new NodeResult( 2, resultCode );
+		return new NodeResult( NodeResultType.Vector2, resultCode );
 	};
 }
 
@@ -404,7 +404,7 @@ public sealed class Blend : ShaderNode
 		if ( Clamp )
 			returnCall = $"saturate( {returnCall} )";
 
-		return new NodeResult( results.Item1.Components, returnCall );
+		return new NodeResult( results.Item1.ResultType, returnCall );
 	};
 }
 
@@ -533,7 +533,7 @@ public sealed class RGBtoHSV : ShaderNode
 	[Hide]
 	public NodeResult.Func Out => ( GraphCompiler compiler ) =>
 	{
-		return new NodeResult( 3, compiler.ResultFunction( "RGB2HSV", $"{compiler.ResultOrDefault( In, Vector3.One )}" ) );
+		return new NodeResult( NodeResultType.Vector3, compiler.ResultFunction( "RGB2HSV", $"{compiler.ResultOrDefault( In, Vector3.One )}" ) );
 	};
 }
 
@@ -548,6 +548,6 @@ public sealed class HSVtoRGB : ShaderNode
 	[Hide]
 	public NodeResult.Func Out => ( GraphCompiler compiler ) =>
 	{
-		return new NodeResult( 3, compiler.ResultFunction( "HSV2RGB", $"{compiler.ResultOrDefault( In, Vector3.One )}" ) );
+		return new NodeResult( NodeResultType.Vector3, compiler.ResultFunction( "HSV2RGB", $"{compiler.ResultOrDefault( In, Vector3.One )}" ) );
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Transform.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Transform.cs
@@ -292,11 +292,11 @@ public sealed class TileAndOffset : ShaderNode
 [Title( "Blend" ), Category( "Transform" ), Icon( "blender" )]
 public sealed class Blend : ShaderNode
 {
-	[Input( typeof( Color ) )]
+	[Input( typeof( Vector4 ) )]
 	[Hide]
 	public NodeInput A { get; set; }
 
-	[Input( typeof( Color ) )]
+	[Input( typeof( Vector4 ) )]
 	[Hide]
 	public NodeInput B { get; set; }
 

--- a/game/editor/ShaderGraph/Code/Nodes/Unary.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Unary.cs
@@ -30,7 +30,7 @@ public abstract class Unary : ShaderNode
 	protected virtual string Op { get; }
 
 	[Hide]
-	protected virtual int? Components { get; } = null;
+	protected virtual NodeResultType? ResultType { get; } = null;
 
 	public Unary() : base()
 	{
@@ -42,7 +42,7 @@ public abstract class Unary : ShaderNode
 	public virtual NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var result = compiler.ResultOrDefault( Input, 0.0f );
-		return result.IsValid ? new NodeResult( Components ?? result.Components, $"{Op}( {result} )" ) : default;
+		return result.IsValid ? new NodeResult( ResultType ?? result.ResultType, $"{Op}( {result} )" ) : default;
 	};
 }
 
@@ -131,14 +131,14 @@ public sealed class DotProduct : ShaderNode
 	[Hide]
 	public NodeInput InputB { get; set; }
 
-	[Output]
+	[Output( typeof( float ) )]
 	[Hide]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var resultA = compiler.ResultOrDefault( InputA, 0.0f );
 		var resultB = compiler.ResultOrDefault( InputB, 0.0f ).Cast( resultA.Components );
 
-		return new NodeResult( 1, $"dot( {resultA}, {resultB} )" );
+		return new NodeResult( NodeResultType.Float, $"dot( {resultA}, {resultB} )" );
 	};
 }
 
@@ -237,7 +237,7 @@ public sealed class Floor : Unary
 public sealed class Length : Unary
 {
 	[Hide]
-	protected override int? Components => 1;
+	protected override NodeResultType? ResultType => NodeResultType.Float;
 
 	[Hide]
 	protected override string Op => "length";
@@ -288,7 +288,16 @@ public sealed class Min : ShaderNode
 
 		int maxComponents = Math.Max( a.IsValid ? a.Components : 1, b.IsValid ? b.Components : 1 );
 
-		return new NodeResult( maxComponents, $"min( {(a.IsValid ? a : "0.0f")}, {(b.IsValid ? b : "0.0f")} )" );
+		NodeResultType resultType = maxComponents switch
+		{
+			1 => NodeResultType.Float,
+			2 => NodeResultType.Vector2,
+			3 => NodeResultType.Vector3,
+			4 => NodeResultType.Vector4,
+			_ => NodeResultType.Invalid,
+		};
+
+		return new NodeResult( resultType, $"min( {(a.IsValid ? a : "0.0f")}, {(b.IsValid ? b : "0.0f")} )" );
 	};
 }
 
@@ -317,7 +326,16 @@ public sealed class Max : ShaderNode
 
 		int maxComponents = Math.Max( a.IsValid ? a.Components : 1, b.IsValid ? b.Components : 1 );
 
-		return new NodeResult( maxComponents, $"max( {(a.IsValid ? a : "0.0f")}, {(b.IsValid ? b : "0.0f")} )" );
+		NodeResultType resultType = maxComponents switch
+		{
+			1 => NodeResultType.Float,
+			2 => NodeResultType.Vector2,
+			3 => NodeResultType.Vector3,
+			4 => NodeResultType.Vector4,
+			_ => NodeResultType.Invalid,
+		};
+
+		return new NodeResult( resultType, $"max( {(a.IsValid ? a : "0.0f")}, {(b.IsValid ? b : "0.0f")} )" );
 	};
 }
 
@@ -368,7 +386,16 @@ public sealed class Step : ShaderNode
 
 		int maxComponents = Math.Max( edge.IsValid ? edge.Components : 1, input.IsValid ? input.Components : 1 );
 
-		return new NodeResult( maxComponents, $"step( {(edge.IsValid ? edge : "0.0f")}, {(input.IsValid ? input : "0.0f")} )" );
+		NodeResultType resultType = maxComponents switch
+		{
+			1 => NodeResultType.Float,
+			2 => NodeResultType.Vector2,
+			3 => NodeResultType.Vector3,
+			4 => NodeResultType.Vector4,
+			_ => NodeResultType.Invalid,
+		};
+
+		return new NodeResult( resultType, $"step( {(edge.IsValid ? edge : "0.0f")}, {(input.IsValid ? input : "0.0f")} )" );
 	};
 }
 
@@ -411,7 +438,16 @@ public sealed class SmoothStep : ShaderNode
 		var edge2String = edge2.IsValid ? edge2.ToString() : compiler.ResultValue( DefaultEdge2 ).ToString();
 		var inputString = input.IsValid ? input.ToString() : compiler.ResultValue( DefaultInput ).ToString();
 
-		return new NodeResult( maxComponents, $"smoothstep( {edge1String}, {edge2String}, {inputString} )" );
+		NodeResultType resultType = maxComponents switch
+		{
+			1 => NodeResultType.Float,
+			2 => NodeResultType.Vector2,
+			3 => NodeResultType.Vector3,
+			4 => NodeResultType.Vector4,
+			_ => NodeResultType.Invalid,
+		};
+
+		return new NodeResult( resultType, $"smoothstep( {edge1String}, {edge2String}, {inputString} )" );
 	};
 }
 
@@ -475,7 +511,7 @@ public sealed class OneMinus : ShaderNode
 	public NodeResult.Func Out => ( GraphCompiler compiler ) =>
 	{
 		var result = compiler.ResultOrDefault( In, 0.0f );
-		return new NodeResult( result.Components, $"1 - {result}" );
+		return new NodeResult( result.ResultType, $"1 - {result}" );
 	};
 
 	public OneMinus() : base()
@@ -545,13 +581,13 @@ public sealed class Distance : ShaderNode
 	[Hide]
 	public NodeInput B { get; set; }
 
-	[Output]
+	[Output( typeof( float ) )]
 	[Hide]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		var resultA = compiler.ResultOrDefault( A, 0.0f );
 		var resultB = compiler.ResultOrDefault( B, 0.0f ).Cast( resultA.Components );
 
-		return new NodeResult( 1, $"distance( {resultA}, {resultB} )" );
+		return new NodeResult( NodeResultType.Float, $"distance( {resultA}, {resultB} )" );
 	};
 }

--- a/game/editor/ShaderGraph/Code/Nodes/Viewport.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Viewport.cs
@@ -8,21 +8,21 @@ public sealed class ViewportNode : ShaderNode
 {
     [Output( typeof( Vector2 ) ), Title( "Size" )]
     [Hide]
-    public static NodeResult.Func ViewportSize => ( GraphCompiler compiler ) => new( 2, "g_vViewportSize" );
+    public static NodeResult.Func ViewportSize => ( GraphCompiler compiler ) => new( NodeResultType.Vector2, "g_vViewportSize" );
 
     [Output( typeof( Vector2 ) ), Title( "Inverse Size" )]
     [Hide]
-    public static NodeResult.Func ViewportInverseSize => ( GraphCompiler compiler ) => new( 2, "g_vInvViewportSize" );
+    public static NodeResult.Func ViewportInverseSize => ( GraphCompiler compiler ) => new( NodeResultType.Vector2, "g_vInvViewportSize" );
 
     [Output( typeof( Vector2 ) ), Title( "Offset" )]
     [Hide]
-    public static NodeResult.Func ViewportOffset => ( GraphCompiler compiler ) => new( 2, "g_vViewportOffset" );
+    public static NodeResult.Func ViewportOffset => ( GraphCompiler compiler ) => new( NodeResultType.Vector2, "g_vViewportOffset" );
 
     [Output( typeof( float ) ), Title( "Min Z" )]
     [Hide]
-    public static NodeResult.Func ViewportMinZ => ( GraphCompiler compiler ) => new( 1, "g_flViewportMinZ" );
+    public static NodeResult.Func ViewportMinZ => ( GraphCompiler compiler ) => new( NodeResultType.Float, "g_flViewportMinZ" );
 
     [Output( typeof( float ) ), Title( "Max Z" )]
     [Hide]
-    public static NodeResult.Func ViewportMaxZ => ( GraphCompiler compiler ) => new( 1, "g_flViewportMaxZ" );
+    public static NodeResult.Func ViewportMaxZ => ( GraphCompiler compiler ) => new( NodeResultType.Float, "g_flViewportMaxZ" );
 }


### PR DESCRIPTION
## Summary

The following pr in short replaces all the usage of 

```cs
public NodeResult( int components, string code, bool constant = false )
```

with 

```cs
public NodeResult( NodeResultType resultType, string code, bool constant = false )
```

while also modifying the `NodeResult` struct so that it stores the `NodeResultType` 

I also replaced any usage of `NodeResultType.Color` with `NodeResultType.Vector4`.

## Motivation & Context

Doing it this way makes more sense and will also better support a future change i have cooking up that involves adding 
`Texture2D` and `TextureCube` NodeResultTypes.

The replacement of `NodeResultType.Color` with `NodeResultType.Vector4` makes sense for me atleast whithin in the context of shhadergraph since it's just another way to represent a float4/vector4.

Nothing really changes for the user except maybe some obsolete warnings on custom c# defined nodes.

## Implementation Details

Make some additional tweaks here and there to support the changes and also
obsoleted both

```cs
public NodeResult( int components, string code, bool constant = false )
```

and

```cs
NodeResultType.Color
```

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂