### PR TITLE
Fix GameObject transform control margin in Editor

### DIFF
--- a/game/addons/tools/Code/Scene/GameObjectInspector/GameObjectTransformControl.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/GameObjectTransformControl.cs
@@ -17,7 +17,7 @@ partial class TransformComponentWidget : ComponentEditorWidget
 	public TransformComponentWidget( SerializedObject obj ) : base( obj )
 	{
 		Layout = Layout.Column();
-		Layout.Margin = new Margin( 0, 5, 0, 4 );
+		Layout.Margin = new Margin( 0, 5, 12, 4 );
 
 		Rebuild();
 	}


### PR DESCRIPTION
# Pull Request

## Summary

Fixes the misaligned transform control in the game objects inspector

## Screenshots / Videos (if applicable)

Before
<img width="698" height="446" alt="image" src="https://github.com/user-attachments/assets/5f83995d-71d8-4451-a89c-4e83e05f5733" />

After
<img width="695" height="442" alt="image" src="https://github.com/user-attachments/assets/ae481f04-e39e-4c6b-984e-b5f111f5e3c1" />

(Highlighted in red for better visibility on the screenshots)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂