### PR TITLE
Editor: Warn before duplicate project session (#10739)

### DIFF
--- a/engine/Launcher/StandaloneTest/Widgets/HomeWidget.cs
+++ b/engine/Launcher/StandaloneTest/Widgets/HomeWidget.cs
@@ -389,6 +389,9 @@ public class HomeWidget : Widget
 
 	public void OpenProject( Project project, string args = null )
 	{
+		if ( !ProjectEditorSessionLock.TryConfirmLaunchFromHubBeforeSpawn( project.ConfigFilePath ) )
+			return;
+
 		ProcessStartInfo info = new ProcessStartInfo( "sbox-dev.exe", $"{Environment.CommandLine} -project \"{project.ConfigFilePath}\" {args ?? ""}" );
 		info.UseShellExecute = true;
 		info.CreateNoWindow = true;

--- a/engine/Sandbox.AppSystem/EditorAppSystem.cs
+++ b/engine/Sandbox.AppSystem/EditorAppSystem.cs
@@ -1,4 +1,7 @@
-﻿namespace Sandbox;
+﻿using System;
+using Editor;
+
+namespace Sandbox;
 
 /// <summary>
 /// Used for sbox-dev editor
@@ -44,10 +47,28 @@ public class EditorAppSystem : AppSystem
 		var path = Utility.CommandLine.GetSwitch( "-project", "" ).TrimQuoted();
 
 		Project project = new() { ConfigFilePath = path };
-		if ( project.LoadMinimal() )
-			return true;
+		if ( !project.LoadMinimal() )
+		{
+			NativeEngine.EngineGlobal.Plat_MessageBox( "Couldn't open project", $"Couldn't open project file: {path}" );
+			return false;
+		}
 
-		NativeEngine.EngineGlobal.Plat_MessageBox( "Couldn't open project", $"Couldn't open project file: {path}" );
-		return false;
+		// Before InitGame / long bootstrap: take per-project mutex so duplicate launches fail fast (see #10739).
+		try
+		{
+			var fullPath = ProjectEditorSessionLock.NormalizeProjectConfigPath( project.ConfigFilePath );
+			if ( !ProjectEditorSessionLock.TryEnterSessionAtStartupBlocking( fullPath ) )
+			{
+				Application.Exit();
+				return false;
+			}
+		}
+		catch ( ArgumentException )
+		{
+			NativeEngine.EngineGlobal.Plat_MessageBox( "Couldn't open project", $"Couldn't open project file: {path}" );
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/engine/Sandbox.Test.Unit/System/ProjectEditorSessionLockTests.cs
+++ b/engine/Sandbox.Test.Unit/System/ProjectEditorSessionLockTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using Editor;
+
+namespace SystemTest;
+
+[TestClass]
+public class ProjectEditorSessionLockTests
+{
+	[TestMethod]
+	public void MutexNameForPath_IsStable_ForSameInput()
+	{
+		var path = Path.GetFullPath( Path.Combine( Path.GetTempPath(), "mutex_test_project", "game.sbproj" ) );
+		var a = ProjectEditorSessionLock.MutexNameForPath( path );
+		var b = ProjectEditorSessionLock.MutexNameForPath( path );
+		Assert.AreEqual( a, b );
+	}
+
+	[TestMethod]
+	public void MutexNameForPath_Differs_ForDifferentPaths()
+	{
+		var a = ProjectEditorSessionLock.MutexNameForPath( @"C:\Temp\A\game.sbproj" );
+		var b = ProjectEditorSessionLock.MutexNameForPath( @"C:\Temp\B\game.sbproj" );
+		Assert.AreNotEqual( a, b );
+	}
+
+	[TestMethod]
+	public void NormalizeProjectConfigPath_AppendsSbproj_ForDirectory()
+	{
+		var root = Path.Combine( Path.GetTempPath(), "norm_test_" + Guid.NewGuid().ToString( "N" ) );
+		Directory.CreateDirectory( root );
+		try
+		{
+			var expected = Path.GetFullPath( Path.Combine( root, ".sbproj" ) );
+			var actual = ProjectEditorSessionLock.NormalizeProjectConfigPath( root );
+			Assert.AreEqual( expected, actual );
+		}
+		finally
+		{
+			try { Directory.Delete( root, true ); } catch { }
+		}
+	}
+}

--- a/engine/Sandbox.Tools/StartupLoadProject.cs
+++ b/engine/Sandbox.Tools/StartupLoadProject.cs
@@ -67,7 +67,7 @@ static class StartupLoadProject
 		//
 		{
 			var projectList = new ProjectList();
-			projectList.TryAddFromFile( path );
+			projectList.TryAddFromFile( Project.Current.ConfigFilePath );
 			projectList.SaveList();
 		}
 
@@ -95,12 +95,14 @@ static class StartupLoadProject
 		if ( string.IsNullOrEmpty( path ) ) throw new ArgumentException( nameof( path ) );
 		Assert.IsNull( Project.Current );
 
+		var pathForLoad = ProjectEditorSessionLock.NormalizeProjectConfigPath( path );
+
 		// This kinda sucks but better than overcomplicating everything.. make sure to update the steps..
 		CurrentStep = 0;
 		TotalSteps = 16;
 
 		// should never be one existing once we remove all this shit
-		Project project = Project.AddFromFile( path, false );
+		Project project = Project.AddFromFile( pathForLoad, false );
 		var parentPackage = project.Config.GetMetaOrDefault<string>( "ParentPackage", null );
 
 		Step( "Initializing filesystem" );

--- a/engine/Sandbox.Tools/ToolsDll.cs
+++ b/engine/Sandbox.Tools/ToolsDll.cs
@@ -1,3 +1,4 @@
+using Editor;
 using NativeEngine;
 using Sandbox.Audio;
 using Sandbox.Engine;
@@ -43,6 +44,7 @@ internal class ToolsDll : IToolsDll
 
 	public void Exiting()
 	{
+		ProjectEditorSessionLock.ReleaseIfHeld();
 		EditorEvent.Run( "app.exit" );
 		EditorCookie?.Save();
 		ProjectCookie?.Save();

--- a/engine/Sandbox.Tools/Utility/ProjectEditorSessionLock.cs
+++ b/engine/Sandbox.Tools/Utility/ProjectEditorSessionLock.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+
+namespace Editor;
+
+/// <summary>
+/// Cross-process lock so only one editor session "owns" a given .sbproj path at a time.
+/// Uses the same path normalization as <see cref="Project.AddFromFile"/> for the mutex key.
+/// </summary>
+internal static class ProjectEditorSessionLock
+{
+	static Mutex _sessionMutex;
+
+	/// <summary>
+	/// Match <see cref="Project.AddFromFile"/> path cleanup, then <c>System.IO.Path.GetFullPath(string)</c>.
+	/// </summary>
+	internal static string NormalizeProjectConfigPath( string path )
+	{
+		if ( string.IsNullOrEmpty( path ) )
+			throw new ArgumentException( "Project path is empty.", nameof( path ) );
+
+		if ( !path.EndsWith( ".sbproj", StringComparison.OrdinalIgnoreCase ) )
+			path = Path.Combine( path, ".sbproj" );
+
+		return Path.GetFullPath( path );
+	}
+
+	internal static string MutexNameForPath( string fullPathToSbproj )
+	{
+		var hash = SHA256.HashData( Encoding.UTF8.GetBytes( fullPathToSbproj ) );
+		var hex = Convert.ToHexString( hash.AsSpan( 0, 16 ) );
+		if ( OperatingSystem.IsWindows() )
+			return @$"Local\SboxEditorProject_{hex}";
+		return $"SboxEditorProject_{hex}";
+	}
+
+	/// <summary>
+	/// Call from <c>EditorAppSystem.CheckProject</c> after <c>LoadMinimal</c> succeeds, before <c>InitGame</c>,
+	/// so the mutex exists before long bootstrap / splash work. Returns false if the user cancels the second instance.
+	/// </summary>
+	internal static bool TryEnterSessionAtStartupBlocking( string fullPathToSbproj )
+	{
+		var name = MutexNameForPath( fullPathToSbproj );
+		bool createdNew;
+		var attempt = new Mutex( initiallyOwned: true, name: name, createdNew: out createdNew );
+
+		if ( createdNew )
+		{
+			_sessionMutex?.Dispose();
+			_sessionMutex = attempt;
+			return true;
+		}
+
+		attempt.Dispose();
+
+		return ShowSecondInstanceDialogBlocking(
+			"This project may already be open in another editor instance.\n\nStart another editor for the same project anyway?" );
+	}
+
+	/// <summary>
+	/// Launcher: if an editor already holds the session lock, confirm before spawning <c>sbox-dev</c>.
+	/// </summary>
+	internal static bool TryConfirmLaunchFromHubBeforeSpawn( string configFilePath )
+	{
+		string fullPath;
+		try
+		{
+			fullPath = NormalizeProjectConfigPath( configFilePath );
+		}
+		catch
+		{
+			return true;
+		}
+
+		var name = MutexNameForPath( fullPath );
+
+		try
+		{
+			using var existing = Mutex.OpenExisting( name );
+			if ( !existing.WaitOne( TimeSpan.Zero ) )
+				return ShowSecondInstanceDialogBlocking(
+					"This project may already be open in another editor instance.\n\nStart another editor for the same project anyway?" );
+
+			existing.ReleaseMutex();
+		}
+		catch ( WaitHandleCannotBeOpenedException )
+		{
+		}
+
+		return true;
+	}
+
+	internal static void ReleaseIfHeld()
+	{
+		_sessionMutex?.Dispose();
+		_sessionMutex = null;
+	}
+
+	static bool ShowSecondInstanceDialogBlocking( string message )
+	{
+		var tcs = new TaskCompletionSource<bool>();
+
+		var popup = new PopupDialogWidget( "⚠️" );
+		popup.WindowTitle = "Project already open";
+		popup.MessageLabel.Text = message;
+
+		popup.ButtonLayout.AddStretchCell();
+		popup.ButtonLayout.Add( new Button( "Cancel" ) { Clicked = () =>
+		{
+			popup.Destroy();
+			tcs.TrySetResult( false );
+		} } );
+		popup.ButtonLayout.Add( new Button.Primary( "Open anyway" ) { Clicked = () =>
+		{
+			popup.Destroy();
+			tcs.TrySetResult( true );
+		} } );
+
+		popup.SetModal( true, true );
+		popup.Hide();
+		popup.Show();
+
+		while ( !tcs.Task.IsCompleted )
+		{
+			Application.Spin();
+			Native.QApp.processEvents();
+			Thread.Yield();
+		}
+
+		return tcs.Task.GetAwaiter().GetResult();
+	}
+}

--- a/engine/Sandbox.Tools/Utility/ProjectEditorSessionLock.cs
+++ b/engine/Sandbox.Tools/Utility/ProjectEditorSessionLock.cs
@@ -108,16 +108,22 @@ internal static class ProjectEditorSessionLock
 		popup.MessageLabel.Text = message;
 
 		popup.ButtonLayout.AddStretchCell();
-		popup.ButtonLayout.Add( new Button( "Cancel" ) { Clicked = () =>
+		popup.ButtonLayout.Add( new Button( "Cancel" )
+		{
+			Clicked = () =>
 		{
 			popup.Destroy();
 			tcs.TrySetResult( false );
-		} } );
-		popup.ButtonLayout.Add( new Button.Primary( "Open anyway" ) { Clicked = () =>
+		}
+		} );
+		popup.ButtonLayout.Add( new Button.Primary( "Open anyway" )
+		{
+			Clicked = () =>
 		{
 			popup.Destroy();
 			tcs.TrySetResult( true );
-		} } );
+		}
+		} );
 
 		popup.SetModal( true, true );
 		popup.Hide();


### PR DESCRIPTION
## Summary

Adds a per-`.sbproj` session mutex so a second editor for the same project shows a **Project already open** dialog (Cancel / Open anyway) instead of stacking instances silently. The lock is taken early in editor startup (after `LoadMinimal`, before `InitGame`) so the prompt appears during load, not only after the main window is up. The standalone launcher checks the same lock before spawning `sbox-dev`.

## Motivation & Context

Opening the same project in multiple editors causes confusing state and wasted work. This makes the duplicate case explicit and matches expectations for a desktop tool.

Fixes: #10739

## Implementation Details

- `ProjectEditorSessionLock`: SHA-256–based named mutex (`Local\...` on Windows), path normalization aligned with `Project.AddFromFile`, modal via `PopupDialogWidget`, release on `ToolsDll.Exiting`.
- `EditorAppSystem.CheckProject`: acquire lock / prompt after successful `LoadMinimal`.
- `StartupLoadProject.OpenProject`: load using normalized path; recent project list uses `Project.Current.ConfigFilePath`.
- `HomeWidget.OpenProject`: `TryConfirmLaunchFromHubBeforeSpawn` before `Process.Start`.
- Unit tests for mutex name stability and path normalization.

**Note:** A very tight race remains if two processes start before either creates the mutex; normal use and hub flow are covered.

## Screenshots / Videos (if applicable)

<img width="701" height="461" alt="s box-public_issue-10739" src="https://github.com/user-attachments/assets/27836d68-6443-45fe-bf8e-8536e56e52f7" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable) — internal helper only
- [x] Unit tests added where applicable — `ProjectEditorSessionLockTests` (full `Sandbox.Test.Unit` may require local Steam/unittest assets)
- [x] I’m okay with this PR being rejected or requested to change 🙂