### PR TITLE
Adding the OnCameraModeChanged method to the PlayerController.IEvents interface

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Camera.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Camera.cs
@@ -24,8 +24,10 @@ public sealed partial class PlayerController : Component
 		{
 			if ( Input.Pressed( ToggleCameraModeButton ) )
 			{
+				var oldValue = ThirdPerson;
 				ThirdPerson = !ThirdPerson;
 				_cameraDistance = 20;
+				IEvents.PostToGameObject( GameObject, x => x.OnCameraModeChanged( oldValue, ThirdPerson ) );
 			}
 		}
 

--- a/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Events.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Events.cs
@@ -18,6 +18,12 @@ public sealed partial class PlayerController : Component
 		void PostCameraSetup( CameraComponent cam ) { }
 
 		/// <summary>
+		/// Called when the player toggles between first and third person by pressing the camera mode button.
+		/// does not trigger if ThirdPerson is set directly from code or the inspector.
+		/// </summary>
+		void OnCameraModeChanged( bool oldValue, bool newValue ) { }
+
+		/// <summary>
 		/// The player has just jumped
 		/// </summary>
 		void OnJumped() { }


### PR DESCRIPTION
# Pull Request

## Summary

Added OnCameraModeChanged method to PlayerController.IEvents interface. This method is triggered when the player toggles between first and third person camera using the default camera toggle button.

## Motivation & Context

Many people creating games with a standard, built-in PlayerController component may need to somehow respond to changes to a property named ThirdPerson via player input (and only then, as the event will be triggered if the value of ThirdPerson is changed by input).
This interface method allows for native response to such changes without adding checks to Update() for every input, etc.

This is useful if you need, for example, to:
- Enable or disable a parameter in the player model renderer or toggle the visibility of the player model itself.
- Change the HUD in any way, such as showing or hiding the crosshair.

## Implementation Details

The method call is located in PlayerController.Camera.cs
The scene event is posted when the camera perspective change key is pressed. This means it won't trigger if changed through code or the inspector.

## Screenshots / Videos (if applicable)

N/A

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂