### PR TITLE
Add Prop.OnGibsCreated

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -132,6 +132,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 	public bool StartAsleep { get; set; }
 
 	[Property] public Action OnPropBreak { get; set; }
+	[Property] public Action<List<Gib>> OnGibsCreated { get; set; }
 	[Property] public Action<DamageInfo> OnPropTakeDamage { get; set; }
 
 	[Property, Hide]
@@ -594,6 +595,8 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 				phys.AngularVelocity = rb.PreAngularVelocity;
 			}
 		}
+
+		OnGibsCreated?.Invoke( gibs );
 
 		return gibs;
 	}


### PR DESCRIPTION
## Summary

Re-submit of #10445 

This adds a callback to Props that is invoked when they are broken and gibs are created.

## Motivation & Context

I was trying to access gibs created when a prop breaks to integrate gibs with the Sandbox undo system (leave the undo entry alive and clean up gibs on undo), but found it basically impossible, since gibs are not connected to the prop that created them in any way.

This callback enables things like this:

<img width="668" height="665" alt="image" src="https://github.com/user-attachments/assets/3408a891-f0d6-45ec-898c-d317661235ff" />

## Implementation Details

A simple callback that passes gibs as an argument.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/50e88045-413a-48a8-a801-100e80638726

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂