### PR TITLE
Target GameObject for DepthOfField

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
@@ -22,7 +22,7 @@ public sealed class DepthOfField : BasePostProcess<DepthOfField>
 	/// <summary>
 	/// Game object to keep in focus, leave blank to set focus manually.
 	/// </summary>
-	[Property, Group( "Target" )]
+	[Property, Group( "Focus" )]
 	public GameObject FocalTarget { get; set; }
 
 	/// <summary>
@@ -30,7 +30,7 @@ public sealed class DepthOfField : BasePostProcess<DepthOfField>
 	/// </summary>
 	[Range( -100, 100, false )]
 	[HideIf( nameof( FocalTarget ), null )]
-	[Property, Group( "Target" )]
+	[Property, Group( "Focus" )]
 	public float FocalOffset { get; set; }
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
@@ -83,7 +83,10 @@ public sealed class DepthOfField : BasePostProcess<DepthOfField>
 		float focalDistance = GetWeighted( ( x ) =>
 		{
 			if ( x.FocalTarget.IsValid() )
-				return Camera.WorldPosition.Distance( x.FocalTarget.WorldPosition ) + FocalOffset;
+			{
+				var cam = Scene.IsEditor ? Scene.Cameras.FirstOrDefault( ( c ) => c.IsSceneEditorCamera == true ) ?? x.Camera : x.Camera;
+				return cam.WorldPosition.Distance( x.FocalTarget.WorldPosition ) + FocalOffset;
+			}
 			return x.FocalDistance;
 		}, 200.0f );
 		float focalLength = GetWeighted( x => x.FocusRange, 500.0f );

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
@@ -20,6 +20,20 @@ public sealed class DepthOfField : BasePostProcess<DepthOfField>
 	internal static int Quality { get; set; } = 3;
 
 	/// <summary>
+	/// Game object to keep in focus, leave blank to set focus manually.
+	/// </summary>
+	[Property, Group( "Target" )]
+	public GameObject FocalTarget { get; set; }
+
+	/// <summary>
+	/// Offsets the focal distance relative to the FocalTarget.
+	/// </summary>
+	[Range( -100, 100, false )]
+	[HideIf( nameof( FocalTarget ), null )]
+	[Property, Group( "Target" )]
+	public float FocalOffset { get; set; }
+
+	/// <summary>
 	/// How blurry to make stuff that isn't in focus.
 	/// </summary>
 	[Range( 0, 100 )]
@@ -30,6 +44,7 @@ public sealed class DepthOfField : BasePostProcess<DepthOfField>
 	/// How far away from the camera to focus in world units.
 	/// </summary>
 	[Range( 1.0f, 1000 )]
+	[ShowIf( nameof( FocalTarget ), null )]
 	[Property, Group( "Focus" ), Icon( "horizontal_distribute" )]
 	public float FocalDistance { get; set; } = 200.0f;
 
@@ -65,7 +80,12 @@ public sealed class DepthOfField : BasePostProcess<DepthOfField>
 		float blurSize = GetWeighted( x => x.BlurSize, 0.0f );
 		if ( blurSize < 0.5f ) return;
 
-		float focalDistance = GetWeighted( x => x.FocalDistance, 200.0f );
+		float focalDistance = GetWeighted( ( x ) =>
+		{
+			if ( x.FocalTarget.IsValid() )
+				return Camera.WorldPosition.Distance( x.FocalTarget.WorldPosition ) + FocalOffset;
+			return x.FocalDistance;
+		}, 200.0f );
 		float focalLength = GetWeighted( x => x.FocusRange, 500.0f );
 
 		float stepScale = StepScales[Quality.Clamp( 0, 3 )];

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/DepthOfField.cs
@@ -85,7 +85,7 @@ public sealed class DepthOfField : BasePostProcess<DepthOfField>
 			if ( x.FocalTarget.IsValid() )
 			{
 				var cam = Scene.IsEditor ? Scene.Cameras.FirstOrDefault( ( c ) => c.IsSceneEditorCamera == true ) ?? x.Camera : x.Camera;
-				return cam.WorldPosition.Distance( x.FocalTarget.WorldPosition ) + FocalOffset;
+				return MathF.Max( cam.WorldRotation.Forward.Dot( x.FocalTarget.WorldPosition - cam.WorldPosition ) + FocalOffset, 15f );
 			}
 			return x.FocalDistance;
 		}, 200.0f );


### PR DESCRIPTION
## Summary
Adds a target object property for the depth of field post processing effect, if the property is set the focal length tracks that point. There's also an additional offset property for scenarios where the desired focal point isn't quite in line with the object in a radial sort of way (e.g. head)

## Motivation & Context
Had to keep adjusting it

Previously opened under https://github.com/Facepunch/sbox-public/pull/10389
Fixes: https://github.com/Facepunch/sbox-public/issues/3376 (give or take)

## Implementation Details
Dot product of relative object position and camera forward, with a minimum focal length of 15 (any lower seems to tend to disable dof completely). In the editor it uses the editor camera instead of BasePostProcess.Camera when getting the distance.

## Video

https://github.com/user-attachments/assets/51874c68-57fa-4086-a9f2-721046e8b849

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂