### PR TITLE
Init GameObjectSystem properties with [DefaultValue]

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObjectSystem/SystemsConfig.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystem/SystemsConfig.cs
@@ -109,7 +109,14 @@ public class SystemsConfig : ConfigData
 		}
 		catch ( Exception ex )
 		{
-			Log.Warning( $"Failed to deserialize {typeName}.{property.Name}: {ex.Message}" );
+			Log.Warning( $"Removing stale GameObjectSystem config value {typeName}.{property.Name}: {ex.Message}" );
+			properties.Remove( property.Name );
+
+			if ( properties.Count == 0 )
+			{
+				Systems.Remove( typeName );
+			}
+
 			return false;
 		}
 	}

--- a/engine/Sandbox.Engine/Scene/GameObjectSystem/SystemsConfig.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystem/SystemsConfig.cs
@@ -31,7 +31,26 @@ public class SystemsConfig : ConfigData
 		if ( TryGetPropertyValue( systemType, property, out var value ) )
 			return value;
 
-		return property.PropertyType.IsValueType ? Activator.CreateInstance( property.PropertyType ) : null;
+		return GetDefaultValue( property );
+	}
+
+	/// <summary>
+	/// Get the default value for a GameObjectSystem property.
+	/// </summary>
+	public static object GetDefaultValue( PropertyDescription property )
+	{
+		if ( property.GetCustomAttribute<DefaultValueAttribute>() is { } defaultValue )
+			return defaultValue.Value;
+
+		var type = property.PropertyType;
+
+		if ( Nullable.GetUnderlyingType( type ) is { } nullableType )
+			type = nullableType;
+
+		if ( type.IsValueType )
+			return Activator.CreateInstance( type );
+
+		return null;
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -284,7 +284,7 @@ public partial class Scene : GameObject
 
 				var currentValue = property.GetValue( system );
 				var hasGlobalValue = ProjectSettings.Systems.TryGetPropertyValue( systemType, property, out var globalValue );
-				var compareValue = hasGlobalValue ? globalValue : property.GetCustomAttribute<DefaultValueAttribute>()?.Value;
+				var compareValue = hasGlobalValue ? globalValue : SystemsConfig.GetDefaultValue( property );
 
 				var currentJson = JsonSerializer.SerializeToNode( currentValue, Json.options );
 				var compareJson = JsonSerializer.SerializeToNode( compareValue, Json.options );

--- a/engine/Sandbox.Test.Unit/Scene/SystemsConfig.cs
+++ b/engine/Sandbox.Test.Unit/Scene/SystemsConfig.cs
@@ -1,0 +1,30 @@
+namespace Scene;
+
+[TestClass]
+public class SystemsConfigTests
+{
+	[TestMethod]
+	public void GetPropertyValue_UsesDefaultValueAttributeWhenUnset()
+	{
+		var typeLibrary = new Sandbox.Internal.TypeLibrary();
+		typeLibrary.AddAssembly( typeof( DefaultValueSystem ).Assembly, false );
+
+		var systemType = typeLibrary.GetType<DefaultValueSystem>();
+		var property = systemType.GetProperty( nameof( DefaultValueSystem.MyInt ) );
+		var config = new Sandbox.SystemsConfig();
+
+		Assert.AreEqual( 123, config.GetPropertyValue( systemType, property ) );
+	}
+
+}
+
+[Expose]
+public sealed class DefaultValueSystem : GameObjectSystem
+{
+	public DefaultValueSystem( Sandbox.Scene scene ) : base( scene )
+	{
+	}
+
+	[Property, DefaultValue( 123 )]
+	public int MyInt { get; set; } = 123;
+}

--- a/engine/Sandbox.Test/Scene/GameObjects/GameObjectSystemSerialization.cs
+++ b/engine/Sandbox.Test/Scene/GameObjects/GameObjectSystemSerialization.cs
@@ -1,0 +1,70 @@
+namespace GameObjects;
+
+[TestClass]
+public class GameObjectSystemSerializationTest
+{
+	private Sandbox.Internal.TypeLibrary _oldTypeLibrary;
+
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		_oldTypeLibrary = Game.TypeLibrary;
+
+		var typeLibrary = new Sandbox.Internal.TypeLibrary();
+		typeLibrary.AddAssembly( typeof( Sandbox.Scene ).Assembly, false );
+		typeLibrary.AddAssembly( typeof( GameObjectSystemDefaultTestSystem ).Assembly, false );
+
+		Game.TypeLibrary = typeLibrary;
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Game.TypeLibrary = _oldTypeLibrary;
+	}
+
+	[TestMethod]
+	public void DefaultValue_IsNotSerializedAsSceneOverride()
+	{
+		var scene = new Sandbox.Scene();
+
+		try
+		{
+			var system = scene.GetSystem<GameObjectSystemDefaultTestSystem>();
+			Assert.IsNotNull( system );
+			Assert.AreEqual( 123, system.MyInt );
+
+			var serialized = scene.Serialize();
+			var properties = serialized["Properties"].AsObject();
+
+			if ( properties.TryGetPropertyValue( "GameObjectSystems", out var systemsNode ) )
+			{
+				Assert.IsFalse( systemsNode.AsObject().ContainsKey( typeof( GameObjectSystemDefaultTestSystem ).FullName ) );
+			}
+
+			system.MyInt = 456;
+
+			serialized = scene.Serialize();
+			properties = serialized["Properties"].AsObject();
+			var systems = properties["GameObjectSystems"].AsObject();
+			var overrides = systems[typeof( GameObjectSystemDefaultTestSystem ).FullName].AsObject();
+
+			Assert.AreEqual( 456, overrides[nameof( GameObjectSystemDefaultTestSystem.MyInt )].GetValue<int>() );
+		}
+		finally
+		{
+			scene.Destroy();
+		}
+	}
+}
+
+[Expose]
+public sealed class GameObjectSystemDefaultTestSystem : GameObjectSystem
+{
+	public GameObjectSystemDefaultTestSystem( Sandbox.Scene scene ) : base( scene )
+	{
+	}
+
+	[Property, DefaultValue( 123 )]
+	public int MyInt { get; set; } = 123;
+}


### PR DESCRIPTION
## Summary
`GameObjectSystem`'s were not respecting `[DefaultValue]` or property initializers.

## Motivation & Context
Missing functionality, this PR brings the functionality in line with what you'd expect to happen on `Component` properties. (Auto filled `[Property]`s). Added test confirming [DefaultValue] is returned instead of default(T).

## Screenshots / Videos (if applicable)
Before:

https://github.com/user-attachments/assets/75cdb811-5501-413d-bf51-8400b3d2d354

After:

https://github.com/user-attachments/assets/bb4ae7ea-ec2a-4721-a9a0-3589f5b28a40

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂