### PR TITLE
Always start splash screen centered

### DIFF
--- a/engine/Sandbox.Tools/Editor/EditorSplashScreen.cs
+++ b/engine/Sandbox.Tools/Editor/EditorSplashScreen.cs
@@ -21,18 +21,9 @@ namespace Editor
 			SetWindowIcon( Pixmap.FromFile( "logo_rounded.png" ) );
 			BackgroundImage = LoadSplashImage();
 
-			// load any saved geometry
-			string geometryCookie = EditorCookie.GetString( "splash.geometry", null );
-			RestoreGeometry( geometryCookie );
-
 			var aspect = (float)BackgroundImage.Height / BackgroundImage.Width;
 			Size = new( 700, (700 * aspect).FloorToInt() + InfoAreaHeight );
-
-			if ( geometryCookie is null )
-			{
-				// fallback to screen centre if there's no saved geo
-				Position = ScreenGeometry.Contain( Size ).Position;
-			}
+			Position = ScreenGeometry.Contain( Size ).Position;
 
 			Show();
 
@@ -84,11 +75,7 @@ namespace Editor
 		public static void StartupFinish()
 		{
 			if ( Singleton.IsValid() )
-			{
-				EditorCookie.Set( "splash.geometry", Singleton.SaveGeometry() );
 				Singleton.Destroy();
-			}
-
 			Singleton = null;
 		}
 

--- a/engine/Sandbox.Tools/Editor/EditorSplashScreen.cs
+++ b/engine/Sandbox.Tools/Editor/EditorSplashScreen.cs
@@ -21,11 +21,17 @@ namespace Editor
 			SetWindowIcon( Pixmap.FromFile( "logo_rounded.png" ) );
 			BackgroundImage = LoadSplashImage();
 
+			// load any saved geometry
+			string geometryCookie = EditorCookie.GetString( "splash.geometry", null );
+			RestoreGeometry( geometryCookie );
+
 			var aspect = (float)BackgroundImage.Height / BackgroundImage.Width;
 			Size = new( 700, (700 * aspect).FloorToInt() + InfoAreaHeight );
-			Position = ScreenGeometry.Contain( Size ).Position;
 
 			Show();
+
+			UpdateGeometry();
+			Position = ScreenGeometry.Contain( Size ).Position;
 
 			//
 			// Resample background image if dpi scale is gonna make us draw it bigger
@@ -75,7 +81,11 @@ namespace Editor
 		public static void StartupFinish()
 		{
 			if ( Singleton.IsValid() )
+			{
+				EditorCookie.Set( "splash.geometry", Singleton.SaveGeometry() );
 				Singleton.Destroy();
+			}
+
 			Singleton = null;
 		}
 


### PR DESCRIPTION
## Summary
Centers the splash screen on the screen, so that if you drag it around to random positions while the editor is opening it won't be stuck off center forever.

Also helps keep things consistent with different splash screen images, geometry cookie only restores the top left position of the window so with different aspect ratios the center of the splash screen could move up and down quite a bit between projects. Now it gets properly centered each time.

## Motivation & Context
A bit subjective but opening in center feels cleaner/ less random to me, and I can't think of any good reason someone would want the splash screen to consistently open anywhere else.

Previously opened under https://github.com/Facepunch/sbox-public/pull/10088

## Implementation Details
It loads the geometry cookie before centering, so if the user drags the splash screen to their second monitor it will respect that while still being centered.

## Screenshot
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/085ba3d7-ad26-48eb-ad7c-9785bc20793f" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂