### PR TITLE
Resolve connection display names locally

### DIFF
--- a/engine/Sandbox.Engine/Game/GameMenu/Friend.cs
+++ b/engine/Sandbox.Engine/Game/GameMenu/Friend.cs
@@ -44,6 +44,11 @@ public partial struct Friend : IEquatable<Friend>
 	public readonly string Name => Internal.Name;
 
 	/// <summary>
+	/// The nickname you've set for this friend, otherwise returns their Steam display name
+	/// </summary>
+	internal readonly string DisplayName => Internal.DisplayName;
+
+	/// <summary>
 	/// Returns true if your friend is online
 	/// </summary>
 	public readonly bool IsOnline => Internal.IsOnline;

--- a/engine/Sandbox.Engine/Platform/Steam/Structs/Friend.cs
+++ b/engine/Sandbox.Engine/Platform/Steam/Structs/Friend.cs
@@ -1,5 +1,4 @@
-﻿using Sandbox;
-using Steamworks.Data;
+﻿using Steamworks.Data;
 
 namespace Steamworks;
 
@@ -14,7 +13,7 @@ internal struct Friend
 
 	public override string ToString()
 	{
-		return $"{Name} ({Id})";
+		return $"{DisplayName} ({Id})";
 	}
 
 	/// <summary>
@@ -79,13 +78,39 @@ internal struct Friend
 	//
 
 	internal static Dictionary<ulong, string> _nameCache = new();
+	internal static Dictionary<ulong, string> _nicknameCache = new();
 	internal static Dictionary<ulong, Relationship> _relationshipCache = new();
 	internal static Dictionary<ulong, FriendState> _stateCache = new();
 	internal static Dictionary<ulong, int> _steamLevelCache = new();
 	internal static Dictionary<ulong, FriendGameInfo?> _gameInfoCache = new();
 
 	public string Name => !SteamFriends.IsInstalled ? null : _nameCache.GetOrCreate( Id.Value, SteamFriends.Internal.GetFriendPersonaName );
+
+	public string Nickname
+	{
+		get
+		{
+			if ( !SteamFriends.IsInstalled || !IsFriend )
+				return null;
+
+			var nickname = _nicknameCache.GetOrCreate( Id.Value, SteamFriends.Internal.GetPlayerNickname );
+			return string.IsNullOrWhiteSpace( nickname ) ? null : nickname;
+		}
+	}
+
+	public string DisplayName
+	{
+		get
+		{
+			if ( !string.IsNullOrWhiteSpace( Nickname ) )
+				return Nickname;
+
+			return string.IsNullOrWhiteSpace( Name ) ? null : Name;
+		}
+	}
+
 	public Relationship Relationship => !SteamFriends.IsInstalled ? Steamworks.Relationship.None : _relationshipCache.GetOrCreate( Id.Value, SteamFriends.Internal.GetFriendRelationship );
+
 	public FriendState State
 	{
 		get
@@ -102,6 +127,7 @@ internal struct Friend
 			return val;
 		}
 	}
+
 	public int SteamLevel => !SteamFriends.IsInstalled ? 0 : _steamLevelCache.GetOrCreate( Id.Value, SteamFriends.Internal.GetFriendSteamLevel );
 
 	public FriendGameInfo? GameInfo => !SteamFriends.IsInstalled ? null : _gameInfoCache.GetOrCreate( Id, x =>
@@ -228,8 +254,14 @@ internal struct Friend
 		if ( changeFlags.Contains( PersonaChange.Name ) )
 			_nameCache.Remove( id );
 
+		if ( changeFlags.Contains( PersonaChange.Nickname ) )
+			_nicknameCache.Remove( id );
+
 		if ( changeFlags.Contains( PersonaChange.RelationshipChanged ) )
+		{
 			_relationshipCache.Remove( id );
+			_nicknameCache.Remove( id );
+		}
 
 		if ( changeFlags.Contains( PersonaChange.Status ) || changeFlags.Contains( PersonaChange.GoneOffline ) || changeFlags.Contains( PersonaChange.ComeOnline ) )
 			_stateCache.Remove( id );

--- a/engine/Sandbox.Engine/Protocol.cs
+++ b/engine/Sandbox.Engine/Protocol.cs
@@ -13,7 +13,7 @@ public static class Protocol
 	/// <summary>
 	/// We cannot talk to servers or clients with a network protocol different to this.
 	/// </summary>
-	public static int Network => 1101;
+	public static int Network => 1102;
 }
 
 // Api Versions
@@ -26,6 +26,7 @@ public static class Protocol
 
 
 // Network Versions
+// 1102. 14th May 2026 - Connection display names are resolved locally
 // 1101. 04th May 2026 - TargetedInternalMessage uses ISerializer (wire format change)
 // 1100. 30th March 2026 - Compress-before-chunk, chunking moved to wire layer
 // 1099. 24th Feburary 2026 - ResourceId is now a long

--- a/engine/Sandbox.Engine/Systems/Networking/PlayerInfo/ConnectionInfoManager.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/PlayerInfo/ConnectionInfoManager.cs
@@ -135,7 +135,6 @@ internal sealed class ConnectionInfo
 
 	public int Ping { get; private set; }
 	public Guid ConnectionId { get; internal set; }
-	public string DisplayName { get; internal set; }
 	public SteamId SteamId { get; internal set; }
 	public DateTimeOffset ConnectionTime { get; internal set; }
 	public bool CanRefreshObjects { get; internal set; } = true;
@@ -161,7 +160,6 @@ internal sealed class ConnectionInfo
 
 	internal void Update( UserInfo userInfo )
 	{
-		DisplayName = userInfo.DisplayName;
 		SteamId = userInfo.SteamId;
 		PartyId = userInfo.PartyId;
 
@@ -200,7 +198,6 @@ internal sealed class ConnectionInfo
 			return;
 
 		UpdateStringTable( "ping", Ping );
-		UpdateStringTable( "name", DisplayName );
 		UpdateStringTable( "state", State );
 		UpdateStringTable( "steamid", SteamId );
 		UpdateStringTable( "connect", ConnectionTime );
@@ -242,9 +239,6 @@ internal sealed class ConnectionInfo
 
 		switch ( key )
 		{
-			case "name":
-				DisplayName = (string)value;
-				break;
 			case "ping":
 				Ping = (int)value;
 				break;

--- a/engine/Sandbox.Engine/Systems/Networking/PlayerInfo/UserInfo.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/PlayerInfo/UserInfo.cs
@@ -4,7 +4,6 @@
 internal struct UserInfo
 {
 	public SteamId SteamId { get; set; }
-	public string DisplayName { get; set; }
 	public DateTimeOffset ConnectionTime { get; set; }
 	public Dictionary<string, string> UserData { get; set; }
 	public int EngineVersion { get; internal set; }
@@ -25,7 +24,6 @@ internal struct UserInfo
 			{
 				ConnectionTime = DateTime.UtcNow,
 				SteamId = Utility.Steam.SteamId,
-				DisplayName = Utility.Steam.PersonaName,
 				EngineVersion = Engine.Protocol.Network,
 				UserData = new(),
 				PartyId = PartyRoom.Current?.Id ?? new( 0 ),

--- a/engine/Sandbox.Engine/Systems/Networking/System/Channel/Connection.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/Channel/Connection.cs
@@ -452,10 +452,42 @@ public abstract partial class Connection
 	internal ConnectionInfo PreInfo { get; set; }
 
 	[ActionGraphInclude]
-	public string DisplayName => Info?.DisplayName ?? "Unknown Player";
+	public string DisplayName
+	{
+		get
+		{
+			if ( SteamId.ValueUnsigned == 0 )
+				return "Unknown Player";
+
+			var isLocalInstance = SteamId.ValueUnsigned >= Utility.Steam.BaseFakeSteamId;
+
+			if ( isLocalInstance )
+				return "Local Player";
+
+			var displayName = FriendInfo.DisplayName;
+			return string.IsNullOrWhiteSpace( displayName ) ? "Unknown Player" : displayName;
+		}
+	}
 
 	[ActionGraphInclude]
 	public SteamId SteamId => Info?.SteamId ?? default;
+
+	/// <summary>
+	/// Steam friend information for this connection
+	/// </summary>
+	public Friend FriendInfo
+	{
+		get
+		{
+			if ( SteamId.ValueUnsigned == 0 )
+				return default;
+
+			if ( field.Id != SteamId.ValueUnsigned )
+				field = new( SteamId.ValueUnsigned );
+
+			return field;
+		}
+	}
 
 	/// <summary>
 	/// The SteamID of the account that actually owns the game in a Steam Family.

--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkConsoleCommands.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkConsoleCommands.cs
@@ -141,7 +141,10 @@ internal static class NetworkConsoleCommands
 
 		foreach ( var info in Networking.System.ConnectionInfo.All.Values )
 		{
-			Log.Info( $"{info.ConnectionId}	{info.SteamId}	{info.State}		{info.DisplayName}		{info.ConnectionTime}" );
+			var connection = Networking.System.FindConnection( info.ConnectionId );
+			var displayName = connection?.DisplayName ?? "Unknown Player";
+
+			Log.Info( $"{info.ConnectionId}	{info.SteamId}	{info.State}		{displayName}		{info.ConnectionTime}" );
 		}
 	}
 

--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
@@ -1,5 +1,4 @@
 ﻿using Sandbox.Engine;
-using Sandbox.Internal;
 
 namespace Sandbox.Network;
 
@@ -138,17 +137,24 @@ internal partial class NetworkSystem
 			return;
 
 		//
-		// Lobbies and steam network connections are trusted, so we can take the display name and Steam Id from them,
+		// Lobbies and steam network connections are trusted, so we can take the Steam Id from them,
 		// we shouldn't trust any other type of connection... but local TCP we can let slide.
 		//
 		if ( source is SteamLobbyConnection slob )
 		{
-			var friend = new Friend( slob.Friend.Id );
 			msg.SteamId = slob.Friend.Id;
-			msg.DisplayName = friend.Name;
 		}
 
-		Log.Info( $"{msg.DisplayName} [{msg.SteamId}] is connecting" );
+		source.PreInfo = new ConnectionInfo( null )
+		{
+			ConnectionId = source.Id,
+			State = source.State
+		};
+
+		source.PreInfo.Update( msg );
+
+		var displayName = source.DisplayName;
+		Log.Info( $"{displayName} [{msg.SteamId}] is connecting" );
 
 		//
 		// If the lobby is set to FriendsOnly, only allow players who are Steam friends with the host.
@@ -160,7 +166,7 @@ internal partial class NetworkSystem
 			// Host is always allowed
 			if ( msg.SteamId != hostSteamId.Value && !new Friend( msg.SteamId ).IsFriend )
 			{
-				Log.Info( $"Kicked {msg.DisplayName} [{msg.SteamId}] - not friends with host [{hostSteamId}]" );
+				Log.Info( $"Kicked {displayName} [{msg.SteamId}] - not friends with host [{hostSteamId}]" );
 				source.Kick( "This lobby is Friends Only." );
 				return;
 			}
@@ -169,17 +175,9 @@ internal partial class NetworkSystem
 
 		var denialReason = "";
 
-		source.PreInfo = new ConnectionInfo( null )
-		{
-			ConnectionId = source.Id,
-			State = source.State
-		};
-
-		source.PreInfo.Update( msg );
-
 		if ( GameSystem is not null && !GameSystem.AcceptConnection( source, ref denialReason ) )
 		{
-			Log.Info( $"Kicking {msg.DisplayName} [{msg.SteamId}] - {denialReason}" );
+			Log.Info( $"Kicking {displayName} [{msg.SteamId}] - {denialReason}" );
 			source.Kick( denialReason );
 			return;
 		}
@@ -187,7 +185,6 @@ internal partial class NetworkSystem
 		source.PreInfo = null;
 		source.State = Connection.ChannelState.Welcome;
 
-		//log.Info( $"Client Name is {data.DisplayName}" );
 		//log.Info( $"Client SteamId is {data.SteamId}" );
 		//log.Info( $"Client EngineVersion is {data.EngineVersion}" );
 
@@ -203,18 +200,6 @@ internal partial class NetworkSystem
 		// They're connected now dummy
 		//
 		msg.ConnectionTime = DateTime.UtcNow;
-
-		//
-		// Make their name unique
-		//
-		var displayName = msg.DisplayName;
-		var index = 2;
-		while ( ConnectionInfo.All.Values.Any( x => string.Equals( x.DisplayName, displayName, StringComparison.OrdinalIgnoreCase ) ) )
-		{
-			displayName = $"{msg.DisplayName} ({index})";
-			index++;
-		}
-		msg.DisplayName = displayName;
 
 		//
 		// Add player info to the manager. This will get sent to all the other players, so this


### PR DESCRIPTION
## Summary

Connection display names are now resolved locally instead of being replicated from the host.

## Motivation & Context

ConnectionInfo.DisplayName was populated by the host and replicated to clients. This meant a player’s display name was based on the host’s local Steam view of that person including host specific friend naming.

Fixes: 
https://github.com/Facepunch/sbox-public/issues/3914

## Implementation Details
- Removed display name from networked connection info. (Bumped network protocol)
- Added a cached Connection.FriendInfo accessor which makes resolving the names locally possible and also paves a way to access things like opening the add friend overlay through Connection. This can be made internal if we do not want it exposed.
- Connection.DisplayName resolves locally from the cached FriendInfo
- Editor instances will be named "Local Player" as we don't replicate display names from the host anymore. Previously these would be something like Name (2).

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂