### PR TITLE
Rebuild descriptors when resizing UI in ScreenshotService. Ensures UI resolution matches screenshot resolution.

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Multimedia/ScreenshotService.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Multimedia/ScreenshotService.cs
@@ -224,6 +224,7 @@ internal static class ScreenshotService
 			rootPanel.PreLayout( screenRect );
 			rootPanel.CalculateLayout();
 			rootPanel.PostLayout();
+			rootPanel.BuildDescriptors();
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Rebuild descriptors when resizing UI in ScreenshotService. Ensures UI resolution matches screenshot resolution.
Fixes UI not scaling with screenshot_highres command.

Before:
<img width="1920" height="1080" alt="sbox 2026 05 12 15 37 22" src="https://github.com/user-attachments/assets/c0a748ad-ffbc-4c3e-8755-b621c084fdb3" />

After:
<img width="1920" height="1080" alt="sbox 2026 05 12 16 05 26" src="https://github.com/user-attachments/assets/c74f8fdc-809a-4b82-a9af-0585436199ec" />


## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂