### PR TITLE
Z Index on sprite rendering method

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
@@ -31,7 +31,7 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 	bool Lighting { get; }
 	Vector2 Pivot { get; }
 	float DepthFeather { get; }
-	float SortDepthBias { get; }
+	int ZIndex { get; }
 	float FogStrength { get; }
 	FilterMode TextureFilter { get; }
 
@@ -141,7 +141,7 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 				}
 
 				float halfSize = MathF.Max( pivotMaxX * 2f * scaleX, pivotMaxY * 2f * scaleY );
-				float biasExpand = MathF.Abs( SortDepthBias );
+				float biasExpand = MathF.Abs( (float)ZIndex );
 				var expand = new Vector3( halfSize + biasExpand, halfSize + biasExpand, halfSize + biasExpand );
 				var particlePos = new Vector3( pos.x, pos.y, pos.z );
 				boundsMin = Vector3.Min( boundsMin, particlePos - expand );
@@ -180,7 +180,7 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 				spritePtr->SequenceTime = sequenceTime;
 				spritePtr->BlendSheetUV = sequenceData;
 				spritePtr->Offset = origin;
-				spritePtr->SortDepthBias = SortDepthBias;
+				spritePtr->ZIndex = ZIndex;
 				spritePtr->SortBiasInKey = IsSorted ? 1u : 0u;
 
 				validCount++;

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
@@ -31,6 +31,7 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 	bool Lighting { get; }
 	Vector2 Pivot { get; }
 	float DepthFeather { get; }
+	float SortDepthBias { get; }
 	float FogStrength { get; }
 	FilterMode TextureFilter { get; }
 
@@ -140,7 +141,8 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 				}
 
 				float halfSize = MathF.Max( pivotMaxX * 2f * scaleX, pivotMaxY * 2f * scaleY );
-				var expand = new Vector3( halfSize, halfSize, halfSize );
+				float biasExpand = MathF.Abs( SortDepthBias );
+				var expand = new Vector3( halfSize + biasExpand, halfSize + biasExpand, halfSize + biasExpand );
 				var particlePos = new Vector3( pos.x, pos.y, pos.z );
 				boundsMin = Vector3.Min( boundsMin, particlePos - expand );
 				boundsMax = Vector3.Max( boundsMax, particlePos + expand );
@@ -178,6 +180,8 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 				spritePtr->SequenceTime = sequenceTime;
 				spritePtr->BlendSheetUV = sequenceData;
 				spritePtr->Offset = origin;
+				spritePtr->SortDepthBias = SortDepthBias;
+				spritePtr->SortBiasInKey = IsSorted ? 1u : 0u;
 
 				validCount++;
 			}

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
@@ -96,6 +96,9 @@ public sealed partial class ParticleSpriteRenderer : ParticleRenderer, Component
 	[Group( "Rendering" )]
 	[Property] public ParticleSortMode SortMode { get; set; }
 
+	[Group( "Rendering" )]
+	[Property] public float SortDepthBias { get; set; }
+
 	/// <summary>
 	/// Amount of feathering applied to the depth, softening its intersection with geometry.
 	/// </summary>

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
@@ -97,7 +97,8 @@ public sealed partial class ParticleSpriteRenderer : ParticleRenderer, Component
 	[Property] public ParticleSortMode SortMode { get; set; }
 
 	[Group( "Rendering" )]
-	[Property] public float SortDepthBias { get; set; }
+	[Property, Range( -64, 64 ), Title( "Z Index" )]
+	public int ZIndex { get; set; }
 
 	/// <summary>
 	/// Amount of feathering applied to the depth, softening its intersection with geometry.

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleTextRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleTextRenderer.cs
@@ -109,7 +109,8 @@ public sealed class ParticleTextRenderer : ParticleRenderer, Component.ExecuteIn
 	[Property] public ParticleSortMode SortMode { get; set; }
 
 	[Group( "Sprite" )]
-	[Property] public float SortDepthBias { get; set; }
+	[Property, Range( -64, 64 ), Title( "Z Index" )]
+	public int ZIndex { get; set; }
 
 	/// <summary>
 	/// Interface property to determine if particles should be sorted

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleTextRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleTextRenderer.cs
@@ -108,6 +108,9 @@ public sealed class ParticleTextRenderer : ParticleRenderer, Component.ExecuteIn
 	[Group( "Sprite" )]
 	[Property] public ParticleSortMode SortMode { get; set; }
 
+	[Group( "Sprite" )]
+	[Property] public float SortDepthBias { get; set; }
+
 	/// <summary>
 	/// Interface property to determine if particles should be sorted
 	/// </summary>

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/SceneSpriteSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/SceneSpriteSystem.cs
@@ -230,8 +230,8 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 	{
 		var flags = InstanceGroupFlags.None;
 
-		// Non-opaque and sorted needs transparency
-		if ( !component.Opaque && component.IsSorted )
+		// Non-opaque batched particles share the transparent/sorted path so all FX sort in one buffer.
+		if ( !component.Opaque && ( component is IBatchedParticleSpriteRenderer || component.IsSorted ) )
 		{
 			flags |= InstanceGroupFlags.Transparent;
 		}
@@ -259,7 +259,10 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 			(renderOptions.AfterUI ? 8 : 0)
 		);
 
-		var tokens = tags.GetTokens();
+		// Batched particle sprites ignore tags here so one GPU sort spans emitters (tags still apply elsewhere).
+		var tokens = component is IBatchedParticleSpriteRenderer
+			? FrozenSet<uint>.Empty
+			: tags.GetTokens();
 		// Single buffer: [4 bytes flags][1 byte renderLayer][4*N bytes tokens] - bounded to 261 bytes by the guard.
 		Span<byte> buf = tokens.Count <= 64 ? stackalloc byte[5 + tokens.Count * 4] : new byte[5 + tokens.Count * 4];
 		MemoryMarshal.Write( buf, in flags );
@@ -275,12 +278,12 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 	private static RenderGroupConfig BuildConfig( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions )
 	{
 		var flags = InstanceGroupFlags.None;
-		if ( !component.Opaque && component.IsSorted ) flags |= InstanceGroupFlags.Transparent;
+		if ( !component.Opaque && ( component is IBatchedParticleSpriteRenderer || component.IsSorted ) ) flags |= InstanceGroupFlags.Transparent;
 		if ( component.Shadows && !component.Additive ) flags |= InstanceGroupFlags.CastShadow;
 		if ( component.Additive ) flags |= InstanceGroupFlags.Additive;
 		if ( component.Opaque ) flags |= InstanceGroupFlags.Opaque;
 
-		return new RenderGroupConfig( flags, renderOptions.Clone(), tags.GetTokens().ToFrozenSet() );
+		return new RenderGroupConfig( flags, renderOptions.Clone(), component is IBatchedParticleSpriteRenderer ? FrozenSet<uint>.Empty : tags.GetTokens().ToFrozenSet() );
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Systems/Movies/Recording/ComponentCapturer.BuiltIn.cs
+++ b/engine/Sandbox.Engine/Systems/Movies/Recording/ComponentCapturer.BuiltIn.cs
@@ -404,6 +404,7 @@ file sealed class ParticleSpriteRendererCapturer : ComponentCapturer<ParticleSpr
 		recorder.Property( nameof( ParticleSpriteRenderer.TextureFilter ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.Alignment ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.SortMode ) ).Capture();
+		recorder.Property( nameof( ParticleSpriteRenderer.SortDepthBias ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.DepthFeather ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.FogStrength ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.FaceVelocity ) ).Capture();
@@ -452,6 +453,7 @@ file sealed class ParticleTextRendererCapturer : ComponentCapturer<ParticleTextR
 
 		recorder.Property( nameof( ParticleTextRenderer.Alignment ) ).Capture();
 		recorder.Property( nameof( ParticleTextRenderer.SortMode ) ).Capture();
+		recorder.Property( nameof( ParticleTextRenderer.SortDepthBias ) ).Capture();
 	}
 }
 

--- a/engine/Sandbox.Engine/Systems/Movies/Recording/ComponentCapturer.BuiltIn.cs
+++ b/engine/Sandbox.Engine/Systems/Movies/Recording/ComponentCapturer.BuiltIn.cs
@@ -404,7 +404,7 @@ file sealed class ParticleSpriteRendererCapturer : ComponentCapturer<ParticleSpr
 		recorder.Property( nameof( ParticleSpriteRenderer.TextureFilter ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.Alignment ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.SortMode ) ).Capture();
-		recorder.Property( nameof( ParticleSpriteRenderer.SortDepthBias ) ).Capture();
+		recorder.Property( nameof( ParticleSpriteRenderer.ZIndex ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.DepthFeather ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.FogStrength ) ).Capture();
 		recorder.Property( nameof( ParticleSpriteRenderer.FaceVelocity ) ).Capture();
@@ -453,7 +453,7 @@ file sealed class ParticleTextRendererCapturer : ComponentCapturer<ParticleTextR
 
 		recorder.Property( nameof( ParticleTextRenderer.Alignment ) ).Capture();
 		recorder.Property( nameof( ParticleTextRenderer.SortMode ) ).Capture();
-		recorder.Property( nameof( ParticleTextRenderer.SortDepthBias ) ).Capture();
+		recorder.Property( nameof( ParticleTextRenderer.ZIndex ) ).Capture();
 	}
 }
 

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
@@ -71,6 +71,8 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		public Vector3 Velocity = Vector3.Zero;
 		public Vector4 BlendSheetUV;
 		public Vector2 Offset;
+		public float SortDepthBias;
+		public uint SortBiasInKey;
 		public SpriteData()
 		{
 
@@ -436,7 +438,8 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 						Lighting = packedExponent,
 						DepthFeather = c.DepthFeather,
 						SamplerIndex = SamplerState.GetBindlessIndex( sampler with { Filter = c.TextureFilter } ),
-						Offset = c.Pivot
+						Offset = c.Pivot,
+						SortBiasInKey = Sorted ? 1u : 0u
 					};
 
 					var pivot = c.Pivot;
@@ -592,7 +595,6 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 
 		// Sorting
 		attributes.Set( "DistanceBuffer", GPUDistanceBuffer );
-		attributes.Set( "CameraPosition", Graphics.CameraPosition );
 
 		SpriteComputeShader.DispatchWithAttributes( attributes, spriteCount, 1, 1 );
 

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
@@ -71,7 +71,8 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		public Vector3 Velocity = Vector3.Zero;
 		public Vector4 BlendSheetUV;
 		public Vector2 Offset;
-		public float SortDepthBias;
+		/// <summary>Draw order for transparent particle sprites: higher draws on top (Source 2 inches along eye ray + stable sort).</summary>
+		public int ZIndex;
 		public uint SortBiasInKey;
 		public SpriteData()
 		{

--- a/game/addons/base/Assets/shaders/sort_cs.shader
+++ b/game/addons/base/Assets/shaders/sort_cs.shader
@@ -59,9 +59,15 @@ CS
 			float distanceB = DistanceBuffer[indexB];
 
 			bool ascending = ( currentIndex & Dim ) == 0;
-			float comparison = ( distanceA - distanceB ) * ( ascending ? 1 : -1 );
+			float distCmp = distanceA - distanceB;
+			bool swap = ( distCmp * ( ascending ? 1 : -1 ) ) > 0;
+			if ( !swap && distCmp == 0.0 && indexA != indexB )
+			{
+				int idxCmp = (indexA < indexB) ? -1 : 1;
+				swap = ( idxCmp * ( ascending ? 1 : -1 ) ) > 0;
+			}
 
-			if ( comparison > 0 )
+			if ( swap )
 			{
 				SortBuffer[currentIndex] = indexB;
 				SortBuffer[compareIndex] = indexA;

--- a/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
@@ -63,13 +63,14 @@ CS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
+		float SortDepthBias;
+		uint SortBiasInKey;
 	};
 	StructuredBuffer<SpriteData> SpriteBuffer < Attribute( "Sprites" ); >;
 	RWStructuredBuffer<SpriteData> SpriteBufferOut < Attribute( "SpriteBufferOut" ); >;
 
 	// Sorting related
 	RWStructuredBuffer<float> DistanceBuffer < Attribute( "DistanceBuffer" ); >;
-	float3 CameraPosition < Attribute ("CameraPosition"); >;
 
 	int SpriteCount < Attribute( "SpriteCount"); >;
 	RWStructuredBuffer<int> AtomicCounter < Attribute( "AtomicCounter" ); >;
@@ -130,17 +131,22 @@ CS
 	}
 
 	#define FLT_MAX 3.402823466e+38f
+	#define SORT_BIAS_DIST_SCALE ( 22.0f / 8388608.0f )
+
+	// applyBiasToKey: particle By Distance adds scaled SortDepthBias to the sort key.
+	float SortKeyFromWorldPos( float3 worldPosition, float sortBias, uint applyBiasToKey )
+	{
+		float3 delta = worldPosition - g_vCameraPositionWs.xyz;
+		float distSq = dot( delta, delta );
+		if ( applyBiasToKey == 0 )
+			return distSq;
+		float biasScale = max( distSq * SORT_BIAS_DIST_SCALE, 0.18f );
+		return distSq + sortBias * biasScale;
+	}
 
 	groupshared int groupWriteSize[64];
     groupshared int groupWriteOffset[64];
     groupshared int groupBaseOffset;
-
-	// Here we calculate sqrt distance, its faster
-	float CalculateDistance(float3 worldPosition)
-	{
-		float3 delta = (worldPosition - CameraPosition);
-		return dot(delta, delta);
-	}
 
 	[numthreads( 64, 1, 1 ) ]
 	void MainCs( uint2 dispatchId : SV_DispatchThreadID, uint3 GTid : SV_GroupThreadID )
@@ -150,12 +156,17 @@ CS
 		bool isValid = i < SpriteCount;
 
 		SpriteData sprite = SpriteBuffer[i];
-		float3 cameraAxis = g_vCameraDirWs;
-		float3 cameraUp = g_vCameraUpDirWs;
 
 		// Transfer sprite to out buffer
 		if(isValid)
 		{
+			float3 toCamera = g_vCameraPositionWs.xyz - sprite.Position;
+			float distToCam = length( toCamera );
+			if ( distToCam > 1e-5f )
+				sprite.Position += ( toCamera / distToCam ) * sprite.SortDepthBias;
+			else if ( length( g_vCameraDirWs.xyz ) > 1e-5f )
+				sprite.Position -= normalize( g_vCameraDirWs.xyz ) * sprite.SortDepthBias;
+
 			if ( sprite.RotationOffset > -1 )
 			{	
 				float4 ss = mul( g_matWorldToView, float4( sprite.Velocity, 0 ) );
@@ -165,7 +176,7 @@ CS
 			}
 
 
-			DistanceBuffer[i] = CalculateDistance(sprite.Position);
+			DistanceBuffer[i] = SortKeyFromWorldPos( sprite.Position, sprite.SortDepthBias, sprite.SortBiasInKey );
 			SpriteBufferOut[i] = sprite;
 		}
 		else
@@ -245,7 +256,7 @@ CS
 
 					b.Position = pos;
 					// We fill distance buffer for sorting
-					DistanceBuffer[writeLocation] = CalculateDistance(b.Position);
+					DistanceBuffer[writeLocation] = SortKeyFromWorldPos( b.Position, b.SortDepthBias, b.SortBiasInKey );
 					SpriteBufferOut[writeLocation] = b;
 
 					index++;
@@ -257,7 +268,7 @@ CS
 
 				// Fil distance buffer for sorting
 				writeLocation = writeOffset + index;
-				DistanceBuffer[writeLocation] = CalculateDistance(b.Position);
+				DistanceBuffer[writeLocation] = SortKeyFromWorldPos( b.Position, b.SortDepthBias, b.SortBiasInKey );
 
 				SpriteBufferOut[writeLocation] = b;
 

--- a/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
@@ -63,7 +63,7 @@ CS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
-		float SortDepthBias;
+		int ZIndex;
 		uint SortBiasInKey;
 	};
 	StructuredBuffer<SpriteData> SpriteBuffer < Attribute( "Sprites" ); >;
@@ -131,17 +131,42 @@ CS
 	}
 
 	#define FLT_MAX 3.402823466e+38f
-	#define SORT_BIAS_DIST_SCALE ( 22.0f / 8388608.0f )
 
-	// applyBiasToKey: particle By Distance adds scaled SortDepthBias to the sort key.
-	float SortKeyFromWorldPos( float3 worldPosition, float sortBias, uint applyBiasToKey )
+	#define ZINDEX_SORT_WEIGHT 268435456.0f
+
+	// ZIndex: Source 2 inches along eye ray; geom = (d−b)²; subtract b*weight for stable float sort keys.
+	float SortParticleDistanceKey( float3 worldPositionBeforeNudge, int zIndex )
 	{
-		float3 delta = worldPosition - g_vCameraPositionWs.xyz;
+		float b = (float)zIndex;
+		float3 delta = worldPositionBeforeNudge - g_vCameraPositionWs.xyz;
 		float distSq = dot( delta, delta );
-		if ( applyBiasToKey == 0 )
-			return distSq;
-		float biasScale = max( distSq * SORT_BIAS_DIST_SCALE, 0.18f );
-		return distSq + sortBias * biasScale;
+		float d = sqrt( distSq );
+		float sortD = d - b;
+		const float minD = 1e-5f;
+		if ( sortD < minD )
+			sortD = minD;
+		float geom = sortD * sortD;
+		return geom - (float)zIndex * ZINDEX_SORT_WEIGHT;
+	}
+
+	float3 RecoverWorldPosBeforeEyeNudge( float3 worldPositionAfterNudge, float sortBiasInches )
+	{
+		if ( abs( sortBiasInches ) < 1e-8f )
+			return worldPositionAfterNudge;
+		float3 toCamera = g_vCameraPositionWs.xyz - worldPositionAfterNudge;
+		float len = length( toCamera );
+		if ( len > 1e-5f )
+			return worldPositionAfterNudge - ( toCamera / len ) * sortBiasInches;
+		if ( length( g_vCameraDirWs.xyz ) > 1e-5f )
+			return worldPositionAfterNudge + normalize( g_vCameraDirWs.xyz ) * sortBiasInches;
+		return worldPositionAfterNudge;
+	}
+
+	float SortParticleDistanceKeyFromDisplayPos( float3 worldPositionAfterEyeNudge, int zIndex )
+	{
+		float b = (float)zIndex;
+		float3 base = RecoverWorldPosBeforeEyeNudge( worldPositionAfterEyeNudge, b );
+		return SortParticleDistanceKey( base, zIndex );
 	}
 
 	groupshared int groupWriteSize[64];
@@ -160,12 +185,16 @@ CS
 		// Transfer sprite to out buffer
 		if(isValid)
 		{
-			float3 toCamera = g_vCameraPositionWs.xyz - sprite.Position;
+			float3 basePos = sprite.Position;
+			float biasF = (float)sprite.ZIndex;
+			DistanceBuffer[i] = SortParticleDistanceKey( basePos, sprite.ZIndex );
+
+			float3 toCamera = g_vCameraPositionWs.xyz - basePos;
 			float distToCam = length( toCamera );
 			if ( distToCam > 1e-5f )
-				sprite.Position += ( toCamera / distToCam ) * sprite.SortDepthBias;
+				sprite.Position = basePos + ( toCamera / distToCam ) * biasF;
 			else if ( length( g_vCameraDirWs.xyz ) > 1e-5f )
-				sprite.Position -= normalize( g_vCameraDirWs.xyz ) * sprite.SortDepthBias;
+				sprite.Position = basePos - normalize( g_vCameraDirWs.xyz ) * biasF;
 
 			if ( sprite.RotationOffset > -1 )
 			{	
@@ -175,8 +204,6 @@ CS
 				sprite.Rotation.z += ToDegrees * atan2( ss.x, ss.y ) + sprite.RotationOffset;
 			}
 
-
-			DistanceBuffer[i] = SortKeyFromWorldPos( sprite.Position, sprite.SortDepthBias, sprite.SortBiasInKey );
 			SpriteBufferOut[i] = sprite;
 		}
 		else
@@ -256,7 +283,7 @@ CS
 
 					b.Position = pos;
 					// We fill distance buffer for sorting
-					DistanceBuffer[writeLocation] = SortKeyFromWorldPos( b.Position, b.SortDepthBias, b.SortBiasInKey );
+					DistanceBuffer[writeLocation] = SortParticleDistanceKeyFromDisplayPos( b.Position, b.ZIndex );
 					SpriteBufferOut[writeLocation] = b;
 
 					index++;
@@ -268,7 +295,7 @@ CS
 
 				// Fil distance buffer for sorting
 				writeLocation = writeOffset + index;
-				DistanceBuffer[writeLocation] = SortKeyFromWorldPos( b.Position, b.SortDepthBias, b.SortBiasInKey );
+				DistanceBuffer[writeLocation] = SortParticleDistanceKeyFromDisplayPos( b.Position, b.ZIndex );
 
 				SpriteBufferOut[writeLocation] = b;
 

--- a/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
@@ -74,7 +74,7 @@ VS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
-		float SortDepthBias;
+		int ZIndex;
 		uint SortBiasInKey;
 	};
 
@@ -295,7 +295,7 @@ PS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
-		float SortDepthBias;
+		int ZIndex;
 		uint SortBiasInKey;
 	};
 

--- a/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
@@ -74,6 +74,8 @@ VS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
+		float SortDepthBias;
+		uint SortBiasInKey;
 	};
 
 	StructuredBuffer<SpriteData> Sprites < Attribute("Sprites"); >; 
@@ -293,6 +295,8 @@ PS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
+		float SortDepthBias;
+		uint SortBiasInKey;
 	};
 
 	StructuredBuffer<SpriteData> Sprites < Attribute("Sprites"); >; 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

It should be normal to apply a z index to our sprite so we can control the order of each sprite for particle composition

## Motivation & Context

Getting Z fighting issue on my particles

Fixes: #846 #10251 

## Implementation Details

Ngl i used claude for this, but basicly it kept the old way of calculate distance, but add the index to it to let us customize the depth

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/8708e22f-39b2-41df-b76a-fd4da8e5320e

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂