### PR TITLE
Move old GameResource extension verification to AssetType Extension setter

### DIFF
--- a/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
+++ b/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
@@ -23,7 +23,26 @@ public class AssetTypeAttribute : System.Attribute, ITypeAttribute, IUninheritab
 	/// <summary>
 	/// File extension for this game resource.
 	/// </summary>
-	public string Extension { get; set; }
+	public string Extension
+	{
+		get;
+		set
+		{
+			if ( value.Length > 8 )
+			{
+				Log.Error( $"Resource extensions should be under 8 characters ({TargetType})" );
+				value = value.Substring( 0, 8 );
+			}
+
+			if ( !value.All( x => char.IsLetter( x ) ) )
+			{
+				Log.Error( $"Resource extensions can only contain letters ({TargetType})" );
+				value = "errored";
+			}
+
+			field = value;
+		}
+	}
 
 	/// <summary>
 	/// Category of this game resource, for grouping in UI.
@@ -112,18 +131,6 @@ public class GameResourceAttribute : AssetTypeAttribute
 
 	public GameResourceAttribute( string title, string extension, string description )
 	{
-		if ( extension.Length > 8 )
-		{
-			Log.Error( $"Resource extensions should be under 8 characters ({TargetType})" );
-			extension = extension.Substring( 0, 8 );
-		}
-
-		if ( !extension.All( x => char.IsLetter( x ) ) )
-		{
-			Log.Error( $"Resource extensions can only contain letters ({TargetType})" );
-			extension = "errored";
-		}
-
 		Name = title;
 		Description = description;
 		Extension = extension;


### PR DESCRIPTION
This shouldn't be a breaking change since the GameResource constructor just uses the same setter.

This fixes the issue where AssetType declarations with invalid extensions end up silently broken in the editor. Try making an AssetType with an extension that's 10 characters long, for example.

This has tripped people up in the Discord, so I was going to add checking. Turns out, it was already there in the old GameResource constructor.
I don't know why it wasn't moved up when GameResource was Obsolete'd, so I moved it up now.

I did a quick test and it seems to work as expected, although with 2 minor issues:
![2026-01-19_11-00-48](https://github.com/user-attachments/assets/6b9c533d-4ff6-4cf0-b987-56dcc74688e5)

1. It prints the error 3 times
2. It prints "null" instead of the proper TargetType

But I think this is still better than silently failing.

Note: remake of #191