### PR TITLE
More consistently clear ListView hovered item

### DIFF
--- a/engine/Sandbox.Tools/Widgets/BaseItemWidget.cs
+++ b/engine/Sandbox.Tools/Widgets/BaseItemWidget.cs
@@ -861,6 +861,8 @@ public partial class BaseItemWidget : BaseScrollWidget
 	[EditorEvent.Frame]
 	public void UpdateIfDirty()
 	{
+		if ( hovered is not null && (!Visible || !IsUnderMouse) )
+			InternalHoverChange( null );
 		if ( !Visible ) return;
 
 		UpdateDynamicSelection();


### PR DESCRIPTION
## Summary
The status bar path that asset browser creates when hovering over items had a bad habit of getting stuck there and blocking the console output, this makes `ListView` better at clearing hovered items so the path can be properly cleared.

## Motivation & Context
Was sometimes kind of annoying.

## Implementation Details
In `ListVIew` if the mouse left the item in such a way that `OnMouseMove` didn't get called (most commonly by moving onto a different window) the hovered item would get stuck. This more deliberately clears the hovered item if the mouse isn't over the widget or the widget isn't visible.

## Screenshots
This path, used to get stuck if you alt tab, now it gets cleared.
<img width="292" height="72" alt="image" src="https://github.com/user-attachments/assets/4bdd3c39-128e-49b7-9bc9-5f44f1e0bfcf" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂