### PR TITLE
Remove `EqualityContract` Record Property From Serialization

### DIFF
--- a/engine/Sandbox.Reflection/TypeLibrary/TypeDescription.cs
+++ b/engine/Sandbox.Reflection/TypeLibrary/TypeDescription.cs
@@ -205,6 +205,12 @@ public sealed class TypeDescription : ISourceLineProvider
 			if ( methodInfo.Name == "GetHashCode" ) return false;
 		}
 
+		// Special case:
+		// `EqualityContract` is an artifact from record types and it's used for hashing / equality.
+		// It's protected read-only and marked as compiler generated and shouldn't be included;
+		// however, because of the `source.IsDynamicAssembly` check below, it falls through the cracks.
+		if ( member.MemberType == MemberTypes.Property && member.Name == "EqualityContract" && member.HasAttribute( typeof( CompilerGeneratedAttribute ) ) ) return false;
+
 		// Assume we're a System or something else if we're not package or Sandbox
 		var assembly = member.DeclaringType.Assembly;
 

--- a/engine/Sandbox.Test.Unit/SerializedObject/TypeLibraryObject.Exclude.cs
+++ b/engine/Sandbox.Test.Unit/SerializedObject/TypeLibraryObject.Exclude.cs
@@ -1,0 +1,17 @@
+namespace SerializedObject;
+
+
+public partial class From_TypeLibrary
+{
+	[TestMethod]
+	public void Exclude_EqualityContract()
+	{
+		var source = new MyRecord();
+
+		var obj = typeLibrary.GetSerializedObject( source );
+
+		var prop = obj.GetProperty( "EqualityContract" );
+
+		Assert.IsNull( prop, "Property should be excluded" );
+	}
+}

--- a/engine/Sandbox.Test.Unit/SerializedObject/TypeLibraryObject.cs
+++ b/engine/Sandbox.Test.Unit/SerializedObject/TypeLibraryObject.cs
@@ -32,6 +32,13 @@ public partial class From_TypeLibrary
 		}
 	}
 
+	public record MyRecord
+	{
+		public string String { get; set; }
+		public Transform Transform { get; set; }
+		public Color Color { get; set; }
+	}
+
 	public struct MyDeepStruct
 	{
 		public string String { get; set; }


### PR DESCRIPTION
# Pull Request

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This is a quick PR to remove the `EqualityContract` property from `record` types from serialization. `EqualityContract` is protected read-only and used internally for hashing / equality; it isn't something that should be serialized or displayed in `ControlWidgets`.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

If the `GenericControlWidget` is used on a `record` type, then it displays the `EqualityContract` property for editing; you can attempt to modify it, but it can't be changed.

Fixes: #10579

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

I don't know all the facets of the `TypeLibrary` or serialization, so another pair of eyes to double check this would be nice.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

The `EqualityContract` record property no longer in the `GenericControlWidget`:
<img width="436" height="180" alt="image" src="https://github.com/user-attachments/assets/02ccec60-6c30-4b5d-a05f-b3c6a22f45e6" />

## Testing

1. Create a `Game - Minimal` project.
2. Paste in the code from the "Media/Files" section below.
3. Create a `Test Resource` game resource in the Asset Browser and edit it.
4. Click the `Test` property.
5. Ensure that:
   - [ ] The `EqualityContract` is not displayed.
   - [ ] The `Test` property works as expected.

## Media/Files

Code for testing:
```cs
using System.Text.Json.Serialization;

namespace Sandbox;

public record Test
{
	[ActionGraphInclude( AutoExpand = true )]
	[JsonInclude]
	[Property]
	public int Foo { get; set; }

	[ActionGraphInclude( AutoExpand = true )]
	[JsonInclude]
	[Property]
	public string Bar { get; set; }
}

[AssetType( Category = "_TEST", Extension = "test", Name = "Test Resource" )]
public class TestResource : GameResource
{
	[Property]
	[Order( 0 )]
	public Test Test { get; set; }
}
```

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂