### PR TITLE
WorldPanelInput now uses appropriate action when `Mouse.Active`

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/UI/WorldInput.cs
+++ b/engine/Sandbox.Engine/Scene/Components/UI/WorldInput.cs
@@ -43,12 +43,12 @@ public sealed class WorldInput : Component
 		WorldPanelInput.MouseRightPressed = Input.Down( RightMouseAction );
 		WorldPanelInput.MouseWheel = Input.MouseWheel;
 
-		// If the mouse is active, we want to use the mouse cursor ray instead, and let's implicitly use MOUSE1/2
+		// If the mouse is active, we want to use the mouse cursor ray instead, and use MOUSE1/2 as backup also
 		if ( Mouse.Active && Scene?.Camera is not null )
 		{
 			WorldPanelInput.Ray = Scene.Camera.ScreenPixelToRay( Mouse.Position );
-			WorldPanelInput.MouseLeftPressed = Input.Keyboard.Down( "MOUSE1" );
-			WorldPanelInput.MouseRightPressed = Input.Keyboard.Down( "MOUSE2" );
+			WorldPanelInput.MouseLeftPressed |= Input.Keyboard.Down( "MOUSE1" );
+			WorldPanelInput.MouseRightPressed |= Input.Keyboard.Down( "MOUSE2" );
 		}
 
 		// If we're in VR, triggers are mouse presses, joystick scrolls


### PR DESCRIPTION
## Summary

`WorldPanelInput` now uses the appropriate left and right mouse actions when `Mouse.Active` is true. Hardcoded inputs `MOUSE1` & `MOUSE2` still work in case any behavior relied on this.

## Motivation & Context

This fix allows controllers and remapped `WorldInput`s to provide input while the mouse is active. Previously, input handling was hardcoded to only recognize left and right mouse clicks when the mouse was active.

This fix was made in response to the issue below.
Fixes: #10780

## Implementation Details

When the mouse is active, `MOUSE1` & `MOUSE2` inputs are now `|=`ed with the mouse pressed fields (as opposed to overwriting them).

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂