### PR TITLE
Include library and transient assets in file networking

### DIFF
--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
@@ -211,6 +211,16 @@ public sealed partial class Project
 	/// </summary>
 	public bool HasAssetsPath() => RootDirectory is not null && System.IO.Directory.Exists( GetAssetsPath() );
 
+	/// <summary>
+	/// Absolute path to the .sbox/transient folder of the project, or <see langword="null"/> if not set.
+	/// </summary>
+	internal string GetTransientsPath() => System.IO.Path.Combine( RootDirectory.FullName, ".sbox", "transient" );
+
+	/// <summary>
+	/// Returns true if the .sbox/transient path exists
+	/// </summary>
+	internal bool HasTransientsPath() => RootDirectory is not null && System.IO.Directory.Exists( GetTransientsPath() );
+
 	internal void Save()
 	{
 		OnSaveProject?.Invoke();

--- a/engine/Sandbox.GameInstance/GameInstanceDll.Network.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.Network.cs
@@ -298,21 +298,41 @@ internal partial class GameInstanceDll
 
 		Log.Info( "Building network files.." );
 
-		// include anything on resource paths
-		var project = Project.Current;
-		if ( project is not null && !string.IsNullOrWhiteSpace( project.Config.Resources ) )
-		{
-			var resourcePaths = project.Config.Resources.Split( "\n", StringSplitOptions.RemoveEmptyEntries )
-			.Select( x => x.Trim() )
-			.Where( x => !x.StartsWith( "//" ) )
-			.Select( x => x.NormalizeFilename( true, false ) );
+		// Create an aggregate filesystem to mount all important game directories to
+		var fs = new AggregateFileSystem();
+		fs.Mount( gameInstance.GameFileSystem );
 
-			_netIncludePaths.AddRange( resourcePaths );
+		if ( Project.Current is { } project )
+		{
+			// Mount the project transients if possible
+			if ( project.HasTransientsPath() )
+				fs.Mount( new LocalFileSystem( project.GetTransientsPath() ) );
+
+			// Include anything on resource paths
+			if ( !string.IsNullOrWhiteSpace( project.Config.Resources ) )
+			{
+				var resourcePaths = project.Config.Resources.Split( "\n", StringSplitOptions.RemoveEmptyEntries )
+					.Select( x => x.Trim() )
+					.Where( x => !x.StartsWith( "//" ) );
+
+				_netIncludePaths.AddRange( resourcePaths );
+			}
 		}
 
-		var fs = gameInstance.GameFileSystem;
-		var files = fs.FindFile( "/", "*", true );
+		// Mount all referenced libraries
+		foreach ( Project library in Project.Libraries.Where( v => v.Active && v.RootDirectory is not null ) )
+		{
+			// Mount the library transients if possible
+			if ( library.HasTransientsPath() )
+				fs.Mount( new LocalFileSystem( library.GetTransientsPath() ) );
 
+			// Mount the library root if possible (do it using the library's package fs)
+			if ( PackageManager.ActivePackages.FirstOrDefault( v => v.Package == library.Package ) is
+			    { } libraryPackage )
+				fs.Mount( libraryPackage.FileSystem );
+		}
+
+		var files = fs.FindFile( "/", "*", true );
 		foreach ( var file in files )
 		{
 			UpdateNetworkFile( fs, file );

--- a/engine/Sandbox.GameInstance/GameInstanceDll.Network.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.Network.cs
@@ -328,7 +328,7 @@ internal partial class GameInstanceDll
 
 			// Mount the library root if possible (do it using the library's package fs)
 			if ( PackageManager.ActivePackages.FirstOrDefault( v => v.Package == library.Package ) is
-			    { } libraryPackage )
+				{ } libraryPackage )
 				fs.Mount( libraryPackage.FileSystem );
 		}
 

--- a/game/sbox.runtimeconfig.json
+++ b/game/sbox.runtimeconfig.json
@@ -6,6 +6,7 @@
       "version": "10.0.0"
     },
     "configProperties": {
+      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
       "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
       "System.Runtime.TieredPGO": true,
       "System.Threading.ThreadPool.UseWindowsThreadPool": true

--- a/game/sbox.runtimeconfig.json
+++ b/game/sbox.runtimeconfig.json
@@ -6,7 +6,6 @@
       "version": "10.0.0"
     },
     "configProperties": {
-      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
       "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
       "System.Runtime.TieredPGO": true,
       "System.Threading.ThreadPool.UseWindowsThreadPool": true


### PR DESCRIPTION
## Summary

Sends library and transient assets to connecting clients

## Motivation & Context

Library assets aren't sent when using the "Join from new instance" button, but the assets work fine locally

Similarly, game transients aren't getting sent, so compiled SVGs etc aren't working on the new instance (unless the game has already been uploaded to sbox.game)

## Implementation Details

I've avoided changes to asset / engine code here, and the only change outside of GameInstance.Network.cs is a new pair of internal methods in Project (which aren't fully necessary, but nice to have)

This PR might be something that could be solved somewhere else (maybe the game FS should be mounting transients?) but I'm not sure