### PR TITLE
Fix UI transform:scale clipping children at original bounds (#10162)

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.Draw.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.Draw.cs
@@ -38,7 +38,11 @@ internal partial class PanelRenderer
 		var attributes = commandList.Attributes;
 
 		attributes.Set( "HasInverseScissor", 0 );
-		SetScissorAttributes( commandList, ScissorGPU );
+
+		// Use drawing panel's GlobalMatrix for correct scissor transform (#10162)
+		var scissor = ScissorGPU;
+		scissor.Matrix = panel.GlobalMatrix ?? Matrix.Identity;
+		SetScissorAttributes( commandList, scissor );
 
 		var rect = panel.Box.Rect;
 		var opacity = panel.Opacity * state.RenderOpacity;

--- a/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Render/PanelRenderer.cs
@@ -48,13 +48,18 @@ internal sealed partial class PanelRenderer
 		// Build transform command list (sets GlobalMatrix and TransformMat attribute)
 		BuildTransformCommandList( panel );
 
-		// Update clip only when scissor actually changed
-		var scissorHash = HashCode.Combine( ScissorGPU.Rect, ScissorGPU.CornerRadius, ScissorGPU.Matrix );
+		// Use the drawing panel's GlobalMatrix so the shader correctly transforms
+		// screen-space pixels back to layout space for the scissor test, regardless
+		// of which ancestor defined the clip rect. Fixes #10162.
+		var panelMatrix = panel.GlobalMatrix ?? Matrix.Identity;
+		var scissorHash = HashCode.Combine( ScissorGPU.Rect, ScissorGPU.CornerRadius, panelMatrix );
 		if ( panel._lastScissorHash != scissorHash )
 		{
 			panel._lastScissorHash = scissorHash;
 			panel.ClipCommandList.Reset();
-			SetScissorAttributes( panel.ClipCommandList, ScissorGPU );
+			var scissor = ScissorGPU;
+			scissor.Matrix = panelMatrix;
+			SetScissorAttributes( panel.ClipCommandList, scissor );
 		}
 
 		// Track render mode so OverrideBlendMode is correct when baking D_BLENDMODE


### PR DESCRIPTION
## Summary

When a UI panel uses transform: scale(...), child elements that extend beyond the original (unscaled) bounds get incorrectly clipped, even though they're visually within the scaled container.

## Motivation & Context

Panels with overflow: hidden and a scaled child would clip at the pre-transform bounds instead of the scaled bounds. This made transform: scale unusable for many UI patterns where children need to fill the scaled area.

Fixes: #10162

## Implementation Details

The GPU scissor pipeline was baking the clip-defining ancestor's GlobalMatrix into ScissorTransformMat, but the shader needs the drawing panel's own GlobalMatrix to correctly undo the transform and map screen-space pixels back to layout space for the clip test.

When a panel inherited a scissor from an ancestor with a different transform (e.g., a container with overflow: hidden and no transform, with a child at scale: 1.2), the matrix mismatch caused content near edges to be clipped at the original unscaled bounds.

The fix overrides ScissorGPU.Matrix with the drawing panel's GlobalMatrix at both scissor bake points in PanelRenderer.cs and PanelRenderer.Draw.cs, so the shader's ScissorTransformMat always pairs correctly with the panel's TransformMat.

## Screenshots / Videos (if applicable)

</>

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂

#10398