### PR TITLE
Fix Linux paths unable to be found if uppercase in base file systems

### DIFF
--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -586,7 +586,7 @@ public class BaseFileSystem
 	/// </summary>
 	internal BaseFileSystem CreateAndMount( string path )
 	{
-		var sub = new LocalFileSystem( path );
+		var sub = new LocalFileSystem( FixPath ( path ) );
 		Mount( sub );
 		return sub;
 	}
@@ -594,8 +594,10 @@ public class BaseFileSystem
 	/// <summary>
 	/// Zio wants good paths to start with '/' - so we add it here if it isn't already on
 	/// </summary>
-	internal static string FixPath( string path )
+	internal string FixPath( string path )
 	{
+		if ( OperatingSystem.IsLinux() ) path = ResolveExt4FilePath( path );
+
 		// Do not allow 0-32 ASCII stuff
 		if ( path.Any( c => char.IsControl( c ) ) ) throw new ArgumentException( "Path cannot contain control characters!", "path" );
 
@@ -604,6 +606,63 @@ public class BaseFileSystem
 
 		if ( path[0] == '/' ) return path;
 		return string.Concat( "/", path );
+	}
+
+	/// <summary>
+	/// Sometimes Linux filesystems cannot be resolved because the engine
+	/// attempts to compare a lowercase path to an uppercase one. This rebuilds
+	/// the folder and file paths in segments to allow the engine to build the uppercase
+	/// variant. This only applies to Zio mounts and will not fix managed calls to the native
+	/// engine.
+	/// </summary>
+	internal string ResolveExt4FilePath( string path )
+	{
+		if ( system is null ) return path;
+
+		var segments = path.Trim( '/' ).Split( '/', StringSplitOptions.RemoveEmptyEntries );
+		if ( segments.Length == 0 ) return path;
+
+		var resolvedSegments = new List<string>( segments.Length );
+
+		foreach ( var segment in segments )
+		{
+			var parentPath = new Zio.UPath( "/" + string.Join( "/", resolvedSegments ) );
+			var candidatePath = new Zio.UPath( parentPath.FullName.TrimEnd( '/' ) + "/" + segment );
+
+			if ( system.DirectoryExists( candidatePath ) )
+			{
+				resolvedSegments.Add( segment );
+				continue;
+			} // If the folder exists already, do nothing.
+
+			try
+			{
+				// BaseFileSystem seems to just handle directory mounts, nothing about file names. If that changes
+				// we can adjust this to Zio.SearchTarget.Both
+				var match = system.EnumeratePaths( parentPath, "*", SearchOption.TopDirectoryOnly, Zio.SearchTarget.Directory )
+					.FirstOrDefault( p => string.Equals( p.FullName.Substring( p.FullName.LastIndexOf( '/' ) + 1 ), segment, StringComparison.OrdinalIgnoreCase ) );
+
+				var fullName = match.FullName;
+				var resolved = string.IsNullOrEmpty( fullName ) ? segment : fullName.Substring( fullName.LastIndexOf( '/' ) + 1 );
+
+				if ( resolved != segment )
+					Log.Info( $"[ResolveExt4FilePath] Corrected folder '{segment}' -> '{resolved}' (parent: {parentPath})" );
+
+				resolvedSegments.Add( resolved );
+			}
+			catch ( System.IO.DirectoryNotFoundException )
+			{
+				Log.Info( $"[ResolveExt4FilePath] DirectoryNotFound at parent '{parentPath}', keeping segment '{segment}'" );
+				resolvedSegments.Add( segment );
+			}
+		}
+
+		var result = string.Join( "/", resolvedSegments );
+
+		if ( result != path.Trim( '/' ) )
+			Log.Info( $"[ResolveExt4FilePath] '{path}' -> '{result}'" );
+
+		return result;
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Filesystem/LocalFileSystem.cs
+++ b/engine/Sandbox.Filesystem/LocalFileSystem.cs
@@ -11,7 +11,8 @@ internal class LocalFileSystem : BaseFileSystem
 	{
 		Physical = new Zio.FileSystems.PhysicalFileSystem();
 
-		var rootPath = Physical.ConvertPathFromInternal( rootFolder.ToLowerInvariant() );
+		rootFolder = OperatingSystem.IsLinux() ? rootFolder : rootFolder.ToLowerInvariant();
+		var rootPath = Physical.ConvertPathFromInternal( rootFolder );
 		system = new Zio.FileSystems.SubFileSystem( Physical, rootPath );
 
 		if ( makereadonly )


### PR DESCRIPTION
**Disclaimer!
Does not affect Windows behavior, but LocalFileSystem needed to have root Path manually checked against OS's. I can change this, but not sure what is recommended for that file.**

# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

On Linux filesystems, Zio cannot find uppercase paths because of hardcoded lowercase-only variants. The game would only post to the LocalFileSystem call where it could find the root path or any uppercase folders in the addons/ directory. This fixes that up until a failure to initialize MenuSystem, which is a separate issue.

## Motivation & Context

Why is this change needed?
CreateAndMount calls in MenuDll are usually hardcoded to lowercase paths, and any FindDirectory lookups will regress to being unable to find uppercase directories because Linux is case sensitive. To allow for folders to be found regardless of case sensitivity, a new method was added to BaseFileSystem to segment walk the path up to the First Or Default variant using BaseFileSystem's internal method FindDirectory.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

There were three implementations I had tested before. I originally would tree the entire SubSystem directory and then add it to a Dictionary so look ups could be O(1) time, but this would be very hard to properly manage and would require refactoring other methods to properly update the dictionary if a file or folder was written or deleted.

The second option was just having Linux convert all directories and files to lowercase-only on runtime, but this caused a regression in several places in the engine.

The third solution, **this solution**, takes a partial path and then traverses the local root to the child folder, and compares the lowercase variant to the FirstOrDefault uppercase variant folder in the segment, and then rebuilds the folder path to get the correct one. It takes about 2-5 cycles to do this, but is the most real-time solution and does not require caching any directories to find them on launch. It also uses internal file methods in BaseFileSystem.

## Screenshots / Videos (if applicable)

Attached is a screenshot of a log, where folders are returned to their uppercase variants. It works for folders only, which was the critical issue with mounted files. There are a few uppercase files handled by MenuSystem.
<img width="2133" height="1100" alt="Screenshot from 2026-04-16 20-23-30" src="https://github.com/user-attachments/assets/7d88a32a-1ae1-4b9e-8347-7be79ecb1e35" />
This fixes pathing up until MenuSystem.
<img width="2116" height="497" alt="Screenshot from 2026-04-16 20-25-43" src="https://github.com/user-attachments/assets/f429e97c-1e2c-4adb-831c-4dd73c7d650d" />
This will not load textures or resource properly. This is handled by EngineFileSystem on Native Engine calls. This is a separate issue. Furthers the load to MenuSystem, where a separate filesystem issue is occurring.
<img width="2016" height="828" alt="image" src="https://github.com/user-attachments/assets/0d22ef70-40f4-4dbe-936a-0434082f2591" />
2026/04/16 20:33:42.5506	[Generic] Error opening stylesheet: /styles/rootpanel.scss (File not found)	System.IO.FileNotFoundException: File not found
File name: '/styles/rootpanel.scss'
   at Sandbox.UI.StyleSheet.UpdateFromFile(String name, Boolean failSilently, GlobalContext ctx) in /home/joshua/Documents/GitHub/notvibecoded/sbox-public/engine/Sandbox.Engine/Systems/UI/Styles/StyleSheet.cs:line 97
2026/04/16 20:33:43.0006	[TypeLibrary] Unknown Type MenuSystem

https://pastebin.com/7Fz2H3qu <- rg "ResolveExt4" log for folder finds.

## Checklist

- [ ] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂