### PR TITLE
Prop: only ignite flammable props from burn or explosion damage, seperate ignite from any damage into a seperate property

### DIFF
--- a/engine/Sandbox.Engine/Resources/Model/Model.Data.Common.cs
+++ b/engine/Sandbox.Engine/Resources/Model/Model.Data.Common.cs
@@ -17,6 +17,11 @@ public partial class Model
 		public bool Flammable { get; }
 
 		/// <summary>
+		/// If true, any damage ignites this prop, not just fire and explosions.
+		/// </summary>
+		public bool IgniteOnAnyDamage { get; }
+
+		/// <summary>
 		/// Should this prop explode when destroyed? If so, this is the radius of the damage from it.
 		/// </summary>
 		public bool Explosive { get; }
@@ -58,6 +63,7 @@ public partial class Model
 			{
 				Health = propData.Health;
 				Flammable = propData.Flammable;
+				IgniteOnAnyDamage = propData.IgniteOnAnyDamage;
 
 				if ( propData.Explosive )
 				{

--- a/engine/Sandbox.Engine/Resources/Model/ModelNodes.cs
+++ b/engine/Sandbox.Engine/Resources/Model/ModelNodes.cs
@@ -49,6 +49,13 @@ public class ModelPropData
 	public bool Flammable { get; set; }
 
 	/// <summary>
+	/// If true, any damage (including bullets and melee) will ignite this prop, not just fire and explosions.
+	/// Requires Flammable to be enabled.
+	/// </summary>
+	[JsonPropertyName( "ignite_on_any_damage" )]
+	public bool IgniteOnAnyDamage { get; set; }
+
+	/// <summary>
 	/// If true we'll explode this prop when it's destroyed
 	/// </summary>
 	public bool Explosive { get; set; }

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -393,13 +393,12 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 	bool ShouldDamageIgnite( in DamageInfo damage )
 	{
-		// Physics impacts only ignite if they do lots of damage
-		if ( damage.Tags.Contains( "impact" ) )
-		{
-			return damage.Damage > Health * 0.5f;
-		}
+		// Props with IgniteOnAnyDamage set in model data ignite from any hit.
+		if ( Model?.Data.IgniteOnAnyDamage == true )
+			return true;
 
-		return true;
+		// By default only fire and explosions ignite flammable props.
+		return damage.Tags.Has( "burn" ) || damage.Tags.Has( "explosion" );
 	}
 
 	public void Ignite()

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -393,13 +393,9 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 	bool ShouldDamageIgnite( in DamageInfo damage )
 	{
-		// Physics impacts only ignite if they do lots of damage
-		if ( damage.Tags.Contains( "impact" ) )
-		{
-			return damage.Damage > Health * 0.5f;
-		}
-
-		return true;
+		// Only fire (burn) and explosions ignite flammable props.
+		// Bullets and melee do not — use a separate flag for that behaviour.
+		return damage.Tags.Has( "burn" ) || damage.Tags.Has( "explosion" );
 	}
 
 	public void Ignite()

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -398,9 +398,15 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 	bool ShouldDamageIgnite( in DamageInfo damage )
 	{
-		// Props with IgniteOnAnyDamage set in model data ignite from any hit.
-		if ( Model?.Data.IgniteOnAnyDamage == true )
+		// Props with IgniteOnAnyDamage set in model data ignite from any hit,
+		// but physics impacts only count if they do more than half the prop's health.
+		if ( IgniteOnAnyDamage )
+		{
+			if ( damage.Tags.Contains( "impact" ) )
+				return damage.Damage > Health * 0.5f;
+
 			return true;
+		}
 
 		// By default only fire and explosions ignite flammable props.
 		return damage.Tags.Has( "burn" ) || damage.Tags.Has( "explosion" );


### PR DESCRIPTION
ShouldDamageIgnite currently returns true for all damage types, so any flammable prop ignites from bullets, melee, crowbars etc. 
Either the name for the IsFlammable property is misleading or this behaviour is wrong.

To solve this, I've seperated IsFlammable into 2 parts
1. Actually being flammable and whether the prop should able to receive fire or be ignited by explosions and other fire (flamethrowers or whatever for example), bringing this behaviour back from gmod/source 1.
2. Renamed the original functionality to something more fitting.


**The bad:**
Models like the explosive oil drum will need to be changed and recompiled/uploaded to enable the ignite on damage behaviour again. This might break things, unsure how I can fix this.
I wanted to split this up, but the two changes go hand in hand.