### PR TITLE
Init EditorAppSystem with the editor app id, stops Steam overlay from appearing in editor with shift + tab.

### DIFF
--- a/engine/Sandbox.AppSystem/EditorAppSystem.cs
+++ b/engine/Sandbox.AppSystem/EditorAppSystem.cs
@@ -5,8 +5,12 @@
 /// </summary>
 public class EditorAppSystem : AppSystem
 {
+	const ulong EditorAppId = 2129370;
+
 	public override void Init()
 	{
+		Application.AppId = EditorAppId;
+
 		LoadSteamDll();
 
 		base.Init();


### PR DESCRIPTION
## Summary

Init EditorAppSystem with the editor app id, stops Steam overlay from appearing in editor with shift + tab. Restores the intended editor navigation functionality.


## Motivation & Context

Steam overlay should not be appearing in editor, shift + tab to navigate backwards is preferred.

Fixes: <!-- #issue-number (if applicable) -->
https://github.com/Facepunch/sbox-public/issues/9955

## Considerations
This will also stop Steam from tracking play time on the game when using the editor, instead the playtime is recorded against the editor.

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂