### PR TITLE
Whitelist `System.Private.CoreLib/System.Threading.Tasks.TaskContinuationOptions`

### DIFF
--- a/engine/Sandbox.Access/Rules/Async.cs
+++ b/engine/Sandbox.Access/Rules/Async.cs
@@ -37,6 +37,8 @@ internal static partial class Rules
 		"System.Private.CoreLib/System.Threading.Tasks.Task.ContinueWith*",
 		"System.Private.CoreLib/System.Threading.Tasks.Task.TaskContinuationOptions",
 
+		"System.Private.CoreLib/System.Threading.Tasks.TaskCreationOptions",
+
 		"System.Private.CoreLib/System.Threading.Tasks.TaskCompletionSource",
 		"System.Private.CoreLib/System.Threading.Tasks.TaskCompletionSource.*",
 		"System.Private.CoreLib/System.Threading.Tasks.TaskCompletionSource`1",


### PR DESCRIPTION
## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This is a quick PR to whitelist [`TaskCreationOptions.RunContinuationsAsynchronously`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcreationoptions?view=net-10.0#system-threading-tasks-taskcreationoptions-runcontinuationsasynchronously).

In short, `TaskCompletionSource` continuations are executed synchronously unless the `TaskCreationOptions.RunContinuationsAsynchronously` option is specified, which sucks.

There was a dotnet TPL cookbook that mentioned it as a best practice, but I can't find it for the life of me, so here's a MSDN devblog instead (see "Conclusion" section at the bottom):
https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

The motivation and context were mentioned in the summary as well; allowing `TaskCompletionSource` to run asynchronously.

Fixes: #10520

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

The other `TaskCreationOptions` flags seem reasonable, but [`TaskCreationOptions.HideScheduler`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcreationoptions?view=net-10.0#system-threading-tasks-taskcreationoptions-hidescheduler) might be problematic and I'd like another pair of eyes on it.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂