### PR TITLE
Add a compile definition when Disable Whitelist is on

### DIFF
--- a/engine/Sandbox.Compiling/CompilerConfiguration.cs
+++ b/engine/Sandbox.Compiling/CompilerConfiguration.cs
@@ -120,6 +120,15 @@ partial class Compiler
 			var symbols = DefineConstants.Split( ";", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries )
 							.ToHashSet();
 
+			if ( !Whitelist )
+			{
+				symbols.Add( "NO_WHITELIST" );
+			}
+			else
+			{
+				symbols.Remove( "NO_WHITELIST" );
+			}
+
 			if ( ReleaseMode == ReleaseMode.Debug )
 			{
 				symbols.Add( "DEBUG" );

--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.Solution.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.Solution.cs
@@ -57,6 +57,11 @@ public sealed partial class Project
 			{
 				compilerSettings.IgnoreFolders.Add( "editor" );
 				compilerSettings.IgnoreFolders.Add( "unittest" );
+
+				if ( Config.IsStandaloneOnly )
+				{
+					compilerSettings.DefineConstants += ";NO_WHITELIST";
+				}
 			}
 
 			project = generator.AddProject( Config.Type, Config.FullIdent, projectName, GetCodePath(), compilerSettings );


### PR DESCRIPTION
My old pull request was accidentally closed due to the Git history...
Old PR: #10341

Original content:
---
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR adds a NO_WHITELIST compile definition whenever whitelist restrictions are disabled, so game code can conditionally compile behavior that is only valid in that mode. It also ensures generatet standalone solution projects receive the same symbol, keeping IDEs build-time defines aligned with compiler behavior.

## Motivation & Context

#3783 requests a compile-time symbol that can be used for #if guards when the option "Disable Whitelist" is enabled. I think that is a relatively easy task, which is also in the Tracker, to help the Facepunch team. It will also help my experiences with the engine. I didn't include tests because I couldn't find any that tested the generation of project solutions. I also couldn't find the right place to test the compilation, but I think these changes are too small to require a unit test. If I have overlooked something or a test is needed, please let me know.

Fixes: #3783

## Implementation Details

CompilerConfiguration now derives NO_WHITELIST directly from the Whitelist setting by adding the symbol when whitelist is disabled and removing it otherwise. Project.Solution also appends NO_WHITELIST for standalone-only generated solutions so solution generation matches the compilers effective define set.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->
-/-

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂