### PR TITLE
Light::Query and fixed light loop for shadows2

### DIFF
--- a/game/addons/base/Assets/shaders/common/classes/Light.hlsl
+++ b/game/addons/base/Assets/shaders/common/classes/Light.hlsl
@@ -7,6 +7,16 @@
 #include "baked_lighting_constants.fxc"
 
 //-----------------------------------------------------------------------------
+// Light::Query result
+//-----------------------------------------------------------------------------
+struct LightRange
+{
+    ClusterRange ClusterRange;
+    uint DynamicCount;
+    uint Count;
+};
+
+//-----------------------------------------------------------------------------
 // Light structure
 //-----------------------------------------------------------------------------
 class Light
@@ -33,95 +43,43 @@ class Light
     // 1.0.
     float Visibility;
 
-    BinnedLight LightData;
+    // Initialize a dynamic light from BinnedLight data
+    void Init( float3 vPositionWs, BinnedLight lightData, float2 vPositionSs );
 
-    void Init( float3 vPositionWs, BinnedLight lightData, float2 screenPos );
-    static Light From( float3 vPositionWs, float4 vPositionSs, uint nLightIndex, float2 vLightMapUV = 0.0f );
-    static uint Count( float4 vPositionSs );
-    float3 GetLightCookie(float3 vPositionWs);
-    float3 GetLightColor(float3 vPositionWs);
-    float3 GetLightDirection(float3 vPositionWs);
-    float3 GetLightPosition();
-    float GetLightAttenuation(float3 vPositionWs);
-    float Shadows(float3 vPositionWs, float2 screenPos);
+    // Collect a range of lights to loop over. Use the result with Light::Fetch
+    static LightRange Query( float4 vPositionSs );
+    static Light Fetch( LightRange query, uint index, float3 vPositionWs, float2 vPositionSs, float2 vLightMapUV = 0.0f );
 };
-
-//-----------------------------------------------------------------------------
-
-void Light::Init( float3 vPositionWs, BinnedLight lightData, float2 screenPos )
-{
-    LightData = lightData;
-
-    Color = GetLightColor( vPositionWs );
-    Direction = GetLightDirection( vPositionWs );
-    Position = GetLightPosition();
-    Attenuation = GetLightAttenuation( vPositionWs );
-    Visibility = Shadows( vPositionWs, screenPos );
-}
 
 // Light::From and Light::Count are implemented after StaticLight (forward reference)
 
-//-----------------------------------------------------------------------------
-
-float3 Light::GetLightCookie(float3 vPositionWs)
+void Light::Init( float3 vPositionWs, BinnedLight lightData, float2 vPositionSs )
 {
-    if ( !LightData.HasLightCookie() )
-        return 1.0f;
-
-    float4 vSample = LightData.SampleLightCookie( LightData.GetCookieUV( vPositionWs ) );
-    return vSample.rgb * vSample.a;
-}
-
-float3 Light::GetLightColor(float3 vPositionWs)
-{
-    return LightData.Color * GetLightCookie(vPositionWs);
-}
-
-float3 Light::GetLightDirection(float3 vPositionWs)
-{
-    float3 vLightDir = normalize(GetLightPosition() - vPositionWs);
-    return vLightDir;
-}
-
-float3 Light::GetLightPosition()
-{
-    return LightData.GetPosition();
-}
-
-float Light::GetLightAttenuation(float3 vPositionWs)
-{
-    const float3 vPositionToLightRayWs = GetLightPosition() - vPositionWs.xyz; // "L"
-    const float3 vPositionToLightDirWs = normalize(vPositionToLightRayWs.xyz);
-    const float flDistToLightSq = dot(vPositionToLightRayWs.xyz, vPositionToLightRayWs.xyz);
-
-    float flOuterConeCos = LightData.SpotLightInnerOuterConeCosines.y;
-    float flConeToDirection = dot(vPositionToLightDirWs.xyz, -LightData.GetDirection()) - flOuterConeCos;
-    if (flConeToDirection <= 0.0)
-    {
-        // Outside spotlight cone
-        return 0.0f;
+    Color = lightData.Color;
+    if ( lightData.HasLightCookie() ) {
+        float4 sample = lightData.SampleLightCookie( lightData.GetCookieUV( vPositionWs ) );
+        Color *= sample.rgb * sample.a;
     }
-
-    float flSpotAtten = flConeToDirection * LightData.SpotLightInnerOuterConeCosines.z;
-    float flLightFalloff = CalculateDistanceFalloff(flDistToLightSq, LightData.LinearFalloff, LightData.QuadraticFalloff, LightData.FalloffBias, 1.0);
-
-    float flLightMask = flLightFalloff * flSpotAtten;
-
-    return flLightMask;
-}
-
-float Light::Shadows(float3 vPositionWs, float2 screenPos)
-{
-    float flShadowScalar = 1.0;
-
-    if (LightData.Type == LightType::LightTypeDirectional)
-        flShadowScalar = DirectionalLightShadow::GetVisibility(vPositionWs, screenPos);
-    else if (LightData.Type == LightType::LightTypePoint)
-        flShadowScalar = ProjectedShadowCube::GetVisibility(LightData.ShadowMapIndex, vPositionWs);
-    else if (LightData.Type == LightType::LightTypeSpot)
-        flShadowScalar = ProjectedShadow::GetVisibility(LightData.ShadowMapIndex, vPositionWs, screenPos);
-
-    return flShadowScalar;
+    Position = lightData.GetPosition();
+    float3 offset = Position - vPositionWs;
+    Direction = normalize( offset );
+    // Attenuation
+    Attenuation = 0.0;
+    float flConeToDirection = dot( Direction, -lightData.GetDirection() ) - lightData.SpotLightInnerOuterConeCosines.y;
+    if ( flConeToDirection > 0.0 )
+    {
+        float flDistToLightSq = dot( offset, offset );
+        float flLightFalloff = CalculateDistanceFalloff( flDistToLightSq, lightData.LinearFalloff, lightData.QuadraticFalloff, lightData.FalloffBias, 1.0 );
+        Attenuation = flLightFalloff * flConeToDirection * lightData.SpotLightInnerOuterConeCosines.z;
+    }
+    // Visibility
+    Visibility = 1.0;
+    if ( lightData.Type == LightType::LightTypeDirectional )
+        Visibility = DirectionalLightShadow::GetVisibility( vPositionWs, vPositionSs );
+    else if ( lightData.Type == LightType::LightTypePoint )
+        Visibility = ProjectedShadowCube::GetVisibility( lightData.ShadowMapIndex, vPositionWs );
+    else if ( lightData.Type == LightType::LightTypeSpot )
+        Visibility = ProjectedShadow::GetVisibility( lightData.ShadowMapIndex, vPositionWs, vPositionSs );
 }
 
 //-----------------------------------------------------------------------------
@@ -239,31 +197,44 @@ class StaticLight
 };
 
 //-----------------------------------------------------------------------------
-// Light::From / Light::Count — defined here because they depend on StaticLight
+// Light::Query / Light::Fetch — defined here because they depend on StaticLight
 //-----------------------------------------------------------------------------
-
-static Light Light::From( float3 vPositionWs, float4 vPositionSs, uint nLightIndex, float2 vLightMapUV )
+static LightRange Light::Query( float4 vPositionSs )
 {
-    uint dynamicCount = Cluster::Query( ClusterItemType_Light, vPositionSs ).Count;
-
-    if ( nLightIndex < dynamicCount )
-    {
-        Light light = (Light)0;
-
-        ClusterRange range = Cluster::Query( ClusterItemType_Light, vPositionSs );
-        uint clusterLocalIndex = min( nLightIndex, range.Count - 1 );
-        uint lightIndex = Cluster::LoadItem( range, clusterLocalIndex );
-
-        light.Init( vPositionWs, DynamicLightConstantByIndex( lightIndex ), vPositionSs.xy );
-        return light;
-    }
-
-    return StaticLight::From( vPositionWs, vLightMapUV, nLightIndex - dynamicCount, vPositionSs.xy );
+    ClusterRange range = Cluster::Query( ClusterItemType_Light, vPositionSs );
+    LightRange query;
+    query.ClusterRange = range;
+    query.Count = range.Count;
+    if ( g_DirectionalLightEnabled )
+        query.Count++;
+    query.DynamicCount = query.Count;
+    query.Count += StaticLight::Count();
+    return query;
 }
 
-static uint Light::Count( float4 vPositionSs )
+static Light Light::Fetch( LightRange query, uint index, float3 vPositionWs, float2 vPositionSs, float2 vLightMapUV )
 {
-    return Cluster::Query( ClusterItemType_Light, vPositionSs ).Count + StaticLight::Count();
+    if ( index < query.ClusterRange.Count ) 
+    {
+        // Initialize dynamic light
+        BinnedLight data = DynamicLightConstantByIndex( Cluster::LoadItem( query.ClusterRange, index ) );
+        Light light = (Light)0;
+        light.Init( vPositionWs, data, vPositionSs );
+        return light;
+    } 
+    else if ( g_DirectionalLightEnabled && index == query.ClusterRange.Count )
+    {
+        // Initialize directional light
+        Light light = (Light)0;
+        light.Color = g_DirectionalLightColor.rgb;
+        light.Position = 0.0;
+        light.Direction = -g_DirectionalLightDirection.xyz;
+        light.Attenuation = 1.0;
+        light.Visibility = DirectionalLightShadow::GetVisibility( vPositionWs, vPositionSs );
+        return light;
+    }
+    // static light
+    return StaticLight::From( vPositionWs, vLightMapUV, index - query.DynamicCount, vPositionSs );
 }
 
 #endif // LIGHT_HLSL


### PR DESCRIPTION
## Summary
The light query stuff from https://github.com/Facepunch/sbox-public/pull/10148 but now it works with shadows2, also returns the directional light as part of the loop.

## Implementation Details
Took the opportunity to remove Light::Count and Light::From since they run significantly worse and anyone who was using them would have to edit their shaders anyway, they are replaced with Light::Query returning a LightRange struct and Light::Fetch, the struct stores the Cluster::Query result so that it doesn't need to be queried twice per light. Looping over lights now looks like
```hlsl
LightRange query = Light::Query( ScreenPosition );
for ( uint x = 0; x < query.Count; x++ )
{
	Light l = Light::Fetch( query, x, WorldPosition, ScreenPosition.xy );
	...
}
```

The directional light (if enabled) is also stuck into a Light struct and fetched as part of the loop, performance is the same and lets the Light class maintain its ease of use. To my knowledge the performance win there was just in keeping it out of cluster.

## Screenshots
<img width="2560" height="1296" alt="image" src="https://github.com/user-attachments/assets/f70f161d-17e4-417c-8420-a6fefd5278c6" />

## On the topic of including the directional light
My assumption is that directional light is being kept separate for performance reasons, so I compared performance with it in the loop and separate in a scene with translucent additive planes stacked 34 high.

Using the Light loop with directional light included
```cs
float4 MainPs( PixelInput i ) : SV_Target0
{
    float3 color = 0.0;
    float3 pos = i.vPositionWithOffsetWs + g_vCameraPositionWs;

    LightRange query = Light::Query( i.vPositionSs ); // with dir light
    for ( uint x = 0; x < query.Count; x++ )
    {
        Light l = Light::Fetch( query, x, pos, i.vPositionSs.xy );
        color += l.Color * l.Attenuation * max( dot( l.Direction, i.vNormalWs ), 0 ) * l.Visibility;
    }

    return float4(color, 1);
}
```
avg 9.14ms, max 10.95ms
<img width="2560" height="1296" alt="image" src="https://github.com/user-attachments/assets/fa97ee0c-4088-4585-bba1-d007a0c989f7" />



Using the Light loop with directional light excluded, plus a separate block for the directional light
```cs
float4 MainPs( PixelInput i ) : SV_Target0
{
    float3 color = 0.0;
    float3 pos = i.vPositionWithOffsetWs + g_vCameraPositionWs;

    LightRange query = Light::Query( i.vPositionSs ); // without dir light
    for ( uint x = 0; x < query.Count; x++ )
    {
        Light l = Light::Fetch( query, x, pos, i.vPositionSs.xy );
        color += l.Color * l.Attenuation * max( dot( l.Direction, i.vNormalWs ), 0 ) * l.Visibility;
    }

    if ( g_DirectionalLightEnabled )
    {
        color += g_DirectionalLightColor.rgb * max( dot( -g_DirectionalLightDirection, i.vNormalWs ), 0 ) * DirectionalLightShadow::GetVisibility( pos, i.vPositionSs.xy );
    }

    return float4(color, 1);
}
```
avg 9.25ms, max 13.01ms
<img width="2560" height="1297" alt="image" src="https://github.com/user-attachments/assets/ab71675a-bd3f-4dc2-9150-aaccf6cc858b" />

I don't think it would be fair to say separated directional light runs worse because the numbers jump around a bit (especially when screen snip is starting) but I think I could confidently say it doesn't run any better, and it's nicer to be able to put the lighting code directly into the loop and not need to worry about the directional light. I can still remove it from the loop but I don't really see the benefit unless there's something I'm missing.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂