### PR TITLE
Fix lipsync not starting when renderer changes

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
@@ -41,8 +41,34 @@ public class Voice : Component
 	[Property, ToggleGroup( "LipSync", Label = "Lip Sync" )]
 	public bool LipSync { get; set; } = true;
 
-	[Property, Group( "LipSync" ), Change( nameof( OnRendererChange ) )]
-	public SkinnedModelRenderer Renderer { get; set; }
+	[Property, Group( "LipSync" )]
+	public SkinnedModelRenderer Renderer
+	{
+		get;
+		set
+		{
+			field = value;
+
+			if ( field.IsValid() && field.Model.IsValid() && field.Model.MorphCount > 0 )
+			{
+				morphs = new float[field.Model.MorphCount];
+
+				if ( sound.IsValid() )
+				{
+					sound.LipSync.Enabled = LipSync;
+				}
+			}
+			else
+			{
+				morphs = null;
+
+				if ( sound.IsValid() )
+				{
+					sound.LipSync.Enabled = false;
+				}
+			}
+		}
+	}
 
 	[Property, Group( "LipSync" ), Range( 0, 5 )]
 	public float MorphScale { get; set; } = 3.0f;
@@ -152,7 +178,7 @@ public class Voice : Component
 
 		soundStream = new SoundStream( VoiceManager.SampleRate );
 
-		if ( Renderer.IsValid() && Renderer.Model.MorphCount > 0 )
+		if ( Renderer.IsValid() && Renderer.Model.IsValid() && Renderer.Model.MorphCount > 0 )
 		{
 			morphs = new float[Renderer.Model.MorphCount];
 		}
@@ -428,27 +454,5 @@ public class Voice : Component
 			LastPlayed = 0;
 			UpdateSound();
 		} );
-	}
-
-	public void OnRendererChange( SkinnedModelRenderer _, SkinnedModelRenderer renderer )
-	{
-		if ( renderer.IsValid() && renderer.Model.MorphCount > 0 )
-		{
-			morphs = new float[renderer.Model.MorphCount];
-
-			if ( sound.IsValid() )
-			{
-				sound.LipSync.Enabled = LipSync;
-			}
-		}
-		else
-		{
-			morphs = null;
-
-			if ( sound.IsValid() )
-			{
-				sound.LipSync.Enabled = false;
-			}
-		}
 	}
 }

--- a/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
@@ -41,7 +41,7 @@ public class Voice : Component
 	[Property, ToggleGroup( "LipSync", Label = "Lip Sync" )]
 	public bool LipSync { get; set; } = true;
 
-	[Property, Group( "LipSync" )]
+	[Property, Group( "LipSync" ), Change( nameof( OnRendererChange ) )]
 	public SkinnedModelRenderer Renderer { get; set; }
 
 	[Property, Group( "LipSync" ), Range( 0, 5 )]
@@ -428,5 +428,27 @@ public class Voice : Component
 			LastPlayed = 0;
 			UpdateSound();
 		} );
+	}
+
+	public void OnRendererChange( SkinnedModelRenderer _, SkinnedModelRenderer renderer )
+	{
+		if ( renderer.IsValid() && renderer.Model.MorphCount > 0 )
+		{
+			morphs = new float[renderer.Model.MorphCount];
+
+			if ( sound.IsValid() )
+			{
+				sound.LipSync.Enabled = LipSync;
+			}
+		}
+		else
+		{
+			morphs = null;
+
+			if ( sound.IsValid() )
+			{
+				sound.LipSync.Enabled = false;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

This pull request adds a property setter to the Renderer property on the Voice transmitter component.
The executed code will enable lipsync if the Renderer is valid.

## Motivation & Context

Fixes: #201 

## Implementation Details

The contents of the setter are taken from the OnInternalEnabled function:
https://github.com/Facepunch/sbox-public/blob/91fa40b1637d772dc5814df5c21931939eda85e8/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs#L155-L158
With just that code, the lip sync would only work when you stopped talking and then started talking again, so I looked at this as well:
https://github.com/Facepunch/sbox-public/blob/91fa40b1637d772dc5814df5c21931939eda85e8/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs#L402-L426
(emphasis on line 417)

The current code seems to work in both instances. Feel free to test it with the sample project in the linked issue.

It also fixes an NRE which exists in the constructor. See previous PR for more info.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂

## Note
Remake of #9905