### PR TITLE
Slightly improve dump_scene by including network ownership details

### DIFF
--- a/engine/Sandbox.Engine/Game/Game/Game.Debug.cs
+++ b/engine/Sandbox.Engine/Game/Game/Game.Debug.cs
@@ -18,6 +18,16 @@ public static partial class Game
 
 		foreach ( var child in scene.Children )
 		{
+			var isNetworked = child.NetworkMode == NetworkMode.Object;
+
+			if ( isNetworked )
+			{
+				var owner = child.Network.Owner;
+				var isHostOwned = owner == null;
+
+				child.Name = $"{child.Name} ({(isHostOwned ? "Host" : owner.DisplayName)})";
+			}
+
 			var jso = child.Serialize( options );
 			if ( jso is null ) continue;
 

--- a/engine/Sandbox.Engine/Game/Game/Game.Debug.cs
+++ b/engine/Sandbox.Engine/Game/Game/Game.Debug.cs
@@ -8,28 +8,24 @@ public static partial class Game
 	internal static void DumpScene()
 	{
 		var scene = ActiveScene;
+
 		if ( !scene.IsValid() )
 			return;
 
 		using var sceneScope = scene.Push();
 
 		var children = new JsonArray();
-		var options = new GameObject.SerializeOptions();
+		var options = new GameObject.SerializeOptions()
+		{
+			SceneForDump = true
+		};
 
 		foreach ( var child in scene.Children )
 		{
-			var isNetworked = child.NetworkMode == NetworkMode.Object;
-
-			if ( isNetworked )
-			{
-				var owner = child.Network.Owner;
-				var isHostOwned = owner == null;
-
-				child.Name = $"{child.Name} ({(isHostOwned ? "Host" : owner.DisplayName)})";
-			}
-
 			var jso = child.Serialize( options );
-			if ( jso is null ) continue;
+
+			if ( jso is null )
+				continue;
 
 			children.Add( jso );
 		}
@@ -38,6 +34,7 @@ public static partial class Game
 			return;
 
 		var json = children.ToJsonString();
+
 		if ( string.IsNullOrWhiteSpace( json ) )
 			return;
 

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Network.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Network.cs
@@ -960,4 +960,12 @@ public partial class GameObject
 			system?.DeltaSnapshots?.Send( go._net, NetFlags.Reliable, true );
 		}
 	}
+
+	public sealed class SceneDumpInfo
+	{
+		public Guid ConnectionId { get; internal set; }
+		public string ConnectionName { get; internal set; }
+	}
+
+	public SceneDumpInfo SceneDump { get; internal set; }
 }

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
@@ -22,6 +22,12 @@ public partial class GameObject
 		public bool SceneForNetwork { get; set; }
 
 		/// <summary>
+		/// If we're serializing for a scene dump we'll include properties which we would otherwise not want serialized.
+		/// e.g. Network.Owner
+		/// </summary>
+		public bool SceneForDump { get; set; }
+
+		/// <summary>
 		/// We're cloning this object
 		/// </summary>
 		[Obsolete( "Has no effect" )]
@@ -142,14 +148,33 @@ public partial class GameObject
 	{
 		options ??= _defaultSerializeOptions;
 
-		if ( !options.ShouldSave( this ) ) return null;
+		if ( !options.ShouldSave( this ) )
+			return null;
+
+		JsonObject json;
 
 		if ( IsOutermostPrefabInstanceRoot && !options.SerializePrefabForDiff && !options.SingleNetworkObject && !options.SceneForNetwork )
 		{
-			return SerializePrefabInstance();
+			json = SerializePrefabInstance();
+		}
+		else
+		{
+			json = SerializeStandard( options );
 		}
 
-		var json = SerializeStandard( options );
+		// If we're serializing for a scene dump append additional metadata
+		if ( options.SceneForDump && NetworkMode == NetworkMode.Object )
+		{
+			var ownerId = Network.OwnerId;
+			var owner = Network.Owner;
+			var ownerName = ownerId == Guid.Empty ? "Host" : owner?.DisplayName ?? $"Unknown Owner - {ownerId}";
+
+			json[JsonKeys.SceneDumpInfo] = new JsonObject
+			{
+				[nameof( SceneDumpInfo.ConnectionId )] = ownerId,
+				[nameof( SceneDumpInfo.ConnectionName )] = ownerName
+			};
+		}
 
 		return json;
 	}
@@ -201,7 +226,7 @@ public partial class GameObject
 		json.Add( JsonKeys.AlwaysTransmit, AlwaysTransmit );
 		json.Add( JsonKeys.OwnerTransfer, (int)OwnerTransfer );
 
-		if ( (!options.SceneForNetwork && !options.SingleNetworkObject)
+		if ( !options.SceneForNetwork && !options.SingleNetworkObject
 				&& (IsNestedPrefabInstanceRoot || (IsOutermostPrefabInstanceRoot && options.SerializePrefabForDiff)) )
 		{
 			if ( options.SerializeForPrefabInstanceToPrefabUpdate && Parent is not null && Parent.IsOutermostPrefabInstanceRoot )
@@ -298,6 +323,17 @@ public partial class GameObject
 	public virtual void Deserialize( JsonObject node, DeserializeOptions options )
 	{
 		ArgumentNullException.ThrowIfNull( node, nameof( node ) );
+
+		SceneDump = null;
+
+		if ( node[JsonKeys.SceneDumpInfo] is JsonObject sceneDumpInfo )
+		{
+			SceneDump = new SceneDumpInfo
+			{
+				ConnectionId = sceneDumpInfo.GetPropertyValue<Guid>( nameof( SceneDumpInfo.ConnectionId ), Guid.Empty ),
+				ConnectionName = sceneDumpInfo.GetPropertyValue<string>( nameof( SceneDumpInfo.ConnectionName ), null )
+			};
+		}
 
 		using var sceneScope = Scene.Push();
 
@@ -648,7 +684,7 @@ public partial class GameObject
 		Flags &= ~flagsToKeep;
 
 		// Copy set flags from source
-		Flags |= (inFlags & flagsToKeep);
+		Flags |= inFlags & flagsToKeep;
 	}
 
 	private bool IsPrefabLoaded( PrefabFile prefabFile )
@@ -1024,6 +1060,8 @@ public partial class GameObject
 		// Editor only keys used to influence serialization logic when performing editor actions
 		internal const string EditorPrefabInstanceNestedSource = "__EditorPrefabNestedInstance";
 		internal const string EditorSkipPrefabBreakOnRefresh = "__EditorSkipPrefabBreakOnRefresh";
-	}
 
+		// Scene dump keys
+		internal const string SceneDumpInfo = "__SceneDumpInfo";
+	}
 }

--- a/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
+++ b/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
@@ -291,23 +291,22 @@ partial class GameObjectNode : TreeNode<GameObject>
 			r.Left += 22;
 		}
 
-		if ( isNetworkRoot && Value.Network.OwnerId != Guid.Empty )
+		if ( isNetworkRoot || Value.SceneDump is not null )
 		{
-			var connection = Connection.Find( Value.Network.OwnerId );
-			if ( connection is null )
+			var ownerName = Value.SceneDump?.ConnectionName;
+
+			if ( Value.Network.OwnerId != Guid.Empty )
 			{
-				Paint.Pen = Theme.Blue;
-				Paint.DrawText( r, $"Unknown Owner - {Value.Network.OwnerId}", TextFlag.LeftCenter );
-				r.Left += 22;
-			}
-			else
-			{
-				Paint.Pen = Theme.Blue;
-				Paint.DrawText( r, $"{connection.DisplayName}", TextFlag.LeftCenter );
-				r.Left += 22;
+				var connection = Connection.Find( Value.Network.OwnerId );
+				ownerName = connection is null ? $"Unknown Owner - {Value.Network.OwnerId}" : connection.DisplayName;
 			}
 
-
+			if ( !string.IsNullOrWhiteSpace( ownerName ) )
+			{
+				Paint.Pen = Theme.Blue;
+				Paint.DrawText( r, ownerName, TextFlag.LeftCenter );
+				r.Left += 22;
+			}
 		}
 
 		if ( Value.Tags.Has( "hidden" ) )
@@ -807,7 +806,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 			if ( !EditorPreferences.CreateObjectsAtOrigin && !parent.IsValid() && SceneViewWidget.Current?.LastSelectedViewportWidget?.IsValid() == true )
 			{
 				// I wonder if we should be tracing and placing it on the surface?
-				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300;
+				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + (SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300);
 			}
 
 			afterCreate?.Invoke( go );
@@ -870,7 +869,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 			if ( !EditorPreferences.CreateObjectsAtOrigin && !parent.IsValid() && SceneViewWidget.Current?.LastSelectedViewportWidget?.IsValid() == true )
 			{
 				// I wonder if we should be tracing and placing it on the surface?
-				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300;
+				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + (SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300);
 			}
 
 			afterCreate?.Invoke( go );
@@ -948,7 +947,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 			if ( !EditorPreferences.CreateObjectsAtOrigin && !parent.IsValid() )
 			{
 				// I wonder if we should be tracing and placing it on the surface?
-				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300;
+				go.LocalPosition = SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraPosition + (SceneViewWidget.Current.LastSelectedViewportWidget.State.CameraRotation.Forward * 300);
 			}
 
 			afterCreate?.Invoke( go );


### PR DESCRIPTION
## Summary

Slightly improve `dump_scene` concmd by including details of network ownership (the name of the player who owns the gameobject). Currently dump_scene retains network mode but has no information pertaining to who owns the object.

## Motivation & Context

Network ownership is sometimes difficult to establish at runtime and is a common cause of networking hiccups, debugging tools for networking as a whole are lacking. This helps ease that a little bit.

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂