### PR TITLE
[Shadergraph] Use TryAdd in MainWindow.OnAttribute

### DIFF
--- a/game/editor/ShaderGraph/Code/MainWindow.cs
+++ b/game/editor/ShaderGraph/Code/MainWindow.cs
@@ -332,32 +332,46 @@ public class MainWindow : DockWindow
 		switch ( value )
 		{
 			case Color v:
-				_float4Attributes.Add( name, v );
-				_preview?.SetAttribute( name, v );
+				if (_float4Attributes.TryAdd(name, v))
+				{
+					_preview?.SetAttribute(name, v);
+				}
 				break;
 			case Vector4 v:
-				_float4Attributes.Add( name, v );
-				_preview?.SetAttribute( name, (Color)v );
+				if (_float4Attributes.TryAdd(name, v))
+				{
+					_preview?.SetAttribute(name, (Color)v);
+				}
 				break;
 			case Vector3 v:
-				_float3Attributes.Add( name, v );
-				_preview?.SetAttribute( name, v );
+				if (_float3Attributes.TryAdd(name, v))
+				{
+					_preview?.SetAttribute(name, v);
+				}
 				break;
 			case Vector2 v:
-				_float2Attributes.Add( name, v );
-				_preview?.SetAttribute( name, v );
+				if (_float2Attributes.TryAdd(name, v))
+				{
+					_preview?.SetAttribute(name, v);
+				}
 				break;
 			case float v:
-				_floatAttributes.Add( name, v );
-				_preview?.SetAttribute( name, v );
+				if (_floatAttributes.TryAdd(name, v))
+				{
+					_preview?.SetAttribute(name, v);
+				}
 				break;
 			case bool v:
-				_boolAttributes.Add( name, v );
-				_preview?.SetAttribute( name, v );
+				if (_boolAttributes.TryAdd(name, v))
+				{
+					_preview?.SetAttribute(name, v);
+				}
 				break;
 			case Texture v:
-				_textureAttributes.Add( name, v );
-				_preview?.SetAttribute( name, v );
+				if (_textureAttributes.TryAdd(name, v))
+				{
+					_preview?.SetAttribute(name, v);
+				}
 				break;
 			default:
 				throw new InvalidOperationException( $"Unsupported attribute type: {value.GetType()}" );

--- a/game/editor/ShaderGraph/Code/MainWindow.cs
+++ b/game/editor/ShaderGraph/Code/MainWindow.cs
@@ -332,45 +332,45 @@ public class MainWindow : DockWindow
 		switch ( value )
 		{
 			case Color v:
-				if (_float4Attributes.TryAdd(name, v))
+				if ( _float4Attributes.TryAdd( name, v ) )
 				{
-					_preview?.SetAttribute(name, v);
+					_preview?.SetAttribute( name, v );
 				}
 				break;
 			case Vector4 v:
-				if (_float4Attributes.TryAdd(name, v))
+				if ( _float4Attributes.TryAdd( name, v ) )
 				{
-					_preview?.SetAttribute(name, (Color)v);
+					_preview?.SetAttribute( name, (Color)v );
 				}
 				break;
 			case Vector3 v:
-				if (_float3Attributes.TryAdd(name, v))
+				if ( _float3Attributes.TryAdd( name, v ) )
 				{
-					_preview?.SetAttribute(name, v);
+					_preview?.SetAttribute( name, v );
 				}
 				break;
 			case Vector2 v:
-				if (_float2Attributes.TryAdd(name, v))
+				if ( _float2Attributes.TryAdd( name, v ) )
 				{
-					_preview?.SetAttribute(name, v);
+					_preview?.SetAttribute( name, v );
 				}
 				break;
 			case float v:
-				if (_floatAttributes.TryAdd(name, v))
+				if ( _floatAttributes.TryAdd( name, v ) )
 				{
-					_preview?.SetAttribute(name, v);
+					_preview?.SetAttribute( name, v );
 				}
 				break;
 			case bool v:
-				if (_boolAttributes.TryAdd(name, v))
+				if ( _boolAttributes.TryAdd( name, v ) )
 				{
-					_preview?.SetAttribute(name, v);
+					_preview?.SetAttribute( name, v );
 				}
 				break;
 			case Texture v:
-				if (_textureAttributes.TryAdd(name, v))
+				if ( _textureAttributes.TryAdd( name, v ) )
 				{
-					_preview?.SetAttribute(name, v);
+					_preview?.SetAttribute( name, v );
 				}
 				break;
 			default:


### PR DESCRIPTION
## Summary

This PR simply makes use of TryAdd function of a dictionary  within the OnAttribute function.

## Motivation & Context

This mainly fixes the case where you have a texture sampler node that's connected to a port involved with the pixel stage and the position offset port at the same time like below :

<img width="2552" height="1287" alt="sbox-dev_qAVQVGM24G" src="https://github.com/user-attachments/assets/be5f9042-b83d-430d-ba82-a03209efa8fc" />


## Implementation Details

Make use of TryAdd within each case of the switch in OnAttribute which will prevent 
`_preview?.SetAttribute( name, v );` from being called if the attribute already exists in the dictionary.

Instead of just putting `TryAdd` within the `Texture` case i make use of it in all cases just to be extra sure 🙂.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂