### PR TITLE
Normalize RPC NetFlags to reliable unless explicitly unreliable

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/Rpc.Attributes.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/Rpc.Attributes.cs
@@ -9,12 +9,21 @@
 public abstract class RpcAttribute : Attribute
 {
 	internal RpcMode Mode { get; set; } = RpcMode.Broadcast;
-	public NetFlags Flags { get; set; } = NetFlags.Reliable;
+
+	public NetFlags Flags { get; set => field = NormalizeFlags( value ); } = NetFlags.Reliable;
 
 	internal RpcAttribute( RpcMode mode, NetFlags flags = NetFlags.Reliable )
 	{
 		Mode = mode;
 		Flags = flags;
+	}
+
+	static NetFlags NormalizeFlags( NetFlags flags )
+	{
+		if ( flags.Contains( NetFlags.Unreliable ) )
+			return flags & ~NetFlags.Reliable;
+
+		return flags | NetFlags.Reliable;
 	}
 }
 

--- a/engine/Sandbox.Test.Unit/Network/RpcAttribute.cs
+++ b/engine/Sandbox.Test.Unit/Network/RpcAttribute.cs
@@ -1,0 +1,32 @@
+namespace Networking;
+
+[TestClass]
+public class RpcAttributeTests
+{
+	[TestMethod]
+	public void Broadcast_DefaultsReliable()
+	{
+		var attribute = new Rpc.BroadcastAttribute();
+
+		Assert.IsTrue( attribute.Flags.Contains( NetFlags.Reliable ) );
+	}
+
+	[TestMethod]
+	public void Broadcast_HostOnlyAddsReliable()
+	{
+		var attribute = new Rpc.BroadcastAttribute( NetFlags.HostOnly );
+
+		Assert.IsTrue( attribute.Flags.Contains( NetFlags.HostOnly ) );
+		Assert.IsTrue( attribute.Flags.Contains( NetFlags.Reliable ) );
+	}
+
+	[TestMethod]
+	public void Broadcast_UnreliableDoesNotAddReliable()
+	{
+		var attribute = new Rpc.BroadcastAttribute( NetFlags.OwnerOnly | NetFlags.Unreliable );
+
+		Assert.IsTrue( attribute.Flags.Contains( NetFlags.OwnerOnly ) );
+		Assert.IsTrue( attribute.Flags.Contains( NetFlags.Unreliable ) );
+		Assert.IsFalse( attribute.Flags.Contains( NetFlags.Reliable ) );
+	}
+}


### PR DESCRIPTION
Summary
Normalize RPC NetFlags so RPCs remain reliable unless NetFlags.Unreliable is explicitly specified.

Motivation & Context
`[Rpc.Broadcast(NetFlags.HostOnly)]` replaces the default flags entirely, meaning the default `NetFlags.Reliable` was secretly dropped if for example you specified that only the host could trigger this broadcast.

The now obsolete `[Broadcast]` attribute preserved reliability because it OR'd permission flags onto NetFlags.Reliable.

Implementation Details
- RpcAttribute.Flags are normalized and are always Reliable unless the Unreliable flag is set.
- Unit tests confirming default reliability and explicit unreliability

Checklist
- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂ted to change 🙂