### PR TITLE
Ability to mark an asset as editor only to stop it from being uploaded in non library projects

### DIFF
--- a/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
+++ b/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
@@ -72,6 +72,11 @@ public enum AssetTypeFlags
 	/// Include thumbnails when publishing as part of another package
 	/// </summary>
 	IncludeThumbnails = 1 << 1,
+
+	/// <summary>
+	/// If set then this resource cannot be published when uploading a game.
+	/// </summary>
+	EditorOnly = 1 << 2,
 }
 
 [Obsolete( "Use AssetType instead" )]

--- a/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
+++ b/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
@@ -74,7 +74,7 @@ public enum AssetTypeFlags
 	IncludeThumbnails = 1 << 1,
 
 	/// <summary>
-	/// If set then this resource cannot be published when uploading a game.
+	/// If set then this resource cannot be uploaded as part of a game or addon. Only when the project that is being uploaded is a libary, can the resource be uploaded.
 	/// </summary>
 	EditorOnly = 1 << 2,
 }

--- a/engine/Sandbox.Tools/Utility/ProjectPublisher/ProjectPublisher.cs
+++ b/engine/Sandbox.Tools/Utility/ProjectPublisher/ProjectPublisher.cs
@@ -512,6 +512,9 @@ public partial class ProjectPublisher
 	/// </summary>
 	public static bool CanPublishFile( Asset a )
 	{
+		// Assets marked as 'EditorOnly' will not be uploaded when the current project is a game project
+		if ( Project.Current.Package.TypeName == "game" && a.AssetType.Flags.HasFlag( AssetTypeFlags.EditorOnly ) ) return false;
+
 		// Core/base shaders should never be uploaded
 		// Ideally I'd just check against mod_base and mod_core but we have weird c# filesystem
 		if ( a.AbsolutePath.Contains( "/addons/base/assets/shaders/", StringComparison.OrdinalIgnoreCase ) ) return false;

--- a/engine/Sandbox.Tools/Utility/ProjectPublisher/ProjectPublisher.cs
+++ b/engine/Sandbox.Tools/Utility/ProjectPublisher/ProjectPublisher.cs
@@ -513,7 +513,7 @@ public partial class ProjectPublisher
 	public static bool CanPublishFile( Asset a )
 	{
 		// Assets marked as 'EditorOnly' will not be uploaded when the current project is a game project
-		if ( Project.Current.Package.TypeName == "game" && a.AssetType.Flags.HasFlag( AssetTypeFlags.EditorOnly ) ) return false;
+		if ( Project.Current.Package.TypeName != "library" && a.AssetType.Flags.HasFlag( AssetTypeFlags.EditorOnly ) ) return false;
 
 		// Core/base shaders should never be uploaded
 		// Ideally I'd just check against mod_base and mod_core but we have weird c# filesystem

--- a/engine/Sandbox.Tools/Utility/ProjectPublisher/ProjectPublisher.cs
+++ b/engine/Sandbox.Tools/Utility/ProjectPublisher/ProjectPublisher.cs
@@ -512,7 +512,7 @@ public partial class ProjectPublisher
 	/// </summary>
 	public static bool CanPublishFile( Asset a )
 	{
-		// Assets marked as 'EditorOnly' will not be uploaded when the current project is a game project
+		// Assets marked as 'EditorOnly' will not be uploaded when the project type of the current project is not 'library'
 		if ( Project.Current.Package.TypeName != "library" && a.AssetType.Flags.HasFlag( AssetTypeFlags.EditorOnly ) ) return false;
 
 		// Core/base shaders should never be uploaded

--- a/game/addons/tools/Code/Inspectors/AssetInspector.cs
+++ b/game/addons/tools/Code/Inspectors/AssetInspector.cs
@@ -83,7 +83,7 @@ public class AssetInspector : InspectorWidget
 			Scroller.Canvas.Layout = Layout.Column();
 			mainWidget.Layout.Add( Scroller );
 
-			if ( !so.IsMultipleTargets && !Asset.IsProcedural )
+			if ( !so.IsMultipleTargets && !Asset.IsProcedural && !Asset.AssetType.Flags.HasFlag( AssetTypeFlags.EditorOnly ) )
 			{
 				CreatePublishUI( Asset, Scroller.Canvas );
 			}


### PR DESCRIPTION
## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This PR enables users to mark an asset as `EditorOnly` to prevent it from being uploaded on a project that isnt a "library"

## Motivation & Context

So that you can have "editor only" resources like shadergraph not get uploaded when uploading anything but a library.

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

Added `EditorOnly` to `AssetTypeFlags`  along with some basic checks in the Engine project and base editor library so that Resources marked like below dont get published when not uploading a library. The marked asset will also not be exported as part of a game export.

```cs
[AssetType( Name = "MyAsset", Extension = "mything", Category = "Custom", Flags = AssetTypeFlags.EditorOnly )]
public sealed class MyAsset : GameResource
{
}
```

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂