### PR TITLE
Add sounds to NS2 mount

### DIFF
--- a/engine/Mounting/Sandbox.Mounting.NS2/GameMount.cs
+++ b/engine/Mounting/Sandbox.Mounting.NS2/GameMount.cs
@@ -22,7 +22,8 @@ public class GameMount : BaseGameMount
 	{
 		{ ".model", ResourceType.Model },
 		{ ".dds", ResourceType.Texture },
-		{ ".material", ResourceType.Material }
+		{ ".material", ResourceType.Material },
+		{ ".fsb", ResourceType.Sound },
 	};
 
 	protected override Task Mount( MountContext context )
@@ -49,6 +50,10 @@ public class GameMount : BaseGameMount
 			else if ( resourceType == ResourceType.Material )
 			{
 				context.Add( resourceType, path, new MaterialLoader( fullPath ) );
+			}
+			else if ( resourceType == ResourceType.Sound )
+			{
+				SoundBankLoader.AddSoundsFromBank( context, fullPath, path );
 			}
 		}
 

--- a/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
+++ b/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
@@ -34,14 +34,6 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 		VORBIS
 	};
 
-	static int WidthForFormat( SoundFormat format ) => format switch
-	{
-		SoundFormat.PCM8 => 1,
-		SoundFormat.PCM16 => 2,
-		SoundFormat.PCM32 => 4,
-		_ => throw new InvalidDataException(),
-	};
-
 	static ulong Bits( ulong val, int start, int len )
 	{
 		var stop = start + len;
@@ -66,7 +58,6 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 		};
 	}
 
-	// CS4012: Parameters of type 'MountContext' cannot be declared in async methods
 	public static void AddSoundsFromBank( MountContext context, string bankPath, string relPath )
 	{
 		using var fs = File.OpenRead( bankPath );
@@ -161,16 +152,16 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 	protected override object Load()
 	{
 		using var fs = File.OpenRead( BankPath );
-
-		// read information
 		using var br = new BinaryReader( fs );
+
+		// read sample information
 		fs.Seek( Info.InfoOffset, SeekOrigin.Begin );
 
 		var raw = br.ReadUInt64();
 		var nextChunk = Bits( raw, 0, 1 );
 		var frequency = Frequency( Bits( raw, 1, 4 ) );
 		var channels = (int)(Bits( raw, 1 + 4, 1 ) + 1);
-		var samples = (int)Bits( raw, 1 + 4 + 1 + 28, 30 );
+		// var samples = (int)Bits( raw, 1 + 4 + 1 + 28, 30 ); - unused
 
 		while ( nextChunk != 0 )
 		{
@@ -201,15 +192,12 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 
 		if ( Info.Format == SoundFormat.MPEG )
 		{
-			var tempfname = $"ns2_{Guid.NewGuid()}.mp3";
-			File.WriteAllBytes( tempfname, fileBytes );
-			Log.Info( $"Wrote <a href=\"{tempfname}\">{tempfname}</a>" );
-			return null;
+			return SoundFile.FromMp3( Path, fileBytes, false );
 		}
 
 		if ( Info.Format == SoundFormat.PCM16 )
 		{
-			return SoundFile.FromPCM( Path, fileBytes, channels, (uint)frequency, 16, false );
+			return SoundFile.FromPcm( Path, fileBytes, channels, (uint)frequency, 16, false );
 		}
 
 		throw new NotImplementedException(); // NS2 only uses PCM16 (wav) and MPEG (mp3) samples.

--- a/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
+++ b/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
@@ -1,0 +1,235 @@
+﻿using ExCSS;
+using Sandbox;
+using System;
+using System.Text;
+
+record struct SampleInformation(
+	int Frequency,
+	int Channels,
+	uint DataOffset,
+	int Samples,
+	SoundBankLoader.SoundFormat Format,
+	uint Length = 0
+);
+
+class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoader<GameMount>
+{
+	private string BankPath { get; init; } = bankPath;
+	private SampleInformation Info { get; init; } = info;
+
+	public enum SoundFormat
+	{
+		None,
+		PCM8,
+		PCM16,
+		PCM24,
+		PCM32,
+		PCMFLOAT,
+		GCADPCM,
+		IMAADPCM,
+		VAG,
+		HEVAG,
+		XMA,
+		MPEG,
+		CELT,
+		AT9,
+		XWMA,
+		VORBIS
+	};
+
+	static int WidthForFormat( SoundFormat format ) => format switch
+	{
+		SoundFormat.PCM8 => 1,
+		SoundFormat.PCM16 => 2,
+		SoundFormat.PCM32 => 4,
+		_ => throw new InvalidDataException(),
+	};
+
+	static ulong Bits( ulong val, int start, int len )
+	{
+		var stop = start + len;
+		var r = val & ((1UL << stop) - 1);
+		return r >> start;
+	}
+
+	static int Frequency( ulong raw )
+	{
+		return raw switch
+		{
+			1 => 8000,
+			2 => 11000,
+			3 => 11025,
+			4 => 16000,
+			5 => 22050,
+			6 => 24000,
+			7 => 32000,
+			8 => 44100,
+			9 => 48000,
+			_ => throw new InvalidDataException()
+		};
+	}
+
+	// CS4012: Parameters of type 'MountContext' cannot be declared in async methods
+	public static void AddSoundsFromBank( MountContext context, string bankPath, string relPath )
+	{
+		var ms = File.OpenRead( bankPath );
+		using var br = new BinaryReader( ms );
+		if ( Encoding.ASCII.GetString( br.ReadBytes( 4 ) ) != "FSB5" ) return;
+
+		var version = br.ReadUInt32();
+		var numSamples = br.ReadUInt32();
+		var sampleHeaderSize = br.ReadUInt32();
+		var nameTableSize = br.ReadUInt32();
+		var dataSize = br.ReadUInt32();
+		var mode = (SoundFormat)br.ReadUInt32();
+
+		ms.Seek( 32, SeekOrigin.Current ); // skip Zero, Hash, Dummy
+
+		var headerSize = ms.Position;
+		var startOfData = (ulong)(headerSize + sampleHeaderSize + nameTableSize);
+
+		var incompleteSamples = new List<SampleInformation>();
+
+		for ( var i = 0; i < numSamples; i++ )
+		{
+			var raw = br.ReadUInt64();
+			var nextChunk = Bits( raw, 0, 1 );
+			var frequency = Frequency( Bits( raw, 1, 4 ) );
+			var channels = (int)(Bits( raw, 1 + 4, 1 ) + 1);
+			var dataOffset = (uint)Bits( raw, 1 + 4 + 1, 28 ) * 16;
+			var samples = (int)Bits( raw, 1 + 4 + 1 + 28, 30 );
+
+			while ( nextChunk != 0 )
+			{
+				var rawi = br.ReadUInt32();
+				nextChunk = Bits( rawi, 0, 1 );
+				var chunkSize = Bits( rawi, 1, 24 );
+				var chunkType = Bits( rawi, 1 + 24, 7 );
+
+				switch ( chunkType )
+				{
+					case 1: // CHANNELS
+						channels = br.ReadChar();
+						break;
+					case 2: // FREQUENCY
+						frequency = (int)br.ReadUInt32();
+						break;
+					default:
+						// skip this
+						ms.Seek( (long)chunkSize, SeekOrigin.Current );
+						break;
+				}
+			}
+
+			var sample = new SampleInformation(
+				frequency,
+				channels,
+				dataOffset,
+				samples,
+				mode
+			);
+
+			incompleteSamples.Add( sample );
+		}
+
+		var startOfNameTable = ms.Position;
+		var sampleNameOffsets = new List<long>();
+		for ( var i = 0; i < numSamples; i++ )
+		{
+			sampleNameOffsets.Add( br.ReadUInt32() );
+		}
+
+		for ( var i = 0; i < numSamples; i++ )
+		{
+			var nameBuilder = new StringBuilder();
+			var b = br.ReadChar();
+			do
+			{
+				nameBuilder.Append( b );
+				b = br.ReadChar();
+			} while ( b != 0 );
+
+			var path = $"{relPath}/{nameBuilder}";
+			var dataStart = incompleteSamples[i].DataOffset;
+			var dataEnd = sampleHeaderSize + nameTableSize + dataSize;
+			if ( i < numSamples - 1 )
+			{
+				dataEnd = incompleteSamples[i + 1].DataOffset;
+			}
+			var sample = incompleteSamples[i] with
+			{
+				DataOffset = dataStart,
+				Length = dataEnd - dataStart
+			};
+
+			context.Add( ResourceType.Sound, path, new SoundBankLoader( bankPath, sample ) );
+		}
+	}
+
+	protected override object Load()
+	{
+		using var bf = File.OpenRead( BankPath );
+		byte[] fileBytes = new byte[Info.Length];
+		bf.Seek( Info.DataOffset, SeekOrigin.Begin );
+		bf.ReadExactly( fileBytes );
+
+		if ( Info.Format == SoundFormat.MPEG )
+		{
+			var tempfname = $"ns2_{Guid.NewGuid()}.mp3";
+			File.WriteAllBytes( tempfname, fileBytes );
+			Log.Info( $"Wrote <a href=\"{tempfname}\">{tempfname}</a>" );
+			return null;
+		}
+
+		if ( Info.Format != SoundFormat.PCM16 )
+		{
+			Log.Info( $"Can't handle format {Info.Format}" );
+			return null;
+		}
+
+		// how do I make a sound from just samples??
+		// for now, generate a temporary .wav and then load it
+
+		var tempf = new MemoryStream();
+
+		{
+			using var wb = new BinaryWriter( tempf );
+			var width = WidthForFormat( Info.Format );
+
+			wb.Write( 'R' );
+			wb.Write( 'I' );
+			wb.Write( 'F' );
+			wb.Write( 'F' );
+			wb.Write( 0 ); // filesize, will be filled in later
+			wb.Write( 'W' );
+			wb.Write( 'A' );
+			wb.Write( 'V' );
+			wb.Write( 'E' );
+			wb.Write( 'f' );
+			wb.Write( 'm' );
+			wb.Write( 't' );
+			wb.Write( ' ' );
+			wb.Write( 16 );
+			wb.Write( (short)1 );  // formatTag: PCM
+			wb.Write( (short)Info.Channels );
+			wb.Write( Info.Frequency );
+			var bytePerBloc = Info.Channels * width;
+			var bytePerSec = bytePerBloc * Info.Frequency;
+			wb.Write( bytePerSec );
+			wb.Write( (short)bytePerBloc );
+			wb.Write( (short)(width * 8) );
+			wb.Write( 'd' );
+			wb.Write( 'a' );
+			wb.Write( 't' );
+			wb.Write( 'a' );
+			wb.Write( fileBytes.Length );
+			wb.Write( fileBytes );
+			// go back and fill in size
+			var size = (int)tempf.Position - 8;
+			tempf.Seek( 4, SeekOrigin.Begin );
+			wb.Write( size );
+		}
+
+		return SoundFile.FromWav( Path, tempf.ToArray(), false );
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
+++ b/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
@@ -1,15 +1,12 @@
-﻿using ExCSS;
-using Sandbox;
+﻿using Sandbox;
 using System;
 using System.Text;
 
 record struct SampleInformation(
-	int Frequency,
-	int Channels,
-	uint DataOffset,
-	int Samples,
 	SoundBankLoader.SoundFormat Format,
-	uint Length = 0
+	long InfoOffset,
+	long DataOffset,
+	long Length = 0
 );
 
 class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoader<GameMount>
@@ -72,73 +69,79 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 	// CS4012: Parameters of type 'MountContext' cannot be declared in async methods
 	public static void AddSoundsFromBank( MountContext context, string bankPath, string relPath )
 	{
-		var ms = File.OpenRead( bankPath );
-		using var br = new BinaryReader( ms );
+		using var fs = File.OpenRead( bankPath );
+		using var br = new BinaryReader( fs );
+
+		// read and verify magic number
 		if ( Encoding.ASCII.GetString( br.ReadBytes( 4 ) ) != "FSB5" ) return;
 
+		// read bank header, notably contains the sound format used in the entire bank
 		var version = br.ReadUInt32();
 		var numSamples = br.ReadUInt32();
 		var sampleHeaderSize = br.ReadUInt32();
 		var nameTableSize = br.ReadUInt32();
 		var dataSize = br.ReadUInt32();
 		var mode = (SoundFormat)br.ReadUInt32();
+		fs.Seek( 32, SeekOrigin.Current ); // skip Zero, Hash, Dummy
 
-		ms.Seek( 32, SeekOrigin.Current ); // skip Zero, Hash, Dummy
-
-		var headerSize = ms.Position;
-		var startOfData = (ulong)(headerSize + sampleHeaderSize + nameTableSize);
-
-		var incompleteSamples = new List<SampleInformation>();
-
+		// now there's a table of information for each sample
+		// figure out where information is stored, but leave reading the info for later
+		var samples = new List<SampleInformation>();
 		for ( var i = 0; i < numSamples; i++ )
 		{
+			var infoOffset = fs.Position;
+
 			var raw = br.ReadUInt64();
 			var nextChunk = Bits( raw, 0, 1 );
-			var frequency = Frequency( Bits( raw, 1, 4 ) );
-			var channels = (int)(Bits( raw, 1 + 4, 1 ) + 1);
 			var dataOffset = (uint)Bits( raw, 1 + 4 + 1, 28 ) * 16;
-			var samples = (int)Bits( raw, 1 + 4 + 1 + 28, 30 );
 
 			while ( nextChunk != 0 )
 			{
 				var rawi = br.ReadUInt32();
 				nextChunk = Bits( rawi, 0, 1 );
 				var chunkSize = Bits( rawi, 1, 24 );
-				var chunkType = Bits( rawi, 1 + 24, 7 );
-
-				switch ( chunkType )
-				{
-					case 1: // CHANNELS
-						channels = br.ReadChar();
-						break;
-					case 2: // FREQUENCY
-						frequency = (int)br.ReadUInt32();
-						break;
-					default:
-						// skip this
-						ms.Seek( (long)chunkSize, SeekOrigin.Current );
-						break;
-				}
+				fs.Seek( (long)chunkSize, SeekOrigin.Current );
 			}
 
 			var sample = new SampleInformation(
-				frequency,
-				channels,
-				dataOffset,
-				samples,
-				mode
+				mode,
+				infoOffset,
+				dataOffset
 			);
 
-			incompleteSamples.Add( sample );
+			samples.Add( sample );
 		}
 
-		var startOfNameTable = ms.Position;
+		// before we continue reading, let's figure out how long each sample is
+		for (var i = 0; i < numSamples; i++)
+		{
+			var dataStart = samples[i].DataOffset;
+			long dataEnd;
+			if ( i < numSamples - 1 )
+			{
+				// the sample ends at the offset for the next sample
+				dataEnd = samples[i + 1].DataOffset;
+			} else
+			{
+				// the sample ends at the end of the bank file data
+				dataEnd = sampleHeaderSize + nameTableSize + dataSize;
+			}
+			samples[i] = samples[i] with { Length = dataEnd - dataStart };
+		}
+
+		// finally, there's a table which has the name for each sample
+		// first there's a list of offsets which we skip because we're reading each name anyway
+		fs.Seek( 4 * numSamples, SeekOrigin.Current );
+		/* this is how you might want to read the name offsets:
+		var startOfNameTable = fs.Position;
 		var sampleNameOffsets = new List<long>();
 		for ( var i = 0; i < numSamples; i++ )
 		{
 			sampleNameOffsets.Add( br.ReadUInt32() );
 		}
+		*/
 
+		// now read each name in sequence and add them to the MountContext
 		for ( var i = 0; i < numSamples; i++ )
 		{
 			var nameBuilder = new StringBuilder();
@@ -150,28 +153,51 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 			} while ( b != 0 );
 
 			var path = $"{relPath}/{nameBuilder}";
-			var dataStart = incompleteSamples[i].DataOffset;
-			var dataEnd = sampleHeaderSize + nameTableSize + dataSize;
-			if ( i < numSamples - 1 )
-			{
-				dataEnd = incompleteSamples[i + 1].DataOffset;
-			}
-			var sample = incompleteSamples[i] with
-			{
-				DataOffset = dataStart,
-				Length = dataEnd - dataStart
-			};
 
-			context.Add( ResourceType.Sound, path, new SoundBankLoader( bankPath, sample ) );
+			context.Add( ResourceType.Sound, path, new SoundBankLoader( bankPath, samples[i] ) );
 		}
 	}
 
 	protected override object Load()
 	{
-		using var bf = File.OpenRead( BankPath );
+		using var fs = File.OpenRead( BankPath );
+
+		// read information
+		using var br = new BinaryReader( fs );
+		fs.Seek( Info.InfoOffset, SeekOrigin.Begin );
+
+		var raw = br.ReadUInt64();
+		var nextChunk = Bits( raw, 0, 1 );
+		var frequency = Frequency( Bits( raw, 1, 4 ) );
+		var channels = (int)(Bits( raw, 1 + 4, 1 ) + 1);
+		var samples = (int)Bits( raw, 1 + 4 + 1 + 28, 30 );
+
+		while ( nextChunk != 0 )
+		{
+			var rawi = br.ReadUInt32();
+			nextChunk = Bits( rawi, 0, 1 );
+			var chunkSize = Bits( rawi, 1, 24 );
+			var chunkType = Bits( rawi, 1 + 24, 7 );
+
+			switch ( chunkType )
+			{
+				case 1: // CHANNELS
+					channels = br.ReadChar();
+					break;
+				case 2: // FREQUENCY
+					frequency = (int)br.ReadUInt32();
+					break;
+				default:
+					// skip this
+					fs.Seek( (long)chunkSize, SeekOrigin.Current );
+					break;
+			}
+		}
+
+		// read file data
 		byte[] fileBytes = new byte[Info.Length];
-		bf.Seek( Info.DataOffset, SeekOrigin.Begin );
-		bf.ReadExactly( fileBytes );
+		fs.Seek( Info.DataOffset, SeekOrigin.Begin );
+		fs.ReadExactly( fileBytes );
 
 		if ( Info.Format == SoundFormat.MPEG )
 		{
@@ -181,12 +207,11 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 			return null;
 		}
 
-		if ( Info.Format != SoundFormat.PCM16 )
+		if ( Info.Format == SoundFormat.PCM16 )
 		{
-			Log.Info( $"Can't handle format {Info.Format}" );
-			return null;
+			return SoundFile.FromPCM( Path, fileBytes, channels, (uint)frequency, 16, false );
 		}
 
-		return SoundFile.FromPCM( Path, fileBytes, Info.Channels, (uint)Info.Frequency, 16, false );
+		throw new NotImplementedException(); // NS2 only uses PCM16 (wav) and MPEG (mp3) samples.
 	}
 }

--- a/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
+++ b/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
@@ -187,49 +187,6 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 			return null;
 		}
 
-		// how do I make a sound from just samples??
-		// for now, generate a temporary .wav and then load it
-
-		var tempf = new MemoryStream();
-
-		{
-			using var wb = new BinaryWriter( tempf );
-			var width = WidthForFormat( Info.Format );
-
-			wb.Write( 'R' );
-			wb.Write( 'I' );
-			wb.Write( 'F' );
-			wb.Write( 'F' );
-			wb.Write( 0 ); // filesize, will be filled in later
-			wb.Write( 'W' );
-			wb.Write( 'A' );
-			wb.Write( 'V' );
-			wb.Write( 'E' );
-			wb.Write( 'f' );
-			wb.Write( 'm' );
-			wb.Write( 't' );
-			wb.Write( ' ' );
-			wb.Write( 16 );
-			wb.Write( (short)1 );  // formatTag: PCM
-			wb.Write( (short)Info.Channels );
-			wb.Write( Info.Frequency );
-			var bytePerBloc = Info.Channels * width;
-			var bytePerSec = bytePerBloc * Info.Frequency;
-			wb.Write( bytePerSec );
-			wb.Write( (short)bytePerBloc );
-			wb.Write( (short)(width * 8) );
-			wb.Write( 'd' );
-			wb.Write( 'a' );
-			wb.Write( 't' );
-			wb.Write( 'a' );
-			wb.Write( fileBytes.Length );
-			wb.Write( fileBytes );
-			// go back and fill in size
-			var size = (int)tempf.Position - 8;
-			tempf.Seek( 4, SeekOrigin.Begin );
-			wb.Write( size );
-		}
-
-		return SoundFile.FromWav( Path, tempf.ToArray(), false );
+		return SoundFile.FromPCM( Path, fileBytes, Info.Channels, (uint)Info.Frequency, 16, false );
 	}
 }

--- a/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
+++ b/engine/Mounting/Sandbox.Mounting.NS2/Resource/SoundBank.cs
@@ -104,7 +104,7 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 		}
 
 		// before we continue reading, let's figure out how long each sample is
-		for (var i = 0; i < numSamples; i++)
+		for ( var i = 0; i < numSamples; i++ )
 		{
 			var dataStart = samples[i].DataOffset;
 			long dataEnd;
@@ -112,7 +112,8 @@ class SoundBankLoader( string bankPath, SampleInformation info ) : ResourceLoade
 			{
 				// the sample ends at the offset for the next sample
 				dataEnd = samples[i + 1].DataOffset;
-			} else
+			}
+			else
 			{
 				// the sample ends at the end of the bank file data
 				dataEnd = sampleHeaderSize + nameTableSize + dataSize;


### PR DESCRIPTION
## Summary

This PR adds the missing sound files to the NS2 mount.

## Motivation & Context

I would like to use the NS2 sounds together with other NS2 assets.

## Implementation Details

The sound files in NS2 are grouped together in FMOD Sound Banks.
I based my implementation on https://github.com/HearthSim/python-fsb5

NS2 only uses MPEG and PCM16 formats inside the banks.

When NS2 is mounted, it will read the header of every bank and add a loader to the context for each sample inside.
The loader will then read inside the bank file at the correct offsets.

What makes this a WIP is that I have no idea how to create sounds from just samples and settings. I'm pretty sure that's internal-only for now. Therefore, I have two approaches for the actual 'loading' part:

1. For PCM16, I create a fake .wav file in memory and load it.
2. For MPEG files I write them to disk as a proof of concept.

Another note: NS2 makes liberal use of the LOOP metadata in the sample chunks. That information is just being skipped for now.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/55aa581b-b25a-4cb1-bc37-550bdb6fd206

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂

## Note

Remake of #10051