### PR TITLE
Editor updates mouse position while game widget is unfocused

### DIFF
--- a/engine/Sandbox.Engine/Systems/Input/InputRouter.Input.cs
+++ b/engine/Sandbox.Engine/Systems/Input/InputRouter.Input.cs
@@ -87,19 +87,11 @@ internal static partial class InputRouter
 	/// </summary>
 	internal static void OnMousePositionChange( float x, float y, float dx, float dy )
 	{
-		ApplyAbsoluteMousePosition( new Vector2( x, y ), new Vector2( dx, dy ) );
-	}
-
-	/// <summary>
-	/// Shared absolute-position path for native and editor-driven mouse updates.
-	/// </summary>
-	internal static void ApplyAbsoluteMousePosition( Vector2 pos, Vector2 delta )
-	{
-		MouseCursorPosition = pos;
+		MouseCursorPosition = new Vector2( x, y );
 
 		if ( InputSystem.GetRelativeMouseMode() )
 		{
-			delta = Vector2.Zero;
+			dx = dy = 0;
 		}
 
 		// If this is set, we're in capture mode - so just update the position
@@ -111,10 +103,10 @@ internal static partial class InputRouter
 			return;
 		}
 
-		MouseCursorDelta += delta;
+		MouseCursorDelta += new Vector2( dx, dy );
 
 		var mouse = Contexts.FirstOrDefault( x => x.MouseState != InputContext.InputState.Ignore );
-		mouse?.In_MousePosition( MouseCursorPosition, delta );
+		mouse?.In_MousePosition( MouseCursorPosition, new Vector2( dx, dy ) );
 	}
 
 	internal static void OnGameControllerButton( int deviceId, GameControllerCode button, bool down )

--- a/engine/Sandbox.Engine/Systems/Input/InputRouter.Input.cs
+++ b/engine/Sandbox.Engine/Systems/Input/InputRouter.Input.cs
@@ -87,30 +87,34 @@ internal static partial class InputRouter
 	/// </summary>
 	internal static void OnMousePositionChange( float x, float y, float dx, float dy )
 	{
-		var delta = new Vector2( 0, 0 );
+		ApplyAbsoluteMousePosition( new Vector2( x, y ), new Vector2( dx, dy ) );
+	}
 
-		// if we're not in relative mode - take the delta from this
-		if ( !NativeEngine.InputSystem.GetRelativeMouseMode() )
+	/// <summary>
+	/// Shared absolute-position path for native and editor-driven mouse updates.
+	/// </summary>
+	internal static void ApplyAbsoluteMousePosition( Vector2 pos, Vector2 delta )
+	{
+		MouseCursorPosition = pos;
+
+		if ( InputSystem.GetRelativeMouseMode() )
 		{
-			delta = new Vector2( dx, dy );
-			MouseCursorDelta += delta;
+			delta = Vector2.Zero;
 		}
 
-		MouseCursorPosition = new Vector2( x, y );
-
-		// if this is set, we're in capture mode - so just update the position
-		// which will update the position of the cursor when we come out of it
+		// If this is set, we're in capture mode - so just update the position
+		// cache we restore when capture ends. This intentionally records the
+		// latest absolute position without moving the OS cursor.
 		if ( mouseCapturePosition is not null )
 		{
 			mouseCapturePosition = MouseCursorPosition;
 			return;
 		}
 
+		MouseCursorDelta += delta;
+
 		var mouse = Contexts.FirstOrDefault( x => x.MouseState != InputContext.InputState.Ignore );
-		if ( mouse is not null )
-		{
-			mouse.In_MousePosition( MouseCursorPosition, delta );
-		}
+		mouse?.In_MousePosition( MouseCursorPosition, delta );
 	}
 
 	internal static void OnGameControllerButton( int deviceId, GameControllerCode button, bool down )

--- a/engine/Sandbox.Tools/GameMode.cs
+++ b/engine/Sandbox.Tools/GameMode.cs
@@ -20,6 +20,8 @@ public static class GameMode
 
 		widget.Focused += WidgetFocused;
 		widget.Blurred += WidgetBlurred;
+		widget.MouseTracking = true;
+		widget.MouseMove += OnPlayWidgetMouseMove;
 
 		NativeEngine.InputSystem.RegisterWindowWithSDL( widget._widget.winId() );
 		g_pEngineServiceMgr.SetEngineState( widget._widget.winId(), widget.SwapChain );
@@ -40,6 +42,8 @@ public static class GameMode
 
 		_inPlay.Focused -= WidgetFocused;
 		_inPlay.Blurred -= WidgetBlurred;
+		_inPlay.MouseMove -= OnPlayWidgetMouseMove;
+		_inPlay.MouseTracking = false;
 
 		NativeEngine.InputSystem.UnregisterWindowFromSDL( _inPlay._widget.winId() );
 
@@ -68,22 +72,15 @@ public static class GameMode
 		NativeEngine.InputSystem.OnEditorGameFocusChange( _inPlay._widget.winId(), false );
 	}
 
-	internal static void Tick()
+	private static void OnPlayWidgetMouseMove( Vector2 local )
 	{
-		// Keep game mouse position updated while the play widget is unfocused.
-		var playWidget = _inPlay;
-		if ( playWidget is null || playWidget.IsFocused )
-			return;
-
-		var local = playWidget.FromScreen( Application.CursorPosition );
-
-		// Don't snap to borders if cursor isn't over the widget.
-		if ( local.x < 0 || local.y < 0 || local.x >= playWidget.Size.x || local.y >= playWidget.Size.y )
+		// SDL handles position when the widget is focused; only fill in the gap when unfocused.
+		if ( _inPlay is null || _inPlay.IsFocused )
 			return;
 
 		var pos = new Vector2( (int)local.x, (int)local.y );
 		var delta = pos - InputRouter.MouseCursorPosition;
 
-		InputRouter.ApplyAbsoluteMousePosition( pos, delta );
+		InputRouter.OnMousePositionChange( pos.x, pos.y, delta.x, delta.y );
 	}
 }

--- a/engine/Sandbox.Tools/GameMode.cs
+++ b/engine/Sandbox.Tools/GameMode.cs
@@ -1,9 +1,10 @@
-﻿using Native;
+using Sandbox.Engine;
 
 namespace Editor;
 
 /// <summary>
-/// Registers a widget with the input system, so it uses SDL.
+/// Registers a widget with the input system to use SDL and manages
+/// inputs and focus as it relates to the editor's game widget.
 /// </summary>
 public static class GameMode
 {
@@ -50,6 +51,9 @@ public static class GameMode
 	/// </summary>
 	private static void WidgetFocused( FocusChangeReason reason )
 	{
+		if ( _inPlay is null )
+			return;
+
 		NativeEngine.InputSystem.OnEditorGameFocusChange( _inPlay._widget.winId(), true );
 	}
 
@@ -58,6 +62,28 @@ public static class GameMode
 	/// </summary>
 	private static void WidgetBlurred( FocusChangeReason reason )
 	{
+		if ( _inPlay is null )
+			return;
+
 		NativeEngine.InputSystem.OnEditorGameFocusChange( _inPlay._widget.winId(), false );
+	}
+
+	internal static void Tick()
+	{
+		// Keep game mouse position updated while the play widget is unfocused.
+		var playWidget = _inPlay;
+		if ( playWidget is null || playWidget.IsFocused )
+			return;
+
+		var local = playWidget.FromScreen( Application.CursorPosition );
+
+		// Don't snap to borders if cursor isn't over the widget.
+		if ( local.x < 0 || local.y < 0 || local.x >= playWidget.Size.x || local.y >= playWidget.Size.y )
+			return;
+
+		var pos = new Vector2( (int)local.x, (int)local.y );
+		var delta = pos - InputRouter.MouseCursorPosition;
+
+		InputRouter.ApplyAbsoluteMousePosition( pos, delta );
 	}
 }

--- a/engine/Sandbox.Tools/ToolsDll.cs
+++ b/engine/Sandbox.Tools/ToolsDll.cs
@@ -263,6 +263,8 @@ internal class ToolsDll : IToolsDll
 			Time.Update( scene.TimeNow, scene.TimeDelta );
 		}
 
+		GameMode.Tick();
+
 		// Escape was pressed in game and wasn't swallowed
 		// so lets change focus from the game window to the main editor
 		// window, which is going to free the mouse cursor from being captured

--- a/engine/Sandbox.Tools/ToolsDll.cs
+++ b/engine/Sandbox.Tools/ToolsDll.cs
@@ -263,8 +263,6 @@ internal class ToolsDll : IToolsDll
 			Time.Update( scene.TimeNow, scene.TimeDelta );
 		}
 
-		GameMode.Tick();
-
 		// Escape was pressed in game and wasn't swallowed
 		// so lets change focus from the game window to the main editor
 		// window, which is going to free the mouse cursor from being captured


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

Bottom line: Fixes undesired behaviour when game widget is unfocused in editor.

- Adds mouse position tracking while unfocused so clicking back into the game widget does not cause a click event on a position your mouse is not hovering.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #10261

As someone developing a point and click game who wants to iterate between IDE / Terminal and s&box, this is a very annoying issue. Every single re-focus click is moving my character somewhere my mouse is not hovering (usually at the border of the screen). This will greatly improve my developer experience while working on games for the engine.

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

While in editor and in play mode, the game widget can be unfocused (editor is unfocused, or interacting with editor panels). In this state, SDL stops reporting mouse positions, so the engine loses track of the cursor while it's hovering over the game widget.

To fix this, GameMode now enables MouseTracking and subscribes to the MouseMove event. When a move is received while the widget is unfocused, it calls InputRouter::OnMousePositionChange with the widget-local cursor position and a computed delta, keeping the mouse state in sync using the same path as native input.

InputRouter::OnMousePositionChange itself is also cleaned up. Position is now set before the relative-mode and capturechecks, and delta accumulation is skipped during mouse capture. GetRelativeMouseMode() is respected, zeroing the delta, which is consistent with pre-existing behaviour.

I've tested this in-editor, in-game, with mouse enabled, disabled, unfocused, in split view, scene view, within prefabs, etc. and can't seem to find any regressions.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

| Before | After |
|--------|--------|
| https://github.com/user-attachments/assets/6ed03098-5bcf-4b71-9e2c-affd38b06a4a | https://github.com/user-attachments/assets/88f1ee4e-89e3-48a0-a8cd-1d78b27a76f5 |
| https://github.com/user-attachments/assets/60dcdede-9aa7-48e6-b63c-e9abbd349997 | https://github.com/user-attachments/assets/f6749237-0305-4840-8811-5b3b4c703605 |
 

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂