### PR TITLE
Add NetList<T>.Slice(start, length)

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
@@ -229,6 +229,31 @@ public sealed class NetList<T> : INetworkSerializer, INetworkReliable, INetworkP
 	}
 
 	/// <summary>
+	/// <inheritdoc cref="List{T}.Slice"/>
+	/// </summary>
+	public List<T> Slice( int start, int length )
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative( start, nameof( start ) );
+		ArgumentOutOfRangeException.ThrowIfNegative( length, nameof( length ) );
+		if ( _list.Count - start < length )
+		{
+			throw new ArgumentException( "start and length do not denote a valid range of elements" );
+		}
+
+		if ( length == 0 )
+		{
+			return [];
+		}
+
+		var output = new List<T>( length - start );
+		for ( var i = start; i < start + length; i++ )
+		{
+			output.Add( _list[i] );
+		}
+		return output;
+	}
+
+	/// <summary>
 	/// <inheritdoc cref="List{T}.Count"/>
 	/// </summary>
 	public int Count => _list.Count;

--- a/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/Containers/NetList.cs
@@ -245,7 +245,7 @@ public sealed class NetList<T> : INetworkSerializer, INetworkReliable, INetworkP
 			return [];
 		}
 
-		var output = new List<T>( length - start );
+		var output = new List<T>( length );
 		for ( var i = start; i < start + length; i++ )
 		{
 			output.Add( _list[i] );

--- a/engine/Sandbox.Test.Unit/Network/NetList.cs
+++ b/engine/Sandbox.Test.Unit/Network/NetList.cs
@@ -141,4 +141,45 @@ public class NetList
 			list[0] = 1;
 		} );
 	}
+
+	[TestMethod]
+	public void Slice()
+	{
+		using var list = new NetList<int>();
+
+		list.Add( 10 );
+		list.Add( 20 );
+		list.Add( 30 );
+		list.Add( 40 );
+		list.Add( 50 );
+
+		var middle = list.Slice( 1, 2 );
+
+		Assert.AreEqual( 2, middle.Count );
+		Assert.AreEqual( 20, middle[0] );
+		Assert.AreEqual( 30, middle[1] );
+
+		var empty = list.Slice( 4, 0 );
+
+		Assert.AreEqual( 0, empty.Count );
+
+		var full = list.Slice( 0, 5 );
+
+		Assert.AreEqual( 5, full.Count );
+		Assert.AreEqual( 10, full[0] );
+		Assert.AreEqual( 50, full[4] );
+
+		Assert.ThrowsException<ArgumentOutOfRangeException>( () =>
+		{
+			list.Slice( 1, -1 );
+		} );
+		Assert.ThrowsException<ArgumentException>( () =>
+		{
+			list.Slice( 1, 10 );
+		} );
+		Assert.ThrowsException<ArgumentException>( () =>
+		{
+			list.Slice( 5, 1 );
+		} );
+	}
 }


### PR DESCRIPTION
## Summary

This PR adds the Slice function to NetList&lt;T&gt;. List&lt;T&gt; has it as well: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.slice?view=net-9.0

## Motivation & Context

I don't remember exactly why I needed this at the time, but it bothered me enough to submit an issue at one point.

Fixes: #1343

## Implementation Details

This is the core of the function:
```cs
		var output = new List<T>( length - start );
		for ( var i = start; i < start + length; i++ )
		{
			output.Add( _list[i] );
		}
		return output;
```
I'm not sure this is the best way, but I did the basics of avoiding LINQ since apparently it does bad allocations, and initializing the output list with a known capacity.
I assume the compiler knows what to do with this to make it better.

For reference, this is how List&lt;T&gt;.Slice is implemented:
```cs
            List<T> list = new List<T>(count);
            Array.Copy(_items, index, list._items, 0, count);
            list._size = count;
            return list;
```
https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs#L690-L693

Since I don't have access to the ObservableCollection&lt;T&gt; internals, and since that doesn't have a Slice function, that's why I decided to make a simple for loop.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂

## Note
Remake of #9951