### PR TITLE
Raise compile timeout from 60 to 120 seconds

### DIFF
--- a/engine/Sandbox.Compiling/CompileGroup.cs
+++ b/engine/Sandbox.Compiling/CompileGroup.cs
@@ -374,7 +374,7 @@ public class CompileGroup : IDisposable
 			// give it a few seconds to build..
 			//
 
-			const double timeoutSeconds = 60d;
+			const double timeoutSeconds = 120d;
 
 			var output = await compiler.GetCompileOutputAsync().WaitAsync( TimeSpan.FromSeconds( timeoutSeconds ) );
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

My game can no longer open in the editor due to compile timeout. Raising this timeout makes it open again.

## Motivation & Context

Big projects can no longer be opened

Fixes:

## Implementation Details

Just raised the timeout

## Screenshots / Videos (if applicable)

## Checklist

- [ x] Code follows existing style and conventions
- [ x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ x] I’m okay with this PR being rejected or requested to change 🙂