### PR TITLE
Addition of 'to' and 'from' control vectors to bridge tool UI

### DIFF
--- a/game/addons/tools/Code/Scene/Mesh/Tools/BridgeTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/BridgeTool.UI.cs
@@ -7,6 +7,8 @@ partial class BridgeTool
 	public static PolygonMesh.BridgeUVMode UVMode { get; set; } = PolygonMesh.BridgeUVMode.Auto;
 	public static float RepeatsU { get; set; } = 1.0f;
 	public static float RepeatsV { get; set; } = 1.0f;
+	public static Vector3 FromControlPointPosition { get; set; } = Vector3.Zero;
+	public static Vector3 ToControlPointPosition { get; set; } = Vector3.Zero;
 
 	public override Widget CreateToolSidebar()
 	{
@@ -33,6 +35,12 @@ partial class BridgeTool
 
 			[Title( "Repeats V" ), Range( 0.01f, 100.0f, true, false ), Step( 0.0625f ), WideMode]
 			public readonly float V { get => RepeatsV; set => RepeatsV = value; }
+
+			[Title( "From Control Point" ), WideMode]
+			public readonly Vector3 FromControlPoint { get => FromControlPointPosition; set => FromControlPointPosition = value; }
+
+			[Title( "To Control Point" ), WideMode]
+			public readonly Vector3 ToControlPoint { get => ToControlPointPosition; set => ToControlPointPosition = value; }
 		}
 
 		[InlineEditor( Label = false )]
@@ -67,12 +75,15 @@ partial class BridgeTool
 
 			Layout.AddStretchCell();
 
+			FromControlPointPosition = _tool._controlPoints[(int)BridgeControlPoint.From];
+			ToControlPointPosition = _tool._controlPoints[(int)BridgeControlPoint.To];
+
 			UpdateMesh();
 		}
 
 		void UpdateMesh()
 		{
-			_tool.UpdateBridge( NumSteps, Twist, UVMode, RepeatsU, RepeatsV );
+			_tool.UpdateBridge( NumSteps, Twist, UVMode, RepeatsU, RepeatsV, FromControlPointPosition, ToControlPointPosition );
 		}
 
 		private void Cancel()

--- a/game/addons/tools/Code/Scene/Mesh/Tools/BridgeTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/BridgeTool.cs
@@ -178,7 +178,7 @@ public partial class BridgeTool( MeshEdge[] edges = null, MeshFace[] faces = nul
 	float _repeatsU;
 	float _repeatsV;
 
-	void UpdateBridge( int steps, int twist, PolygonMesh.BridgeUVMode uvMode, float repeatsU, float repeatsV )
+	void UpdateBridge( int steps, int twist, PolygonMesh.BridgeUVMode uvMode, float repeatsU, float repeatsV, Vector3 fromControlPointPosition, Vector3 toControlPointPosition )
 	{
 		if ( _editMesh is null ) return;
 
@@ -190,6 +190,8 @@ public partial class BridgeTool( MeshEdge[] edges = null, MeshFace[] faces = nul
 		_uvMode = uvMode;
 		_repeatsU = repeatsU;
 		_repeatsV = repeatsV;
+		_controlPoints[(int)BridgeControlPoint.From] = fromControlPointPosition;
+		_controlPoints[(int)BridgeControlPoint.To] = toControlPointPosition;
 
 		var mesh = new PolygonMesh();
 		mesh.Transform = _editMesh.Transform;
@@ -627,6 +629,19 @@ public partial class BridgeTool( MeshEdge[] edges = null, MeshFace[] faces = nul
 
 		_controlPoints[(int)cp] = controlPointPosition;
 
+		switch ( (int)cp )
+		{
+			case (int)BridgeControlPoint.From:
+				FromControlPointPosition = controlPointPosition;
+				break;
+			case (int)BridgeControlPoint.To:
+				ToControlPointPosition = controlPointPosition;
+				break;
+			default:
+				Console.WriteLine( $"Invalid control point index: {(int)cp}" );
+				break;
+		}
+
 		if ( _controlPointDragLocked )
 		{
 			var delta = controlPointPosition - basis.Position;
@@ -637,7 +652,7 @@ public partial class BridgeTool( MeshEdge[] edges = null, MeshFace[] faces = nul
 			SetControlPointFromDeltas( BridgeControlPoint.To, normalDelta, tangentDelta );
 		}
 
-		UpdateBridge( _steps, _twist, _uvMode, _repeatsU, _repeatsV );
+		UpdateBridge( _steps, _twist, _uvMode, _repeatsU, _repeatsV, _controlPoints[(int)BridgeControlPoint.From], _controlPoints[(int)BridgeControlPoint.To] );
 	}
 
 	static Vector3 GridSnapOnPlane( Vector3 point, Vector3 origin, Vector3 planeNormal, Vector3 tangent )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Motivated by a comment I saw on the s&box subreddit (see below), I implemented the control point positions into the bridge tool UI. This was relatively simple, achieved by adding elements for the 'to' and 'from' vector to the BridgeProperties struct and adding Vector3 arguments for each to the bridge tool's UpdateBridge function. Within the tool, the control point vectors are updated based on the passed vectors such that the control points and bridge are recalculated.

This change is useful for providing data transparency and enabling precise bridges between scene elements.

## Motivation & Context

I was motivated to implement this feature by a comment on the Reddit thread of the s&box subreddit where a user /u/AngryNeox expressed the hope that the control point vectors would be exposed in the UI. They said that this could be useful if users want a specific curve. 

Link to the thread:
https://www.reddit.com/r/sandbox/comments/1st0jst/the_new_mapping_bridge_tool_by_layla_facepunch/

Fixes: Not applicable to a specific issue

## Implementation Details

Largely as outlined in the summary, there were not particularly any non-obvious changes.

## Screenshots / Videos (if applicable)

<img width="1280" height="467" alt="Screenshot 2026-04-26 221037" src="https://github.com/user-attachments/assets/41b27d33-8d14-477d-9617-6bac744a87c8" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing 
- [x] I’m okay with this PR being rejected or requested to change 🙂