### PR TITLE
Unfocusing a TreeView item should commit any pending name change

### DIFF
--- a/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
+++ b/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
@@ -1,6 +1,4 @@
-﻿using Sandbox.UI;
-
-namespace Editor;
+﻿namespace Editor;
 
 public partial class TreeView : BaseItemWidget
 {
@@ -387,7 +385,7 @@ public partial class TreeView : BaseItemWidget
 		// Create popup for renaming this item
 		//
 
-		var indent = item.Column * IndentWidth + ExpandWidth + 20;
+		var indent = (item.Column * IndentWidth) + ExpandWidth + 20;
 		var popup = new PopupWidget( this );
 		popup.Layout = Layout.Column();
 		popup.Position = ToScreen( item.Rect.TopLeft + new Vector2( indent, 0 ) );
@@ -400,7 +398,7 @@ public partial class TreeView : BaseItemWidget
 		var isCompleted = false;
 		var onComplete = () =>
 		{
-			if ( isCompleted ) 
+			if ( isCompleted )
 				return;
 
 			isCompleted = true;

--- a/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
+++ b/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
@@ -397,11 +397,18 @@ public partial class TreeView : BaseItemWidget
 		var lineEdit = popup.Layout.Add( new LineEdit() );
 		lineEdit.Text = first?.Name ?? "";
 
+		var isCompleted = false;
 		var onComplete = () =>
 		{
-			if ( !popup.Visible ) return;
+			if ( isCompleted ) 
+				return;
 
-			first?.OnRename( item, lineEdit.Text, items );
+			isCompleted = true;
+
+			if ( !string.IsNullOrEmpty( lineEdit.Text ) )
+			{
+				first?.OnRename( item, lineEdit.Text, items );
+			}
 
 			popup.Close();
 		};


### PR DESCRIPTION
## Summary

Unfocusing a TreeView item should commit any pending name change. The early Visible return was blocking as the popup is already hidden at this point. Added guard against empty string names.

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂