### PR TITLE
Don't Normalize Remote URIs

### DIFF
--- a/engine/Sandbox.Engine/Resources/Textures/Loader/DataUriImageLoader.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Loader/DataUriImageLoader.cs
@@ -10,7 +10,7 @@ internal static class ImageDataUri
 
 	internal static bool IsAppropriate( string uri )
 	{
-		return uri.StartsWith( InlinePrefixPng ) || uri.StartsWith( InlinePrefixJpeg );
+		return uri.StartsWith( InlinePrefixPng, StringComparison.OrdinalIgnoreCase ) || uri.StartsWith( InlinePrefixJpeg, StringComparison.OrdinalIgnoreCase );
 	}
 
 	internal static Texture Load( string uri, bool warnOnMissing )
@@ -36,7 +36,7 @@ internal static class ImageDataUri
 
 	private static bool TryParseDataImage( string prefix, string image, out byte[] data )
 	{
-		if ( !image.StartsWith( prefix ) )
+		if ( !image.StartsWith( prefix, StringComparison.OrdinalIgnoreCase ) )
 		{
 			data = null;
 			return false;

--- a/engine/Sandbox.Engine/Resources/Textures/Texture.Load.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Texture.Load.cs
@@ -51,21 +51,6 @@ public partial class Texture
 		return LoadInternal( filesystem, filepath, warnOnMissing );
 	}
 
-
-	private static bool IsLikelyRemoteOrDataUri( string filepath )
-	{
-		if ( filepath.StartsWith( "http://", System.StringComparison.OrdinalIgnoreCase ) )
-			return true;
-
-		if ( filepath.StartsWith( "https://", System.StringComparison.OrdinalIgnoreCase ) )
-			return true;
-
-		if ( filepath.StartsWith( "data:", System.StringComparison.OrdinalIgnoreCase ) )
-			return true;
-
-		return false;
-	}
-
 	/// <summary>
 	/// All the helpers should flow through this to actually load
 	/// </summary>
@@ -79,7 +64,7 @@ public partial class Texture
 		if ( Sandbox.Mounting.Directory.TryLoad( filepath, ResourceType.Texture, out object model ) && model is Texture m )
 			return m;
 
-		if ( !IsLikelyRemoteOrDataUri( filepath ) )
+		if ( !TextureLoader.ImageUrl.IsAppropriate( filepath ) && !TextureLoader.ImageDataUri.IsAppropriate( filepath ) )
 			filepath = filepath.NormalizeFilename( false );
 
 		if ( filepath.StartsWith( '/' ) )
@@ -278,7 +263,7 @@ public partial class Texture
 	{
 		if ( string.IsNullOrWhiteSpace( filepath ) ) return null;
 
-		if ( !IsLikelyRemoteOrDataUri( filepath ) )
+		if ( !TextureLoader.ImageUrl.IsAppropriate( filepath ) && !TextureLoader.ImageDataUri.IsAppropriate( filepath ) )
 			filepath = filepath.NormalizeFilename( false );
 
 		return Game.Resources.Get<Texture>( filepath );

--- a/engine/Sandbox.Engine/Resources/Textures/Texture.Load.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Texture.Load.cs
@@ -51,6 +51,21 @@ public partial class Texture
 		return LoadInternal( filesystem, filepath, warnOnMissing );
 	}
 
+
+	private static bool IsLikelyRemoteOrDataUri( string filepath )
+	{
+		if ( filepath.StartsWith( "http://", System.StringComparison.OrdinalIgnoreCase ) )
+			return true;
+
+		if ( filepath.StartsWith( "https://", System.StringComparison.OrdinalIgnoreCase ) )
+			return true;
+
+		if ( filepath.StartsWith( "data:", System.StringComparison.OrdinalIgnoreCase ) )
+			return true;
+
+		return false;
+	}
+
 	/// <summary>
 	/// All the helpers should flow through this to actually load
 	/// </summary>
@@ -64,15 +79,16 @@ public partial class Texture
 		if ( Sandbox.Mounting.Directory.TryLoad( filepath, ResourceType.Texture, out object model ) && model is Texture m )
 			return m;
 
-		var normalizedFilename = filepath.NormalizeFilename( false );
+		if ( !IsLikelyRemoteOrDataUri( filepath ) )
+			filepath = filepath.NormalizeFilename( false );
 
-		if ( normalizedFilename.StartsWith( '/' ) )
-			normalizedFilename = normalizedFilename[1..];
+		if ( filepath.StartsWith( '/' ) )
+			filepath = filepath[1..];
 
-		if ( Find( normalizedFilename ) is Texture existing )
+		if ( Find( filepath ) is Texture existing )
 			return existing;
 
-		var tex = TryToLoad( filesystem, normalizedFilename, warnOnMissing );
+		var tex = TryToLoad( filesystem, filepath, warnOnMissing );
 		if ( tex == null )
 			return null;
 
@@ -262,7 +278,8 @@ public partial class Texture
 	{
 		if ( string.IsNullOrWhiteSpace( filepath ) ) return null;
 
-		filepath = filepath.NormalizeFilename( false );
+		if ( !IsLikelyRemoteOrDataUri( filepath ) )
+			filepath = filepath.NormalizeFilename( false );
 
 		return Game.Resources.Get<Texture>( filepath );
 	}


### PR DESCRIPTION

## Summary

Based on #10013
The other PR hasn't had any activity in 2 months and exceeded the scope of what I wanted to be fixed.

## Motivation & Context

Remote URLs and data URIs should preserve their original casing.
The previous normalization path applied lowercase rules intended for local file paths to all texture inputs.

Fixes: https://github.com/Facepunch/sbox-public/issues/9986

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂