### PR TITLE
Refactored SittingStyle enum to match animation indices

### DIFF
--- a/game/addons/base/code/Components/Citizen/CitizenAnimationHelper.cs
+++ b/game/addons/base/code/Components/Citizen/CitizenAnimationHelper.cs
@@ -392,12 +392,12 @@ public sealed class CitizenAnimationHelper : Component, Component.ExecuteInEdito
 	public enum SittingStyle
 	{
 		None,
+		Chair = 1,
 		Chair01 = 1,
-		Chair = 1, // alias for backward compatibility
 		Chair02 = 2,
 		Chair03 = 3,
+		Floor = 4,
 		Ground01 = 4,
-		Floor = 4, // alias for backward compatibility
 		Ground02 = 5,
 		Ground03 = 6,
 		Ground04 = 7

--- a/game/addons/base/code/Components/Citizen/CitizenAnimationHelper.cs
+++ b/game/addons/base/code/Components/Citizen/CitizenAnimationHelper.cs
@@ -392,8 +392,15 @@ public sealed class CitizenAnimationHelper : Component, Component.ExecuteInEdito
 	public enum SittingStyle
 	{
 		None,
-		Chair,
-		Floor
+		Chair01 = 1,
+		Chair = 1, // alias for backward compatibility
+		Chair02 = 2,
+		Chair03 = 3,
+		Ground01 = 4,
+		Floor = 4, // alias for backward compatibility
+		Ground02 = 5,
+		Ground03 = 6,
+		Ground04 = 7
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Currently, SittingStyle.Floor and SittingStyle.Chair in CitizenAnimationHelper both map to animation indices 1 and 2 which are chair sitting poses.

<img width="401" height="257" alt="grafik" src="https://github.com/user-attachments/assets/ba970b69-fc31-47ab-8fbb-26e2ee10070e" />

This PR expands the enum to include explicit entries for all sitting animations while maintaining backward compatibility by keeping Floor and Chair as aliases.

## Motivation & Context

There are no posts/issues about this, but i want to use this in my Game

## Implementation Details

## Screenshots / Videos (if applicable)

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂