### PR TITLE
Props: ignite gibs when a burning prop breaks

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -610,6 +610,15 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 			}
 		}
 
+		// If this prop was on fire, ignite the gibs so the fire carries over.
+		if ( IsOnFire )
+		{
+			foreach ( var gib in gibs )
+			{
+				gib.Ignite();
+			}
+		}
+
 		return gibs;
 	}
 


### PR DESCRIPTION
Adds a check in CreateGibs() — if IsOnFire, each spawned gib gets Ignite(). The current API doesn't support passing remaining lifetime (unlike gmod which inherits it), so gibs always get a fresh timer rather than the parent's remaining burn time.

This mimics the behaviour of Garry's Mod as well as real life.

It would be worth noting that as gibs get smaller, the particles doesn't adjust to that, so the flames might appear to get more and more dense, not a bug but I believe changes to counter that are out of scope of the PR. 