### PR TITLE
Add apply-and-continue shortcut for clipping

### DIFF
--- a/game/addons/tools/Code/Scene/Mesh/Tools/ClipTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/ClipTool.UI.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Editor.MeshEditor;
+﻿namespace Editor.MeshEditor;
 
 partial class ClipTool
 {
@@ -62,6 +61,9 @@ partial class ClipTool
 
 		[Shortcut( "mesh.clip-apply", "enter", typeof( SceneViewWidget ) )]
 		void Apply() => _tool.Apply();
+
+		[Shortcut( "mesh.clip-apply-stay", "space", typeof( SceneViewWidget ) )]
+		void ApplyAndContinue() => _tool.Apply( false );
 
 		[Shortcut( "mesh.clip-cancel", "ESC", typeof( SceneViewWidget ) )]
 		void Cancel() => _tool.Cancel();

--- a/game/addons/tools/Code/Scene/Mesh/Tools/ClipTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/ClipTool.cs
@@ -1,4 +1,3 @@
-
 namespace Editor.MeshEditor;
 
 [Alias( "tools.clip-tool" )]
@@ -72,7 +71,9 @@ public partial class ClipTool : EditorTool
 
 			foreach ( var group in Selection.OfType<MeshFace>().GroupBy( f => f.Component ) )
 			{
-				_targets[group.Key] = (group.Key.Mesh, [.. group.Select( f => f.Handle )]);
+				var selectedFaces = new HashSet<HalfEdgeMesh.FaceHandle>( group.Select( f => f.Handle ) );
+				var targetFaces = selectedFaces.Count == group.Key.Mesh.FaceHandles.Count() ? null : selectedFaces;
+				_targets[group.Key] = (group.Key.Mesh, targetFaces);
 			}
 		}
 
@@ -276,11 +277,17 @@ public partial class ClipTool : EditorTool
 
 	void Apply()
 	{
+		Apply( true );
+	}
+
+	void Apply( bool closeTool = true )
+	{
 		if ( !CanApply ) return;
 
 		_applied = true;
 
 		var components = _targets.Keys.Where( x => x.IsValid() ).ToArray();
+		var selectAllFacesAfterApply = _faceSelection && _targets.Values.Any( x => x.Faces is null );
 
 		_newEdges.Clear();
 
@@ -294,7 +301,8 @@ public partial class ClipTool : EditorTool
 			.WithGameObjectCreations()
 			.Push() )
 		{
-			Selection.Clear();
+			if ( closeTool || _faceSelection )
+				Selection.Clear();
 
 			foreach ( var (component, data) in _targets.ToArray() )
 			{
@@ -303,14 +311,15 @@ public partial class ClipTool : EditorTool
 				if ( _faceSelection == false && KeepMode == ClipKeepMode.Both )
 				{
 					var newMesh = ApplyClipBoth( component, data.Faces );
-					Selection.Add( newMesh.GameObject );
+					if ( closeTool )
+						Selection.Add( newMesh.GameObject );
 				}
 				else
 				{
 					ApplyClip( component, _plane.Value, KeepMode, data.Faces );
 				}
 
-				if ( _faceSelection == false )
+				if ( closeTool && _faceSelection == false )
 				{
 					Selection.Add( component.GameObject );
 				}
@@ -318,19 +327,33 @@ public partial class ClipTool : EditorTool
 
 			if ( _faceSelection )
 			{
-				foreach ( var edge in _newEdges )
+				if ( selectAllFacesAfterApply )
 				{
-					if ( !edge.IsValid() )
-						continue;
+					foreach ( var (component, data) in _targets )
+					{
+						if ( !component.IsValid() || data.Faces is not null )
+							continue;
 
-					var mesh = edge.Component.Mesh;
-					mesh.GetFacesConnectedToEdge( edge.Handle, out var faceA, out var faceB );
+						foreach ( var face in component.Mesh.FaceHandles )
+							Selection.Add( new MeshFace( component, face ) );
+					}
+				}
+				else
+				{
+					foreach ( var edge in _newEdges )
+					{
+						if ( !edge.IsValid() )
+							continue;
 
-					if ( faceA.IsValid )
-						Selection.Add( new MeshFace( edge.Component, faceA ) );
+						var mesh = edge.Component.Mesh;
+						mesh.GetFacesConnectedToEdge( edge.Handle, out var faceA, out var faceB );
 
-					if ( faceB.IsValid )
-						Selection.Add( new MeshFace( edge.Component, faceB ) );
+						if ( faceA.IsValid )
+							Selection.Add( new MeshFace( edge.Component, faceA ) );
+
+						if ( faceB.IsValid )
+							Selection.Add( new MeshFace( edge.Component, faceB ) );
+					}
 				}
 			}
 
@@ -339,8 +362,16 @@ public partial class ClipTool : EditorTool
 		}
 
 		Reset();
+		_applied = false;
 
-		EditorToolManager.SetSubTool( _faceSelection ? nameof( FaceTool ) : nameof( ObjectSelection ) );
+		if ( closeTool )
+		{
+			EditorToolManager.SetSubTool( _faceSelection ? nameof( FaceTool ) : nameof( ObjectSelection ) );
+		}
+		else if ( _faceSelection )
+		{
+			CacheSelectedMeshes();
+		}
 	}
 
 	void Cancel()


### PR DESCRIPTION
## Summary

Add `Spacebar` support to apply a clip **without exiting** `ClipTool`, matching Hammer-style workflow.

## Motivation & Context
Repeated clipping is a common blockout workflow. Exiting the tool after every cut slows iteration.  
This change enables fast consecutive cuts while staying in the clipping context.

## Implementation Details

- Added a Space shortcut (mesh.clip-apply-stay) in ClipTool.UI.cs.
- Space now applies the current cut and keeps ClipTool active.
- Enter behavior is unchanged: apply + exit tool.
- Kept selection/target handling aligned with existing clip behavior so repeated cuts work predictably, including face-selection cases.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/cf76c1f1-8892-4022-b7a1-ddaf507ca1d7

## Checklist

- [x] Code follows existing style and conventions  
- [x] No unnecessary formatting or unrelated changes  
- [ ] Public APIs are documented (if applicable)  
- [ ] Unit tests added where applicable and all passing  
- [x] I’m okay with this PR being rejected or requested to change 🙂