### PR TITLE
Fix inset with comma breaking scss shadow lists

### DIFF
--- a/engine/Sandbox.System/Utility/Parse.cs
+++ b/engine/Sandbox.System/Utility/Parse.cs
@@ -559,7 +559,7 @@ namespace Sandbox
 			if ( !p.IsLetter )
 				return false;
 
-			var w = p.ReadWord( null, true );
+			var w = p.ReadWord( ",", true );
 			switch ( w )
 			{
 				case "inset":


### PR DESCRIPTION
## Summary
Styles such as this one, in which inset is followed by a comma
```css
box-shadow: 1px 1px #b0a58d inset, -1px -1px #24221f inset;
```
weren't working because of an issue in `Parse.TryReadShadowInset`

## Motivation & Context
Needed multiple box-shadows to rip off gold source vgui window styling

## Implementation Details
`ReadWord` in `TryReadShadowInset` would read "inset," instead of "inset", then fail the check for "inset" and not advance the pointer. With the pointer not advanced SetShadow would end its loop and ignore the second shadow entirely. ReadWord is now set to stop upon reaching the comma, such that only "inset" is read and the check passes and loop continues.

## Screenshots / Videos (if applicable)
<img width="147" height="84" alt="image" src="https://github.com/user-attachments/assets/f8b57946-76b1-4631-860e-9eb7d7d305be" />
(would previously only show the first shadow and not be inset)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂