### PR TITLE
Change image format to default in ScreenshotService

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Multimedia/ScreenshotService.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Multimedia/ScreenshotService.cs
@@ -58,7 +58,7 @@ internal static class ScreenshotService
 
 					pData.CopyTo( bitmap.GetBuffer() );
 
-					var rgbData = bitmap.ToFormat( ImageFormat.RGB888 );
+					var rgbData = bitmap.ToFormat( ImageFormat.Default );
 					Services.Screenshots.AddScreenshotToLibrary( rgbData, width, height );
 
 					var dir = Path.GetDirectoryName( filePath );


### PR DESCRIPTION
## Summary
POTENTIAL fix for #10845.

PLEASE NOTE THAT: I could not verify if my change actually fixes the issue.
I am unable to test it myself as I'm running it on Linux and I don't know how to (I'm sorry).
This is just the most logical solution I could come up with from looking at the code.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

#10845

## Implementation Details

replace image format from RGB888 to default, which theoretically solves the colour inversion issue.

## Screenshots / Videos (if applicable)

Unable to test.

## Checklist

- [] If someone also experiences a similar issue, please test it on behalf of me.