### PR TITLE
Linux fix case-sensitive filesystem errors

### DIFF
--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
@@ -165,6 +165,11 @@ public sealed partial class Project
 	}
 
 	/// <summary>
+	/// Absolute path of a folder
+	/// </summary>
+	private string FindPlatformPath( params string[] args ) => SandboxSystemExtensions.FindPlatformPath( args );
+
+	/// <summary>
 	/// Absolute path to the location of the <c>.sbproj</c> file of the project.
 	/// </summary>
 	public string GetRootPath() => RootDirectory.FullName;
@@ -178,7 +183,7 @@ public sealed partial class Project
 	/// <summary>
 	/// Absolute path to the Code folder of the project.
 	/// </summary>
-	public string GetCodePath() => System.IO.Path.Combine( RootDirectory.FullName, "Code" );
+	public string GetCodePath() => FindPlatformPath( RootDirectory.FullName, "Code" );
 
 	/// <summary>
 	/// Returns true if the Code path exists
@@ -188,7 +193,7 @@ public sealed partial class Project
 	/// <summary>
 	/// Absolute path to the Editor folder of the project.
 	/// </summary>
-	public string GetEditorPath() => System.IO.Path.Combine( RootDirectory.FullName, "Editor" );
+	public string GetEditorPath() => FindPlatformPath( RootDirectory.FullName, "Editor" );
 
 	/// <summary>
 	/// Returns true if the Editor path exists
@@ -198,13 +203,13 @@ public sealed partial class Project
 	/// <summary>
 	/// Absolute path to the Assets folder of the project, or <see langword="null"/> if not set.
 	/// </summary>
-	public string GetAssetsPath() => System.IO.Path.Combine( RootDirectory.FullName, "Assets" );
+	public string GetAssetsPath() => FindPlatformPath( RootDirectory.FullName, "Assets" );
 
 	/// <summary>
 	/// Absolute path to the Localization folder of the project, or <see langword="null"/> if not set.
 	/// </summary>
 	/// <returns></returns>
-	public string GetLocalizationPath() => System.IO.Path.Combine( RootDirectory.FullName, "Localization" );
+	public string GetLocalizationPath() => FindPlatformPath( RootDirectory.FullName, "Localization" );
 
 	/// <summary>
 	/// Returns true if the Assets path exists

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -602,12 +602,8 @@ public class BaseFileSystem
 		if ( path.Length < 1 )
 			return "/";
 
-		if ( Platform.IsLinux() && system != null )
-		{
-			var before = path.NormalizeFilename( true );
-			path = Platform.BuildZioPath( system, before );
-			Log.Info( $"[FixPath] '{before}' -> '{path}'" );
-		}
+		if ( Platform.IsLinuxPlatform() && system != null ) // resolves linux filesystem misses
+			path = Platform.BuildZioPath( system, path );
 
 		if ( path[0] == '/' ) return path;
 		return string.Concat( "/", path );

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Text.Json;
 using Zio.FileSystems;
 
@@ -427,7 +427,7 @@ public class BaseFileSystem
 		if ( !WatchEnabled )
 			return;
 
-		path = NormalizeFilename ( path );
+		path = NormalizeFilename( path );
 
 		// Ignore common visual studio spam
 		if ( path.EndsWith( ".tmp" ) || path.EndsWith( "~" ) )

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Text.Json;
 using Zio.FileSystems;
 
@@ -222,7 +222,7 @@ public class BaseFileSystem
 	internal string GetRelativePath( string path )
 	{
 		if ( string.IsNullOrWhiteSpace( path ) ) return null;
-		return GetRelativePath( system, path.ToLowerInvariant() );
+		return GetRelativePath( system, NormalizeFilename( path ) );
 	}
 
 	/// <summary>
@@ -427,7 +427,7 @@ public class BaseFileSystem
 		if ( !WatchEnabled )
 			return;
 
-		path = path.ToLower();
+		path = NormalizeFilename ( path );
 
 		// Ignore common visual studio spam
 		if ( path.EndsWith( ".tmp" ) || path.EndsWith( "~" ) )
@@ -594,13 +594,20 @@ public class BaseFileSystem
 	/// <summary>
 	/// Zio wants good paths to start with '/' - so we add it here if it isn't already on
 	/// </summary>
-	internal static string FixPath( string path )
+	internal string FixPath( string path )
 	{
 		// Do not allow 0-32 ASCII stuff
 		if ( path.Any( c => char.IsControl( c ) ) ) throw new ArgumentException( "Path cannot contain control characters!", "path" );
 
 		if ( path.Length < 1 )
 			return "/";
+
+		if ( Platform.IsLinux() && system != null )
+		{
+			path = Platform.BuildZioPath( system, path.NormalizeFilename( true ) );
+			var exists = system.FileExists( path ) || system.DirectoryExists( path );
+			Log.Info( $"[Ext4] FixPath: '{path}' exists={exists}" );
+		}
 
 		if ( path[0] == '/' ) return path;
 		return string.Concat( "/", path );
@@ -611,6 +618,6 @@ public class BaseFileSystem
 	/// </summary>
 	internal static string NormalizeFilename( string filepath )
 	{
-		return filepath.ToLower().Replace( "\\", "/" ); // we can probably do more here
+		return filepath.NormalizeFilename( true );
 	}
 }

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -604,9 +604,9 @@ public class BaseFileSystem
 
 		if ( Platform.IsLinux() && system != null )
 		{
-			path = Platform.BuildZioPath( system, path.NormalizeFilename( true ) );
-			var exists = system.FileExists( path ) || system.DirectoryExists( path );
-			Log.Info( $"[Ext4] FixPath: '{path}' exists={exists}" );
+			var before = path.NormalizeFilename( true );
+			path = Platform.BuildZioPath( system, before );
+			Log.Info( $"[FixPath] '{before}' -> '{path}'" );
 		}
 
 		if ( path[0] == '/' ) return path;

--- a/engine/Sandbox.Filesystem/LocalFileSystem.cs
+++ b/engine/Sandbox.Filesystem/LocalFileSystem.cs
@@ -11,7 +11,7 @@ internal class LocalFileSystem : BaseFileSystem
 	{
 		Physical = new Zio.FileSystems.PhysicalFileSystem();
 
-		var rootPath = Physical.ConvertPathFromInternal( rootFolder.ToLowerInvariant() );
+		var rootPath = Physical.ConvertPathFromInternal( rootFolder.NormalizeFilename( false ) ); // setting to true will prepend a '/' in front of C:
 		system = new Zio.FileSystems.SubFileSystem( Physical, rootPath );
 
 		if ( makereadonly )

--- a/engine/Sandbox.Filesystem/Platform/Linux.cs
+++ b/engine/Sandbox.Filesystem/Platform/Linux.cs
@@ -8,17 +8,22 @@ namespace Sandbox;
 /// </summary>
 internal static partial class Platform
 {
-	internal static bool IsLinux() => SandboxSystemExtensions.IsLinuxPlatform(); // returns true if running a linux filesystem
-	internal static System.Collections.Concurrent.ConcurrentDictionary<string, string> directoryCache = new( StringComparer.Ordinal ); // manages duplicate calls to same file
+	private static System.Collections.Concurrent.ConcurrentDictionary<string, string> directoryCache = new( StringComparer.Ordinal ); // manages duplicate calls to same file
+	private static bool PathExists( Zio.IFileSystem system, string path ) =>  ( system.DirectoryExists( path ) || system.FileExists( path ) ) ? true : false;
+	internal static bool IsLinuxPlatform() => SandboxSystemExtensions.IsLinuxPlatform(); // returns true if running a linux filesystem
 
+	/// <summary>
+	/// Rebuilds false missing file-paths by finding their uppercase variant
+	/// on case-sensitive Linux machines
+	/// </summary>
+	/// <param name="system"></param>
+	/// <param name="path"></param>
+	/// <returns></returns>
 	internal static string BuildZioPath( Zio.IFileSystem system, string path )
 	{
-		// ui imports are often hardcoded lowercase. this checks for lowercase only files
-		// and manages uppercase walks if needed. skip existing files.
-		var original = path;
-		path = path.ToLowerInvariant();
+		path = path.NormalizeFilename( true );
 
-		if ( system.DirectoryExists( path ) || system.FileExists( path ) )
+		if ( PathExists( system, path ) )
 			return path;
 
 		if ( directoryCache.TryGetValue( path, out var cached ) )
@@ -27,12 +32,14 @@ internal static partial class Platform
 		var segments = path.Trim('/').Split( '/', StringSplitOptions.RemoveEmptyEntries );
 		var resolved = ResolveCaseInsensitive( system, segments, path );
 
-		if ( resolved != path )
+		if ( !directoryCache.ContainsKey(path) && PathExists( system, resolved ) ) // don't cache missing paths
 		{
+			Log.Info($"[Platform] Cache resolved ... {path} -> {resolved}");
 			directoryCache.TryAdd( path, resolved );
-			Log.Info( $"[BuildZioPath] '{original}' -> '{resolved}'" );
 		}
+			
 
+		// return all paths, even nonexistent. possible directory or file creation
 		return resolved;
 	}
 
@@ -51,6 +58,6 @@ internal static partial class Platform
 			current = match;
 		}
 
-		return current.FullName;
+		return current.FullName.NormalizeFilename();
 	}
 }

--- a/engine/Sandbox.Filesystem/Platform/Linux.cs
+++ b/engine/Sandbox.Filesystem/Platform/Linux.cs
@@ -15,6 +15,7 @@ internal static partial class Platform
 	{
 		// ui imports are often hardcoded lowercase. this checks for lowercase only files
 		// and manages uppercase walks if needed. skip existing files.
+		var original = path;
 		path = path.ToLowerInvariant();
 
 		if ( system.DirectoryExists( path ) || system.FileExists( path ) )
@@ -27,7 +28,10 @@ internal static partial class Platform
 		var resolved = ResolveCaseInsensitive( system, segments, path );
 
 		if ( resolved != path )
+		{
 			directoryCache.TryAdd( path, resolved );
+			Log.Info( $"[BuildZioPath] '{original}' -> '{resolved}'" );
+		}
 
 		return resolved;
 	}

--- a/engine/Sandbox.Filesystem/Platform/Linux.cs
+++ b/engine/Sandbox.Filesystem/Platform/Linux.cs
@@ -1,0 +1,52 @@
+
+
+namespace Sandbox;
+
+/// <summary>
+/// Manages BaseFileSystem calls on Linux machines. Takes case-insensitive NTFS paths and
+/// rebuilds them to their case-sensitive variants.
+/// </summary>
+internal static partial class Platform
+{
+	internal static bool IsLinux() => SandboxSystemExtensions.IsLinuxPlatform(); // returns true if running a linux filesystem
+	internal static System.Collections.Concurrent.ConcurrentDictionary<string, string> directoryCache = new( StringComparer.Ordinal ); // manages duplicate calls to same file
+
+	internal static string BuildZioPath( Zio.IFileSystem system, string path )
+	{
+		// ui imports are often hardcoded lowercase. this checks for lowercase only files
+		// and manages uppercase walks if needed. skip existing files.
+		path = path.ToLowerInvariant();
+
+		if ( system.DirectoryExists( path ) || system.FileExists( path ) )
+			return path;
+
+		if ( directoryCache.TryGetValue( path, out var cached ) )
+			return cached;
+
+		var segments = path.Trim('/').Split( '/', StringSplitOptions.RemoveEmptyEntries );
+		var resolved = ResolveCaseInsensitive( system, segments, path );
+
+		if ( resolved != path )
+			directoryCache.TryAdd( path, resolved );
+
+		return resolved;
+	}
+
+	private static string ResolveCaseInsensitive( Zio.IFileSystem system, string[] segments, string fallback )
+	{
+		var current = Zio.UPath.Root;
+
+		foreach ( var segment in segments )
+		{
+			var match = system.EnumeratePaths( current, "*", System.IO.SearchOption.TopDirectoryOnly, Zio.SearchTarget.Both )
+				.FirstOrDefault( e => string.Equals( System.IO.Path.GetFileName( e.FullName ), segment, StringComparison.OrdinalIgnoreCase ) );
+
+			if ( match == default )
+				return fallback;
+
+			current = match;
+		}
+
+		return current.FullName;
+	}
+}

--- a/engine/Sandbox.Filesystem/Platform/Linux.cs
+++ b/engine/Sandbox.Filesystem/Platform/Linux.cs
@@ -9,7 +9,7 @@ namespace Sandbox;
 internal static partial class Platform
 {
 	private static System.Collections.Concurrent.ConcurrentDictionary<string, string> directoryCache = new( StringComparer.Ordinal ); // manages duplicate calls to same file
-	private static bool PathExists( Zio.IFileSystem system, string path ) =>  ( system.DirectoryExists( path ) || system.FileExists( path ) ) ? true : false;
+	private static bool PathExists( Zio.IFileSystem system, string path ) => (system.DirectoryExists( path ) || system.FileExists( path )) ? true : false;
 	internal static bool IsLinuxPlatform() => SandboxSystemExtensions.IsLinuxPlatform(); // returns true if running a linux filesystem
 
 	/// <summary>
@@ -29,15 +29,11 @@ internal static partial class Platform
 		if ( directoryCache.TryGetValue( path, out var cached ) )
 			return cached;
 
-		var segments = path.Trim('/').Split( '/', StringSplitOptions.RemoveEmptyEntries );
+		var segments = path.Trim( '/' ).Split( '/', StringSplitOptions.RemoveEmptyEntries );
 		var resolved = ResolveCaseInsensitive( system, segments, path );
 
-		if ( !directoryCache.ContainsKey(path) && PathExists( system, resolved ) ) // don't cache missing paths
-		{
-			Log.Info($"[Platform] Cache resolved ... {path} -> {resolved}");
+		if ( !directoryCache.ContainsKey( path ) && PathExists( system, resolved ) ) // don't cache missing paths
 			directoryCache.TryAdd( path, resolved );
-		}
-			
 
 		// return all paths, even nonexistent. possible directory or file creation
 		return resolved;

--- a/engine/Sandbox.System/Extend/PathExtensions.cs
+++ b/engine/Sandbox.System/Extend/PathExtensions.cs
@@ -5,171 +5,18 @@ namespace Sandbox;
 
 public static partial class SandboxSystemExtensions
 {
-    /// <summary>
-	/// Checks if the OS is Linux and assumes the filesystem is ext4
-	/// </summary>
-	/// <returns></returns>
-	public static bool IsLinuxPlatform() => OperatingSystem.IsLinux();
-
 	/// <summary>
-	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT); excludes case-sensitive filesystems
+	/// Resolves paths for the current platform. On Linux, performs case-insensitive segment walking.
+	/// When <paramref name="resolveBasePath"/> is true, the first path is trusted as-is and only
+	/// the remaining paths are walked. When false, all paths including the first are walked.
+	/// Use only for full system to engine subroot paths
 	/// </summary>
-	public static string NormalizeFilename( this string str, bool enforceInitialSlash = true ) => NormalizeFilename( str, enforceInitialSlash, true, '/' );
-
-	/// <summary>
-	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT; excludes case-sensitive filesystems
-	/// </summary>
-	public static string NormalizeFilename( this string str, bool enforceInitialSlash, bool enforceLowerCase, char targetSeparator = '/' )
+	public static string FindPlatformPath( bool resolveBasePath, params string[] parts )
 	{
-		if ( IsLinuxPlatform() ) enforceLowerCase = false;
+		if ( parts.Length == 0 ) return string.Empty;
 
-		if ( str.Length == 0 )
-		{
-			return enforceInitialSlash ? string.Create( 1, targetSeparator, static ( span, sep ) => span[0] = sep ) : str;
-		}
-
-		var startsWithSeparator = str[0] == targetSeparator || str[0] == '/' || str[0] == '\\';
-		var addLeadingSeparator = enforceInitialSlash && !startsWithSeparator;
-
-		var resultLength = str.Length + (addLeadingSeparator ? 1 : 0);
-		return string.Create( resultLength, (str, addLeadingSeparator, enforceLowerCase, targetSeparator), static ( span, state ) =>
-		{
-			var (source, addSep, lowerCase, sep) = state;
-			var dest = 0;
-
-			if ( addSep )
-			{
-				span[dest++] = sep;
-			}
-
-			for ( var i = 0; i < source.Length; i++ )
-			{
-				var c = source[i];
-
-				if ( c == '/' || c == '\\' )
-				{
-					c = sep;
-				}
-
-				if ( lowerCase )
-				{
-					c = char.ToLowerInvariant( c );
-				}
-
-				span[dest++] = c;
-			}
-		} );
-	}
-
-	/// <summary>
-	/// Adds or replaces the extension of <paramref name="path"/> to <paramref name="ext"/>.
-	/// </summary>
-	/// <param name="path">A file path with or without an extension.</param>
-	/// <param name="ext">A file extension with or without a leading period.</param>
-	/// <returns></returns>
-	public static string WithExtension( this string path, string ext )
-	{
-		ArgumentNullException.ThrowIfNull( path, nameof( path ) );
-		ArgumentNullException.ThrowIfNull( ext, nameof( ext ) );
-
-		if ( !ext.StartsWith( '.' ) ) ext = $".{ext}";
-
-		var curExt = Path.GetExtension( path );
-
-		if ( string.Equals( curExt, ext, StringComparison.OrdinalIgnoreCase ) )
-		{
-			return path;
-		}
-
-		return $"{path[..^curExt.Length]}{ext}";
-	}
-
-	static Regex simplifyregex = new Regex( @"[^\\/]+(?<!\.\.)[\\/]\.\.[\\/]", RegexOptions.Compiled );
-
-	/// <summary>
-	/// Gets rid of ../'s (from /path/folder/../file.txt to /path/file.txt)
-	/// </summary>
-	/// <param name="str"></param>
-	/// <returns></returns>
-	public static string SimplifyPath( this string str )
-	{
-		while ( true )
-		{
-			var newPath = simplifyregex.Replace( str, "" );
-			if ( newPath == str ) break;
-			str = newPath;
-		}
-		return str;
-	}
-
-    private static char[] FilenameDelim = new[] { '/', '\\' };
-
-	/// <summary>
-	/// If the string is longer than this amount of characters then truncate it
-	/// If appendage is defined, it will be appended to the end of truncated strings (ie, "..")
-	/// </summary>
-	public static string TruncateFilename( this string str, int maxLength, string appendage = null )
-	{
-		if ( string.IsNullOrEmpty( str ) ) return str;
-		if ( str.Length <= maxLength ) return str;
-
-		maxLength -= 3; //account for delimiter spacing
-
-		string final;
-		List<string> parts;
-
-		int loops = 0;
-		while ( loops++ < 100 )
-		{
-			parts = str.Split( FilenameDelim ).ToList();
-			parts.RemoveRange( parts.Count - 1 - loops, loops );
-			if ( parts.Count == 1 )
-			{
-				return parts.Last();
-			}
-
-			parts.Insert( parts.Count - 1, "..." );
-			final = string.Join( "/", parts.ToArray() );
-			if ( final.Length < maxLength )
-			{
-				return final;
-			}
-		}
-
-		return str.Split( FilenameDelim ).ToList().Last();
-	}
-
-    /// <summary>
-	/// Make the passed in string filename safe. This replaces any invalid characters with "_".
-	/// </summary>
-	public static string GetFilenameSafe( this string input )
-	{
-		// Get the array of invalid characters
-		char[] invalidChars = Path.GetInvalidFileNameChars();
-
-		// Replace invalid characters with an underscore
-		return new string( input.Select( ch => invalidChars.Contains( ch ) ? '_' : ch ).ToArray() );
-	}
-
-
-	/// <summary>
-	/// Resolves partial paths on a root for Windows and non-Windows operating systems.
-	/// </summary>
-	/// <param name="parts">First argument must be a root path.</param>
-    public static string FindPlatformPath( params string[] parts ) => FindPlatformPath( true, parts );
-
-	/// <summary>
-	/// Resolves paths for Windows and non-Windows operating systems.
-	/// Use to segment walk a full path instead of partial only.
-	/// </summary>
-	public static string FindPlatformPath( bool enforceBasePath = true, params string[] parts )
-	{
-        // you need to make it so that the first argument is a rootpath
-        // its safer and doesn't need to be walked up
-        // only the partial paths needs to be managed properly
-		// Normalize filename takes care of \\ to /
 		// set normalize to false to prevent a prepended / on C: root
-		var combined = Path.Combine( parts ).NormalizeFilename( false ); 
+		var combined = Path.Combine( parts ).NormalizeFilename( false );
 
 		if ( !IsLinuxPlatform() )
 			return combined;
@@ -177,26 +24,24 @@ public static partial class SandboxSystemExtensions
 		if ( Directory.Exists( combined ) || File.Exists( combined ) )
 			return combined;
 
-		var resolved = ResolveCaseInsensitive( enforceBasePath, parts ) ?? combined;
+		var current = resolveBasePath ? parts[0] : string.Empty;
+		var toWalk = resolveBasePath ? parts[1..] : parts;
+
+		var resolved = ResolveCaseInsensitive( current, toWalk ) ?? combined;
 		Log.Info( $"[FindPlatformPath] '{combined}' -> '{resolved}'" );
 		return resolved;
 	}
 
-	private static string ResolveCaseInsensitive( bool enforceBasePath, params string[] parts )
+	/// <summary>
+	/// Resolves paths for the current platform, treating the first path as a trusted base.
+	/// </summary>
+	public static string FindPlatformPath( params string[] parts ) => FindPlatformPath( true, parts );
+
+	private static string ResolveCaseInsensitive( string current, string[] parts )
 	{
-		// enforcing a base path prevents a full walk
-		// means first string option will not be walked,
-		// and only the partial path is walked in sbox-public directory
-		if ( parts.Length == 0 ) return null;
-
-		var current = enforceBasePath ? parts[0] : string.Empty;
-		var partials = enforceBasePath ? parts.AsSpan( 1 ) : parts.AsSpan();
-
-		foreach ( var part in partials )
+		foreach ( var part in parts )
 		{
-			var segments = part.ToLowerInvariant().Split( '/', StringSplitOptions.RemoveEmptyEntries );
-
-			foreach ( var segment in segments )
+			foreach ( var segment in part.Split( '/', StringSplitOptions.RemoveEmptyEntries ) )
 			{
 				if ( !Directory.Exists( current ) )
 					return null;

--- a/engine/Sandbox.System/Extend/PathExtensions.cs
+++ b/engine/Sandbox.System/Extend/PathExtensions.cs
@@ -177,7 +177,9 @@ public static partial class SandboxSystemExtensions
 		if ( Directory.Exists( combined ) || File.Exists( combined ) )
 			return combined;
 
-		return ResolveCaseInsensitive( enforceBasePath, parts ) ?? combined;
+		var resolved = ResolveCaseInsensitive( enforceBasePath, parts ) ?? combined;
+		Log.Info( $"[FindPlatformPath] '{combined}' -> '{resolved}'" );
+		return resolved;
 	}
 
 	private static string ResolveCaseInsensitive( bool enforceBasePath, params string[] parts )

--- a/engine/Sandbox.System/Extend/PathExtensions.cs
+++ b/engine/Sandbox.System/Extend/PathExtensions.cs
@@ -1,0 +1,212 @@
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Sandbox;
+
+public static partial class SandboxSystemExtensions
+{
+    /// <summary>
+	/// Checks if the OS is Linux and assumes the filesystem is ext4
+	/// </summary>
+	/// <returns></returns>
+	public static bool IsLinuxPlatform() => OperatingSystem.IsLinux();
+
+	/// <summary>
+	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT); excludes case-sensitive filesystems
+	/// </summary>
+	public static string NormalizeFilename( this string str, bool enforceInitialSlash = true ) => NormalizeFilename( str, enforceInitialSlash, true, '/' );
+
+	/// <summary>
+	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT; excludes case-sensitive filesystems
+	/// </summary>
+	public static string NormalizeFilename( this string str, bool enforceInitialSlash, bool enforceLowerCase, char targetSeparator = '/' )
+	{
+		if ( IsLinuxPlatform() ) enforceLowerCase = false;
+
+		if ( str.Length == 0 )
+		{
+			return enforceInitialSlash ? string.Create( 1, targetSeparator, static ( span, sep ) => span[0] = sep ) : str;
+		}
+
+		var startsWithSeparator = str[0] == targetSeparator || str[0] == '/' || str[0] == '\\';
+		var addLeadingSeparator = enforceInitialSlash && !startsWithSeparator;
+
+		var resultLength = str.Length + (addLeadingSeparator ? 1 : 0);
+		return string.Create( resultLength, (str, addLeadingSeparator, enforceLowerCase, targetSeparator), static ( span, state ) =>
+		{
+			var (source, addSep, lowerCase, sep) = state;
+			var dest = 0;
+
+			if ( addSep )
+			{
+				span[dest++] = sep;
+			}
+
+			for ( var i = 0; i < source.Length; i++ )
+			{
+				var c = source[i];
+
+				if ( c == '/' || c == '\\' )
+				{
+					c = sep;
+				}
+
+				if ( lowerCase )
+				{
+					c = char.ToLowerInvariant( c );
+				}
+
+				span[dest++] = c;
+			}
+		} );
+	}
+
+	/// <summary>
+	/// Adds or replaces the extension of <paramref name="path"/> to <paramref name="ext"/>.
+	/// </summary>
+	/// <param name="path">A file path with or without an extension.</param>
+	/// <param name="ext">A file extension with or without a leading period.</param>
+	/// <returns></returns>
+	public static string WithExtension( this string path, string ext )
+	{
+		ArgumentNullException.ThrowIfNull( path, nameof( path ) );
+		ArgumentNullException.ThrowIfNull( ext, nameof( ext ) );
+
+		if ( !ext.StartsWith( '.' ) ) ext = $".{ext}";
+
+		var curExt = Path.GetExtension( path );
+
+		if ( string.Equals( curExt, ext, StringComparison.OrdinalIgnoreCase ) )
+		{
+			return path;
+		}
+
+		return $"{path[..^curExt.Length]}{ext}";
+	}
+
+	static Regex simplifyregex = new Regex( @"[^\\/]+(?<!\.\.)[\\/]\.\.[\\/]", RegexOptions.Compiled );
+
+	/// <summary>
+	/// Gets rid of ../'s (from /path/folder/../file.txt to /path/file.txt)
+	/// </summary>
+	/// <param name="str"></param>
+	/// <returns></returns>
+	public static string SimplifyPath( this string str )
+	{
+		while ( true )
+		{
+			var newPath = simplifyregex.Replace( str, "" );
+			if ( newPath == str ) break;
+			str = newPath;
+		}
+		return str;
+	}
+
+    private static char[] FilenameDelim = new[] { '/', '\\' };
+
+	/// <summary>
+	/// If the string is longer than this amount of characters then truncate it
+	/// If appendage is defined, it will be appended to the end of truncated strings (ie, "..")
+	/// </summary>
+	public static string TruncateFilename( this string str, int maxLength, string appendage = null )
+	{
+		if ( string.IsNullOrEmpty( str ) ) return str;
+		if ( str.Length <= maxLength ) return str;
+
+		maxLength -= 3; //account for delimiter spacing
+
+		string final;
+		List<string> parts;
+
+		int loops = 0;
+		while ( loops++ < 100 )
+		{
+			parts = str.Split( FilenameDelim ).ToList();
+			parts.RemoveRange( parts.Count - 1 - loops, loops );
+			if ( parts.Count == 1 )
+			{
+				return parts.Last();
+			}
+
+			parts.Insert( parts.Count - 1, "..." );
+			final = string.Join( "/", parts.ToArray() );
+			if ( final.Length < maxLength )
+			{
+				return final;
+			}
+		}
+
+		return str.Split( FilenameDelim ).ToList().Last();
+	}
+
+    /// <summary>
+	/// Make the passed in string filename safe. This replaces any invalid characters with "_".
+	/// </summary>
+	public static string GetFilenameSafe( this string input )
+	{
+		// Get the array of invalid characters
+		char[] invalidChars = Path.GetInvalidFileNameChars();
+
+		// Replace invalid characters with an underscore
+		return new string( input.Select( ch => invalidChars.Contains( ch ) ? '_' : ch ).ToArray() );
+	}
+
+
+	/// <summary>
+	/// Resolves partial paths on a root for Windows and non-Windows operating systems.
+	/// </summary>
+	/// <param name="parts">First argument must be a root path.</param>
+    public static string FindPlatformPath( params string[] parts ) => FindPlatformPath( true, parts );
+
+	/// <summary>
+	/// Resolves paths for Windows and non-Windows operating systems.
+	/// Use to segment walk a full path instead of partial only.
+	/// </summary>
+	public static string FindPlatformPath( bool enforceBasePath = true, params string[] parts )
+	{
+        // you need to make it so that the first argument is a rootpath
+        // its safer and doesn't need to be walked up
+        // only the partial paths needs to be managed properly
+		// Normalize filename takes care of \\ to /
+		// set normalize to false to prevent a prepended / on C: root
+		var combined = Path.Combine( parts ).NormalizeFilename( false ); 
+
+		if ( !IsLinuxPlatform() )
+			return combined;
+
+		if ( Directory.Exists( combined ) || File.Exists( combined ) )
+			return combined;
+
+		return ResolveCaseInsensitive( enforceBasePath, parts ) ?? combined;
+	}
+
+	private static string ResolveCaseInsensitive( bool enforceBasePath, params string[] parts )
+	{
+		// enforcing a base path prevents a full walk
+		// means first string option will not be walked,
+		// and only the partial path is walked in sbox-public directory
+		if ( parts.Length == 0 ) return null;
+
+		var current = enforceBasePath ? parts[0] : string.Empty;
+		var partials = enforceBasePath ? parts.AsSpan( 1 ) : parts.AsSpan();
+
+		foreach ( var part in partials )
+		{
+			var segments = part.ToLowerInvariant().Split( '/', StringSplitOptions.RemoveEmptyEntries );
+
+			foreach ( var segment in segments )
+			{
+				if ( !Directory.Exists( current ) )
+					return null;
+
+				var match = Directory.EnumerateFileSystemEntries( current )
+					.FirstOrDefault( e => string.Equals( Path.GetFileName( e ), segment, StringComparison.OrdinalIgnoreCase ) );
+
+				if ( match is null ) return null;
+				current = match;
+			}
+		}
+
+		return current;
+	}
+}

--- a/engine/Sandbox.System/Extend/StringExtensions.cs
+++ b/engine/Sandbox.System/Extend/StringExtensions.cs
@@ -94,7 +94,7 @@ public static partial class SandboxSystemExtensions
 	/// </summary>
 	public static string NormalizeFilename( this string str, bool enforceInitialSlash, bool enforceLowerCase, char targetSeparator = '/' )
 	{
-		if ( IsLinuxPlatform() ) enforceLowerCase = false; 
+		if ( IsLinuxPlatform() ) enforceLowerCase = false;
 
 		if ( str.Length == 0 )
 		{

--- a/engine/Sandbox.System/Extend/StringExtensions.cs
+++ b/engine/Sandbox.System/Extend/StringExtensions.cs
@@ -79,7 +79,101 @@ public static partial class SandboxSystemExtensions
 		return str.Trim();
 	}
 
+	/// <summary>
+	/// Checks if the OS is Linux
+	/// </summary>
+	public static bool IsLinuxPlatform() => OperatingSystem.IsLinux();
 
+	/// <summary>
+	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT); excludes lowercasing linux filepaths
+	/// </summary>
+	public static string NormalizeFilename( this string str, bool enforceInitialSlash = true ) => NormalizeFilename( str, enforceInitialSlash, true, '/' );
+
+	/// <summary>
+	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT); excludes lowercasing linux filepaths
+	/// </summary>
+	public static string NormalizeFilename( this string str, bool enforceInitialSlash, bool enforceLowerCase, char targetSeparator = '/' )
+	{
+		if ( IsLinuxPlatform() ) enforceLowerCase = false; 
+
+		if ( str.Length == 0 )
+		{
+			return enforceInitialSlash ? string.Create( 1, targetSeparator, static ( span, sep ) => span[0] = sep ) : str;
+		}
+
+		var startsWithSeparator = str[0] == targetSeparator || str[0] == '/' || str[0] == '\\';
+		var addLeadingSeparator = enforceInitialSlash && !startsWithSeparator;
+
+		var resultLength = str.Length + (addLeadingSeparator ? 1 : 0);
+		return string.Create( resultLength, (str, addLeadingSeparator, enforceLowerCase, targetSeparator), static ( span, state ) =>
+		{
+			var (source, addSep, lowerCase, sep) = state;
+			var dest = 0;
+
+			if ( addSep )
+			{
+				span[dest++] = sep;
+			}
+
+			for ( var i = 0; i < source.Length; i++ )
+			{
+				var c = source[i];
+
+				if ( c == '/' || c == '\\' )
+				{
+					c = sep;
+				}
+
+				if ( lowerCase )
+				{
+					c = char.ToLowerInvariant( c );
+				}
+
+				span[dest++] = c;
+			}
+		} );
+	}
+
+	/// <summary>
+	/// Adds or replaces the extension of <paramref name="path"/> to <paramref name="ext"/>.
+	/// </summary>
+	/// <param name="path">A file path with or without an extension.</param>
+	/// <param name="ext">A file extension with or without a leading period.</param>
+	/// <returns></returns>
+	public static string WithExtension( this string path, string ext )
+	{
+		ArgumentNullException.ThrowIfNull( path, nameof( path ) );
+		ArgumentNullException.ThrowIfNull( ext, nameof( ext ) );
+
+		if ( !ext.StartsWith( '.' ) ) ext = $".{ext}";
+
+		var curExt = Path.GetExtension( path );
+
+		if ( string.Equals( curExt, ext, StringComparison.OrdinalIgnoreCase ) )
+		{
+			return path;
+		}
+
+		return $"{path[..^curExt.Length]}{ext}";
+	}
+
+	static Regex simplifyregex = new Regex( @"[^\\/]+(?<!\.\.)[\\/]\.\.[\\/]", RegexOptions.Compiled );
+
+	/// <summary>
+	/// Gets rid of ../'s (from /path/folder/../file.txt to /path/file.txt)
+	/// </summary>
+	/// <param name="str"></param>
+	/// <returns></returns>
+	public static string SimplifyPath( this string str )
+	{
+		while ( true )
+		{
+			var newPath = simplifyregex.Replace( str, "" );
+			if ( newPath == str ) break;
+			str = newPath;
+		}
+		return str;
+	}
 
 
 	static Regex splitregex = new Regex( "\"(?<1>[^\"]+)?\"|'(?<1>[^']+)?'|(?<1>\\S+)", RegexOptions.Compiled );
@@ -296,6 +390,44 @@ public static partial class SandboxSystemExtensions
 
 		return string.Concat( str, appendage );
 	}
+
+	private static char[] FilenameDelim = new[] { '/', '\\' };
+
+	/// <summary>
+	/// If the string is longer than this amount of characters then truncate it
+	/// If appendage is defined, it will be appended to the end of truncated strings (ie, "..")
+	/// </summary>
+	public static string TruncateFilename( this string str, int maxLength, string appendage = null )
+	{
+		if ( string.IsNullOrEmpty( str ) ) return str;
+		if ( str.Length <= maxLength ) return str;
+
+		maxLength -= 3; //account for delimiter spacing
+
+		string final;
+		List<string> parts;
+
+		int loops = 0;
+		while ( loops++ < 100 )
+		{
+			parts = str.Split( FilenameDelim ).ToList();
+			parts.RemoveRange( parts.Count - 1 - loops, loops );
+			if ( parts.Count == 1 )
+			{
+				return parts.Last();
+			}
+
+			parts.Insert( parts.Count - 1, "..." );
+			final = string.Join( "/", parts.ToArray() );
+			if ( final.Length < maxLength )
+			{
+				return final;
+			}
+		}
+
+		return str.Split( FilenameDelim ).ToList().Last();
+	}
+
 
 	/// <summary>
 	/// An extended Contains which takes a StringComparison.
@@ -792,6 +924,18 @@ public static partial class SandboxSystemExtensions
 			return false;
 
 		return true;
+	}
+
+	/// <summary>
+	/// Make the passed in string filename safe. This replaces any invalid characters with "_".
+	/// </summary>
+	public static string GetFilenameSafe( this string input )
+	{
+		// Get the array of invalid characters
+		char[] invalidChars = Path.GetInvalidFileNameChars();
+
+		// Replace invalid characters with an underscore
+		return new string( input.Select( ch => invalidChars.Contains( ch ) ? '_' : ch ).ToArray() );
 	}
 
 }

--- a/engine/Sandbox.System/Extend/StringExtensions.cs
+++ b/engine/Sandbox.System/Extend/StringExtensions.cs
@@ -79,94 +79,7 @@ public static partial class SandboxSystemExtensions
 		return str.Trim();
 	}
 
-	/// <summary>
-	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT)
-	/// </summary>
-	public static string NormalizeFilename( this string str, bool enforceInitialSlash = true ) => NormalizeFilename( str, enforceInitialSlash, true, '/' );
 
-	/// <summary>
-	/// Puts a filename into the format /path/filename.ext (from path\FileName.EXT)
-	/// </summary>
-	public static string NormalizeFilename( this string str, bool enforceInitialSlash, bool enforceLowerCase, char targetSeparator = '/' )
-	{
-		if ( str.Length == 0 )
-		{
-			return enforceInitialSlash ? string.Create( 1, targetSeparator, static ( span, sep ) => span[0] = sep ) : str;
-		}
-
-		var startsWithSeparator = str[0] == targetSeparator || str[0] == '/' || str[0] == '\\';
-		var addLeadingSeparator = enforceInitialSlash && !startsWithSeparator;
-
-		var resultLength = str.Length + (addLeadingSeparator ? 1 : 0);
-		return string.Create( resultLength, (str, addLeadingSeparator, enforceLowerCase, targetSeparator), static ( span, state ) =>
-		{
-			var (source, addSep, lowerCase, sep) = state;
-			var dest = 0;
-
-			if ( addSep )
-			{
-				span[dest++] = sep;
-			}
-
-			for ( var i = 0; i < source.Length; i++ )
-			{
-				var c = source[i];
-
-				if ( c == '/' || c == '\\' )
-				{
-					c = sep;
-				}
-
-				if ( lowerCase )
-				{
-					c = char.ToLowerInvariant( c );
-				}
-
-				span[dest++] = c;
-			}
-		} );
-	}
-
-	/// <summary>
-	/// Adds or replaces the extension of <paramref name="path"/> to <paramref name="ext"/>.
-	/// </summary>
-	/// <param name="path">A file path with or without an extension.</param>
-	/// <param name="ext">A file extension with or without a leading period.</param>
-	/// <returns></returns>
-	public static string WithExtension( this string path, string ext )
-	{
-		ArgumentNullException.ThrowIfNull( path, nameof( path ) );
-		ArgumentNullException.ThrowIfNull( ext, nameof( ext ) );
-
-		if ( !ext.StartsWith( '.' ) ) ext = $".{ext}";
-
-		var curExt = Path.GetExtension( path );
-
-		if ( string.Equals( curExt, ext, StringComparison.OrdinalIgnoreCase ) )
-		{
-			return path;
-		}
-
-		return $"{path[..^curExt.Length]}{ext}";
-	}
-
-	static Regex simplifyregex = new Regex( @"[^\\/]+(?<!\.\.)[\\/]\.\.[\\/]", RegexOptions.Compiled );
-
-	/// <summary>
-	/// Gets rid of ../'s (from /path/folder/../file.txt to /path/file.txt)
-	/// </summary>
-	/// <param name="str"></param>
-	/// <returns></returns>
-	public static string SimplifyPath( this string str )
-	{
-		while ( true )
-		{
-			var newPath = simplifyregex.Replace( str, "" );
-			if ( newPath == str ) break;
-			str = newPath;
-		}
-		return str;
-	}
 
 
 	static Regex splitregex = new Regex( "\"(?<1>[^\"]+)?\"|'(?<1>[^']+)?'|(?<1>\\S+)", RegexOptions.Compiled );
@@ -383,44 +296,6 @@ public static partial class SandboxSystemExtensions
 
 		return string.Concat( str, appendage );
 	}
-
-	private static char[] FilenameDelim = new[] { '/', '\\' };
-
-	/// <summary>
-	/// If the string is longer than this amount of characters then truncate it
-	/// If appendage is defined, it will be appended to the end of truncated strings (ie, "..")
-	/// </summary>
-	public static string TruncateFilename( this string str, int maxLength, string appendage = null )
-	{
-		if ( string.IsNullOrEmpty( str ) ) return str;
-		if ( str.Length <= maxLength ) return str;
-
-		maxLength -= 3; //account for delimiter spacing
-
-		string final;
-		List<string> parts;
-
-		int loops = 0;
-		while ( loops++ < 100 )
-		{
-			parts = str.Split( FilenameDelim ).ToList();
-			parts.RemoveRange( parts.Count - 1 - loops, loops );
-			if ( parts.Count == 1 )
-			{
-				return parts.Last();
-			}
-
-			parts.Insert( parts.Count - 1, "..." );
-			final = string.Join( "/", parts.ToArray() );
-			if ( final.Length < maxLength )
-			{
-				return final;
-			}
-		}
-
-		return str.Split( FilenameDelim ).ToList().Last();
-	}
-
 
 	/// <summary>
 	/// An extended Contains which takes a StringComparison.
@@ -917,18 +792,6 @@ public static partial class SandboxSystemExtensions
 			return false;
 
 		return true;
-	}
-
-	/// <summary>
-	/// Make the passed in string filename safe. This replaces any invalid characters with "_".
-	/// </summary>
-	public static string GetFilenameSafe( this string input )
-	{
-		// Get the array of invalid characters
-		char[] invalidChars = Path.GetInvalidFileNameChars();
-
-		// Replace invalid characters with an underscore
-		return new string( input.Select( ch => invalidChars.Contains( ch ) ? '_' : ch ).ToArray() );
 	}
 
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Re-upload
https://github.com/Facepunch/sbox-public/pull/10568

## Prerequisites
On Linux, a double-free error occurs and crashes the game. The provided shim is needed.
Make a launch.sh script -> https://pastebin.com/raw/TJSsuDxX
Make a no_double_free.c file -> https://pastebin.com/raw/9pcnqmdy
Put them in as -
sbox-public/game/launch.sh
sbox-public/game/no_double_free.c
Then run the launch script. The launch script manages a file location issue with libskiasharp and libharfbuzz by symlinking.

## Summary

Fixes:
* Project.cs not resolving Project subroots ( GetCodePath(), GetAssetsPath(), etc. ) due to hardcoded filepaths being lowercase.
* Zio not resolving hardcoded UI imports and some mismatched pathnames for assets.
* Explicit ToLowerInvariant calls forcing lowercase only roots on engine launchh

## Motivation & Context

Two main issues:
* Some file paths are hardcoded and need to be rebuilt.
* Some paths are forced lowercase and need to be normalized.

This builds the engine to run natively on Linux by redirecting case-insensitive filepaths to their case-sensitive variants to allow the game to launch to the menu. I managed ToLowerInvariant calls by using the existing "NormalizeFilename" in StringExtensions.cs. NormalizeFilename has a one-line change to check if the existing system is a Linux system, and assumes case-sensitivity. NormalizeFilename was a good solution, because it normalizes the entire path, not just a filename even though the method name is misleading. It also manages other NormalizeFilename calls on the engine already without having to create new case-sensitive wrappers for other parts of the base.

For incoming assets in BaseFileSystem that are lowercase, the path is rebuilt by a Zio resolver for Linux systems that segment walks the directory to find the uppercase variant.

## Implementation Details

StringExtensions.cs : NormalizeFilename() -> changes 1 line to check for Linux Operating systems and forces uppercase.
BaseFileSystem : FixPath() -> rebuilds filepath to uppercase variant by walking up the directory and enumerating the uppercase version for Linux systems using new class in Platform/Linux.cs
Project.cs : GetCodePath(), GetAssetsPath(), etc. -> Wrapped a managed path combine method that automatically returns the base path on NTFS filesystems, and walks the partial path on ext4 filesystems.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->


**Before.**
<img width="2336" height="612" alt="Screenshot from 2026-04-18 02-23-01" src="https://github.com/user-attachments/assets/34484d0c-41b3-4baa-b5ed-d73e2bcd6777" />


**After.**
<img width="1907" height="1103" alt="Screenshot from 2026-04-09 04-23-12" src="https://github.com/user-attachments/assets/84387e88-4b63-4b8c-97f0-a5617120373f" />

## Tests
Includes 5-6 logs of BuildZioPath method in Linux.cs : Sandbox.FileSystem
https://filebin.net/223pn5qin7z81i1z
In platform_path_cached.txt, caching was resolved to only 11 instances now by only caching paths that exist, but the log shows more entries because it was not updated.
PathExists limits caches from hundreds to less than 20.

## Potential Issues
I am highly confident the ERROR_FILEOPENs occurring in sbox.log are caused by the native engine casting lowercase only partial-paths. Source games are shipped with lowercase only files and directories. This likely done to make managing path lookups O(1) on any OS by doing a simple lowercase-only string compare. sbox could technically get shipped to Linux systems this way so little is needed for string comparison requirements. Casefolding is not an option, because the path has to be discovered in order for the engine to have something to compare it to. The Zio method was written more cleanly this time after Matt's thoughts.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂