### PR TITLE
Async AcceptConnection

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Markers/INetworkListener.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Markers/INetworkListener.cs
@@ -1,5 +1,25 @@
 ﻿namespace Sandbox;
 
+// TODO: where does this go?
+public struct ConnectionRequestResult
+{
+	public bool IsAccepted;
+	public string Reason;
+
+	public static ConnectionRequestResult Accept() => new()
+	{
+		IsAccepted = true,
+	};
+
+	public static ConnectionRequestResult Reject( string reason ) => new()
+	{
+		IsAccepted = false,
+		Reason = reason,
+	};
+
+	public static implicit operator bool( ConnectionRequestResult result ) => result.IsAccepted;
+}
+
 public abstract partial class Component
 {
 	/// <summary>
@@ -13,9 +33,21 @@ public abstract partial class Component
 		/// </summary>
 		/// <param name="channel"></param>
 		/// <param name="reason">The reason to display to the client.</param>
+		[Obsolete( $"Use the other overload" )]
 		bool AcceptConnection( Connection channel, ref string reason )
 		{
 			return true;
+		}
+
+		/// <summary>
+		/// Called on the host to decide whether to accept a <see cref="Connection"/>.
+		/// If any <see cref="Component"/> that implements this returns a rejection, the connection will be denied.
+		/// </summary>
+		/// <param name="channel"></param>
+		/// <returns></returns>
+		async Task<ConnectionRequestResult> AcceptConnection( Connection channel )
+		{
+			return ConnectionRequestResult.Accept();
 		}
 
 		/// <summary>

--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -649,11 +649,25 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 	{
 		foreach ( var c in Game.ActiveScene.GetAll<Component.INetworkListener>() )
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			if ( !c.AcceptConnection( channel, ref reason ) )
 				return false;
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		return true;
+	}
+
+	public override async Task<ConnectionRequestResult> AcceptConnection( Connection channel )
+	{
+		foreach ( var c in Game.ActiveScene.GetAll<Component.INetworkListener>() )
+		{
+			var result = await c.AcceptConnection( channel );
+
+			if ( !result ) return result;
+		}
+
+		return ConnectionRequestResult.Accept();
 	}
 
 	public override void OnConnected( Connection client )

--- a/engine/Sandbox.Engine/Systems/Networking/System/GameNetworkSystem/GameNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/GameNetworkSystem/GameNetworkSystem.cs
@@ -30,6 +30,11 @@ public abstract partial class GameNetworkSystem : IDisposable
 		return true;
 	}
 
+	public virtual async Task<ConnectionRequestResult> AcceptConnection( Connection channel )
+	{
+		return ConnectionRequestResult.Accept();
+	}
+
 	public virtual void GetMountedVPKs( Connection source, ref MountedVPKsResponse msg ) { }
 
 	public virtual void GetSnapshot( Connection source, ref SnapshotMsg msg ) { }

--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
@@ -160,9 +160,6 @@ internal partial class NetworkSystem
 			}
 		}
 
-
-		var denialReason = "";
-
 		source.PreInfo = new ConnectionInfo( null )
 		{
 			ConnectionId = source.Id,
@@ -171,11 +168,27 @@ internal partial class NetworkSystem
 
 		source.PreInfo.Update( msg );
 
-		if ( GameSystem is not null && !GameSystem.AcceptConnection( source, ref denialReason ) )
+		if ( GameSystem is not null )
 		{
-			Log.Info( $"Kicking {msg.DisplayName} [{msg.SteamId}] - {denialReason}" );
-			source.Kick( denialReason );
-			return;
+			var denialReason = "";
+			var shouldReject = !GameSystem.AcceptConnection( source, ref denialReason );
+
+			if ( !shouldReject )
+			{
+				var result = await GameSystem.AcceptConnection( source );
+				if ( !result )
+				{
+					shouldReject = true;
+					denialReason = result.Reason;
+				}
+			}
+
+			if ( shouldReject )
+			{
+				Log.Info( $"Kicking {msg.DisplayName} [{msg.SteamId}] - {denialReason}" );
+				source.Kick( denialReason );
+				return;
+			}
 		}
 
 		source.PreInfo = null;


### PR DESCRIPTION
## Summary

This PR replaces AcceptConnection with an async version. The original functionality is left in place, but marked as Obsolete.

## Motivation & Context

An async function lets you make a time-consuming call like a check with a database or on-disk ban list without causing a server freeze on connections.

Fixes: #1563

## Implementation Details

Discussion happened in Discord: https://discord.com/channels/833983068468936704/895597253316714497/1468245963356508322
The initial implementation was just a string where null means no rejection.
Further discussion led to a new ConnectionRequestResult struct with static defaults so it can be expanded in the future if need be.

**Note**: I have no idea where the ConnectionRequestResult struct should go. I can either follow instructions or you can feel free to pull in the PR and edit it to your hearts content.

## Screenshots / Videos (if applicable)

(Note: this video was recorded before the rework but not much has changed)

https://github.com/user-attachments/assets/585d87e7-369b-43cc-9b02-e574ca9b2447

Sample projects:
- [rejectconnection initial.zip](https://github.com/user-attachments/files/25050006/rejectconnection.initial.zip)
- **[rejectconnection struct.zip](https://github.com/user-attachments/files/25050012/rejectconnection.struct.zip)**

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂

## Note

Remake of #9962. I had to recreate the commit because I couldn't figure out how to rebase with merge conflicts.

As a reminder of where we're at:

- [ ] Where does `ConnectionRequestResult` go? Right now it's sitting in the Sandbox namespace inside an unrelated code file.
- [ ] There is currently a bug where if an exception is thrown inside AcceptConnection, the connecting user gets stuck on the loading screen. Should that be fixed at the same time?