### PR TITLE
Change DragEvent constructor to public access

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Panel/Event/DragEvent.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Panel/Event/DragEvent.cs
@@ -27,7 +27,7 @@ public class DragEvent : PanelEvent
 	/// </summary>
 	public Vector2 ScreenPosition;
 
-	internal DragEvent( string event_name, Panel active, Vector2 localDragStart, Vector2 globalDragStart ) : base( event_name, active )
+	public DragEvent( string event_name, Panel active, Vector2 localDragStart, Vector2 globalDragStart ) : base( event_name, active )
 	{
 		Name = event_name;
 		Target = active;


### PR DESCRIPTION
# Pull Request

## Summary

This PR makes `DragEvent` publicly instantiable, similarly to `MousePanelEvent`.

The goal is to allow custom UI/input systems to forward native drag events correctly while still using the existing Razor UI event pipeline.

---

## Motivation & Context

I'm currently working on a feature that adds support for rendering panels to a `RenderTarget`.

To make this work, I need to implement custom input handling so Razor UI features can continue to behave natively even outside the standard `WorldInput` pipeline.

For example, forwarding native mouse events already works correctly:

```csharp
if ( _active != null )
{
	SwitchPseudoClass( PseudoClass.Active, true, _active );

	_active.CreateEvent(
		new MousePanelEvent( "onmousedown", _active, "mouseleft" )
	);
}
```

However, unlike `MousePanelEvent`, `DragEvent` cannot currently be instantiated because its constructor is internal.

Unfortunately, `WorldInput` cannot be used for this particular use case because the interaction position is computed manually from mesh UV coordinates rather than screen-space input.

Making `DragEvent` publicly constructible would allow advanced custom rendering/input scenarios to integrate properly with the existing UI system and native drag behavior.

Fixes: N/A

---

## Implementation Details

The change simply exposes the `DragEvent` constructor publicly so external assemblies can create valid drag events and forward them through `panel.CreateEvent(...)`.

This keeps behavior consistent with `MousePanelEvent` and avoids the need for custom drag-event reimplementations that are incompatible with native UI components.

---

## Screenshots / Videos (if applicable)


https://github.com/user-attachments/assets/425054d4-f976-4fb6-ae91-edf1af89a46a



---

## Checklist

* [x] Code follows existing style and conventions
* [x] No unnecessary formatting or unrelated changes
* [ ] Public APIs are documented (if applicable)
* [ ] Unit tests added where applicable and all passing
* [x] I’m okay with this PR being rejected or requested to change 🙂
