### PR TITLE
Fix project files for AssemblyReferences

### DIFF
--- a/engine/Sandbox.Access/AccessControl.Resolve.cs
+++ b/engine/Sandbox.Access/AccessControl.Resolve.cs
@@ -51,14 +51,6 @@ public partial class AccessControl
 		}
 
 		//
-		// We only resolve certain named dlls from disk - and certainly not package.
-		//
-		if ( !name.Name.StartsWith( "Sandbox.", StringComparison.OrdinalIgnoreCase ) &&
-			 !name.Name.StartsWith( "System.", StringComparison.OrdinalIgnoreCase ) &&
-			 name.Name != "Microsoft.AspNetCore.Components" )
-			throw NotResolved( name );
-
-		//
 		// Now look at our System. and Sandbox. assemblies
 		//
 		if ( GlobalAssemblyCache.TryGetValue( name, out var systemAssembly ) )

--- a/engine/Sandbox.Compiling/CompilerConfiguration.cs
+++ b/engine/Sandbox.Compiling/CompilerConfiguration.cs
@@ -82,6 +82,7 @@ partial class Compiler
 		/// <summary>
 		/// Each unique element of <see cref="AssemblyReferences"/>
 		/// </summary>
+		[JsonIgnore]
 		public IReadOnlySet<string> DistinctAssemblyReferences => new HashSet<string>( AssemblyReferences.Where( IsPermittedAssemblyReference ), StringComparer.OrdinalIgnoreCase );
 
 		public void Clean()

--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.Solution.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.Solution.cs
@@ -19,6 +19,23 @@ public sealed partial class Project
 		return false;
 	}
 
+	/// <summary>
+	/// Get the compiler settings adjusted with Project.Config.
+	/// </summary>
+	/// <returns></returns>
+	Compiler.Configuration GetEffectiveCompileSettings()
+	{
+		var compilerSettings = Config.GetCompileSettings();
+
+		if ( Config.IsStandaloneOnly )
+		{
+			compilerSettings.Unsafe = true;
+			compilerSettings.Whitelist = false;
+		}
+
+		return compilerSettings;
+	}
+
 	internal async Task GenerateProject( Sandbox.SolutionGenerator.Generator generator )
 	{
 		// justify the async
@@ -51,7 +68,7 @@ public sealed partial class Project
 			//
 			// Code project
 			//
-			var compilerSettings = Config.GetCompileSettings();
+			var compilerSettings = GetEffectiveCompileSettings();
 
 			if ( Config.Type == "game" )
 			{
@@ -183,7 +200,7 @@ public sealed partial class Project
 		if ( !HasServersideCode() )
 			return default;
 
-		var serverSettings = Config.GetCompileSettings();
+		var serverSettings = GetEffectiveCompileSettings();
 		serverSettings.DefineConstants += ";SERVER";
 
 		var project = generator.AddProject( Config.Type,
@@ -222,7 +239,7 @@ public sealed partial class Project
 		if ( !HasEditorPath() )
 			return default;
 
-		var compilerSettings = Config.GetCompileSettings();
+		var compilerSettings = GetEffectiveCompileSettings();
 		var project = generator.AddProject( "tool", $"{Config.FullIdent}.editor", $"{projectName}.editor", GetEditorPath(), compilerSettings );
 		project.IsEditorProject = true;
 
@@ -257,7 +274,7 @@ public sealed partial class Project
 		if ( !dirinfo.Exists )
 			return default;
 
-		var compilerSettings = Config.GetCompileSettings();
+		var compilerSettings = GetEffectiveCompileSettings();
 		var project = generator.AddProject( "unittest", $"{Config.FullIdent}.unittest", $"{projectName}.unittest", dirinfo.FullName, compilerSettings );
 		project.IsUnitTestProject = true;
 

--- a/engine/Sandbox.SolutionGenerator/Generator.cs
+++ b/engine/Sandbox.SolutionGenerator/Generator.cs
@@ -79,7 +79,7 @@ namespace Sandbox.SolutionGenerator
 					WarningsAsErrors = p.Settings.WarningsAsErrors,
 					TreatWarningsAsErrors = p.Settings.TreatWarningsAsErrors,
 					DefineConstants = p.Settings.DefineConstants,
-					Unsafe = p.Type == "tool",
+					Unsafe = p.Settings.Unsafe,
 					IgnoreFolders = p.Settings.IgnoreFolders.ToList(),
 					IsEditorProject = p.IsEditorProject,
 					IsUnitTestProject = p.IsUnitTestProject,


### PR DESCRIPTION
## Summary

Remove useless DistinctAssemblyReferences in .sbproj. 
Add AssemblyReferences and unsafe settings in .csproj.

## Motivation & Context

You need to manually edit .csproj each time you load project settings. This is a pain in the ass.
Poeple wonder what DistinctAssemblyReferences  is in .sbproj when it is a mistake.

## Question for maintainers

because engine/Launcher/Shared/LauncherEnvironment.cs:89, assembly are relative to the managed bins. From this function, you can't get the project settings and the project path, so it is impossible to have a dll in your project. Was this instended ?

If this is merged, should I edit Facepunch/sbox-docs or will you do it ?

Is AssemblyReferences only for when Whitelist = false ?