### PR TITLE
Iterating over GameObjects when trying to make multiple a prefab instead of silently leaving the method.

### DIFF
--- a/game/addons/tools/Code/Editor/AssetList/AssetList.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.cs
@@ -736,23 +736,26 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 	private void OnDropGameObject( DragEvent ev )
 	{
 		if ( Browser?.CurrentLocation == null ) return;
-		if ( ev.Data.Object is not GameObject[] gos || gos.Length != 1 ) return;
+		if ( ev.Data.Object is not GameObject[] gos || gos.Length <= 0 ) return;
 
-		var target = gos[0];
-		var location = Path.Combine( Browser.CurrentLocation.Path, $"{target.Name}.prefab" );
-
-		if ( AssetSystem.FindByPath( location ) != null )
+		foreach(GameObject go in gos)
 		{
-			Log.Warning( "A prefab already exists at " + location );
-			return;
-		}
+			GameObject target = go;
+			string location = Path.Combine(Browser.CurrentLocation.Path, $"{target.Name}.prefab");
 
-		var session = SceneEditorSession.Resolve( target );
-		using var scene = session.Scene.Push();
-		using ( session.UndoScope( "Convert GameObject To Prefab" ).WithGameObjectChanges( target, GameObjectUndoFlags.All ).Push() )
-		{
-			EditorUtility.Prefabs.ConvertGameObjectToPrefab( target, location );
-			EditorUtility.InspectorObject = target;
+			if (AssetSystem.FindByPath(location) != null)
+			{
+				Log.Warning("A prefab already exists at " + location);
+				continue;
+			}
+
+			var session = SceneEditorSession.Resolve(target);
+			using var scene = session.Scene.Push();
+			using (session.UndoScope("Convert GameObject To Prefab").WithGameObjectChanges(target, GameObjectUndoFlags.All).Push())
+			{
+				EditorUtility.Prefabs.ConvertGameObjectToPrefab(target, location);
+				EditorUtility.InspectorObject = target;
+			}
 		}
 
 		Refresh();

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.cs
@@ -734,11 +734,15 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 	}
 
 	private void OnDropGameObject( DragEvent ev )
-	{
-		if ( Browser?.CurrentLocation == null ) return;
-		if ( ev.Data.Object is not GameObject[] gos || gos.Length <= 0 ) return;
+{
+    if ( Browser?.CurrentLocation == null ) return;
+	if (ev.Data.Object is not GameObject[] gos || gos.Length <= 0) return;
 
-		foreach(GameObject go in gos)
+    Scene.ISceneEditorSession session = SceneEditorSession.Resolve(gos[0]);
+	using var scene = session.Scene.Push();
+	using (session.UndoScope("Convert GameObject To Prefab").WithGameObjectChanges(gos, GameObjectUndoFlags.All).Push())
+	{
+		foreach (GameObject go in gos)
 		{
 			GameObject target = go;
 			string location = Path.Combine(Browser.CurrentLocation.Path, $"{target.Name}.prefab");
@@ -747,19 +751,22 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 			{
 				Log.Warning("A prefab already exists at " + location);
 				continue;
-			}
+            }
 
-			var session = SceneEditorSession.Resolve(target);
-			using var scene = session.Scene.Push();
-			using (session.UndoScope("Convert GameObject To Prefab").WithGameObjectChanges(target, GameObjectUndoFlags.All).Push())
+			try // I tried debugging it but nothing is null. The exception must be happening somewhere internally. Just skip it and dont exit the loop if it happens.
+            {
+                EditorUtility.Prefabs.ConvertGameObjectToPrefab(target, location);
+                EditorUtility.InspectorObject = target;
+            }
+			catch(Exception ex)
 			{
-				EditorUtility.Prefabs.ConvertGameObjectToPrefab(target, location);
-				EditorUtility.InspectorObject = target;
+				Log.Error($"Prefab for '{target.Name}' could not be created. Skipping. Error message: {ex}");
 			}
-		}
-
-		Refresh();
+        }
 	}
+
+	Refresh();
+}
 
 	public override void OnDragDrop( DragEvent ev )
 	{


### PR DESCRIPTION
# Pull Request

---

## Summary

<!--
I was trying to make multiple scene objects into a bunch of prefabs. Hundreds of them at once.
Instead of having to select one, drag it and drop it onto the Asset Browser, just select all now and drag them at once.
-->

## Motivation & Context

<!--
Even with the time it took to implement it still saved me hours of work right now. Will be helpful with any kind of bigger project/asset import.
-->

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

<!--
`EditorUtility.Prefabs.ConvertGameObjectToPrefab(target, location);` is a very volatile method.
For some reason it sometimes errors with a nullref, even when I debug it everything has a value. There must be some internal problem going on with it. For safety I try catch it and just tell the user it didn't work and move on.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [NA] Public APIs are documented (if applicable)
- [NA] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂