### PR TITLE
Prevent selecting hidden objects in mapper

### DIFF
--- a/game/addons/tools/Code/Scene/Mesh/Tools/ObjectSelection.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/ObjectSelection.cs
@@ -262,16 +262,18 @@ public sealed partial class ObjectSelection( MeshTool tool ) : SelectionTool
 	public override BBox CalculateSelectionBounds()
 	{
 		return BBox.FromBoxes( _objects
-			.Where( x => x.IsValid() )
+			.Where( x => x.IsValid() && !x.Tags.Has( "Hidden" ) )
 			.Select( x => x.GetBounds() ) );
 	}
 
 	public override void OnSelectionChanged()
 	{
-		_objects = Selection.OfType<GameObject>().ToArray();
+		_objects = Selection.OfType<GameObject>().ToArray()
+			.Where( x => !x.Tags.Has( "Hidden" ) )
+			.ToArray();
 		_meshes = Selection.OfType<GameObject>()
 			.Select( x => x.GetComponent<MeshComponent>() )
-			.Where( x => x.IsValid() )
+			.Where( x => x.IsValid() && !x.Tags.Has( "Hidden" ) )
 			.ToArray();
 
 		_transformVertices.Clear();
@@ -332,6 +334,7 @@ public sealed partial class ObjectSelection( MeshTool tool ) : SelectionTool
 
 	void Select( GameObject element )
 	{
+		if ( element.Tags.Has( "Hidden" ) ) return;
 		bool ctrl = Application.KeyboardModifiers.HasFlag( KeyboardModifiers.Ctrl );
 		bool shift = Application.KeyboardModifiers.HasFlag( KeyboardModifiers.Shift );
 		bool contains = Selection.Contains( element );
@@ -366,6 +369,7 @@ public sealed partial class ObjectSelection( MeshTool tool ) : SelectionTool
 
 		foreach ( var go in Scene.GetAllObjects( true ) )
 		{
+			if ( go.Tags.Has( "Hidden" ) ) continue;
 			var bounds = go.GetBounds();
 			if ( !frustum.IsInside( bounds, !fullyInside ) )
 			{
@@ -486,3 +490,4 @@ public sealed partial class ObjectSelection( MeshTool tool ) : SelectionTool
 		Tool?.MoveMode?.OnBegin( this );
 	}
 }
+


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR adds some checks in a few functions within ObjectSelection.cs to ensure that GameObjects with the "hidden" tag aren't selectable.

## Motivation & Context

This change is needed as raised by the issue #10684. Users are likely to be hiding GameObjects during editor work precisely because they don't want them getting in the way or being selected, so it being possible to select them makes hiding them not as useful as it ought to be. Other 3D and game editors behave in the way that issue #10684 is requesting.

Fixes: #10684 

## Implementation Details

Relatively self-explanatory, I have added a number of checks like `.Where( x => !x.Tags.Has( "Hidden" ) )` in functions like `OnBoxSelect()`, `OnSelectionChanged()` and so on such that hidden objects can't be selected or at least not selected in such a way that causes interference or unintended actions such as the movement of a hidden element.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂