### PR TITLE
Label supports style attribute, seed with ComputedStyles

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Controls/Label.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Controls/Label.cs
@@ -321,33 +321,36 @@ namespace Sandbox.UI
 				sizeFinalized = false;
 			}
 		}
+		
 		private Styles HtmlStyleLookup( INode node )
 		{
+			// Seed with the label's own computed styles so inherited properties are present
+			var s = new Styles();
+			s.Add( ComputedStyle );
+			
+			var blocks = AllStyleSheets
+				.SelectMany( x => x.Nodes )
+				.Select( x => x.Test( node ) )
+				.Where( x => x is not null )
+				.ToList();
+			
+			if ( blocks.Count > 0 )
+			{
+				blocks.Sort( StyleOrderer.Instance );
+				
+				foreach ( var entry in blocks )
+					s.Add( entry.Block.Styles );
+				
+				s.ApplyScale( FindRootPanel().ScaleToScreen );
+			}
+			
+			// Inline styles applied last, highest specificity wins
 			if ( node.GetAttribute( "style", null ) is string styles )
 			{
-				Log.Warning( "TODO: Apply Html Styles" );
+				var p = new Parse( styles );
+				StyleParser.ParseStyles( ref p, s );
 			}
-
-			var blocks = AllStyleSheets
-							.SelectMany( x => x.Nodes )
-							.Select( x => x.Test( node ) )
-							.Where( x => x is not null )
-							.ToList();
-
-			if ( blocks.Count == 0 )
-				return null;
-
-			blocks.Sort( StyleOrderer.Instance );
-
-			var s = new Styles();
-
-			foreach ( var entry in blocks )
-			{
-				s.Add( entry.Block.Styles );
-			}
-
-			s.ApplyScale( FindRootPanel().ScaleToScreen );
-
+			
 			return s;
 		}
 

--- a/engine/Sandbox.Engine/Systems/UI/Controls/Label.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Controls/Label.cs
@@ -321,36 +321,36 @@ namespace Sandbox.UI
 				sizeFinalized = false;
 			}
 		}
-		
+
 		private Styles HtmlStyleLookup( INode node )
 		{
 			// Seed with the label's own computed styles so inherited properties are present
 			var s = new Styles();
 			s.Add( ComputedStyle );
-			
+
 			var blocks = AllStyleSheets
 				.SelectMany( x => x.Nodes )
 				.Select( x => x.Test( node ) )
 				.Where( x => x is not null )
 				.ToList();
-			
+
 			if ( blocks.Count > 0 )
 			{
 				blocks.Sort( StyleOrderer.Instance );
-				
+
 				foreach ( var entry in blocks )
 					s.Add( entry.Block.Styles );
-				
+
 				s.ApplyScale( FindRootPanel().ScaleToScreen );
 			}
-			
+
 			// Inline styles applied last, highest specificity wins
 			if ( node.GetAttribute( "style", null ) is string styles )
 			{
 				var p = new Parse( styles );
 				StyleParser.ParseStyles( ref p, s );
 			}
-			
+
 			return s;
 		}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Allows label rich text to support the style attribute and seeds labels properly with css inheritance

## Motivation & Context

For the longest time a big irk I've had with the new IsRich property on labels was that they didn't support the style attribute, and thus you couldn't do a whole lot with it in regards to actually writing rich text.

This PR fixes said issue, and also properly cascades inherited styles so only the style you are applying changes.

## Screenshots / Videos (if applicable)

https://gyazo.com/9ac9e0dd3b07a99ab77da153a168e0be

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂