### PR TITLE
Treat AltGr as right Alt when capturing keybinds

### DIFF
--- a/engine/Sandbox.Test.Unit/Editor/KeyEventTests.cs
+++ b/engine/Sandbox.Test.Unit/Editor/KeyEventTests.cs
@@ -1,0 +1,13 @@
+using Editor;
+
+namespace EditorTests;
+
+[TestClass]
+public class KeyEventTests
+{
+	[TestMethod]
+	public void AltGrUsesRightAltKeyName()
+	{
+		Assert.AreEqual( "RAlt", KeyEvent.GetKeyName( KeyCode.AltGr, 0xA5, "" ) );
+	}
+}

--- a/engine/Sandbox.Tools/Qt/Event/MouseEvent.cs
+++ b/engine/Sandbox.Tools/Qt/Event/MouseEvent.cs
@@ -106,7 +106,7 @@ public ref struct KeyEvent
 		NativeKeyCode = ptr.nativeVirtualKey();
 		NativeScanCode = ptr.nativeScanCode();
 		KeyboardModifiers = QtHelpers.Translate( ptr.modifiers() );
-		Name = GetKeyName();
+		Name = GetKeyName( Key, NativeKeyCode, Text );
 
 		if ( Key == KeyCode.Backspace ) Text = "";
 		if ( Key == KeyCode.Delete ) Text = "";
@@ -183,10 +183,10 @@ public ref struct KeyEvent
 		return name;
 	}
 
-	string GetKeyName()
+	internal static string GetKeyName( KeyCode key, uint nativeKeyCode, string text )
 	{
 		// Check if the key is a native key that isn't supported by KeyCode
-		switch ( NativeKeyCode )
+		switch ( nativeKeyCode )
 		{
 			case 0x0D: return "Enter"; // Enter
 			case 0x20: return "Space"; // Spacebar
@@ -250,15 +250,17 @@ public ref struct KeyEvent
 			case 0xDC: return "\\"; // Backslash
 			case 0xDD: return "]"; // Right bracket
 			case 0xDE: return "'"; // Apostrophe
+			case 0xA5: return "RAlt"; // VK_RMENU; reported as AltGr on some keyboard layouts
 		}
 
 		// If it's a Keycode, then remap a few keys to their more common names
-		switch ( Key )
+		switch ( key )
 		{
 			case KeyCode.Delete: return "Del";
 			case KeyCode.Escape: return "Esc";
 			case KeyCode.Insert: return "Ins";
 			case KeyCode.Control: return "Ctrl";
+			case KeyCode.AltGr: return "RAlt";
 			case KeyCode.BracketLeft: return "[";
 			case KeyCode.BracketRight: return "]";
 			case KeyCode.Equal: return "=";
@@ -274,13 +276,13 @@ public ref struct KeyEvent
 		}
 
 		// Otherwise, just return the name of the Enum
-		var keyName = Enum.GetName( typeof( KeyCode ), Key );
+		var keyName = Enum.GetName( typeof( KeyCode ), key );
 
 		// If keyName is null then we likely have a non-english keyboard layout
 		if ( keyName is null )
 		{
 			// Try to get the key name from the text
-			keyName = Text;
+			keyName = text;
 		}
 
 		return keyName;


### PR DESCRIPTION
﻿## Summary
- Normalize Qt `AltGr` / Windows `VK_RMENU` key events to the same `RAlt` name the game input runtime uses.
- Adds a focused regression test for the editor key-name normalization path.
- Keeps the existing keybind widget flow intact so captured project input actions continue using `KeyEvent.GetButtonCodeName()`.

Fixes #10664.

## Root cause
On non-US keyboard layouts, AltGr is reported through Qt as a right Alt key with a synthetic control modifier. The editor key-capture path was not normalizing that event to the runtime binding name, so configuring a game input action could save a different chord than the game actually treats as the physical key.

## Validation
- `git diff --check`
- Attempted: `dotnet test engine/Sandbox.Test.Unit/Sandbox.Test.Unit.csproj --filter "FullyQualifiedName~EditorTests.KeyEventTests.AltGrUsesRightAltKeyName"` using local .NET SDK `10.0.203`.
- The focused test did not reach execution in this checkout because the baseline engine build is missing local native/source-generated dependencies (`System.Speech`, `NativeEngine.*`, render/physics/VR interop types). Code generation itself completed before those baseline compile errors.
