### PR TITLE
Use ToString and [Title] for component control widget

### DIFF
--- a/game/addons/tools/Code/Scene/GameObjectInspector/ComponentControlWidget.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/ComponentControlWidget.cs
@@ -92,7 +92,7 @@ public class ComponentControlWidget : ControlWidget
 			rect.Left += 22;
 			var title = component.ToString();
 			if ( title == component.GetType().ToString() )
-				title = $"{type.Title} on ({component.GameObject?.Name ?? "null"})";
+				title = $"{TypeLibrary.GetType( component.GetType() ).Title} on ({component.GameObject?.Name ?? "null"})";
 			Paint.DrawText( rect, title, TextFlag.LeftCenter );
 			Cursor = CursorShape.Finger;
 		}

--- a/game/addons/tools/Code/Scene/GameObjectInspector/ComponentControlWidget.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/ComponentControlWidget.cs
@@ -90,7 +90,10 @@ public class ComponentControlWidget : ControlWidget
 			Paint.SetPen( Theme.Green );
 			Paint.DrawIcon( rect, icon, 14, TextFlag.LeftCenter );
 			rect.Left += 22;
-			Paint.DrawText( rect, $"{component.GetType().Name} on ({component.GameObject?.Name ?? "null"})", TextFlag.LeftCenter );
+			var title = component.ToString();
+			if ( title == component.GetType().ToString() )
+				title = $"{component.GetType().Name} on ({component.GameObject?.Name ?? "null"})";
+			Paint.DrawText( rect, title, TextFlag.LeftCenter );
 			Cursor = CursorShape.Finger;
 		}
 

--- a/game/addons/tools/Code/Scene/GameObjectInspector/ComponentControlWidget.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/ComponentControlWidget.cs
@@ -82,7 +82,7 @@ public class ComponentControlWidget : ControlWidget
 			Paint.SetPen( Theme.TextControl.WithAlpha( 0.3f ) );
 			Paint.DrawIcon( rect, icon, 14, TextFlag.LeftCenter );
 			rect.Left += 22;
-			Paint.DrawText( rect, $"None ({type?.Name})", TextFlag.LeftCenter );
+			Paint.DrawText( rect, $"None ({type?.Title})", TextFlag.LeftCenter );
 			Cursor = CursorShape.None;
 		}
 		else
@@ -92,7 +92,7 @@ public class ComponentControlWidget : ControlWidget
 			rect.Left += 22;
 			var title = component.ToString();
 			if ( title == component.GetType().ToString() )
-				title = $"{component.GetType().Name} on ({component.GameObject?.Name ?? "null"})";
+				title = $"{type.Title} on ({component.GameObject?.Name ?? "null"})";
 			Paint.DrawText( rect, title, TextFlag.LeftCenter );
 			Cursor = CursorShape.Finger;
 		}


### PR DESCRIPTION
## Summary
Uses `ToString()` for component control widget text, but only if `ToString()` has been overridden.
Also uses title instead of type name for the default `Component on (GameObject)` text.

## Motivation & Context
Wanted to display some extra stuff in there.

## Implementation Details
This just checks the result of `ToString()` against what the default implementation does (`GetType().ToString()`), and expands to the full `Component on (GameObject)` string if it matches. There's probably ways to check that with reflection instead, but from what I could find that would add a lot of complexity for no real benefit.

## Screenshot
<img width="594" height="327" alt="image" src="https://github.com/user-attachments/assets/986f4c93-daa4-4c63-8476-7d86f183bd99" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂