### PR TITLE
Fix parent move from particle effect

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
@@ -397,6 +397,8 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 
 	Transform lastTransform;
 
+	Transform prevLastTransform;
+
 	ConcurrentQueue<Particle> deleteList = new ConcurrentQueue<Particle>();
 
 	/// <summary>
@@ -454,6 +456,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 
 		isWarmed = false;
 		lastTransform = WorldTransform;
+		prevLastTransform = WorldTransform;
 	}
 
 	protected override void OnDisabled()
@@ -518,10 +521,10 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 
 		if ( _parentMoved && frame > 0 && localSpace > 0.001f )
 		{
-			var localPos = lastTransform.PointToLocal( p.Position );
+			var localPos = prevLastTransform.PointToLocal( p.Position );
 			var worldPos = _worldTx.PointToWorld( localPos );
 
-			var localVelocity = lastTransform.NormalToLocal( p.Velocity.Normal );
+			var localVelocity = prevLastTransform.NormalToLocal( p.Velocity.Normal );
 			var worldVelocity = _worldTx.NormalToWorld( localVelocity ) * p.Velocity.Length;
 
 			p.Position = p.Position.LerpTo( worldPos, localSpace );
@@ -735,8 +738,9 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		if ( ForceSpace == SimulationSpace.Local )
 			_worldForce = _worldTx.Rotation * ForceDirection;
 
-		Vector3 lastPos = lastTransform.Position;
-		Transform deltaTransform = _worldTx.ToLocal( lastTransform );
+		prevLastTransform = lastTransform;
+		lastTransform = _worldTx;
+		Transform deltaTransform = _worldTx.ToLocal( prevLastTransform );
 
 		_parentMoved = deltaTransform != global::Transform.Zero;
 
@@ -758,8 +762,6 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 		MaxParticleSize = _maxSize;
 
 		OnPostStep?.Invoke( _timeDelta );
-
-		lastTransform = WorldTransform;
 	}
 
 	[Obsolete( "Pass in a delta" )]
@@ -926,7 +928,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 
 		Particles.Remove( p );
 
-		if ( Particle.Pool.Count < 4096 )
+		if ( Particle.Pool.Count < 512 )
 			Particle.Pool.Enqueue( p );
 
 		SceneMetrics.ParticlesDestroyed++;

--- a/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs
@@ -928,7 +928,7 @@ public sealed partial class ParticleEffect : Component, Component.ExecuteInEdito
 
 		Particles.Remove( p );
 
-		if ( Particle.Pool.Count < 512 )
+		if ( Particle.Pool.Count < 4096 )
 			Particle.Pool.Enqueue( p );
 
 		SceneMetrics.ParticlesDestroyed++;


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
When a FollowerPrefab contains a ParticleEffect with LocalSpace = 1, those particles should follow the follower's emitter as it moves. However, they don't — the _parentMoved flag is always false for follower ParticleEffects, so the local-space position adjustment is never applied.
<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #1520 

## Implementation Details
Track two transforms instead of one:

_prevLastTransform — where the emitter was at the start of the previous frame's PreStep
lastTransform (repurposed) — where the emitter is at the start of the current frame's PreStep
By comparing these two, we detect movement that happened between two PreStep calls (i.e., the parent moving the follower during last frame's UpdateParticle).
<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->
Remove the unused Vector3 lastPos = lastTransform.Position; line too
## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/5dd29b25-2dcd-4468-9254-8f2731b59361


<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂