### PR TITLE
Open project startup scene when loading default editor layout

### DIFF
--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -343,6 +343,9 @@ public class EditorMainWindow : DockWindow
 
 	record struct LayoutFile( string Name, string Json );
 
+	private bool IsTheDefaultScene( SceneEditorSession s ) =>
+		s.Scene.Source is null && !s.HasUnsavedChanges;
+
 	protected override void RestoreDefaultDockLayout()
 	{
 		var layout = FileSystem.Config.ReadJsonOrDefault<LayoutFile>( $"/editor/layout/default.json", default );
@@ -350,6 +353,19 @@ public class EditorMainWindow : DockWindow
 		if ( layout.Json is null ) return;
 
 		DockManager.State = layout.Json;
+
+		// if we pressed Reset Layout we shouldn't open the startup scene.
+		if ( !EditorWindow.Visible )
+		{
+			var startupScene = Project.Current.Package.GetMeta<string>( "StartupScene", null );
+			if ( startupScene != null )
+			{
+				if ( SceneEditorSession.CreateFromPath( startupScene ) is not null )
+				{
+					SceneEditorSession.All.Where( IsTheDefaultScene ).FirstOrDefault()?.Destroy();
+				}
+			}
+		}
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -343,9 +343,6 @@ public class EditorMainWindow : DockWindow
 
 	record struct LayoutFile( string Name, string Json );
 
-	private bool IsTheDefaultScene( SceneEditorSession s ) =>
-		s.Scene.Source is null && !s.HasUnsavedChanges;
-
 	protected override void RestoreDefaultDockLayout()
 	{
 		var layout = FileSystem.Config.ReadJsonOrDefault<LayoutFile>( $"/editor/layout/default.json", default );
@@ -354,16 +351,30 @@ public class EditorMainWindow : DockWindow
 
 		DockManager.State = layout.Json;
 
-		// if we pressed Reset Layout we shouldn't open the startup scene.
+		// This code should only execute on startup, not when a user presses Reset Layout
 		if ( !EditorWindow.Visible )
 		{
-			var startupScene = Project.Current.Package.GetMeta<string>( "StartupScene", null );
-			if ( !string.IsNullOrWhiteSpace( startupScene ) )
+			// The default layout json is static and doesn't know what a project's startup scene is
+			// We need to look it up and open it if it exists
+			TryToOpenStartupScene();
+		}
+	}
+
+	// The default scene is the empty scene editor that appears in default.json
+	private bool IsTheDefaultScene( SceneEditorSession s ) =>
+		s.Scene.Source is null && !s.HasUnsavedChanges;
+
+	void TryToOpenStartupScene()
+	{
+		var startupScene = Project.Current.Package.GetMeta<string>( "StartupScene", null );
+		if ( !string.IsNullOrWhiteSpace( startupScene ) )
+		{
+			var s = SceneEditorSession.CreateFromPath( startupScene );
+			var startupSceneEditorWasCreated = s is not null;
+
+			if ( startupSceneEditorWasCreated )
 			{
-				if ( SceneEditorSession.CreateFromPath( startupScene ) is not null )
-				{
-					SceneEditorSession.All.Where( IsTheDefaultScene ).FirstOrDefault()?.Destroy();
-				}
+				SceneEditorSession.All.Where( IsTheDefaultScene ).FirstOrDefault()?.Destroy();
 			}
 		}
 	}

--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -358,7 +358,7 @@ public class EditorMainWindow : DockWindow
 		if ( !EditorWindow.Visible )
 		{
 			var startupScene = Project.Current.Package.GetMeta<string>( "StartupScene", null );
-			if ( startupScene != null )
+			if ( !string.IsNullOrWhiteSpace( startupScene ) )
 			{
 				if ( SceneEditorSession.CreateFromPath( startupScene ) is not null )
 				{


### PR DESCRIPTION
## Summary

When the editor opens a new project it follows this flow to load a layout:
https://github.com/Facepunch/sbox-public/blob/9dc248e660288a36e317b8f0a4703e21e102b510/engine/Sandbox.Tools/Qt/DockWindow.cs#L43-L48
If the cookie doesn't exist, it loads the default layout from a json file
https://github.com/Facepunch/sbox-public/blob/9dc248e660288a36e317b8f0a4703e21e102b510/engine/Sandbox.Tools/Editor/EditorMainWindow.cs#L346-L353

This PR adds some code to the latter function which loads the project's defined startup scene instead of the json's defined empty scene.

## Motivation & Context

Fixes: #418 

## Implementation Details

I was trying different ways to make sure this doesn't have any adverse effects on the View -> Reset Layout option. The best way I could think of was to simply check if the main window is visible.
As far as I know, it is only ever not visible during startup.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂

## Note
Remake of 10177