### PR TITLE
Re-enabled 'None' anti-aliasing option with a warning tooltip

### DIFF
--- a/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
+++ b/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
@@ -113,7 +113,7 @@
 
     List<Option> AntiAliasingOptions = new List<Option>()
     {
-     //   new Option("None", MultisampleAmount.MultisampleNone),
+        new Option("None", MultisampleAmount.MultisampleNone),
         new Option("2x", MultisampleAmount.Multisample2x),
         new Option("4x", MultisampleAmount.Multisample4x),
         new Option("8x", MultisampleAmount.Multisample8x),


### PR DESCRIPTION
## Summary

The 'None' anti-aliasing option in video settings has been re-enabled with an appropriate warning tooltip attached. This allows users to fully disable anti-aliasing in order to further improve performance.

## Motivation & Context

As long as they are warned of potential visual artifacts, players should be allowed to sacrifice visual fidelity in order to improve performance. 

This change was made in response to the suggestion below. It was also a way for me to dip my feet into the s&box codebase.

Fixes #10767

## Implementation Details

Apart from uncommenting the 'None' anti-aliasing option, I added a tooltip specific to the option which warns of potential visual artifacts. 
I also updated `ButtonGroup` so that `Option.Tooltip` is actually applied to the generated buttons, since it was previously ignored.

## Screenshot of Addition
_When hovering the 'None' option:_
<img width="1011" height="109" alt="image" src="https://github.com/user-attachments/assets/fe091354-8ca5-4f03-8e64-88be22841c30" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂