### PR TITLE
Exclude Parents From Selection Isolation In Editor

### DIFF
--- a/game/addons/tools/Code/Scene/SceneEditorMenus.cs
+++ b/game/addons/tools/Code/Scene/SceneEditorMenus.cs
@@ -507,7 +507,21 @@ public static class SceneEditorMenus
 		if ( selected.Length == 0 )
 			return;
 
-		var selectedSet = selected.ToHashSet();
+		HashSet<GameObject> selectedSet = [.. selected];
+		foreach ( var go in selected )
+		{
+			if ( go.IsRoot )
+				continue;
+
+			var next = go.Parent;
+			while ( true )
+			{
+				if ( !selectedSet.Add( next ) ) break;
+				if ( next.IsRoot ) break;
+				next = next.Parent;
+			}
+		}
+
 		var allObjects = SceneEditorSession.Active.Scene
 			.GetAllObjects( true )
 			.Where( go => go is not Scene )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR adds a GameObject's parents to the selection for isolation in the editor. Preventing the GameObject from being hidden due to it's parent's state.

## Motivation & Context

Before this change any GameObject with a parent would be hidden when attempting to isolate it. This made it hard to effectively use the editor's selection isolation shortcut when an object was grouped under another object. As seen in #10840

Fixes: #10840 

## Implementation Details

Loops through all of the selected GameObjects to see find their parents, skipping parents already in the list. Then adding the found parents to the list of selected objects before hiding them. This leaves the parent active which may be undesirable at times but, this felt like a more reasonable change than adding an exclusion to the tags system just for this.

## Screenshots / Videos (if applicable)

| Before| After |
|--------|--------|
| <img width="318" height="77" alt="image" src="https://github.com/user-attachments/assets/095a82f3-02e9-4212-8ee6-849d05aca33c" />| <img width="309" height="78" alt="image" src="https://github.com/user-attachments/assets/4c04ab53-4a6e-4542-bc89-97dad9bebff8" />| 
## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂