### PR TITLE
[Shadergraph] replace BaseNode.EditorAttribute with BaseNode.NodeValueEditor

### DIFF
--- a/game/addons/tools/Code/ShaderGraph/BaseNode.cs
+++ b/game/addons/tools/Code/ShaderGraph/BaseNode.cs
@@ -151,11 +151,11 @@ public abstract class BaseNode : INode
 	}
 
 	[System.AttributeUsage( AttributeTargets.Property )]
-	public class EditorAttribute : Attribute
+	public class NodeValueEditorAttribute : Attribute
 	{
 		public string ValueName;
 
-		public EditorAttribute( string valueName )
+		public NodeValueEditorAttribute( string valueName )
 		{
 			ValueName = valueName;
 		}
@@ -387,7 +387,7 @@ public class PlugInfo
 
 	public ValueEditor CreateEditor( NodeUI node, Plug plug, Type type )
 	{
-		var editor = Property?.GetCustomAttribute<BaseNode.EditorAttribute>();
+		var editor = Property?.GetCustomAttribute<BaseNode.NodeValueEditorAttribute>();
 
 		if ( editor is not null )
 		{

--- a/game/addons/tools/Code/ShaderGraph/Compiler/GraphCompiler.cs
+++ b/game/addons/tools/Code/ShaderGraph/Compiler/GraphCompiler.cs
@@ -905,7 +905,7 @@ public sealed partial class GraphCompiler
 		}
 		else
 		{
-			var editorAttribute = property.GetCustomAttribute<BaseNode.EditorAttribute>();
+			var editorAttribute = property.GetCustomAttribute<BaseNode.NodeValueEditorAttribute>();
 			if ( editorAttribute == null )
 				return null;
 
@@ -1097,7 +1097,7 @@ public sealed partial class GraphCompiler
 			}
 			else
 			{
-				var editorAttribute = property.GetCustomAttribute<BaseNode.EditorAttribute>();
+				var editorAttribute = property.GetCustomAttribute<BaseNode.NodeValueEditorAttribute>();
 				if ( editorAttribute == null )
 					continue;
 

--- a/game/addons/tools/Code/ShaderGraph/Result.cs
+++ b/game/addons/tools/Code/ShaderGraph/Result.cs
@@ -26,7 +26,7 @@ public sealed class Result : BaseResult
 	[ShowIf( nameof( IsLit ), true )]
 	public NodeInput Emission { get; set; }
 
-	[Hide, Editor( nameof( DefaultOpacity ) )]
+	[Hide, NodeValueEditor( nameof( DefaultOpacity ) )]
 	[Input( typeof( float ) )]
 	public NodeInput Opacity { get; set; }
 
@@ -35,17 +35,17 @@ public sealed class Result : BaseResult
 	[ShowIf( nameof( IsLit ), true )]
 	public NodeInput Normal { get; set; }
 
-	[Hide, Editor( nameof( DefaultRoughness ) )]
+	[Hide, NodeValueEditor( nameof( DefaultRoughness ) )]
 	[Input( typeof( float ) )]
 	[ShowIf( nameof( IsLit ), true )]
 	public NodeInput Roughness { get; set; }
 
-	[Hide, Editor( nameof( DefaultMetalness ) )]
+	[Hide, NodeValueEditor( nameof( DefaultMetalness ) )]
 	[Input( typeof( float ) )]
 	[ShowIf( nameof( IsLit ), true )]
 	public NodeInput Metalness { get; set; }
 
-	[Hide, Editor( nameof( DefaultAmbientOcclusion ) )]
+	[Hide, NodeValueEditor( nameof( DefaultAmbientOcclusion ) )]
 	[Input( typeof( float ) )]
 	[ShowIf( nameof( IsLit ), true )]
 	public NodeInput AmbientOcclusion { get; set; }

--- a/game/editor/ShaderGraph/Code/Nodes/Binary.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Binary.cs
@@ -128,7 +128,7 @@ public sealed class Lerp : ShaderNode
 	public NodeInput B { get; set; }
 
 	[Input( typeof( float ) ), Title( "Fraction" )]
-	[Hide, Editor( nameof( Fraction ) )]
+	[Hide, NodeValueEditor( nameof( Fraction ) )]
 	public NodeInput C { get; set; }
 
 	[InputDefault( nameof( A ) )]
@@ -215,28 +215,28 @@ public sealed class RemapValue : ShaderNode
 	/// The minimum range of the input
 	/// </summary>
 	[Input( typeof( float ) ), Title( "In Min" )]
-	[Hide, Editor( nameof( InMin ) )]
+	[Hide, NodeValueEditor( nameof( InMin ) )]
 	public NodeInput B { get; set; }
 
 	/// <summary>
 	/// The maximum range of the input
 	/// </summary>
 	[Input( typeof( float ) ), Title( "In Max" )]
-	[Hide, Editor( nameof( InMax ) )]
+	[Hide, NodeValueEditor( nameof( InMax ) )]
 	public NodeInput C { get; set; }
 
 	/// <summary>
 	/// The output minimum range the input should map to
 	/// </summary>
 	[Input( typeof( float ) ), Title( "Out Min" )]
-	[Hide, Editor( nameof( OutMin ) )]
+	[Hide, NodeValueEditor( nameof( OutMin ) )]
 	public NodeInput D { get; set; }
 
 	/// <summary>
 	/// The output maximum range the input should map to
 	/// </summary>
 	[Input( typeof( float ) ), Title( "Out Max" )]
-	[Hide, Editor( nameof( OutMax ) )]
+	[Hide, NodeValueEditor( nameof( OutMax ) )]
 	public NodeInput E { get; set; }
 
 	/// <summary>

--- a/game/editor/ShaderGraph/Code/Nodes/Noise.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Noise.cs
@@ -63,12 +63,12 @@ public sealed class VoronoiNoise : ShaderNode
 	public NodeInput Coords { get; set; }
 
 	[Input( typeof( float ) ), Title( "Angle Offset" )]
-	[Hide, Editor( nameof( AngleOffset ) )]
+	[Hide, NodeValueEditor( nameof( AngleOffset ) )]
 	[MinMax( 0.0f, 6.28319f )]
 	public NodeInput A { get; set; }
 
 	[Input( typeof( float ) ), Title( "Cell Density" )]
-	[Hide, Editor( nameof( CellDensity ) )]
+	[Hide, NodeValueEditor( nameof( CellDensity ) )]
 	[MinMax( 0.0f, 100.0f )]
 	public NodeInput B { get; set; }
 

--- a/game/editor/ShaderGraph/Code/Nodes/Parameter.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Parameter.cs
@@ -10,7 +10,7 @@ public sealed class Float : ParameterNode<float>
 	[Hide] public float Step => UI.Step;
 
 	[Output( typeof( float ) ), Title( "Value" )]
-	[Hide, Editor( nameof( Value ) ), Range( nameof( Min ), nameof( Max ), nameof( Step ) )]
+	[Hide, NodeValueEditor( nameof( Value ) ), Range( nameof( Min ), nameof( Max ), nameof( Step ) )]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		return compiler.ResultParameter( Name, Value, Min, Max, Min != Max, IsAttribute, UI );
@@ -81,14 +81,14 @@ public sealed class Float2 : ParameterNode<Vector2>
 	/// <summary>
 	/// X component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueX ) ), Title( "X" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueX ) ), Title( "X" )]
 	[Range( nameof( MinX ), nameof( MaxX ), nameof( Step ) )]
 	public NodeResult.Func X => ( GraphCompiler compiler ) => Component( "x", ValueX, compiler );
 
 	/// <summary>
 	/// Y component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueY ) ), Title( "Y" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueY ) ), Title( "Y" )]
 	[Range( nameof( MinY ), nameof( MaxY ), nameof( Step ) )]
 	public NodeResult.Func Y => ( GraphCompiler compiler ) => Component( "y", ValueY, compiler );
 
@@ -157,21 +157,21 @@ public sealed class Float3 : ParameterNode<Vector3>
 	/// <summary>
 	/// X component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueX ) ), Title( "X" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueX ) ), Title( "X" )]
 	[Range( nameof( MinX ), nameof( MaxX ), nameof( Step ) )]
 	public NodeResult.Func X => ( GraphCompiler compiler ) => Component( "x", ValueX, compiler );
 
 	/// <summary>
 	/// Y component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueY ) ), Title( "Y" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueY ) ), Title( "Y" )]
 	[Range( nameof( MinY ), nameof( MaxY ), nameof( Step ) )]
 	public NodeResult.Func Y => ( GraphCompiler compiler ) => Component( "y", ValueY, compiler );
 
 	/// <summary>
 	/// Z component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueZ ) ), Title( "Z" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueZ ) ), Title( "Z" )]
 	[Range( nameof( MinZ ), nameof( MaxZ ), nameof( Step ) )]
 	public NodeResult.Func Z => ( GraphCompiler compiler ) => Component( "z", ValueZ, compiler );
 
@@ -193,7 +193,7 @@ public sealed class Float3 : ParameterNode<Vector3>
 public sealed class Float4 : ParameterNode<Color>
 {
 	[Output( typeof( Color ) ), Title( "RGBA" )]
-	[Hide, Editor( nameof( Value ) )]
+	[Hide, NodeValueEditor( nameof( Value ) )]
 	public NodeResult.Func Result => ( GraphCompiler compiler ) =>
 	{
 		return compiler.ResultParameter( Name, Value, default, default, false, IsAttribute, UI );
@@ -230,25 +230,25 @@ public sealed class Float4 : ParameterNode<Color>
 	/// <summary>
 	/// Red component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueR ) ), Title( "Red" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueR ) ), Title( "Red" )]
 	public NodeResult.Func R => ( GraphCompiler compiler ) => Component( "r", ValueR, compiler );
 
 	/// <summary>
 	/// Green component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueG ) ), Title( "Green" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueG ) ), Title( "Green" )]
 	public NodeResult.Func G => ( GraphCompiler compiler ) => Component( "g", ValueG, compiler );
 
 	/// <summary>
 	/// Green component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueB ) ), Title( "Blue" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueB ) ), Title( "Blue" )]
 	public NodeResult.Func B => ( GraphCompiler compiler ) => Component( "b", ValueB, compiler );
 
 	/// <summary>
 	/// Alpha component of result
 	/// </summary>
-	[Output( typeof( float ) ), Hide, Editor( nameof( ValueA ) ), Title( "Alpha" )]
+	[Output( typeof( float ) ), Hide, NodeValueEditor( nameof( ValueA ) ), Title( "Alpha" )]
 	public NodeResult.Func A => ( GraphCompiler compiler ) => Component( "a", ValueA, compiler );
 
 	public Float4()

--- a/game/editor/ShaderGraph/Code/Nodes/Transform.cs
+++ b/game/editor/ShaderGraph/Code/Nodes/Transform.cs
@@ -301,7 +301,7 @@ public sealed class Blend : ShaderNode
 	public NodeInput B { get; set; }
 
 	[Input( typeof( float ) ), Title( "Fraction" )]
-	[Hide, Editor( nameof( Fraction ) )]
+	[Hide, NodeValueEditor( nameof( Fraction ) )]
 	public NodeInput C { get; set; }
 
 	[InputDefault( nameof( A ) )]


### PR DESCRIPTION
## Summary

Replaced `BaseNode.EditorAttribute` with `BaseNode.NodeValueEditor` 

## Motivation & Context

The main reason for doing this is to avoid any potential conflicts with  `EditorAttribute` in `Sandbox.System/Attributes/UtilityAttributes.cs`. Some users may encounter this if they have custom nodes.

## Implementation Details

Renamed  `BaseNode.EditorAttribute` to `BaseNode.NodeValueEditorAttribute` 

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂