### PR TITLE
Linux fix Zio paths not resolving folder paths due to case sensitivity mismatch.

### DIFF
--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -596,74 +596,31 @@ public class BaseFileSystem
 	/// </summary>
 	internal string FixPath( string path )
 	{
-		if ( OperatingSystem.IsLinux() ) path = ResolveExt4FilePath( path );
-
 		// Do not allow 0-32 ASCII stuff
 		if ( path.Any( c => char.IsControl( c ) ) ) throw new ArgumentException( "Path cannot contain control characters!", "path" );
 
 		if ( path.Length < 1 )
 			return "/";
 
-		if ( path[0] == '/' ) return path;
-		return string.Concat( "/", path );
+		if ( path[0] != '/' ) path = string.Concat('/', path);
+
+		if ( OperatingSystem.IsLinux() )
+			path = ManageExt4.ResolveLinuxFilePath( system, path );
+
+		return path;
 	}
 
 	/// <summary>
-	/// Sometimes Linux filesystems cannot be resolved because the engine
-	/// attempts to compare a lowercase path to an uppercase one. This rebuilds
-	/// the folder and file paths in segments to allow the engine to build the uppercase
-	/// variant. This only applies to Zio mounts and will not fix managed calls to the native
-	/// engine.
+	/// Passes through case handled paths for Zio system root paths
 	/// </summary>
-	internal string ResolveExt4FilePath( string path )
+	/// <param name="path"></param>
+	/// <returns></returns>
+	internal string NormalizePath( string path )
 	{
-		if ( system is null ) return path;
+		path = path.Replace( "\\", "/" );
+		if ( OperatingSystem.IsWindows() ) path = path.ToLowerInvariant(); 
 
-		var segments = path.Trim( '/' ).Split( '/', StringSplitOptions.RemoveEmptyEntries );
-		if ( segments.Length == 0 ) return path;
-
-		var resolvedSegments = new List<string>( segments.Length );
-
-		foreach ( var segment in segments )
-		{
-			var parentPath = new Zio.UPath( "/" + string.Join( "/", resolvedSegments ) );
-			var candidatePath = new Zio.UPath( parentPath.FullName.TrimEnd( '/' ) + "/" + segment );
-
-			if ( system.DirectoryExists( candidatePath ) )
-			{
-				resolvedSegments.Add( segment );
-				continue;
-
-			} // If the folder exists already, do nothing.
-
-			try
-			{
-				// BaseFileSystem seems to just handle directory mounts, nothing about file names. If that changes
-				// we can adjust this to Zio.SearchTarget.Both
-				var match = system.EnumeratePaths( parentPath, "*", SearchOption.TopDirectoryOnly, Zio.SearchTarget.Directory )
-					.FirstOrDefault( p => string.Equals( p.FullName.Substring( p.FullName.LastIndexOf( '/' ) + 1 ), segment, StringComparison.OrdinalIgnoreCase ) );
-
-				var fullName = match.FullName;
-				var resolved = string.IsNullOrEmpty( fullName ) ? segment : fullName.Substring( fullName.LastIndexOf( '/' ) + 1 );
-
-				if ( resolved != segment )
-					Log.Info( $"[ResolveExt4FilePath] Corrected folder '{segment}' -> '{resolved}' (parent: {parentPath})" );
-
-				resolvedSegments.Add( resolved );
-			}
-			catch ( System.IO.DirectoryNotFoundException )
-			{
-				Log.Info( $"[ResolveExt4FilePath] DirectoryNotFound at parent '{parentPath}', keeping segment '{segment}'" );
-				resolvedSegments.Add( segment );
-			}
-		}
-
-		var result = string.Join( "/", resolvedSegments );
-
-		if ( result != path.Trim( '/' ) )
-			Log.Info( $"[ResolveExt4FilePath] '{path}' -> '{result}'" );
-
-		return result;
+		return path;
 	}
 
 	/// <summary>
@@ -673,4 +630,5 @@ public class BaseFileSystem
 	{
 		return filepath.ToLower().Replace( "\\", "/" ); // we can probably do more here
 	}
+
 }

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -586,7 +586,7 @@ public class BaseFileSystem
 	/// </summary>
 	internal BaseFileSystem CreateAndMount( string path )
 	{
-		var sub = new LocalFileSystem( path );
+		var sub = new LocalFileSystem( FixPath ( path ) );
 		Mount( sub );
 		return sub;
 	}
@@ -594,8 +594,10 @@ public class BaseFileSystem
 	/// <summary>
 	/// Zio wants good paths to start with '/' - so we add it here if it isn't already on
 	/// </summary>
-	internal static string FixPath( string path )
+	internal string FixPath( string path )
 	{
+		if ( OperatingSystem.IsLinux() ) path = ResolveExt4FilePath( path );
+
 		// Do not allow 0-32 ASCII stuff
 		if ( path.Any( c => char.IsControl( c ) ) ) throw new ArgumentException( "Path cannot contain control characters!", "path" );
 
@@ -604,6 +606,63 @@ public class BaseFileSystem
 
 		if ( path[0] == '/' ) return path;
 		return string.Concat( "/", path );
+	}
+
+	/// <summary>
+	/// Sometimes Linux filesystems cannot be resolved because the engine
+	/// attempts to compare a lowercase path to an uppercase one. This rebuilds
+	/// the folder and file paths in segments to allow the engine to build the uppercase
+	/// variant. This only applies to Zio mounts and will not fix managed calls to the native
+	/// engine.
+	/// </summary>
+	internal string ResolveExt4FilePath( string path )
+	{
+		if ( system is null ) return path;
+
+		var segments = path.Trim( '/' ).Split( '/', StringSplitOptions.RemoveEmptyEntries );
+		if ( segments.Length == 0 ) return path;
+
+		var resolvedSegments = new List<string>( segments.Length );
+
+		foreach ( var segment in segments )
+		{
+			var parentPath = new Zio.UPath( "/" + string.Join( "/", resolvedSegments ) );
+			var candidatePath = new Zio.UPath( parentPath.FullName.TrimEnd( '/' ) + "/" + segment );
+
+			if ( system.DirectoryExists( candidatePath ) )
+			{
+				resolvedSegments.Add( segment );
+				continue;
+			} // If the folder exists already, do nothing.
+
+			try
+			{
+				// BaseFileSystem seems to just handle directory mounts, nothing about file names. If that changes
+				// we can adjust this to Zio.SearchTarget.Both
+				var match = system.EnumeratePaths( parentPath, "*", SearchOption.TopDirectoryOnly, Zio.SearchTarget.Directory )
+					.FirstOrDefault( p => string.Equals( p.FullName.Substring( p.FullName.LastIndexOf( '/' ) + 1 ), segment, StringComparison.OrdinalIgnoreCase ) );
+
+				var fullName = match.FullName;
+				var resolved = string.IsNullOrEmpty( fullName ) ? segment : fullName.Substring( fullName.LastIndexOf( '/' ) + 1 );
+
+				if ( resolved != segment )
+					Log.Info( $"[ResolveExt4FilePath] Corrected folder '{segment}' -> '{resolved}' (parent: {parentPath})" );
+
+				resolvedSegments.Add( resolved );
+			}
+			catch ( System.IO.DirectoryNotFoundException )
+			{
+				Log.Info( $"[ResolveExt4FilePath] DirectoryNotFound at parent '{parentPath}', keeping segment '{segment}'" );
+				resolvedSegments.Add( segment );
+			}
+		}
+
+		var result = string.Join( "/", resolvedSegments );
+
+		if ( result != path.Trim( '/' ) )
+			Log.Info( $"[ResolveExt4FilePath] '{path}' -> '{result}'" );
+
+		return result;
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -586,7 +586,7 @@ public class BaseFileSystem
 	/// </summary>
 	internal BaseFileSystem CreateAndMount( string path )
 	{
-		var sub = new LocalFileSystem( FixPath( path ) );
+		var sub = new LocalFileSystem( path );
 		Mount( sub );
 		return sub;
 	}

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -586,7 +586,7 @@ public class BaseFileSystem
 	/// </summary>
 	internal BaseFileSystem CreateAndMount( string path )
 	{
-		var sub = new LocalFileSystem( FixPath ( path ) );
+		var sub = new LocalFileSystem( FixPath( path ) );
 		Mount( sub );
 		return sub;
 	}
@@ -633,6 +633,7 @@ public class BaseFileSystem
 			{
 				resolvedSegments.Add( segment );
 				continue;
+
 			} // If the folder exists already, do nothing.
 
 			try

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -602,7 +602,7 @@ public class BaseFileSystem
 		if ( path.Length < 1 )
 			return "/";
 
-		if ( path[0] != '/' ) path = string.Concat('/', path);
+		if ( path[0] != '/' ) path = string.Concat( '/', path );
 
 		if ( OperatingSystem.IsLinux() )
 			path = ManageExt4.ResolveLinuxFilePath( system, path );
@@ -618,7 +618,7 @@ public class BaseFileSystem
 	internal string NormalizePath( string path )
 	{
 		path = path.Replace( "\\", "/" );
-		if ( OperatingSystem.IsWindows() ) path = path.ToLowerInvariant(); 
+		if ( OperatingSystem.IsWindows() ) path = path.ToLowerInvariant();
 
 		return path;
 	}

--- a/engine/Sandbox.Filesystem/LocalFileSystem.cs
+++ b/engine/Sandbox.Filesystem/LocalFileSystem.cs
@@ -10,9 +10,8 @@ internal class LocalFileSystem : BaseFileSystem
 	internal LocalFileSystem( string rootFolder, bool makereadonly = false )
 	{
 		Physical = new Zio.FileSystems.PhysicalFileSystem();
-		rootFolder = OperatingSystem.IsLinux() ? rootFolder : rootFolder.ToLowerInvariant();
 
-		var rootPath = Physical.ConvertPathFromInternal( rootFolder );
+		var rootPath = Physical.ConvertPathFromInternal( NormalizePath( rootFolder ) );
 		system = new Zio.FileSystems.SubFileSystem( Physical, rootPath );
 
 		if ( makereadonly )

--- a/engine/Sandbox.Filesystem/LocalFileSystem.cs
+++ b/engine/Sandbox.Filesystem/LocalFileSystem.cs
@@ -10,8 +10,8 @@ internal class LocalFileSystem : BaseFileSystem
 	internal LocalFileSystem( string rootFolder, bool makereadonly = false )
 	{
 		Physical = new Zio.FileSystems.PhysicalFileSystem();
-
 		rootFolder = OperatingSystem.IsLinux() ? rootFolder : rootFolder.ToLowerInvariant();
+
 		var rootPath = Physical.ConvertPathFromInternal( rootFolder );
 		system = new Zio.FileSystems.SubFileSystem( Physical, rootPath );
 

--- a/engine/Sandbox.Filesystem/LocalFileSystem.cs
+++ b/engine/Sandbox.Filesystem/LocalFileSystem.cs
@@ -11,7 +11,8 @@ internal class LocalFileSystem : BaseFileSystem
 	{
 		Physical = new Zio.FileSystems.PhysicalFileSystem();
 
-		var rootPath = Physical.ConvertPathFromInternal( rootFolder.ToLowerInvariant() );
+		rootFolder = OperatingSystem.IsLinux() ? rootFolder : rootFolder.ToLowerInvariant();
+		var rootPath = Physical.ConvertPathFromInternal( rootFolder );
 		system = new Zio.FileSystems.SubFileSystem( Physical, rootPath );
 
 		if ( makereadonly )

--- a/engine/Sandbox.Filesystem/ManageExt4.cs
+++ b/engine/Sandbox.Filesystem/ManageExt4.cs
@@ -1,0 +1,58 @@
+using System.IO;
+
+namespace Sandbox;
+
+/// <summary>
+/// This class is for managing any operating systems that use case-insensitive filesystems such as Linux.
+/// This is its own class so that if adaptations are needed in the future they can exclusively be done
+/// here without having the methods be internally used in the BaseFileSystem, so we can maintain a
+/// clear separation between Facepunch's source code and be as unaggressive as possible
+/// with any Linux related changes that are approved.
+/// </summary>
+internal static class ManageExt4
+{
+	/// <summary>
+	/// Linux filesystems cannot be resolved because the engine
+	/// attempts to compare a lowercase path to an uppercase one. This rebuilds
+	/// the file paths in segments to allow the engine to build the uppercase
+	/// variant for Zio file systems.
+	/// </summary>
+	internal static string ResolveLinuxFilePath( Zio.IFileSystem system, string path )
+	{
+		if ( system is null ) return path;
+
+		if ( system.DirectoryExists( path ) || system.FileExists( path ) )
+			return path;
+
+		var segments = path.Trim( '/' ).Split( '/', StringSplitOptions.RemoveEmptyEntries );
+		var resolvedSegments = new List<string>( segments.Length );
+
+		foreach ( var segment in segments )
+		{
+			// rebuild
+			var ext4Path = new Zio.UPath( "/" + string.Join( "/", resolvedSegments ) );
+
+			try
+			{
+				// enumerate upath
+				var resolved = system
+					.EnumeratePaths( ext4Path, "*", SearchOption.TopDirectoryOnly, Zio.SearchTarget.Directory )
+					.Select( p => p.FullName.Substring( p.FullName.LastIndexOf( '/' ) + 1 ) )
+					.FirstOrDefault( name => string.Equals( name, segment, StringComparison.OrdinalIgnoreCase ) )
+					?? segment;
+
+				//Log.Info( $"[ResolveLinuxFilePath] '{segment}' -> '{resolved}' (parent: {ext4Path})" );
+				resolvedSegments.Add( resolved );
+			}
+			catch ( System.IO.DirectoryNotFoundException ) // Files return fine, case sensitive paths dont.
+			{
+				resolvedSegments.Add( segment );
+			}
+		}
+
+		// The enumerated uppercase variants are reconstructed for the result
+		var result = "/" + string.Join( "/", resolvedSegments );
+
+		return result;
+	}
+}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Prerequisites
There is a native bug where a double-free occurs. A shim is needed to run the base game.
Make a launch.sh script -> https://pastebin.com/raw/TJSsuDxX
Make a no_double_free.c file -> https://pastebin.com/raw/9pcnqmdy
Put both in /game folder and run ./launch.sh (try a few times if you cannot see FP logo) 
Also puts libskiasharp and libharfbuzz in managed folder, which is correct order needed.

If you see "Couldn't Create MenuSystem!" that means code is working. To get to missing texture screen, rename:
/addons/base/code -> /addons/base/Code
/addons/tools/assets -> /addons/tools/Assets
This is a separate file path issue in Project.cs from Sandbox.Engine.

## Summary

This fixes filepath issues that occur in `Sandbox.FileSystem`, where roughly 200 incoming file paths mounted
through Zio are lowercase-only. This issue happens in *CreateSubSystem* when the game is
launched (i.e. *CreateSubSystem()* received *addons/citizen/assets* which cannot resolve
*addons/citizen/Assets*).

## Motivation & Context

This builds the engine to work natively on Linux. This is an incremental change that is part of 3 other ones. The game can run natively if the file path resolutions can be met properly. This change gets the filesystem a third of the way there. The original plan was to cache directories in a SubSystem by walking the entire tree for each mount, but it would be hard to keep track of, and this issue only occurred for about 200 file paths out of 2000 in the base addons.

An alternative solution was to make the entire Linux filesystem be lowercase and compare uppercase directories to lowercase variants, but it regressed the engine in several places and is not worth it for such a small issue in Zio.

## Implementation Details

Revised with Claude

* *ResolveLinuxFilePath()* added to *FixPath()* in *BaseFileSystem.cs* — corrects incoming paths for all existing fs methods
* *FixPath()* is no longer a static method because it is only used internally in `Sandbox.FileSystem` and is required to pass non-static system variable into Linux method
* *LocalFileSystem* uses *NormalizePath()* (a variant of `NormalizeFilename`) to normalize file roots to OS-specific paths
* *FixPath()* behavior is unchanged except for a new ext4 check
* *ManageExt4.cs* added as a dedicated class for Linux-only fixes going forward

When a path doesn't exist as-is, *ResolveLinuxFilePath()* breaks it into segments and walks back up the root, enumerating child directories and matching case-insensitively until the correct path is reconstructed. Most paths resolve without this — only ~200 of ~2,000 calls need the walk.

*ManageExt4.cs* exists to maintain a clear separation between Linux and Windows concerns. The ultimate goal is to <u>never regress anything Windows-related</u>, keeping changes to *BaseFileSystem* minimal (<15 lines). It also gives a single place to handle future divergences — for example, if *CreateDirectory()* is called with */code* in one place and */Code* in another, Linux ends up with two folders while Windows has one. That kind of fix can live here and be forgotten about, without requiring Facepunch developers to audit every path choice.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->


**Before.**
<img width="2336" height="612" alt="Screenshot from 2026-04-18 02-23-01" src="https://github.com/user-attachments/assets/34484d0c-41b3-4baa-b5ed-d73e2bcd6777" />


**After.**
<img width="1907" height="1103" alt="Screenshot from 2026-04-09 04-23-12" src="https://github.com/user-attachments/assets/84387e88-4b63-4b8c-97f0-a5617120373f" />

## Tests
This is a log of the filepaths being parsed correctly.
https://pastebin.com/raw/TaFXAgVU

## Potential Issues
I am highly confident the ERROR_FILEOPENs are not related to Zio, but rather the way that resources are sent to NativeEngine calls elsewhere in GameInstanceDll or MenuDll. I would recommend confirming that this is a standalone issue before accepting this solution. 

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂