### PR TITLE
Added discard changes modal to avatar editor back button

### DIFF
--- a/game/addons/menu/Code/AvatarEditor/AvatarUI.razor
+++ b/game/addons/menu/Code/AvatarEditor/AvatarUI.razor
@@ -1,5 +1,6 @@
 @using Sandbox;
 @using Sandbox.UI;
+@using MenuProject.Modals;
 @namespace MenuProject.AvatarEditor
 @inherits PanelComponent
 
@@ -82,7 +83,18 @@
 
 	void BackToMainMenu()
 	{
-		returnToMainMenu = true;
+		  if ( !Manager.HasUnsavedChanges )
+		  {
+			  returnToMainMenu = true;
+			  return;
+		  }
+
+		  ModalSystem.Instance.DiscardChanges( result =>
+		  {
+			  if ( result == DiscardChangesModal.DiscardResult.Cancel ) return;
+			  if ( result == DiscardChangesModal.DiscardResult.Save ) Manager.SaveChanges();
+			  returnToMainMenu = true;
+		  } );
 	}
 
 	protected override void OnUpdate()

--- a/game/addons/menu/Code/ModalSystem.cs
+++ b/game/addons/menu/Code/ModalSystem.cs
@@ -220,6 +220,13 @@ public class ModalSystem : IModalSystem
 		} );
 	}
 
+	public void DiscardChanges( Action<DiscardChangesModal.DiscardResult> onResult )
+	{
+		var modal = new DiscardChangesModal();
+		modal.OnResult = onResult;
+		Push( modal );
+	}
+
 	public void Report( string packageIdent )
 	{
 		Push( new ReportModal() { PackageIdent = packageIdent } );

--- a/game/addons/menu/Code/Modals/DiscardChangesModal.razor
+++ b/game/addons/menu/Code/Modals/DiscardChangesModal.razor
@@ -1,0 +1,34 @@
+﻿@using Sandbox
+@using Sandbox.UI
+
+@namespace MenuProject.Modals
+@inherits MenuProject.Modals.BaseModal
+
+<root>
+    <div class="window">
+		<div class="header">
+			<i>warning</i>
+			<label class="heading">Warning</label>
+		</div>
+		<div class="body">
+			<label class="body">Your avatar has unsaved changes. Are you sure you want to leave?</label>
+		</div>
+		<div class="footer">
+			<Button class="clicky primary" Icon="save" @onclick="@( () => Finish(DiscardResult.Save) )">Save</Button>
+			<Button class="clicky primary" Icon="delete" @onclick="@( () => Finish(DiscardResult.Discard) )">Discard</Button>
+			<Button class="clicky primary" Icon="close" @onclick="@( () => Finish(DiscardResult.Cancel) )">Cancel</Button>
+		</div>
+    </div>
+</root>
+
+@code
+{
+	public Action<DiscardResult> OnResult { get; set; }
+	public enum DiscardResult { Save, Discard, Cancel }
+
+	void Finish( DiscardResult result )
+	{
+		OnResult?.Invoke( result );
+		Delete();
+	}
+}

--- a/game/addons/menu/Code/Modals/DiscardChangesModal.razor.scss
+++ b/game/addons/menu/Code/Modals/DiscardChangesModal.razor.scss
@@ -1,0 +1,41 @@
+DiscardChangesModal
+{
+	font-family: Poppins;
+
+	.window
+	{
+		width: 450px;
+		pointer-events: all;
+		background: linear-gradient( to bottom, #1d212f, #1c202d );
+		flex-direction: column;
+		border-radius: 16px;
+		box-shadow: 2px 2px 20px #0005;
+	}
+
+	.header
+	{
+		margin: 2px;
+		border-radius: 16px 16px 0px 0px;
+		padding: 8px 16px;
+		color: white;
+		background-color: #323b5233;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+	}
+
+	.body
+	{
+		padding: 12px 16px;
+		color: white;
+		font-size: 16px;
+		flex-direction: column;
+	}
+
+	.footer
+	{
+		padding: 8px 16px 16px 16px;
+		justify-content: center;
+		gap: 8px;
+	}
+}


### PR DESCRIPTION
## Summary

*Updated copy of closed PR #10787*

Added a pop-up when leaving the avatar editor with unsaved changes. The pop-up prompts you to either save or discard your changes, or to stay in the avatar editor.

## Motivation & Context

Prior to this, pressing back in the avatar editor without saving wiped your changes. Now, ignorant first-time users or users who forgot to save will be prompted to save/discard/stay.

This addition was made in response to the following issues.
Fixes: #10784
Fixes: #10756

## Implementation Details

The addition required:
- Creating a new `DiscardChangesModal` razor element and `.scss` file.
- Adding a `DiscardChanges` method to `ModalSystem.cs` to push the new discard changes modal element.
- Modifying the `AvatarUI` logic to create the pop-up if the user tries to leave with unsaved changes.

## Screenshots / Videos

<img width="1460" height="1016" alt="image" src="https://github.com/user-attachments/assets/a1125dab-aea1-4eb2-87b0-ef8df70cc5e0" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂