### PR TITLE
Fix framerate limit not saving

### DIFF
--- a/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
+++ b/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
@@ -186,7 +186,7 @@
         ShadowQuality = MenuUtility.RenderSettings.ShadowQuality;
         MotionBlurScale = MenuUtility.RenderSettings.MotionBlurScale;
 
-        // FrameRateLimit = MenuUtility.RenderSettings.FrameRateLimit; // TODO!!!
+        FrameRateLimit = MenuUtility.RenderSettings.MaxFrameRate;
     }
 
     public void OnRestore()
@@ -244,7 +244,7 @@
         MenuUtility.RenderSettings.ShadowQuality = ShadowQuality;
         MenuUtility.RenderSettings.MotionBlurScale = MotionBlurScale;
 
-        // MenuUtility.RenderSettings.FrameRateLimit = FrameRateLimit; // TODO!!!
+        MenuUtility.RenderSettings.MaxFrameRate = FrameRateLimit;
 
         MenuUtility.RenderSettings.Apply();
     }


### PR DESCRIPTION
My old pull request was accidentally closed due to the Git history...
Old PR: #10362

In the old PR, @xezno was assigned and a review was requested from him.

Original content:
---
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR fixes the video settings menu so the "Framerate Limit (game)" value is loaded from the saved render settings and written back when applying changes. This resolves a bug where the slider always reverted to 0 after reopening the settings.

## Motivation & Context

The setting was exposed in the UI, but it was never actually connected to the persisted render setting. The menu code still had commented-out TODO lines referring to a non existent property, so the slider defaulted to 0 on reopen and user changes were never saved. I ran git blame and found the commit 38b5f797c, which commented it out. It was probably forgotten to implement before the commit was made.

Fixes: #10361

## Implementation Details

Replaced the commented out FrameRateLimit references in VideoSettings.razor with the actual persisted render setting.
If I missed anything, let me know :9

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->
-/-

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂