### PR TITLE
Fix standalone startup timing event submission

### DIFF
--- a/engine/Sandbox.Engine/Core/Bootstrap.cs
+++ b/engine/Sandbox.Engine/Core/Bootstrap.cs
@@ -312,11 +312,7 @@ internal static class Bootstrap
 		{
 			StartupTiming.FinishTimer( "Time" );
 			StartupTiming.SetValue( "package.ident", Application.GameIdent );
-
-			if ( !Application.IsStandalone )
-			{
-				StartupTiming.Submit( true );
-			}
+			StartupTiming.Submit( true );
 		}
 
 		if ( Application.IsBenchmark )

--- a/engine/Sandbox.Engine/Core/Bootstrap.cs
+++ b/engine/Sandbox.Engine/Core/Bootstrap.cs
@@ -312,7 +312,11 @@ internal static class Bootstrap
 		{
 			StartupTiming.FinishTimer( "Time" );
 			StartupTiming.SetValue( "package.ident", Application.GameIdent );
-			StartupTiming.Submit( true );
+
+			if ( !Application.IsStandalone )
+			{
+				StartupTiming.Submit( true );
+			}
 		}
 
 		if ( Application.IsBenchmark )

--- a/engine/Sandbox.Engine/Services/Api/Api.EventManager.cs
+++ b/engine/Sandbox.Engine/Services/Api/Api.EventManager.cs
@@ -13,7 +13,7 @@ internal static partial class Api
 		/// </summary>
 		private static void Add( EventRecord e )
 		{
-			if ( !Application.IsRetail )
+			if ( !Application.IsRetail || Application.IsStandalone )
 				return;
 
 			Pending.Add( e );
@@ -91,12 +91,15 @@ internal static partial class Api
 		/// </summary>
 		internal static async Task PostEventsAsync( EventRecord[] records )
 		{
+			if ( Sandbox.Backend.Account is null )
+				return;
+
 			var values = new
 			{
 				Events = records
 			};
 
-			await Sandbox.Backend.Account?.SubmitEvents( values );
+			await Sandbox.Backend.Account.SubmitEvents( values );
 		}
 	}
 }


### PR DESCRIPTION
This pull request was accidentally closed due to the Git history...
Old PR: #10280

Original content:
---
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

I fixed the standalone startup exception by skipping submission of the StartupTiming.Game analytics event during standalone boot.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #10270

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->
I traced the NullReferenceException in Sandbox.Api.Events.PostEventsAsync to the startup timing event fired from Bootstrap.LoadingFinished. Therefore I added a standalone check so that this startup telemetry is not submitted in standalone builds, where that backend event path is not available. 

I'm still new to C# and wouldn't exactly say I know this engine inside and out, which is why I'm a little unsure if this is the right way to fix it.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->
-/-

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂