### PR TITLE
Linux fix SubFileSystem partial paths differing from Physical fs

### DIFF
--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
@@ -178,7 +178,7 @@ public sealed partial class Project
 	/// <summary>
 	/// Absolute path to the Code folder of the project.
 	/// </summary>
-	public string GetCodePath() => System.IO.Path.Combine( RootDirectory.FullName, "Code" );
+	public string GetCodePath() => PlatformPath.Combine( RootDirectory.FullName, "Code" );
 
 	/// <summary>
 	/// Returns true if the Code path exists
@@ -188,7 +188,7 @@ public sealed partial class Project
 	/// <summary>
 	/// Absolute path to the Editor folder of the project.
 	/// </summary>
-	public string GetEditorPath() => System.IO.Path.Combine( RootDirectory.FullName, "Editor" );
+	public string GetEditorPath() => PlatformPath.Combine( RootDirectory.FullName, "Editor" );
 
 	/// <summary>
 	/// Returns true if the Editor path exists
@@ -198,13 +198,13 @@ public sealed partial class Project
 	/// <summary>
 	/// Absolute path to the Assets folder of the project, or <see langword="null"/> if not set.
 	/// </summary>
-	public string GetAssetsPath() => System.IO.Path.Combine( RootDirectory.FullName, "Assets" );
+	public string GetAssetsPath() => PlatformPath.Combine( RootDirectory.FullName, "Assets" );
 
 	/// <summary>
 	/// Absolute path to the Localization folder of the project, or <see langword="null"/> if not set.
 	/// </summary>
 	/// <returns></returns>
-	public string GetLocalizationPath() => System.IO.Path.Combine( RootDirectory.FullName, "Localization" );
+	public string GetLocalizationPath() => PlatformPath.Combine( RootDirectory.FullName, "Localization" );
 
 	/// <summary>
 	/// Returns true if the Assets path exists

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -34,6 +34,7 @@ public class BaseFileSystem
 	/// Returns true if this filesystem is read only
 	/// </summary>
 	public bool IsReadOnly => system is ReadOnlyFileSystem;
+	private bool IsLinux() => OperatingSystem.IsLinux();
 
 	internal bool WatchEnabled = true;
 	internal bool PendingDispose = false;
@@ -321,7 +322,8 @@ public class BaseFileSystem
 	{
 		// Log.Trace( $"CreateFileSystem( {path} ) [{GetFullPath(path)}]" );
 
-		var sub = new Zio.FileSystems.SubFileSystem( system, FixPath( path ), false );
+		var sub = IsLinux() ? new CaseInsensitiveSubFileSystem( system, FixPath ( path ), false ) : 
+			new Zio.FileSystems.SubFileSystem( system, FixPath( path ), false );
 		return new BaseFileSystem( sub );
 	}
 

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -322,7 +322,7 @@ public class BaseFileSystem
 	{
 		// Log.Trace( $"CreateFileSystem( {path} ) [{GetFullPath(path)}]" );
 
-		var sub = IsLinux() ? new CaseInsensitiveSubFileSystem( system, FixPath ( path ), false ) : 
+		var sub = IsLinux() ? new CaseInsensitiveSubFileSystem( system, FixPath( path ), false ) :
 			new Zio.FileSystems.SubFileSystem( system, FixPath( path ), false );
 		return new BaseFileSystem( sub );
 	}

--- a/engine/Sandbox.Filesystem/CaseInsensitiveSubFileSystem.cs
+++ b/engine/Sandbox.Filesystem/CaseInsensitiveSubFileSystem.cs
@@ -29,7 +29,7 @@ internal sealed class CaseInsensitiveSubFileSystem : SubFileSystem
 		var sub = SubPath.FullName;
 
 		if ( !fullPath.StartsWith( sub, StringComparison.OrdinalIgnoreCase )
-			|| ( fullPath.Length > sub.Length && fullPath[sub.Length] != UPath.DirectorySeparator ) )
+			|| (fullPath.Length > sub.Length && fullPath[sub.Length] != UPath.DirectorySeparator) )
 		{
 			throw new InvalidOperationException( $"The path `{path}` returned by the delegate filesystem is not rooted to the subpath `{SubPath}`" );
 		}

--- a/engine/Sandbox.Filesystem/CaseInsensitiveSubFileSystem.cs
+++ b/engine/Sandbox.Filesystem/CaseInsensitiveSubFileSystem.cs
@@ -1,0 +1,41 @@
+using Zio;
+using Zio.FileSystems;
+
+namespace Sandbox;
+
+/// <summary>
+/// A <see cref="SubFileSystem"/> that performs the delegate-path prefix check using
+/// <see cref="StringComparison.OrdinalIgnoreCase"/>, so paths bubbling up from a
+/// case-sensitive disk (Linux) won't fail the rooting check just because their casing
+/// doesn't match the SubPath the mount was constructed with.
+/// </summary>
+internal sealed class CaseInsensitiveSubFileSystem : SubFileSystem
+{
+	public CaseInsensitiveSubFileSystem( IFileSystem fileSystem, UPath subPath, bool owned = true )
+		: base( fileSystem, subPath, owned ) { }
+
+	protected override UPath ConvertPathFromDelegate( UPath path )
+	{
+		// compares first path string of sub fs path
+		// to partial path in physical fs
+
+		// CreateAndMount gives manual paths
+		// and folder might not match what engine has or what directories bootstrap rebuilds
+		// it varies very often
+
+		// i.e. disk is /menu/code/AvatarEditor/UI/Workshop/WorkshopPackageList.razor.scss but got /menu/Code
+
+		var fullPath = path.FullName;
+		var sub = SubPath.FullName;
+
+		if ( !fullPath.StartsWith( sub, StringComparison.OrdinalIgnoreCase )
+			|| ( fullPath.Length > sub.Length && fullPath[sub.Length] != UPath.DirectorySeparator ) )
+		{
+			throw new InvalidOperationException( $"The path `{path}` returned by the delegate filesystem is not rooted to the subpath `{SubPath}`" );
+		}
+
+		//Log.Info($"[Linux SFS] {fullPath} : {sub}");
+		var remainder = fullPath.Substring( sub.Length );
+		return remainder.Length == 0 ? UPath.Root : new UPath( remainder );
+	}
+}

--- a/engine/Sandbox.Filesystem/PlatformPath.cs
+++ b/engine/Sandbox.Filesystem/PlatformPath.cs
@@ -1,0 +1,28 @@
+using Zio;
+using Zio.FileSystems;
+
+namespace Sandbox;
+
+/// <summary>
+/// Static path-resolution helpers that route through Zio's case-insensitive
+/// filesystem on Linux, and pass through unchanged on case-insensitive platforms.
+/// </summary>
+public static class PlatformPath
+{
+	private static readonly PhysicalFileSystem _fs = OperatingSystem.IsLinux()
+		? new CaseInsensitivePhysicalFileSystem()
+		: new PhysicalFileSystem();
+
+	/// <summary>
+	/// Combine <paramref name="parts"/> into a single path and resolve to the casing
+	/// actually present on disk. On Windows/macOS this is a pass-through;
+	/// on Linux it walks the path through the cached case-insensitive resolver.
+	/// </summary>
+	public static string Combine( params string[] parts )
+	{
+		UPath path = System.IO.Path.Combine( parts );
+		var resolved = _fs.ConvertPathToInternal( path );
+		Log.Info( $"[PlatformPath] {path} -> {resolved}" );
+		return resolved;
+	}
+}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Will reopen once I fix a quick thing

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

Sandbox.FileSystem instantiates a PhysicalFileSystem to manage case sensitivity on different OS's depending on their filesystem to resolve path casing, but SubFileSystem's partial path does not match what PhysicalFileSystem's path is returning which causes small paths in sub to return falsely. i.e. ( Phy fs : {addons/menu}/code/someresourceshere != sub fs : addons/menu/Code). I added a case insensitive resolver for SubFileSystem to compare physical fs casing with the sub filesystem when those paths are pushed in from CreateAndMount. Everything else in BaseFileSystem works as intended, but there is one call where SubFileSystem is instantiated and had to checked.

I also added a PlatformPath. I am still testing this, but it is a static class that will just create a LocalFileSystem and resolve full paths in places like Project.cs

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

This is the last change needed for the managed side to resolve everything correctly and allow the game to boot to the menu on Linux systems and fixes linux server Imports.cs error.

Fixes: <!-- #issue-number (if applicable) -->

## Before PR'ing, I will
Remove the log.info comments or else they'll spam the console
Remove PlatformPath or come up with a better solution before including it

Logs are for your testing, PlatformPath I wanted tips on.

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

I had considered just managing ComposeFileSystem, which SubFileSystem inherits so I didn't have to perform a Linux check on BaseFileSystem, but that delegate method is an abstract method there so the lowest level possible was to create a new SubFileSystem class for case-sensitive resolves. 

PlatformPath I am still testing, but I wanted to get your opinion on whether or not we should just create a LocalFileSystem object here in a static method and then manage path combines or other full paths without needing a new segment walk method for raw paths.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂