### PR TITLE
Make Game.Overlay properties static

### DIFF
--- a/engine/Sandbox.Engine/Game/Game/Game.Overlay.cs
+++ b/engine/Sandbox.Engine/Game/Game/Game.Overlay.cs
@@ -235,11 +235,11 @@ public static partial class Game
 		/// <summary>
 		/// Returns true if any overlay is open
 		/// </summary>
-		public bool IsOpen => IModalSystem.Current?.IsModalOpen ?? false;
+		public static bool IsOpen => IModalSystem.Current?.IsModalOpen ?? false;
 
 		/// <summary>
 		/// Returns true if the pause menu overlay is open
 		/// </summary>
-		public bool IsPauseMenuOpen => IModalSystem.Current?.IsPauseMenuOpen ?? false;
+		public static bool IsPauseMenuOpen => IModalSystem.Current?.IsPauseMenuOpen ?? false;
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Make overlay properties available through `Game.Overlay` so you don't need to create an `Overlay` instance.

## Motivation & Context

The docs/example already show `Game.Overlay.IsOpen`, so the API should match that.

Fixes: N/A

## Implementation Details

Made the overlay properties static so `Game.Overlay.IsOpen` and `Game.Overlay.IsPauseMenuOpen` work directly.

## Screenshots / Videos (if applicable)

N/A

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂