### PR TITLE
static Game.Overlay.IsAnyOpen and Game.Overlay.IsPauseOpen

### DIFF
--- a/engine/Sandbox.Engine/Game/Game/Game.Overlay.cs
+++ b/engine/Sandbox.Engine/Game/Game/Game.Overlay.cs
@@ -235,11 +235,11 @@ public static partial class Game
 		/// <summary>
 		/// Returns true if any overlay is open
 		/// </summary>
-		public bool IsOpen => IModalSystem.Current?.IsModalOpen ?? false;
+		public static bool IsOpen => IModalSystem.Current?.IsModalOpen ?? false;
 
 		/// <summary>
 		/// Returns true if the pause menu overlay is open
 		/// </summary>
-		public bool IsPauseMenuOpen => IModalSystem.Current?.IsPauseMenuOpen ?? false;
+		public static bool IsPauseMenuOpen => IModalSystem.Current?.IsPauseMenuOpen ?? false;
 	}
 }

--- a/engine/Sandbox.Engine/Game/Game/Game.Overlay.cs
+++ b/engine/Sandbox.Engine/Game/Game/Game.Overlay.cs
@@ -18,7 +18,7 @@ public static partial class Game
 	/// Game.Overlay.ShowGameModal("facepunch.sandbox");
 	///
 	/// // Check if any overlay is currently open
-	/// if (Game.Overlay.IsOpen)
+	/// if (Game.Overlay.IsOverlayOpen)
 	/// {
 	///     // Pause game logic or input
 	/// }
@@ -232,14 +232,20 @@ public static partial class Game
 			IModalSystem.Current?.CloseAll( immediate );
 		}
 
+		[Obsolete( "Use Game.Overlay.IsOverlayOpen" )]
+		public bool IsOpen => IsOverlayOpen;
+
+		[Obsolete( "Use Game.Overlay.IsPauseOpen" )]
+		public bool IsPauseMenuOpen => IsPauseOpen;
+
 		/// <summary>
 		/// Returns true if any overlay is open
 		/// </summary>
-		public static bool IsOpen => IModalSystem.Current?.IsModalOpen ?? false;
+		public static bool IsOverlayOpen => IModalSystem.Current?.IsModalOpen ?? false;
 
 		/// <summary>
 		/// Returns true if the pause menu overlay is open
 		/// </summary>
-		public static bool IsPauseMenuOpen => IModalSystem.Current?.IsPauseMenuOpen ?? false;
+		public static bool IsPauseOpen => IModalSystem.Current?.IsPauseMenuOpen ?? false;
 	}
 }


### PR DESCRIPTION
## Summary
2 properties in Game.Overlay that could be static, are referred to as static, and make much more sense being static.
```cs
Game.Overlay.IsOverlayOpen
Game.Overlay.IsPauseOpen
```

previously
```cs
var overlay = new Game.Overlay();
overlay.IsOpen
overlay.IsPauseMenuOpen
```

## Motivation & Context
Didn't feel like keeping track of an instance of Game.Overlay

## Implementation Details
Seemed I should obsolete rather than just make the existing properties static to avoid breaking things. New names aren't quite as good though.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂