### PR TITLE
Expose viewport bg color in editor preferences

### DIFF
--- a/engine/Sandbox.Tools/EditorPreferences.cs
+++ b/engine/Sandbox.Tools/EditorPreferences.cs
@@ -71,6 +71,16 @@ public static class EditorPreferences
 	}
 
 	/// <summary>
+	/// Camera viewport background color
+	/// </summary>
+	[Title( "Background Color" )]
+	public static Color CameraBackgroundColor
+	{
+		get => EditorCookie.Get( "SceneView.CameraBgColor", (Color)"#32415e" );
+		set => EditorCookie.Set( "SceneView.CameraBgColor", value );
+	}
+
+	/// <summary>
 	/// The closest thing to render
 	/// </summary>
 	[Title( "ZNear" )]

--- a/game/addons/tools/Code/Editor/EditorPreferences/PageSceneView.cs
+++ b/game/addons/tools/Code/Editor/EditorPreferences/PageSceneView.cs
@@ -12,6 +12,7 @@ internal class PageSceneView : Widget
 		var sheet = new ControlSheet();
 
 		sheet.AddProperty( () => EditorPreferences.CameraFieldOfView );
+		sheet.AddProperty( () => EditorPreferences.CameraBackgroundColor );
 
 		sheet.AddProperty( () => EditorPreferences.CameraZNear );
 		sheet.AddProperty( () => EditorPreferences.CameraZFar );

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
@@ -215,7 +215,7 @@ public partial class SceneViewportWidget : Widget
 			Renderer.Camera = _activeCamera;
 		}
 
-		_activeCamera.BackgroundColor = "#32415e";
+		_activeCamera.BackgroundColor = EditorPreferences.CameraBackgroundColor;
 		_activeCamera.WorldPosition = State.CameraPosition;
 		_activeCamera.WorldRotation = State.CameraRotation;
 


### PR DESCRIPTION
## Summary
Allows the background color for the editor camera to be set via editor preferences, as opposed to being hard coded. By default it uses the previously hard coded value.

## Motivation & Context
I personally prefer dark gray in my viewport backgrounds.

Previously opened under https://github.com/Facepunch/sbox-public/pull/10295

## Video

https://github.com/user-attachments/assets/b1a49baf-cfd3-4b2a-a25b-6d706e56356c

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂