### PR TITLE
Clear material override before applying model material group

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Render/ModelRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/ModelRenderer.cs
@@ -256,6 +256,7 @@ public partial class ModelRenderer : Renderer, ExecuteInEditor, ITintable, IMate
 
 		if ( HasMaterialGroups )
 		{
+			_sceneObject.SetMaterialOverride( null );
 			_sceneObject.SetMaterialGroup( MaterialGroup );
 		}
 		else


### PR DESCRIPTION
## Summary
Clearing a material override on a model with material groups would not remove the material override from a ModelRenderer until the material group was manually set again.

Fixes:
https://github.com/Facepunch/sbox-public/issues/10807

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂