### PR TITLE
Add CascadeDistance to DirectionalLight component.

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Light/DirectionalLight.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/DirectionalLight.cs
@@ -71,12 +71,32 @@ public class DirectionalLight : Light
 	[Property, Group( "Shadows" ), HideIf( nameof( ShadowCascadeCount ), 1 )]
 	public CascadeVisualizer Visualizer { get; set; } = new();
 
+	/// <summary>
+	/// Maximum distance from the camera that directional light shadows are rendered.
+	/// Set to 0 to use the global <c>r.shadows.csm.distance</c> ConVar value (default 15000).
+	/// </summary>
+	[Property, Group( "Shadows" ), Title( "Shadow Distance" ), Range( 0, 50000 )]
+	[InfoBox( "Maximum shadow cascade distance in world units. 0 uses the global quality setting." )]
+	public float ShadowCascadeDistance
+	{
+		get;
+		set
+		{
+			if ( field == value ) return;
+			field = value;
+
+			if ( _so.IsValid() )
+				_so.CascadeDistance = value;
+		}
+	} = 0f;
+
 	protected override SceneLight CreateSceneObject()
 	{
 		return _so = new SceneDirectionalLight( Scene.SceneWorld, WorldRotation, LightColor )
 		{
 			ShadowCascadeCount = ShadowCascadeCount,
-			ShadowCascadeSplitRatio = ShadowCascadeSplitRatio
+			ShadowCascadeSplitRatio = ShadowCascadeSplitRatio,
+			CascadeDistance = ShadowCascadeDistance
 		};
 	}
 

--- a/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.Directional.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.Directional.cs
@@ -272,7 +272,7 @@ internal partial class ShadowMapper
 			return;
 
 		int numCascades = Math.Min( light.lightNative.GetShadowCascades(), MaxCascades );
-		float farClip = CascadeDistance;
+		float farClip = light is SceneDirectionalLight { CascadeDistance: > 0f } dl ? dl.CascadeDistance : CascadeDistance;
 		int shadowmapSize = MaxCascadeResolution;
 		float splitRatio = light.lightNative.GetShadowCascadeSplitRatio();
 

--- a/engine/Sandbox.Engine/Systems/SceneSystem/Lights/SceneDirectionalLight.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/Lights/SceneDirectionalLight.cs
@@ -47,6 +47,14 @@ public sealed class SceneDirectionalLight : SceneLight
 	}
 
 	/// <summary>
+	/// Per-light override for the maximum shadow cascade distance.
+	/// When set to a value greater than 0, this overrides the global
+	/// <c>r.shadows.csm.distance</c> ConVar for this light only.
+	/// A value of 0 (the default) means "use the global ConVar value".
+	/// </summary>
+	public float CascadeDistance { get; set; } = 0f;
+
+	/// <summary>
 	/// Set the max distance of the shadow cascade
 	/// </summary>
 	public void SetCascadeDistanceScale( float distance )


### PR DESCRIPTION
## Summary

Adds a `ShadowCascadeDistance` property to the `DirectionalLight` component, allowing per-light control over the maximum shadow cascade distance. When set to `0` (the default), the light falls back to the global `r.shadows.csm.distance` ConVar value.

## Motivation & Context

Previously, the maximum shadow cascade distance for directional lights was only controllable via the global `r.shadows.csm.distance` ConVar (defaulting to 15000 units). There was no way to override this on a per-light basis from the editor or in code, making it difficult to tune shadow quality for individual scenes or lights without affecting all directional lights globally.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

- **`DirectionalLight.cs`** — Added a `ShadowCascadeDistance` float property (grouped under "Shadows", titled "Shadow Distance", range 0–50000) with an `[InfoBox]` hint. The setter propagates the value to the underlying `SceneDirectionalLight` scene object immediately if it is valid, following the same pattern used by other properties on this component.
- **`SceneDirectionalLight.cs`** — Added a `CascadeDistance` float property (default `0f`) to the scene-level light object. Includes XML doc comments explaining the override semantics.
- **`ShadowMapper.Directional.cs`** — Updated the `farClip` calculation to use a pattern match: if the light is a `SceneDirectionalLight` with a `CascadeDistance > 0`, that value is used; otherwise the global `CascadeDistance` ConVar fallback is used. This keeps the override opt-in and non-breaking.

The value `0` is used as a sentinel meaning "use the global setting," which avoids introducing a nullable type and keeps the property simple to use in the editor.

## Screenshots / Videos (if applicable)
https://github.com/user-attachments/assets/90e39fb2-86a7-483d-b443-d9992e404f3b

<!-- UI, editor, rendering, or gameplay changes are much easier to review with visuals. -->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂