### PR TITLE
Fix SceneRenderingWidget viewport flashing on Linux/XWayland

### DIFF
--- a/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
+++ b/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
@@ -41,6 +41,12 @@ public class SceneRenderingWidget : Frame
 		SetFlag( Flag.WA_NoSystemBackground, true );
 		SetFlag( Flag.WA_OpaquePaintEvent, true );
 
+		// On Linux/XWayland, Qt's software paint cycle fires on mouse-enter and click
+		// expose events, briefly clearing the native window before the next SwapChain
+		// present and causing a visible flash. Since all rendering goes through the
+		// SwapChain, the Qt paint path serves no purpose and can be suppressed entirely.
+		OnPaintOverride = () => true;
+
 		SwapChain = WidgetUtil.CreateSwapChain( _widget, RenderSettings.Instance.AntiAliasQuality.ToEngine() );
 		RenderSettings.Instance.OnVideoSettingsChanged += HandleVideoChanged;
 


### PR DESCRIPTION
## Problem

On Linux with Wayland compositors (tested on Arch + Hyprland + NVIDIA via Proton-GE), the scene viewport flashes black on every mouse-enter and click event.

**Root cause:** `SceneRenderingWidget` creates an embedded native X11 child window via `WA_NativeWindow`. Under XWayland, when this window receives input events (enter/click), the compositor fires Qt expose events. Qt's software paint path is then invoked — but since the widget renders exclusively via a Vulkan SwapChain, the Qt paint path draws nothing, briefly leaving the native window in an undefined/cleared state before the next SwapChain present. This one-frame gap is visible as a black flash.

## Fix

Set `OnPaintOverride = () => true` in the constructor to suppress Qt's software paint cycle entirely. Since all rendering goes through `g_pRenderDevice.Present(SwapChain)` in `RenderAll()`, the Qt paint path has no purpose on this widget and can safely be skipped.

The existing flags (`WA_PaintOnScreen`, `WA_NoSystemBackground`, `WA_OpaquePaintEvent`) already express the intent that Qt should not manage painting here — this change makes it explicit at the managed level.

## Testing

- **Before:** viewport flashes black on mouse-enter and click on Arch Linux / Hyprland / XWayland
- **After:** no flash observed
- No behaviour change expected on Windows or non-XWayland Linux sessions

## Environment

- Arch Linux, Hyprland (Wayland), NVIDIA RTX 4070 Laptop, Proton-GE, s&box via Steam