### PR TITLE
Add custom code editor option with browse button

### DIFF
--- a/game/addons/tools/Code/CodeEditors/CodeEditor.Custom.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditor.Custom.cs
@@ -1,0 +1,52 @@
+namespace Editor.CodeEditors;
+
+/// <summary>
+/// Opens source files with a user-picked executable. The path is persisted in
+/// an editor cookie and is configured via the browse button on the code editor
+/// control. Useful as a fallback when Visual Studio / Rider / VS Code aren't
+/// installed, or for any editor not covered by a dedicated <see cref="ICodeEditor"/>.
+/// </summary>
+[Title( "Custom" )]
+[Description( "Manually selected code editor" )]
+public class CustomCodeEditor : ICodeEditor
+{
+	public static string CustomPath
+	{
+		get => EditorCookie.GetString( "CodeEditor.CustomPath", "" );
+		set => EditorCookie.SetString( "CodeEditor.CustomPath", value );
+	}
+
+	/// <summary>
+	/// Opens the file in the custom editor. <paramref name="line"/> and
+	/// <paramref name="column"/> are ignored — the argument syntax to jump to a
+	/// line varies per editor (<c>path:line:col</c>, <c>-n{line}</c>, <c>+line</c>)
+	/// and can't be predicted for an arbitrary executable.
+	/// </summary>
+	public void OpenFile( string path, int? line = null, int? column = null )
+		=> Launch( $"\"{path}\"" );
+
+	public void OpenSolution()
+		=> Launch( $"\"{CodeEditor.AddonSolutionPath()}\"" );
+
+	public void OpenAddon( Project addon )
+		=> OpenSolution();
+
+	public bool IsInstalled()
+	{
+		var path = CustomPath;
+		return !string.IsNullOrEmpty( path ) && System.IO.File.Exists( path );
+	}
+
+	private void Launch( string arguments )
+	{
+		var exe = CustomPath;
+		if ( string.IsNullOrEmpty( exe ) ) return;
+
+		System.Diagnostics.Process.Start( new System.Diagnostics.ProcessStartInfo
+		{
+			FileName = exe,
+			Arguments = arguments,
+			CreateNoWindow = true,
+		} );
+	}
+}

--- a/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
+++ b/game/addons/tools/Code/CodeEditors/CodeEditorControlWidget.cs
@@ -1,4 +1,6 @@
-﻿
+
+using Editor.CodeEditors;
+
 namespace Editor;
 
 [CustomEditor( typeof( ICodeEditor ) )]
@@ -7,6 +9,8 @@ public class CodeEditorControlWidget : ControlWidget
 	public CodeEditorControlWidget( SerializedProperty property ) : base( property )
 	{
 		Layout = Layout.Row();
+		Layout.Spacing = 4;
+		Layout.Margin = new Sandbox.UI.Margin( 0, 0, 4, 0 );
 
 		var comboBox = new ComboBox( this );
 
@@ -24,6 +28,9 @@ public class CodeEditorControlWidget : ControlWidget
 		{
 			if ( codeEditor.TargetType == typeof( ICodeEditor ) ) continue;
 
+			// Skip CustomCodeEditor from auto-discovery, we handle it separately
+			if ( codeEditor.TargetType == typeof( CustomCodeEditor ) ) continue;
+
 			var instance = codeEditor.Create<ICodeEditor>();
 
 			comboBox.AddItem(
@@ -36,11 +43,82 @@ public class CodeEditorControlWidget : ControlWidget
 			);
 		}
 
-		if ( CodeEditor.Current is not null )
+		// If a custom editor path is configured, add it with the exe name
+		var customPath = CustomCodeEditor.CustomPath;
+		if ( !string.IsNullOrEmpty( customPath ) )
 		{
-			comboBox.TrySelectNamed( DisplayInfo.ForType( CodeEditor.Current.GetType() ).Name );
+			var exeName = System.IO.Path.GetFileNameWithoutExtension( customPath );
+			comboBox.AddItem(
+				exeName,
+				null,
+				() => property.SetValue( new CustomCodeEditor() ),
+				customPath,
+				false,
+				System.IO.File.Exists( customPath )
+			);
 		}
 
-		Layout.Add( comboBox );
+		if ( CodeEditor.Current is not null )
+		{
+			if ( CodeEditor.Current is CustomCodeEditor && !string.IsNullOrEmpty( customPath ) )
+			{
+				comboBox.TrySelectNamed( System.IO.Path.GetFileNameWithoutExtension( customPath ) );
+			}
+			else
+			{
+				comboBox.TrySelectNamed( DisplayInfo.ForType( CodeEditor.Current.GetType() ).Name );
+			}
+		}
+
+		Layout.Add( comboBox, 1 );
+		Layout.Add( new IconButton( "more_horiz", () => BrowseForEditor( property, comboBox ) )
+		{
+			ToolTip = "Browse for a code editor executable"
+		} );
+	}
+
+	private void BrowseForEditor( SerializedProperty property, ComboBox comboBox )
+	{
+		var fd = new FileDialog( null )
+		{
+			Title = "Select Code Editor",
+		};
+
+		if ( OperatingSystem.IsWindows() )
+		{
+			fd.DefaultSuffix = ".exe";
+			fd.SetNameFilter( "Executables (*.exe)" );
+		}
+		else
+		{
+			fd.SetNameFilter( "All files (*)" );
+		}
+
+		fd.SetFindExistingFile();
+		fd.SetModeOpen();
+
+		if ( !fd.Execute() ) return;
+
+		var selectedPath = fd.SelectedFile;
+		if ( string.IsNullOrEmpty( selectedPath ) ) return;
+
+		CustomCodeEditor.CustomPath = selectedPath;
+
+		var exeName = System.IO.Path.GetFileNameWithoutExtension( selectedPath );
+
+		if ( comboBox.FindIndex( exeName ) is null )
+		{
+			comboBox.AddItem(
+				exeName,
+				null,
+				() => property.SetValue( new CustomCodeEditor() ),
+				selectedPath,
+				false,
+				true
+			);
+		}
+
+		property.SetValue( new CustomCodeEditor() );
+		comboBox.TrySelectNamed( exeName );
 	}
 }


### PR DESCRIPTION
## Summary

Adds a browse button ("...") next to the code editor dropdown in preferences, letting you manually point to any editor executable. Useful when auto-detection fails, the editor isn't one of the bundled options, or you have a custom install.

## Motivation & Context

The current dropdown only lists Visual Studio, Rider, and VS Code, detected via the Windows registry. This doesn't cover:

- Editors not on the list (Sublime, Fleet, Zed, Vim/Neovim, Emacs, etc.)
- Portable / non-standard installs that skip registry entries
- Users on Linux, where registry-based detection doesn't apply

This PR is a simple fallback for all those cases.

## Implementation Details

- New `CustomCodeEditor` class implementing `ICodeEditor`. Path persisted in `EditorCookie` under the key `CodeEditor.CustomPath`.
- Browse button added to `CodeEditorControlWidget` using `IconButton` + `FileDialog` — same pattern as `FilePathControlWidget` in MovieMaker.
- `FileDialog` filter is platform-aware: `*.exe` on Windows, `All files (*)` elsewhere.
- `CustomCodeEditor` is intentionally excluded from auto-discovery in `CodeEditorControlWidget`; the entry only appears once the user has picked a path, and it's labeled with the selected exe name so multiple picks are distinguishable.
- `line` / `column` parameters on `OpenFile` are intentionally ignored (documented with an XML comment) — the jump-to-line argument syntax varies per editor (`path:line:col`, `-n{line}`, `+line`, ...) and can't be predicted for an arbitrary executable.

## Screenshots / Videos

https://github.com/user-attachments/assets/8b44ff0d-e338-4fe8-8e6e-acefbe7f8aea

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙏