### PR TITLE
TextRenderer: Remove calculating bounds for TextColor (#10300)

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Render/TextRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/TextRenderer.cs
@@ -255,8 +255,11 @@ if ( _so is TextSceneObject so )
 		{
 			_textScope.FontSize = value;
 
-			if ( _so is TextSceneObject so )
-				so.TextScope = _textScope;
+			if ( _so.IsValid() )
+			{
+				_so.TextScope = _textScope;
+				_so.CalculateBounds();
+			}
 		}
 	}
 	public int FontWeight
@@ -266,8 +269,11 @@ if ( _so is TextSceneObject so )
 		{
 			_textScope.FontWeight = value;
 
-			if ( _so is TextSceneObject so )
-				so.TextScope = _textScope;
+			if ( _so.IsValid() )
+			{
+				_so.TextScope = _textScope;
+				_so.CalculateBounds();
+			}
 		}
 	}
 
@@ -278,8 +284,11 @@ if ( _so is TextSceneObject so )
 		{
 			_textScope.FontName = value;
 
-			if ( _so is TextSceneObject so )
-				so.TextScope = _textScope;
+			if ( _so.IsValid() )
+			{
+				_so.TextScope = _textScope;
+				_so.CalculateBounds();
+			}
 		}
 	}
 
@@ -290,8 +299,11 @@ if ( _so is TextSceneObject so )
 		{
 			_textScope.Text = value;
 
-			if ( _so is TextSceneObject so )
-				so.TextScope = _textScope;
+			if ( _so.IsValid() )
+			{
+				_so.TextScope = _textScope;
+				_so.CalculateBounds();
+			}
 		}
 	}
 

--- a/engine/Sandbox.Engine/Scene/Components/Render/TextRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/TextRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Sandbox;
@@ -240,7 +240,7 @@ public sealed class TextRenderer : Renderer, Component.ExecuteInEditor
 		{
 			_textScope.TextColor = value;
 
-			if ( _so is TextSceneObject so )
+if ( _so is TextSceneObject so )
 				so.TextScope = _textScope;
 		}
 	}


### PR DESCRIPTION
## Summary

Adding a 3d text object in a scene causes a crash after a few seconds. The crash is related to bounds where they did not recalculate previously.

## Motivation & Context

Fixes #10300

## Implementation Details

When updating text-related properties, replace the previous pattern match with a validity check (_so.IsValid()), assign the updated TextScope to the scene object, and call CalculateBounds(). This affects TextColor, FontSize, FontWeight, FontName and Text so that the scene object's bounds are kept in sync after scope changes.

## Screenshots / Videos (if applicable)

-/-

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂