### PR TITLE
Fixed formatting for [InlineEditor] in collections

### DIFF
--- a/game/addons/tools/Code/Widgets/ControlWidgets/DictionaryControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/DictionaryControlWidget.cs
@@ -98,7 +98,7 @@ public class DictionaryControlWidget : ControlObjectWidget
 
 			var index = y;
 			//grid.AddCell( 0, y, new IconButton( "drag_handle" ) { IconSize = 13, Foreground = Theme.ControlBackground, Background = Color.Transparent, FixedWidth = Theme.RowHeight, FixedHeight = Theme.RowHeight } );
-			grid.AddCell( 1, y, keyControl, 1, 1, keyControl.CellAlignment );
+			grid.AddCell( 1, y, keyControl, 1, 1, TextFlag.Top );
 			grid.AddCell( 2, y, new IconButton( ":" ) { IconSize = 13, Foreground = Theme.TextControl, Background = Color.Transparent, FixedWidth = Theme.RowHeight, FixedHeight = Theme.RowHeight } );
 			grid.AddCell( 3, y, valControl, 1, 1, valControl.CellAlignment );
 

--- a/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
@@ -175,7 +175,7 @@ public class GenericControlWidget : ControlObjectWidget
 	{
 		Layout = Layout.Column();
 
-		if ( attribute.Label )
+		if ( attribute.Label && SerializedProperty.Parent is not SerializedCollection )
 		{
 			Layout.Add( ControlSheet.CreateLabel( SerializedProperty ) );
 		}


### PR DESCRIPTION
## Summary
Fixes 2 issues, most notably the erroneous gap appearing above entries in collections marked with [InlineEditor] and a bit less notably (as in less commonly seen) the widgets for dictionary keys being stretched to the height of the values entire [InlineEditor] control sheet.

## Motivation & Context
A high mileage pr, previously under https://github.com/Facepunch/sbox-public/pull/89. Figured I would take the opportunity to make the implementation a little cleaner since I needed to redo it (and then redo it again) for my own build of sbox anyway.

Fixes: https://github.com/Facepunch/sbox-public/issues/2123, https://github.com/Facepunch/sbox-public/issues/1666

## Implementation Details
[InlineEditor] includes an optional label above the control sheet, works fine in normal use but in collections there's nothing for the label to display so it's left blank, thus the extra spacing there. Because there's never anything for the label to display in a collection it can always be omitted when adding controls for SerializedCollection.

## Screenshots
Some before/after shots, first in a test game resource and second in a real one from an older project. Making [InlineEditor] look good with dictionaries probably requires some additional effort, but at least they work in a more sane way now.
<img width="1733" height="1492" alt="image" src="https://github.com/user-attachments/assets/280e2ec2-1a21-43ef-b94e-2cc3a55f20b8" />
<img width="1125" height="917" alt="image" src="https://github.com/user-attachments/assets/c4f6d5ff-e810-404b-88f2-59aa6eeccf6f" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂