### PR TITLE
Fix scrolling in game overview and reviews

### DIFF
--- a/game/addons/menu/Code/MenuUI/Components/PortalTarget.razor.scss
+++ b/game/addons/menu/Code/MenuUI/Components/PortalTarget.razor.scss
@@ -2,4 +2,6 @@
 PortalTarget
 {
     flex-direction: column;
+    flex-shrink: 0;
+    width: 100%;
 }

--- a/game/addons/menu/Code/Modals/PackageModals/Components/PackageDescription.razor.scss
+++ b/game/addons/menu/Code/Modals/PackageModals/Components/PackageDescription.razor.scss
@@ -1,17 +1,17 @@
 
 PackageDescription
 {
+    flex-direction: column;
     flex-shrink: 0;
     padding: 32px;
     color: #6f7688;
-    overflow: hidden;
     width: 100%;
     
 }
 
 PackageDescription HtmlPanel
 {
-    flex-grow: 1;
+    flex-grow: 0;
     flex-shrink: 0;
 }
 

--- a/game/addons/menu/Code/Modals/PackageModals/Components/PackageReviews.razor.scss
+++ b/game/addons/menu/Code/Modals/PackageModals/Components/PackageReviews.razor.scss
@@ -1,24 +1,18 @@
 PackageReviews
 {
     flex-direction: column;
+    flex-shrink: 0;
+    max-width: 100%;
+    width: 100%;
 }
 
 PackageReviews .review-list
 {
     flex-direction: column;
     padding: 32px;
-    flex-shrink: 1;
-    gap: 1rem;
-    overflow: hidden;
-    width: 100%;
-}
-
-PackageReviews
-{
-    overflow: hidden;
-    max-width: 100%;
-    overflow-y: scroll;
     flex-shrink: 0;
+    gap: 1rem;
+    width: 100%;
 }
 
 PackageReviews > h2


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Fixes scrolling in the menu package modal so users can read the full game overview and more than a few reviews.

## Motivation & Context

The game overview and reviews page in the menu couldn't be scrolled, which meant long descriptions and review lists were getting cut off.

Fixes: N/A

## Implementation Details

This change removes the nested scroll behavior inside the package modal content and lets the main content area handle vertical scrolling.

It also updates the overview, reviews, and portal target layout styles so the content can grow to its full height instead of being clipped inside a shrinking flex container.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/d3590eab-119c-432e-831e-616ead75589f

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂