### PR TITLE
Add style tag support to labels with IsRich

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Controls/Label.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Controls/Label.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Html;
+using Sandbox.Html;
 using Sandbox.Rendering;
 using System.Globalization;
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Adds support for the css "style" property to labels with the parameter IsRich being true.

## Motivation & Context

Someone else made a PR for this earlier, but it ended up being accidentally closed by sbox-bot, and I don't know if the original poster knows about it, and this is something that I REALLY want, so I decided to do it again in hopes that it gets in faster.

Thanks @Marky-S for the original pull request.

If someone at FP thinks my extra PR is useless feel free to close it.

## Implementation Details

 - Styles parsed and applied with internal tools

## Screenshots / Videos (if applicable)

`<span style="color: #ff4040;">red</span> <span style="color: #7eff7e;">green</span> <span style="color: #5a5aff;">blue</span>`
Before:
<img width="1311" height="550" alt="{3D0E90FE-7169-4099-8F0D-944F5085D301}" src="https://github.com/user-attachments/assets/0bce321e-6c5f-48a2-a7e2-bf58fa96c763" />
After:
<img width="1311" height="550" alt="{5FEE8869-EC37-4394-8C53-511175862105}" src="https://github.com/user-attachments/assets/3e070f3d-14ee-417d-ac3d-e6b97d061b1c" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂