### PR TITLE
Fix storage page taking minutes to scan large caches

### DIFF
--- a/game/addons/menu/Code/Modals/Settings/Storage.razor
+++ b/game/addons/menu/Code/Modals/Settings/Storage.razor
@@ -171,7 +171,7 @@
             SizeBreakdown[type] += entry.Size;
 
 
-            if (sw.ElapsedMilliseconds > 1 )
+            if (sw.ElapsedMilliseconds > 16)
             {
                 sw.Restart();
                 await Task.DelayRealtime( 1 );


### PR DESCRIPTION
## Summary

The Storage settings page was taking a long time to scan my download caches.  The UI consumer in `Storage.razor` was awaiting `Task.DelayRealtime(1)` once per ~1ms of CPU work, and on Windows that bottoms out at the OS timer granularity (~15ms), so every yield was a full UI frame.

Bumped the yield threshold from 1ms to 16ms so the loop yields once per frame.

## Motivation & Context

On my 17.5GB local cache, the Storage page took ~2 minutes to calculate it all, with disk idle the whole time.

Fixes:

## Implementation Details

One line change in `game/addons/menu/Code/Modals/Settings/Storage.razor`:
```diff
- if (sw.ElapsedMilliseconds > 1 )
+ if (sw.ElapsedMilliseconds > 16)
```

## Screenshots / Videos (if applicable)

Not applicable

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change