### PR TITLE
Use Material icon for SoundPointComponent's handle since the png is missing

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Audio/SoundPointComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/SoundPointComponent.cs
@@ -7,7 +7,7 @@ namespace Sandbox;
 [Category( "Audio" )]
 [Title( "Sound Point" )]
 [Icon( "volume_up" )]
-[EditorHandle( "materials/gizmo/sound.png" )]
+[EditorHandle( Icon = "volume_up" )]
 [Tint( EditorTint.Green )]
 public sealed class SoundPointComponent : BaseSoundComponent, Component.ITemporaryEffect
 {


### PR DESCRIPTION
Before:
![Missing texture](https://github.com/user-attachments/assets/506a779e-1508-4b09-9fcd-1270a4304255)

After:
![Present icon](https://github.com/user-attachments/assets/643cae2e-d51b-4023-932e-5079199b2c3c)

Note: remake of #198