### PR TITLE
Fix GetComponentsInParent usage in TriggerHurt

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/TriggerHurt.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/TriggerHurt.cs
@@ -42,7 +42,7 @@ public sealed class TriggerHurt : Component
 
 		timeSinceDamage = 0;
 
-		foreach ( var touching in Collider.Touching.SelectMany( x => x.GetComponentsInParent<IDamageable>().Distinct() ) )
+		foreach ( var touching in Collider.Touching.SelectMany( x => x.GetComponentsInParent<IDamageable>() ).Distinct() )
 		{
 			if ( touching is not Component target ) continue;
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This PR makes a function supposed to remove duplicates in an IEnumerable work like expected.

It solves the problem of TriggerHurt firing twice when a Player Controller enters a collider (set as a trigger) due to the Player Controller's 2 colliders.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->
I was just messing around and trying to deal damage with a zone on my Player Controller, then found out that the zone dealt 2 times the damage in one go

So fixing that will keep dev from dealing 2 times the damage the TriggerHurt Component was set to on a Player Controller, and remove the need to create a custom component, based on TriggerHurt, with the slight difference of fixing the `Distinct()` 's position

Fixes: <!-- #issue-number (if applicable) --> https://github.com/Facepunch/sbox-public/issues/10809


## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->
`Distinct()` function was acting on a IEnumerable of 1 element instead of the list given by `SelectMany()`
So I just moved the `Distinct()` function, at line 45, one parenthese to the right! x,)

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂