### PR TITLE
Update VoiceComponent to check IsOwner instead of IsProxy

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
@@ -197,7 +197,7 @@ public class Voice : Component
 		set => _isListening = value;
 		get
 		{
-			if ( IsProxy ) return false;
+			if ( !IsOwner ) return false;
 			if ( Mode == ActivateMode.AlwaysOn ) return true;
 			if ( Mode == ActivateMode.PushToTalk )
 			{
@@ -221,7 +221,7 @@ public class Voice : Component
 		if ( !sound.IsValid() ) return;
 
 		sound.Volume = Volume;
-		sound.Loopback = !IsProxy && !Loopback;
+		sound.Loopback = IsOwner && !Loopback;
 
 		if ( WorldspacePlayback )
 		{
@@ -296,7 +296,7 @@ public class Voice : Component
 
 	private void OnVoice( Memory<byte> compressed )
 	{
-		if ( IsProxy ) return;
+		if ( !IsOwner ) return;
 		if ( singleRecorder != this ) return;
 
 		if ( Networking.System is not null )


### PR DESCRIPTION
## Summary

`IsProxy` returns false if the game object is orphaned. This would result in strange behavior where a voice transmitter component could be used by multiple clients.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂