### PR TITLE
[SHADERGRAPH] Fix UV on triplanar node

### DIFF
--- a/game/addons/tools/Code/ShaderGraph/Compiler/ShaderTemplate.cs
+++ b/game/addons/tools/Code/ShaderGraph/Compiler/ShaderTemplate.cs
@@ -444,7 +444,7 @@ float3 HSV2RGB( float3 c )
 	public static string TexTriplanar_Color => @"
 float4 TexTriplanar_Color( in Texture2D tTex, in SamplerState sSampler, float3 vPosition, float3 vNormal )
 {
-	float2 uvX = vPosition.zy;
+	float2 uvX = vPosition.yz;
 	float2 uvY = vPosition.xz;
 	float2 uvZ = vPosition.xy;
 
@@ -469,7 +469,7 @@ float4 TexTriplanar_Color( in Texture2D tTex, in SamplerState sSampler, float3 v
 	public static string TexTriplanar_Normal => @"
 float3 TexTriplanar_Normal( in Texture2D tTex, in SamplerState sSampler, float3 vPosition, float3 vNormal )
 {
-	float2 uvX = vPosition.zy;
+	float2 uvX = vPosition.yz;
 	float2 uvY = vPosition.xz;
 	float2 uvZ = vPosition.xy;
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

I was using the triplanar node but the result were not matching what unity can have with proper aligned triplanar projection

## Motivation & Context

importing some triplanar shaders

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details



## Screenshots / Videos (if applicable)

Before:
<img width="2847" height="1210" alt="image" src="https://github.com/user-attachments/assets/7c21b78e-eb1e-4772-91d6-c75f8505db23" />

after:
<img width="2843" height="1150" alt="image" src="https://github.com/user-attachments/assets/9fe3417d-5f30-4874-8e3b-c862a23193d7" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂