### PR TITLE
Fix initial project load opening blank scene instead of minimal.scene

### DIFF
--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -1,9 +1,12 @@
-﻿using NativeEngine;
+﻿using System;
+using NativeEngine;
 
 namespace Editor;
 
 public class EditorMainWindow : DockWindow
 {
+	const string MinimalScenePath = "scenes/minimal.scene";
+
 	internal static EditorMainWindow Current;
 
 	Menu FileMenu { get; init; }
@@ -342,24 +345,55 @@ public class EditorMainWindow : DockWindow
 		NativeEngine.InputSystem.SetEditorMainWindow( _widget.winId() );
 	}
 
-	record struct LayoutFile( string Name, string Json );
+	private readonly record struct LayoutFile( string Json );
 
 	protected override void RestoreDefaultDockLayout()
 	{
 		var layout = FileSystem.Config.ReadJsonOrDefault<LayoutFile>( $"/editor/layout/default.json", default );
-		if ( layout.Name is null ) return;
-		if ( layout.Json is null ) return;
+		if ( layout.Json is null )
+			return;
 
 		var json = layout.Json;
-
-		// On first launch, open the project's startup scene instead of a blank untitled scene
-		var startupScene = Project.Current?.Config.GetMetaOrDefault<string>( "StartupScene", null );
-		if ( !string.IsNullOrWhiteSpace( startupScene ) )
+		var startupScene = GetStartupScenePath();
+		if ( startupScene is not null )
 		{
 			json = json.Replace( "SceneDock:untitled", $"SceneDock:{startupScene}" );
 		}
 
 		DockManager.State = json;
+	}
+
+	private static string GetStartupScenePath()
+	{
+		var startupScene = Project.Current?.Config.GetMetaOrDefault<string>( "StartupScene", null );
+		if ( IsValidStartupScenePath( startupScene ) )
+		{
+			return NormalizeAssetPath( startupScene );
+		}
+
+		if ( IsValidStartupScenePath( MinimalScenePath ) )
+		{
+			return MinimalScenePath;
+		}
+
+		return null;
+	}
+
+	private static bool IsValidStartupScenePath( string path )
+	{
+		path = NormalizeAssetPath( path );
+		if ( string.IsNullOrWhiteSpace( path ) )
+			return false;
+
+		if ( !path.EndsWith( ".scene", StringComparison.OrdinalIgnoreCase ) )
+			return false;
+
+		return AssetSystem.FindByPath( path ) is not null;
+	}
+
+	private static string NormalizeAssetPath( string path )
+	{
+		return path?.Replace( '\\', '/' ).TrimStart( '/' );
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Pull Request

  Thanks for contributing to s&box ❤️
  Please fill out the sections below to help us review your change efficiently.

  ———

  ## Summary

  Fixes an editor layout issue where new projects could open with an untitled scene instead of the generated scenes/minimal.scene.

  When restoring the default editor layout, the editor now prefers the configured StartupScene when it exists and falls back to scenes/minimal.scene when it does not. This also keeps Reset Layout consistent with first-time default layout restore.

  ## Motivation & Context

  New projects generate a minimal scene, but the default editor layout could still restore an untitled scene tab. That made new projects look like no scene had been created or selected.

  This also meant manually restoring the default layout could reopen the wrong scene state instead of the expected startup/default scene.

  Fixes: https://github.com/Facepunch/sbox-public/issues/418

  ## Implementation Details

  - Updated EditorMainWindow default layout restoration to resolve an initial scene path before applying the layout.
  - When restoring the default layout:
      - prefer the configured StartupScene when it is valid and exists
      - fall back to scenes/minimal.scene when the startup scene is missing
      - ignore invalid or non-.scene paths
  - Kept the behavior at the layout level by replacing the default SceneDock:untitled entry in the restored layout state, so the correct scene dock is created directly.

  ## Screenshots / Videos (if applicable)

  N/A - editor startup/layout behavior change only.

  ## Checklist

  - [x] Code follows existing style and conventions
  - [x] No unnecessary formatting or unrelated changes
  - [x] Public APIs are documented (if applicable)
  - [x] Unit tests added where applicable and all passing
  - [x] I'm okay with this PR being rejected or requested to change