### PR TITLE
Use correct tintMask in material output

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/Material/MaterialMenu.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/Material/MaterialMenu.cs
@@ -134,7 +134,7 @@ internal static class MaterialMenu
 		string tintMask = assetPeers.Where( x => x.Name.Contains( "_mask" ) ).Select( x => x.RelativePath ).FirstOrDefault();
 		if ( tintMask != null )
 		{
-			tintMask = $"\n	F_TINT_MASK 1\n	TextureTintMask \"{texSelfIllum}\"";
+			tintMask = $"\n	F_TINT_MASK 1\n	TextureTintMask \"{tintMask}\"";
 		}
 
 		var file = $@"


### PR DESCRIPTION
## Summary

Fix copy-paste bug in `MaterialMenu.CreateMaterialUsingImageFiles` where the `TextureTintMask` field was incorrectly using the `texSelfIllum` variable instead of the `tintMask` variable.

## Motivation & Context

When creating a material from image files via "Create Material" in the Asset Browser, if the selected images include a `_mask` texture, the generated `.vmat` would incorrectly assign the self-illum texture path to `TextureTintMask` instead of the actual tint mask texture path. This meant the tint mask was either wrong (pointing to the self-illum texture) or empty if no self-illum image existed.

## Implementation Details

Single-line fix on line 137 of `MaterialMenu.cs`: changed the string interpolation from `"{texSelfIllum}"` to `"{tintMask}"` so the `TextureTintMask` field uses the correct resolved path.

This follows the same pattern used by `texMetallic` and `texSelfIllum` blocks above, where each variable is reassigned to the full material property string containing its own path.

## Screenshots / Videos (if applicable)

N/A — no visual change, purely a logic fix in generated material file output.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂
