### PR TITLE
Added `SyncFlags.Predicted`

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Component.Network.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Component.Network.cs
@@ -63,10 +63,12 @@ public abstract partial class Component
 
 			if ( !net.dataTable.HasControl( slot ) )
 			{
-				if ( !NetworkTable.IsReadingChanges )
+				var attribute = p.GetAttribute<SyncAttribute>();
+				var isPredicted = attribute?.Flags.HasFlag( SyncFlags.Predicted ) ?? false;
+
+				if ( !NetworkTable.IsReadingChanges && !isPredicted )
 					return;
 
-				var attribute = p.GetAttribute<SyncAttribute>();
 				var interpolate = attribute?.Flags.HasFlag( SyncFlags.Interpolate ) ?? false;
 
 				if ( interpolate && p.Value is not null )

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Network.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Network.cs
@@ -423,9 +423,13 @@ public partial class GameObject
 
 		if ( !net.dataTable.HasControl( slot ) )
 		{
-			if ( NetworkTable.IsReadingChanges )
-				p.Setter( p.Value );
+			var attribute = p.GetAttribute<SyncAttribute>();
+			var isPredicted = attribute?.Flags.HasFlag( SyncFlags.Predicted ) ?? false;
 
+			if ( !NetworkTable.IsReadingChanges && !isPredicted )
+				return;
+
+			p.Setter( p.Value );
 			return;
 		}
 

--- a/engine/Sandbox.Engine/Scene/GameObjectSystem/GameObjectSystem.Network.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystem/GameObjectSystem.Network.cs
@@ -74,10 +74,12 @@ public abstract partial class GameObjectSystem : IDeltaSnapshot
 
 			if ( !dataTable.HasControl( slot ) )
 			{
-				if ( !NetworkTable.IsReadingChanges )
+				var attribute = p.GetAttribute<SyncAttribute>();
+				var isPredicted = attribute?.Flags.HasFlag( SyncFlags.Predicted ) ?? false;
+
+				if ( !NetworkTable.IsReadingChanges && !isPredicted )
 					return;
 
-				var attribute = p.GetAttribute<SyncAttribute>();
 				var interpolate = attribute?.Flags.HasFlag( SyncFlags.Interpolate ) ?? false;
 
 				if ( interpolate && p.Value is not null )

--- a/engine/Sandbox.Engine/Scene/Networking/SyncFlags.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SyncFlags.cs
@@ -21,5 +21,11 @@ public enum SyncFlags : uint
 	/// The value will be interpolated between ticks. This is currently only supported for <see cref="float"/>, <see cref="double"/>, <see cref="Angles"/>,
 	/// <see cref="Rotation"/>, <see cref="Transform"/>, <see cref="Vector3"/>.
 	/// </summary>
-	Interpolate = 4
+	Interpolate = 4,
+
+	/// <summary>
+	/// Non-owners may temporarily set this value for client-side prediction.
+	/// The value will be overwritten when authoritative data arrives from the owner/host.
+	/// </summary>
+	Predicted = 8
 }

--- a/engine/Sandbox.Test/Scene/GameObjects/Network.cs
+++ b/engine/Sandbox.Test/Scene/GameObjects/Network.cs
@@ -622,4 +622,110 @@ public class NetworkTests
 	{
 		[Sync] public int SyncInt { get; set; }
 	}
+
+	private class PredictedNetworkTestComponent : Component
+	{
+		[Sync( SyncFlags.Predicted )] public int PredictedSyncInt { get; set; }
+	}
+
+	[TestMethod]
+	public void PredictedProperty_NonOwnerCanSetLocally()
+	{
+		Assert.IsNotNull( TypeLibrary.GetType<ModelRenderer>(), "TypeLibrary hasn't been given the game assembly" );
+
+		using var scope = new Scene().Push();
+
+		var client = new NetworkSystem( "client", TypeLibrary );
+		Networking.System = client;
+
+		var sceneSystem = new SceneNetworkSystem( TypeLibrary, client );
+		client.GameSystem = sceneSystem;
+
+		var client1 = new MockConnection( Guid.NewGuid() );
+		var client2 = new MockConnection( Guid.NewGuid() );
+
+		Connection.Local = client1;
+
+		var go = new GameObject();
+		var comp = go.Components.Create<PredictedNetworkTestComponent>();
+		comp.PredictedSyncInt = 100;
+
+		go.NetworkSpawn( Connection.Local );
+
+		Connection.Local = client2;
+
+		comp.PredictedSyncInt = 999;
+
+		Assert.AreEqual( 999, comp.PredictedSyncInt );
+	}
+
+	[TestMethod]
+	public void PredictedProperty_OverwrittenByNetwork()
+	{
+		Assert.IsNotNull( TypeLibrary.GetType<ModelRenderer>(), "TypeLibrary hasn't been given the game assembly" );
+
+		using var scope = new Scene().Push();
+
+		var client = new NetworkSystem( "client", TypeLibrary );
+		Networking.System = client;
+
+		var sceneSystem = new SceneNetworkSystem( TypeLibrary, client );
+		client.GameSystem = sceneSystem;
+
+		var client1 = new MockConnection( Guid.NewGuid() );
+		var client2 = new MockConnection( Guid.NewGuid() );
+
+		Connection.Local = client1;
+
+		var go = new GameObject();
+		go.Network.Interpolation = false;
+		var comp = go.Components.Create<PredictedNetworkTestComponent>();
+		comp.PredictedSyncInt = 100;
+
+		go.NetworkSpawn( Connection.Local );
+
+		IDeltaSnapshot networkObject = go._net;
+		var state = networkObject.WriteSnapshotState();
+		var snapshot = new DeltaSnapshot();
+		snapshot.CopyFrom( networkObject, state, 2 );
+
+		Connection.Local = client2;
+
+		comp.PredictedSyncInt = 999;
+		Assert.AreEqual( 999, comp.PredictedSyncInt );
+
+		using ( var reader = ByteStream.CreateReader( SerializeSnapshot( snapshot ) ) )
+		{
+			sceneSystem.DeltaSnapshots.OnDeltaSnapshot( client1, reader );
+		}
+
+		Assert.AreEqual( 100, comp.PredictedSyncInt );
+	}
+
+	[TestMethod]
+	public void PredictedProperty_RegisterSyncProps()
+	{
+		Assert.IsNotNull( Game.TypeLibrary.GetType<ModelRenderer>(), "TypeLibrary hasn't been given the game assembly" );
+
+		using var scope = new Scene().Push();
+
+		var testComponentType = Game.TypeLibrary.GetType<PredictedNetworkTestComponent>();
+		Assert.IsNotNull( testComponentType );
+
+		var testSyncPropertyType = testComponentType.GetProperty( "PredictedSyncInt" );
+		Assert.IsNotNull( testSyncPropertyType );
+
+		var testPropertyId = testSyncPropertyType.Identity;
+
+		var go = new GameObject();
+		var comp = go.Components.Create<PredictedNetworkTestComponent>();
+		comp.PredictedSyncInt = 42;
+
+		var propId = NetworkObject.GetPropertySlot( testPropertyId, comp.Id );
+
+		go.NetworkSpawn();
+
+		Assert.IsTrue( go._net.dataTable.IsRegistered( propId ) );
+		Assert.AreEqual( 42, comp.PredictedSyncInt );
+	}
 }


### PR DESCRIPTION
## Summary

Right now only owners can change `[Sync]` properties and there are cases where you might want to fire off an RPC to the owner, which would then cause the property to change. You can't preemptively set that value, so you're stuck waiting for the owner to respond.

Solution: Add a SyncFlags.Predicted flag so non-owners can temporarily set Sync properties. Values are only local; when authoritative data arrives from the owner, it overwrites the predicted value.

## Motivation & Context

Imagine there's a button with a number displayed above it. The button is owned by the host. I press the button as a client and I have to wait until the host gets my RPC, updates the value on their end, and then the sync value for the number gets back to me. If I have a 100ms ping to the host, that's at least a 200ms delay before i see the number go up.

With a predicted value I can increment the number on the client side and show it go up immediately.

## Implementation Details

It's pretty straightforward, if a property has `SyncFlags.Predicted` then the client can change it. It will get overridden when we receive a change from the owner.

`Interpolated` and `Predicated` can technically be used at the same time. Not sure why you would want to do this, but it's possible. However the client-set value will be interpolated as well, I went back and forth on whether it should ignore interpolation.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂