### PR TITLE
Add middle-click reset functionality to FloatControlWidget

### DIFF
--- a/engine/Sandbox.Tools/ControlWidget/FloatControlWidget.cs
+++ b/engine/Sandbox.Tools/ControlWidget/FloatControlWidget.cs
@@ -321,6 +321,14 @@ public class FloatControlWidget : StringControlWidget
 			dragging = false;
 			PropertyFinishEdit();
 		}
+
+		if ( e.MiddleMouseButton && !ReadOnly )
+		{
+			SerializedProperty.SetValue( SerializedProperty.GetDefault() );
+			LineEdit.Text = ValueToString();
+			LineEdit.Blur();
+			Update();
+		}
 	}
 
 	protected virtual void OnDragValue( decimal add ) { /*Value = add;*/ }


### PR DESCRIPTION
## Summary

Re-submit of #10473

Middle click any FloatControlWidget in the editor to reset it to default value (0).

## Motivation & Context

Very handy, 3ds max does this

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/35c737bd-130e-4604-ae4c-8ccd93b4979d

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂