### PR TITLE
Fix point light shadows breaking when shadow res decreases

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.ProjectedCube.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Shadows/ShadowMapper.ProjectedCube.cs
@@ -71,7 +71,7 @@ internal partial class ShadowMapper
 		cacheEntry.ScreenSize = flScreenSize;
 
 		// Do we want a bigger resolution for this shadow map now?
-		if ( cacheEntry.CurrentResolution < desiredResolution )
+		if ( cacheEntry.CurrentResolution != desiredResolution )
 		{
 			ReleaseTexture( cacheEntry.ShadowMap, cacheEntry.CurrentResolution, cacheEntry.IsCube );
 			cacheEntry.ShadowMap = AcquireTexture( desiredResolution, isCube: true );


### PR DESCRIPTION
## Summary
Solves an issue where shadows on point lights would break if the desired resolution decreased

https://github.com/user-attachments/assets/949c6d10-1e8c-45f6-b1af-65c03319bc1f

## Motivation & Context
Previously opened under https://github.com/Facepunch/sbox-public/pull/10383

## Implementation Details
`ShadowMapper.Projected` had
```cs
// Do we want a bigger resolution for this shadow map now?
if ( cacheEntry.CurrentResolution != desiredResolution )
```
whereas `ShadowMapper.ProjectedCube` had
```cs
// Do we want a bigger resolution for this shadow map now?
if ( cacheEntry.CurrentResolution < desiredResolution )
```
Spotlights work and point lights didn't, so despite the comment I believe != to be correct.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂