### PR TITLE
Fixed margin for full screen viewport

### DIFF
--- a/engine/Sandbox.Tools/Editor/FullScreenManager.cs
+++ b/engine/Sandbox.Tools/Editor/FullScreenManager.cs
@@ -5,6 +5,11 @@ namespace Editor;
 /// </summary>
 internal partial class FullScreenManager
 {
+	public FullScreenManager()
+	{
+		EditorEvent.Register( this );
+	}
+
 	public bool IsActive => Widget.IsValid();
 
 	/// <summary>
@@ -39,8 +44,6 @@ internal partial class FullScreenManager
 
 		Widget = null;
 		PreviousParent = null;
-
-		EditorEvent.Register( this );
 	}
 
 	[EditorEvent.Frame]
@@ -57,12 +60,18 @@ internal partial class FullScreenManager
 
 	private Vector2 GetTargetPosition()
 	{
-		return new Vector2( 0, EditorWindow.MenuWidget.Size.y );
+		var position = new Vector2( 0, EditorWindow.MenuWidget.Size.y );
+		if ( EditorWindow.IsMaximized )
+			position += 8;
+		return position;
 	}
 
 	private Vector2 GetTargetSize()
 	{
-		return EditorWindow.Size - Widget.Position - new Vector2( 0, EditorWindow.StatusBar.Size.y + 4 );
+		var size = EditorWindow.Size - Widget.Position - new Vector2( 0, EditorWindow.StatusBar.Size.y + 4 );
+		if ( EditorWindow.IsMaximized )
+			size -= 8;
+		return size;
 	}
 
 	private void SetWidgetLayout()
@@ -104,13 +113,5 @@ internal partial class FullScreenManager
 
 		// Lay the widget out
 		SetWidgetLayout();
-
-		// Maximized window has no margin - we need to account for that
-		// Typical window margin is 8,8,8,8 so we'll use those values
-		if ( EditorWindow.IsMaximized )
-		{
-			Widget.Position += new Vector2( 8, 8 );
-			Widget.Size -= new Vector2( 8, 8 );
-		}
 	}
 }


### PR DESCRIPTION
## Summary
The edge of the viewport has been getting cut off in full screen for a while, this fixes that. Additionally it fixes a bug in which the size of a full screen viewport wouldn't update with the window size.

## Motivation & Context
Annoyed me.

## Implementation Details
The code to fix this was already there but it was only called in layout, the fixed margin size was being reset each frame by other code that didn't include the margin adjustment. The adjustment now takes place in `GetTargetPosition()` and `GetTargetSize()` such that all of the code uses the adjusted values.

FullScreenManager was also registering for editor events in the wrong place (was in `Clear()`, which only gets called when exiting full screen) so the position and size of the widget wouldn't update on the first full screen of the session.

## Screenshots
<img width="241" height="162" alt="image" src="https://github.com/user-attachments/assets/d8df00d3-2cd2-4130-af7f-77d5bc0221a0" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂