### PR TITLE
Fix editor DPI maximize window issue

### DIFF
--- a/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
+++ b/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
@@ -34,6 +34,25 @@ public class SceneRenderingWidget : Frame
 	private Vector2 _savedMinSize;
 	private Vector2 _savedMaxSize;
 
+	/// <summary>
+	/// Releases the recording size lock on all active SceneRenderingWidgets.
+	/// Called from <see cref="Window.OnWindowStateChange"/> because Qt only delivers
+	/// WindowStateChange to the top-level window, not to child widgets.
+	/// Without this, a lock left active while the window is minimized would keep
+	/// the min/max size constraint in place on restore/maximize, causing layout and
+	/// swap-chain issues.
+	/// </summary>
+	internal static void ReleaseAllRecordingLocksForWindowStateChange()
+	{
+		foreach ( var w in All )
+		{
+			if ( !w._sizeLockedForRecording ) continue;
+			w.MinimumSize = w._savedMinSize;
+			w.MaximumSize = w._savedMaxSize;
+			w._sizeLockedForRecording = false;
+		}
+	}
+
 	public SceneRenderingWidget( Widget parent = null ) : base( parent )
 	{
 		SetFlag( Flag.WA_NativeWindow, true );

--- a/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
+++ b/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
@@ -112,7 +112,7 @@ public class SceneRenderingWidget : Frame
 			MaximumSize = Size;
 			_sizeLockedForRecording = true;
 		}
-		else if ( !ScreenRecorder.IsRecording() && _sizeLockedForRecording )
+		else if ( _sizeLockedForRecording && (!ScreenRecorder.IsRecording() || sceneCamera?.IsRecordingCamera != true) )
 		{
 			MinimumSize = _savedMinSize;
 			MaximumSize = _savedMaxSize;
@@ -189,6 +189,7 @@ public class SceneRenderingWidget : Frame
 		input.RightMouse = Application.MouseButtons.HasFlag( MouseButtons.Right );
 
 		input.CursorPosition -= ScreenPosition;
+
 		input.CursorRay = camera.GetRay( input.CursorPosition, Size );
 
 		if ( !input.IsHovered )

--- a/engine/Sandbox.Tools/Qt/Widget.Events.cs
+++ b/engine/Sandbox.Tools/Qt/Widget.Events.cs
@@ -443,8 +443,6 @@ namespace Editor
 
 		internal void InternalOnEvent( Native.EventType e )
 		{
-			// Unused for now
-
 			if ( e == Native.EventType.LayoutRequest || e == Native.EventType.Resize )
 			{
 				if ( _recurseBreaker )
@@ -470,6 +468,21 @@ namespace Editor
 			{
 				OnVisibilityChanged( false );
 			}
+
+			if ( e == Native.EventType.WindowStateChange )
+			{
+				OnWindowStateChange();
+			}
+		}
+
+		/// <summary>
+		/// Called when the window state changes between minimized, maximized, and normal.
+		/// Fires for both managed calls (MakeMinimized etc.) and OS/taskbar-driven changes.
+		/// Note: Qt only delivers this event to the top-level window, not to child widgets.
+		/// </summary>
+		protected virtual void OnWindowStateChange()
+		{
+
 		}
 
 		internal bool InternalFocusNextPrevChild( bool next )

--- a/engine/Sandbox.Tools/Qt/Window.Cookies.cs
+++ b/engine/Sandbox.Tools/Qt/Window.Cookies.cs
@@ -52,6 +52,9 @@ namespace Editor
 			if ( !this.IsValid() )
 				return;
 
+			if ( IsMinimized )
+				return;
+
 			var state = SaveState();
 			var geo = SaveGeometry();
 

--- a/engine/Sandbox.Tools/Qt/Window.cs
+++ b/engine/Sandbox.Tools/Qt/Window.cs
@@ -1,4 +1,4 @@
-using Sandbox;
+﻿using Sandbox;
 using Sandbox.Utility;
 using System;
 
@@ -138,6 +138,10 @@ namespace Editor
 		protected override void OnWindowStateChange()
 		{
 			base.OnWindowStateChange();
+
+			// Qt only dispatches WindowStateChange to the top-level window, not children.
+			// Release recording size locks so they don't affect the layout on restore.
+			SceneRenderingWidget.ReleaseAllRecordingLocksForWindowStateChange();
 
 			if ( IsMinimized )
 			{

--- a/engine/Sandbox.Tools/Qt/Window.cs
+++ b/engine/Sandbox.Tools/Qt/Window.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox;
+using Sandbox;
 using Sandbox.Utility;
 using System;
 
@@ -130,8 +130,49 @@ namespace Editor
 			SetWindowIcon( "logo_rounded.png" );
 		}
 
+		// Saved at WindowStateChange→normal (from minimized); corrects Qt's stale
+		// normalGeometry that can force a wrong size on the first resize after restore.
+		private Vector2 _pendingRestoreSize;
+		private bool _wasMinimized;
+
+		protected override void OnWindowStateChange()
+		{
+			base.OnWindowStateChange();
+
+			if ( IsMinimized )
+			{
+				_wasMinimized = true;
+				_pendingRestoreSize = default;
+			}
+			else if ( _wasMinimized )
+			{
+				// Capture the correct size right after restore, before Qt can fire a
+				// QResizeEvent from its stale internal normalGeometry.
+				_wasMinimized = false;
+				_pendingRestoreSize = Size;
+			}
+			else
+			{
+				_wasMinimized = false;
+			}
+		}
+
 		protected override void OnResize()
 		{
+			// If restoring from minimized, Qt may fire a bogus QResizeEvent from a stale
+			// normalGeometry (set by a previous restoreGeometry() call). Correct it once.
+			if ( _pendingRestoreSize != default )
+			{
+				var target = _pendingRestoreSize;
+				_pendingRestoreSize = default;
+
+				if ( Size != target && !IsMinimized && !IsMaximized )
+				{
+					Size = target;
+					return;
+				}
+			}
+
 			base.OnResize();
 
 			// Force redraw the titlebar so that we can change the maximize button


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

So when maximizing editor window, most of times it get stuck like that 1/2 times
<img width="3826" height="2144" alt="image" src="https://github.com/user-attachments/assets/405d2299-63c3-4ca3-a338-d644e53de2ee" />

## Motivation & Context

So annoying to try maximize 2/3 times

Fixes: #1651

## Implementation Details

So the issue is that there was 2 recording logic
Lock condition (line 107): IsRecording() && sceneCamera.IsRecordingCamera == true
Unlock condition (line 115): !IsRecording() && _sizeLockedForRecording

So i changed to do:
// before:
else if ( !ScreenRecorder.IsRecording() && _sizeLockedForRecording )
// after:
else if ( _sizeLockedForRecording && (!ScreenRecorder.IsRecording() || sceneCamera?.IsRecordingCamera != true) )

## Screenshots / Videos (if applicable)


## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂