### PR TITLE
Add [ReadOnlyIf] attribute, make sure Colliders containing physics meshes are visibly static in inspector

### DIFF
--- a/engine/Sandbox.Engine/Editor/Hammer/ConditionalVisibilityAttributes.cs
+++ b/engine/Sandbox.Engine/Editor/Hammer/ConditionalVisibilityAttributes.cs
@@ -90,3 +90,38 @@ public class ShowIfAttribute : HideIfAttribute
 		return !base.TestCondition( so );
 	}
 }
+
+/// <summary>
+/// Make this property read-only if a given property within the same class has the given value. Used typically in the Editor Inspector.
+/// </summary>
+[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = true )]
+public class ReadOnlyIfAttribute : InspectorReadOnlyAttribute
+{
+	/// <summary>
+	/// Property name to test.
+	/// </summary>
+	public string PropertyName { get; set; }
+
+	/// <summary>
+	/// Property value to test against.
+	/// </summary>
+	public object Value { get; set; }
+
+	public ReadOnlyIfAttribute( string propertyName, object value )
+	{
+		PropertyName = propertyName;
+		Value = value;
+	}
+
+	public override bool TestCondition( SerializedObject so )
+	{
+		if ( so.TryGetProperty( PropertyName, out var property ) )
+		{
+			var value = property.GetValue<object>();
+			return Equals( value, Value );
+		}
+
+		Log.Warning( $"ReadOnlyIfAttribute: Couldn't find property '{PropertyName}' on {so.TypeName}" );
+		return false;
+	}
+}

--- a/engine/Sandbox.Engine/Scene/Components/Collider/Collider.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/Collider.cs
@@ -9,7 +9,10 @@ public abstract partial class Collider : Component, Component.ExecuteInEditor, C
 
 	private bool _static;
 
-	[Property, HideIf( nameof( IsConcave ), true )]
+	/// <summary>
+	/// Whether this collider should be static or dynamic, static colliders are more performant but can't move.
+	/// </summary>
+	[Property, ReadOnlyIf( nameof( IsConcave ), true )]
 	public bool Static
 	{
 		get => _static || IsConcave;

--- a/engine/Sandbox.Engine/Scene/Components/Collider/ModelCollider.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/ModelCollider.cs
@@ -21,8 +21,8 @@ public class ModelCollider : Collider, IHasModel
 		set
 		{
 			_model = value;
-			
-			if( value == null )
+
+			if ( value == null )
 			{
 				_hasCollisionMesh = false;
 				Static = false;
@@ -59,9 +59,11 @@ public class ModelCollider : Collider, IHasModel
 		if ( !Gizmo.IsSelected && !Gizmo.IsHovered )
 			return;
 
-		if ( Model is null ) return;
+		if ( Model is null )
+			return;
 
-		if ( Model.Physics is null ) return;
+		if ( Model.Physics is null )
+			return;
 
 		Gizmo.Draw.Color = Gizmo.Colors.Green;
 

--- a/engine/Sandbox.Engine/Scene/Components/Collider/ModelCollider.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/ModelCollider.cs
@@ -10,6 +10,9 @@
 public class ModelCollider : Collider, IHasModel
 {
 	private Model _model;
+	private bool _hasCollisionMesh;
+
+	public override bool IsConcave => _hasCollisionMesh;
 
 	[Property]
 	public Model Model
@@ -18,6 +21,12 @@ public class ModelCollider : Collider, IHasModel
 		set
 		{
 			_model = value;
+			
+			if( value == null )
+			{
+				_hasCollisionMesh = false;
+				Static = false;
+			}
 
 			UpdateShape();
 		}
@@ -85,6 +94,8 @@ public class ModelCollider : Collider, IHasModel
 
 	protected override IEnumerable<PhysicsShape> CreatePhysicsShapes( PhysicsBody targetBody, Transform local )
 	{
+		_hasCollisionMesh = false;
+
 		if ( Model is null || Model.Physics is null )
 			yield break;
 
@@ -129,6 +140,8 @@ public class ModelCollider : Collider, IHasModel
 
 			foreach ( var mesh in part.Meshes )
 			{
+				_hasCollisionMesh = true;
+
 				var shape = targetBody.AddShape( mesh, bx, false, true );
 				Assert.NotNull( shape, "Mesh shape was null" );
 

--- a/engine/Sandbox.System/SerializedObject/SerializedProperty.cs
+++ b/engine/Sandbox.System/SerializedObject/SerializedProperty.cs
@@ -424,6 +424,22 @@ public abstract partial class SerializedProperty : IValid
 	}
 
 	/// <summary>
+	/// Returns true if this property should be read-only in the inspector.
+	/// </summary>
+	public bool IsConditionalReadOnly()
+	{
+		if ( Parent is null ) return false;
+
+		foreach ( var attr in GetAttributes<InspectorReadOnlyAttribute>() )
+		{
+			if ( attr.TestCondition( Parent ) )
+				return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
 	/// Return true if this is a nullable value type
 	/// </summary>
 	public bool IsNullable
@@ -519,6 +535,14 @@ public abstract partial class SerializedProperty : IValid
 /// Hide a property if a condition matches.
 /// </summary>
 public abstract class InspectorVisibilityAttribute : System.Attribute
+{
+	public abstract bool TestCondition( SerializedObject so );
+}
+
+/// <summary>
+/// Make a property read-only if a condition matches.
+/// </summary>
+public abstract class InspectorReadOnlyAttribute : System.Attribute
 {
 	public abstract bool TestCondition( SerializedObject so );
 }

--- a/engine/Sandbox.Tools/ControlWidget/ControlWidget.cs
+++ b/engine/Sandbox.Tools/ControlWidget/ControlWidget.cs
@@ -16,6 +16,28 @@ public abstract class ControlWidget : Widget
 
 	public SerializedProperty SerializedProperty { get; private set; }
 
+	private bool _isConditionalReadOnly;
+
+	public override bool ReadOnly
+	{
+		get => base.ReadOnly || _isConditionalReadOnly;
+		set => base.ReadOnly = value;
+	}
+
+	public bool ConditionalReadOnly
+	{
+		get => _isConditionalReadOnly;
+		set
+		{
+			if ( _isConditionalReadOnly == value )
+				return;
+
+			_isConditionalReadOnly = value;
+			ReadOnly = base.ReadOnly;
+			Update();
+		}
+	}
+
 	/// <summary>
 	/// If none, when in a grid, the control will fill the entire cell
 	/// </summary>
@@ -38,7 +60,7 @@ public abstract class ControlWidget : Widget
 		//
 		// I think this should be more explicit, only readonly if there's a [readonly] property
 		//
-		if ( !property.IsEditable && property.PropertyType.IsValueType || property.HasAttribute<ReadOnlyAttribute>() )
+		if ( (!property.IsEditable && property.PropertyType.IsValueType) || property.HasAttribute<ReadOnlyAttribute>() )
 			base.ReadOnly = true;
 
 		if ( property.TryGetAttribute<TintAttribute>( out var tintAttribute ) )

--- a/game/addons/tools/Code/Editor/ControlSheet/ControlSheetRow.cs
+++ b/game/addons/tools/Code/Editor/ControlSheet/ControlSheetRow.cs
@@ -1,6 +1,4 @@
-﻿using Sandbox.UI;
-
-namespace Editor;
+﻿namespace Editor;
 
 /// <summary>
 /// Represents a single row in a control sheet UI, providing editing and validation functionality for a serialized
@@ -20,7 +18,9 @@ class ControlSheetRow : Widget
 	{
 		this.property = property;
 		FocusMode = FocusMode.Click;
+
 		ControlWidget = editor;
+		ControlWidget.ConditionalReadOnly = property.IsConditionalReadOnly();
 
 		property.OnFinishEdit += OnPropertyFinishEdit;
 
@@ -71,7 +71,10 @@ class ControlSheetRow : Widget
 
 	public bool UpdateVisibility()
 	{
+		ControlWidget.ConditionalReadOnly = property.IsConditionalReadOnly();
+
 		var ss = property.ShouldShow();
+
 		if ( ss == !Hidden )
 			return false;
 
@@ -149,7 +152,7 @@ class ControlSheetRow : Widget
 		if ( hasLabel )
 		{
 			label.ContentMargins = isExpanded ? new( 0, 0, 0, 4 ) : new( 0, 0, 4, 0 );
-			gridLayout.AddCell( 2, 5, label, xSpan: (isExpanded ? 2 : 1), alignment: TextFlag.LeftTop );
+			gridLayout.AddCell( 2, 5, label, xSpan: isExpanded ? 2 : 1, alignment: TextFlag.LeftTop );
 			gridLayout.AddCell( 3 - (isExpanded ? 1 : 0), 5 + (isExpanded ? 1 : 0), ControlWidget, alignment: TextFlag.LeftTop );
 		}
 		else

--- a/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/GenericControlWidget.cs
@@ -38,6 +38,7 @@ public class GenericControlWidget : ControlObjectWidget
 			foreach ( var key in keys )
 			{
 				var widget = Layout.Add( ControlSheetRow.CreateEditor( key ) );
+				widget.ConditionalReadOnly = key.IsConditionalReadOnly();
 				widget.Visible = key.ShouldShow();
 				KeyPropertyWidgets.Add( key, widget );
 			}
@@ -230,6 +231,7 @@ public class GenericControlWidget : ControlObjectWidget
 
 		foreach ( var kvp in KeyPropertyWidgets )
 		{
+			kvp.Value.ConditionalReadOnly = kvp.Key.IsConditionalReadOnly();
 			kvp.Value.Visible = kvp.Key.ShouldShow();
 		}
 	}


### PR DESCRIPTION
Add `[ReadOnlyIf]` attribute, use it in Collider on the Static property in place of `[HideIf]` attribute. 
ModelCollider now reacts to its given model, marks itself as static if the given model has a physics mesh.

## Motivation & Context
**ModelCollider**
Users were able to toggle the Static property on ModelColliders containing a physics mesh, these always need to be static as they can't be physically simulated. 

**ReadOnlyIf**
If something is marked as static by the engine we should let the user know that it's static rather than hiding the property with a [HideIf] attribute. The Static property will now always be visible but if the engine is setting it we'll let the user know about it and stop them from changing it. Added an XML summary to Static to reinforce what the static property is doing.

## Screenshots / Videos (if applicable)
Before:

https://github.com/user-attachments/assets/4eb384cc-bbd7-4222-836c-776c8f563580


After:

https://github.com/user-attachments/assets/42e55f4a-558b-4e19-a18f-9600966511bf


## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂