### PR TITLE
Add material icon hint in IconAttribute

### DIFF
--- a/engine/Sandbox.System/Attributes/EditorAtributes.cs
+++ b/engine/Sandbox.System/Attributes/EditorAtributes.cs
@@ -285,6 +285,7 @@ public class ToggleGroupAttribute : GroupAttribute
 /// <summary>
 /// Sets the icon of a type or a type member. Colors are expected in HTML formats, like "rgb(255,255,255)" or "#FFFFFF".
 /// This info can then be retrieved via DisplayInfo library.
+/// The icon is typically the name of a <a href="https://fonts.google.com/icons">material icon</a>.
 /// </summary>
 public sealed class IconAttribute : System.Attribute, IIconProvider, IIconAttribute, IUninheritable
 {


### PR DESCRIPTION
## Summary

I was scrolling through documentation issues and noticed this low-hanging fruit.

## Motivation & Context

Fixes: #1329

## Implementation Details

I wanted to rename the argument to 'name' since it would make the documentation's text flow better, but that is technically a breaking change so I left it alone.

## Screenshots / Videos (if applicable)

![2026-04-09_20-46-36](https://github.com/user-attachments/assets/a8b50e18-c92d-4fe7-a0cf-ceb2d6ce2952)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂

## Note
Remake of #10429 