### PR TITLE
Recursive type substitution fix in TypeLibrary.MakeGenericType

### DIFF
--- a/engine/Sandbox.Reflection/TypeLibrary/TypeDescription.cs
+++ b/engine/Sandbox.Reflection/TypeLibrary/TypeDescription.cs
@@ -683,6 +683,31 @@ public sealed class TypeDescription : ISourceLineProvider
 		if ( genericParams.Length != typeArgs.Length )
 			return null;
 
+
+		// Make a map from generic type parameters to type arguments
+		var substitutions = new Dictionary<Type, Type>();
+		for ( int i = 0; i < genericParams.Length; i++ )
+		{
+			var param = genericParams[i];
+			var arg = typeArgs[i];
+			substitutions.Add( param, arg );
+		}
+
+		// Substitutes generic type parameters in a type definition with type arguments
+		Type Substitute( Type type )
+		{
+			if ( !type.IsGenericType )
+				return type;
+			var genericDefinition = type.GetGenericTypeDefinition();
+			var genericParams = type.GenericTypeArguments;
+			for ( int i = 0; i < genericParams.Length; i++ )
+			{
+				if ( substitutions.TryGetValue( genericParams[i], out var substitutedType ) )
+					genericParams[i] = Substitute( substitutedType );
+			}
+			return genericDefinition.MakeGenericType( genericParams );
+		}
+
 		for ( int i = 0; i < genericParams.Length; i++ )
 		{
 			var param = genericParams[i];
@@ -727,7 +752,7 @@ public sealed class TypeDescription : ISourceLineProvider
 			var constraints = param.GetGenericParameterConstraints();
 			foreach ( var constraint in constraints )
 			{
-				if ( !constraint.IsAssignableFrom( arg ) )
+				if ( !Substitute( constraint ).IsAssignableFrom( arg ) )
 					return null;
 			}
 		}

--- a/engine/Sandbox.Reflection/TypeLibrary/TypeDescription.cs
+++ b/engine/Sandbox.Reflection/TypeLibrary/TypeDescription.cs
@@ -699,7 +699,7 @@ public sealed class TypeDescription : ISourceLineProvider
 			if ( !type.IsGenericType )
 				return type;
 			var genericDefinition = type.GetGenericTypeDefinition();
-			var genericParams = type.GenericTypeArguments;
+			var genericParams = type.GetGenericArguments();
 			for ( int i = 0; i < genericParams.Length; i++ )
 			{
 				if ( substitutions.TryGetValue( genericParams[i], out var substitutedType ) )

--- a/engine/Sandbox.Test.Unit/Reflection/TypeLibraryTest.cs
+++ b/engine/Sandbox.Test.Unit/Reflection/TypeLibraryTest.cs
@@ -340,6 +340,12 @@ public class TypeCollection
 		void DoSomething( T value );
 	}
 
+	public interface IConstraintBreaker2<T, T2, T3>
+	{
+		void DoSomething( T value );
+		void DoSomething2( T2 value );
+		void DoSomething3( T3 value );
+	}
 
 
 	/// <summary>
@@ -360,6 +366,25 @@ public class TypeCollection
 									.CreateGeneric<IConstraintBreaker<TypeWrapper>>( [typeof( TypeWrapper )] );
 		Assert.IsNull( badboy );
 	}
+
+
+	/// <summary>
+	/// 
+	/// </summary>
+	[TestMethod]
+	public void ObeyRecursiveGenericConstraints()
+	{
+		var tl = new Sandbox.Internal.TypeLibrary();
+		tl.AddAssembly( ThisAssembly, true );
+
+		var goodboy = tl.GetType( typeof( ConstraintBreaker2<> ) )
+									.CreateGeneric<ConstraintBreaker2TypeErased>( [typeof( ConstraintBreaker2Inner )] );
+		Assert.IsNotNull( goodboy );
+
+		var badboy = tl.GetType( typeof( ConstraintBreaker2<> ) )
+									.CreateGeneric<ConstraintBreaker2TypeErased>( [typeof( TypeWrapper )] );
+		Assert.IsNull( badboy );
+	}
 }
 
 [Expose, MyType]
@@ -377,5 +402,42 @@ public class ConstraintBreaker<T> : IConstraintBreaker<T> where T : unmanaged
 	public void DoSomething( T value )
 	{
 
+	}
+}
+
+
+public class ConstraintBreaker2Inner :
+	IConstraintBreaker2<
+		ConstraintBreaker2Inner,
+		ConstraintBreaker2Inner,
+		ConstraintBreaker2Inner
+	>
+{
+	public void DoSomething( ConstraintBreaker2Inner value )
+	{
+
+	}
+
+	public void DoSomething2( ConstraintBreaker2Inner value )
+	{
+
+	}
+
+	public void DoSomething3( ConstraintBreaker2Inner value )
+	{
+
+	}
+}
+
+public class ConstraintBreaker2TypeErased { }
+
+[Expose]
+public class ConstraintBreaker2<T> : ConstraintBreaker2TypeErased where T : IConstraintBreaker2<T, T, T>
+{
+	public void DoSomething( T value )
+	{
+		value.DoSomething( value );
+		value.DoSomething2( value );
+		value.DoSomething3( value );
 	}
 }

--- a/engine/Sandbox.Test.Unit/Reflection/TypeLibraryTest.cs
+++ b/engine/Sandbox.Test.Unit/Reflection/TypeLibraryTest.cs
@@ -367,6 +367,19 @@ public class TypeCollection
 		Assert.IsNull( badboy );
 	}
 
+	/// <summary>
+	/// 
+	/// </summary>
+	[TestMethod]
+	public void ObeyGenericConstraints2()
+	{
+		var tl = new Sandbox.Internal.TypeLibrary();
+		tl.AddAssembly( ThisAssembly, true );
+
+		var goodboy = tl.GetType( typeof( IConstraintBreaker3<> ) )
+									.MakeGenericType( [typeof( ConstraintBreaker3 )] );
+		Assert.IsNotNull( goodboy );
+	}
 
 	/// <summary>
 	/// 
@@ -439,5 +452,20 @@ public class ConstraintBreaker2<T> : ConstraintBreaker2TypeErased where T : ICon
 		value.DoSomething( value );
 		value.DoSomething2( value );
 		value.DoSomething3( value );
+	}
+}
+
+
+public interface IConstraintBreaker3<T> where T : IConstraintBreaker3<T>
+{
+	void DoSomething( T value );
+}
+
+[Expose]
+public class ConstraintBreaker3 : IConstraintBreaker3<ConstraintBreaker3>
+{
+	public void DoSomething( ConstraintBreaker3 value )
+	{
+
 	}
 }


### PR DESCRIPTION
# Pull Request
Previous (closed) PR: #164

## Summary

Constraints keep their generic parameters, which doesn't work with types that are the ones to be used in the construction, f.e.:
- class `Add<T> where T : IAdditionOperators<T, T, T>` - original type and some constraints
- We go check the first generic argument - `T`, we are trying to put `float` in there
- Get `T`'s constraints - `IAdditionOperators<T, T, T>` - the only constraint
- Check if `IAdditionOperators<T, T, T>` "is assignable from" `float` - which it is not, because there are still `T`s in there

For this to work we need to substitute all the generic arguments with their corresponding types into the constraint first and only then check if it is assignable from the current type argument

There's also a few new tests

## Motivation & Context

Type abuse to make use of JIT compilation, etc.

Fixes: #314 

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂