### PR TITLE
Register dropped files as assets

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetLocations.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetLocations.cs
@@ -85,7 +85,7 @@ public class AssetLocations : TreeView
 	protected override void OnDragHoverItem( DragEvent ev, VirtualWidget item )
 	{
 		base.OnDragHoverItem( ev, item );
-		ev.Action = DropAction.Move;
+		ev.Action = ev.HasCtrl ? DropAction.Move : DropAction.Copy;
 	}
 
 	protected override void OnDropOnItem( DragEvent ev, VirtualWidget item )
@@ -108,9 +108,9 @@ public class AssetLocations : TreeView
 			if ( asset == null )
 				continue;
 
-			ev.Action = ev.HasCtrl ? DropAction.Copy : DropAction.Move;
+			ev.Action = ev.HasCtrl ? DropAction.Move : DropAction.Copy;
 
-			if ( ev.HasCtrl )
+			if ( ev.Action == DropAction.Copy )
 				EditorUtility.CopyAssetToDirectory( asset, directory );
 			else
 				EditorUtility.MoveAssetToDirectory( asset, directory );

--- a/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.cs
@@ -143,6 +143,7 @@ class FolderNode : TreeNode<LocalAssetBrowser.Location>
 					// Move Directory
 					EditorUtility.RenameDirectory( file, destinationFile );
 					DirectoryEntry.RenameMetadata( file, destinationFile );
+					DroppedAssetRegistration.Register( destinationFile );
 				}
 				else
 				{
@@ -154,6 +155,8 @@ class FolderNode : TreeNode<LocalAssetBrowser.Location>
 						System.IO.File.Copy( file, destinationFile );
 					else
 						System.IO.File.Move( file, destinationFile );
+
+					DroppedAssetRegistration.Register( destinationFile );
 				}
 			}
 			else
@@ -170,6 +173,38 @@ class FolderNode : TreeNode<LocalAssetBrowser.Location>
 		rootParent.Dirty();
 
 		return dropAction;
+	}
+}
+
+static class DroppedAssetRegistration
+{
+	public static void Register( string path )
+	{
+		if ( System.IO.File.Exists( path ) )
+		{
+			RegisterFile( path );
+			return;
+		}
+
+		if ( !System.IO.Directory.Exists( path ) )
+			return;
+
+		foreach ( var file in System.IO.Directory.EnumerateFiles( path, "*", SearchOption.AllDirectories ) )
+		{
+			RegisterFile( file );
+		}
+	}
+
+	private static void RegisterFile( string path )
+	{
+		var extension = System.IO.Path.GetExtension( path );
+		if ( string.IsNullOrWhiteSpace( extension ) )
+			return;
+
+		if ( extension.Equals( ".meta", StringComparison.OrdinalIgnoreCase ) )
+			return;
+
+		AssetSystem.RegisterFile( path );
 	}
 }
 

--- a/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.cs
@@ -123,7 +123,7 @@ class FolderNode : TreeNode<LocalAssetBrowser.Location>
 
 	public override DropAction OnDragDrop( BaseItemWidget.ItemDragEvent e )
 	{
-		var dropAction = e.HasCtrl ? DropAction.Copy : DropAction.Move;
+		var dropAction = e.HasCtrl ? DropAction.Move : DropAction.Copy;
 		if ( !e.IsDrop ) return dropAction;
 
 		foreach ( var file in e.Data.Files )
@@ -140,9 +140,14 @@ class FolderNode : TreeNode<LocalAssetBrowser.Location>
 
 				if ( System.IO.Directory.Exists( file ) )
 				{
-					// Move Directory
-					EditorUtility.RenameDirectory( file, destinationFile );
-					DirectoryEntry.RenameMetadata( file, destinationFile );
+					if ( dropAction == DropAction.Copy )
+						DroppedAssetRegistration.CopyDirectory( file, destinationFile );
+					else
+					{
+						EditorUtility.RenameDirectory( file, destinationFile );
+						DirectoryEntry.RenameMetadata( file, destinationFile );
+					}
+
 					DroppedAssetRegistration.Register( destinationFile );
 				}
 				else
@@ -192,6 +197,24 @@ static class DroppedAssetRegistration
 		foreach ( var file in System.IO.Directory.EnumerateFiles( path, "*", SearchOption.AllDirectories ) )
 		{
 			RegisterFile( file );
+		}
+	}
+
+	public static void CopyDirectory( string source, string destination )
+	{
+		if ( !System.IO.Directory.Exists( source ) )
+			return;
+
+		System.IO.Directory.CreateDirectory( destination );
+
+		foreach ( var file in System.IO.Directory.EnumerateFiles( source, "*", SearchOption.TopDirectoryOnly ) )
+		{
+			System.IO.File.Copy( file, System.IO.Path.Combine( destination, System.IO.Path.GetFileName( file ) ) );
+		}
+
+		foreach ( var directory in System.IO.Directory.EnumerateDirectories( source, "*", SearchOption.TopDirectoryOnly ) )
+		{
+			CopyDirectory( directory, System.IO.Path.Combine( destination, System.IO.Path.GetFileName( directory ) ) );
 		}
 	}
 

--- a/game/addons/tools/Code/Editor/AssetBrowser/PathWidget.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/PathWidget.cs
@@ -304,12 +304,12 @@ public class PathWidget : Widget
 				return;
 			}
 
-			ev.Action = ev.HasCtrl ? DropAction.Copy : DropAction.Move;
+			ev.Action = ev.HasCtrl ? DropAction.Move : DropAction.Copy;
 		}
 
 		public override void OnDragDrop( DragEvent ev )
 		{
-			ev.Action = ev.HasCtrl ? DropAction.Copy : DropAction.Move;
+			ev.Action = ev.HasCtrl ? DropAction.Move : DropAction.Copy;
 
 			foreach ( var file in ev.Data.Files )
 			{
@@ -324,9 +324,14 @@ public class PathWidget : Widget
 
 					if ( Directory.Exists( file ) )
 					{
-						// Move Directory
-						EditorUtility.RenameDirectory( file, destinationFile );
-						DirectoryEntry.RenameMetadata( file, destinationFile );
+						if ( ev.Action == DropAction.Copy )
+							DroppedAssetRegistration.CopyDirectory( file, destinationFile );
+						else
+						{
+							EditorUtility.RenameDirectory( file, destinationFile );
+							DirectoryEntry.RenameMetadata( file, destinationFile );
+						}
+
 						DroppedAssetRegistration.Register( destinationFile );
 					}
 					else

--- a/game/addons/tools/Code/Editor/AssetBrowser/PathWidget.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/PathWidget.cs
@@ -327,6 +327,7 @@ public class PathWidget : Widget
 						// Move Directory
 						EditorUtility.RenameDirectory( file, destinationFile );
 						DirectoryEntry.RenameMetadata( file, destinationFile );
+						DroppedAssetRegistration.Register( destinationFile );
 					}
 					else
 					{
@@ -338,6 +339,8 @@ public class PathWidget : Widget
 							File.Copy( file, destinationFile );
 						else
 							File.Move( file, destinationFile );
+
+						DroppedAssetRegistration.Register( destinationFile );
 					}
 				}
 				else

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
@@ -204,6 +204,11 @@ public partial class AssetList
 		}
 
 		var selection = SelectedItems.OfType<AssetEntry>().ToList();
+		foreach ( var entry in selection )
+		{
+			entry.EnsureAssetRegistered();
+		}
+
 		var directories = SelectedItems.OfType<DirectoryEntry>().ToList();
 
 		if ( directories.Any() )

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.cs
@@ -680,16 +680,16 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 			return;
 
 		if ( ev.HasCtrl )
-			ev.Action = DropAction.Copy;
-		else
 			ev.Action = DropAction.Move;
+		else
+			ev.Action = DropAction.Copy;
 	}
 
 	bool hasJustMoved = false;
 
 	private void OnDrop( DragEvent ev, string directory )
 	{
-		ev.Action = ev.HasCtrl ? DropAction.Copy : DropAction.Move;
+		ev.Action = ev.HasCtrl ? DropAction.Move : DropAction.Copy;
 		if ( ev.Action == DropAction.Move && Browser.ShowRecursiveFiles )
 			return;
 
@@ -708,9 +708,14 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 				if ( System.IO.Directory.Exists( file ) )
 				{
 					if ( Browser.CurrentLocation.Path == directory ) continue;
-					// Move Directory
-					EditorUtility.RenameDirectory( file, destinationFile );
-					DirectoryEntry.RenameMetadata( file, destinationFile );
+					if ( ev.Action == DropAction.Copy )
+						DroppedAssetRegistration.CopyDirectory( file, destinationFile );
+					else
+					{
+						EditorUtility.RenameDirectory( file, destinationFile );
+						DirectoryEntry.RenameMetadata( file, destinationFile );
+					}
+
 					DroppedAssetRegistration.Register( destinationFile );
 				}
 				else
@@ -719,7 +724,7 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 					if ( System.IO.Path.GetFullPath( file ) == System.IO.Path.GetFullPath( destinationFile ) )
 						continue;
 
-					if ( ev.HasCtrl ) System.IO.File.Copy( file, destinationFile );
+					if ( ev.Action == DropAction.Copy ) System.IO.File.Copy( file, destinationFile );
 					else System.IO.File.Move( file, destinationFile );
 
 					DroppedAssetRegistration.Register( destinationFile );
@@ -728,7 +733,7 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 			else
 			{
 				if ( asset.IsDeleted ) continue;
-				if ( ev.HasCtrl ) EditorUtility.CopyAssetToDirectory( asset, directory );
+				if ( ev.Action == DropAction.Copy ) EditorUtility.CopyAssetToDirectory( asset, directory );
 				else EditorUtility.MoveAssetToDirectory( asset, directory );
 			}
 		}

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.cs
@@ -711,6 +711,7 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 					// Move Directory
 					EditorUtility.RenameDirectory( file, destinationFile );
 					DirectoryEntry.RenameMetadata( file, destinationFile );
+					DroppedAssetRegistration.Register( destinationFile );
 				}
 				else
 				{
@@ -720,6 +721,8 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 
 					if ( ev.HasCtrl ) System.IO.File.Copy( file, destinationFile );
 					else System.IO.File.Move( file, destinationFile );
+
+					DroppedAssetRegistration.Register( destinationFile );
 				}
 			}
 			else

--- a/game/addons/tools/Code/Editor/AssetList/Entries/AssetEntry.cs
+++ b/game/addons/tools/Code/Editor/AssetList/Entries/AssetEntry.cs
@@ -20,6 +20,25 @@ public class AssetEntry : IAssetListEntry
 	public string AbsolutePath => Asset?.AbsolutePath ?? FileInfo.FullName;
 	public AssetType AssetType => Asset?.AssetType ?? null;
 
+	public Asset EnsureAssetRegistered()
+	{
+		if ( Asset is not null )
+			return Asset;
+
+		if ( !FileInfo.Exists )
+			return null;
+
+		var extension = Path.GetExtension( FileInfo.Name );
+		if ( string.IsNullOrWhiteSpace( extension ) )
+			return null;
+
+		if ( extension.Equals( ".meta", StringComparison.OrdinalIgnoreCase ) )
+			return null;
+
+		Asset = AssetSystem.RegisterFile( FileInfo.FullName );
+		return Asset;
+	}
+
 	public AssetEntry( Asset asset ) : this( new FileInfo( asset.AbsolutePath ), asset )
 	{
 


### PR DESCRIPTION
Fixes an issue where external files dropped into the asset browser were copied into the project but not registered with AssetSystem until editor restart.

Changes:
- Register dropped files after copy/move
- Handle dropped folders recursively
- Lazily register plain file entries before opening the asset context menu
