### PR TITLE
Bootstrap: cd to script directory before dotnet run

### DIFF
--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -1,4 +1,5 @@
-@echo off
+@echo on
+cd /d "%~dp0"
 
 dotnet run --project .\engine\Tools\SboxBuild\SboxBuild.csproj -- build --config Developer
 dotnet run --project .\engine\Tools\SboxBuild\SboxBuild.csproj -- build-shaders

--- a/Bootstrap.bat
+++ b/Bootstrap.bat
@@ -1,4 +1,4 @@
-@echo on
+@echo off
 cd /d "%~dp0"
 
 dotnet run --project .\engine\Tools\SboxBuild\SboxBuild.csproj -- build --config Developer


### PR DESCRIPTION
## Summary

Ensures `Bootstrap.bat` always runs `dotnet` from the repository root by changing to the script’s directory first.

Without this, launching the batch file from Explorer or any shell whose current directory is not the repo (for example `C:\Windows\System32`) makes relative paths like `.\engine\Tools\SboxBuild\SboxBuild.csproj` resolve incorrectly and `dotnet` reports that the project file does not exist.

## Motivation & Context

Contributors and CI-like setups often run `Bootstrap.bat` without already being `cd`’d into the clone. Windows can leave the working directory as `System32` when the script is started from certain shortcuts or contexts, which breaks all relative `dotnet --project` paths.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

Adds `cd /d "%~dp0"` near the top of `Bootstrap.bat`, after `@echo on`.

`%~dp0` expands to the drive and path of the batch file, so every subsequent command runs with the repo root as the current directory regardless of how the script was launched. `/d` allows changing drives when the repo lives on a different letter than the starting cwd.

No engine behavior changes beyond making the bootstrap script resolve paths reliably.

## Screenshots / Videos (if applicable)

N/A — batch-file path resolution only.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂