### PR TITLE
Add ChangeScene(SceneFile) and ChangeScene(string) overloads

### DIFF
--- a/engine/Sandbox.Engine/Game/Game/Game.Scene.cs
+++ b/engine/Sandbox.Engine/Game/Game/Game.Scene.cs
@@ -28,6 +28,36 @@ public static partial class Game
 	/// the new scene (broadcast the scene change.) If we're in a networking
 	/// session, then only the host can change the scene.
 	/// </summary>
+	/// <param name="scene"></param>
+	/// <returns>Whether the scene was changed successfully.</returns>
+	public static bool ChangeScene( SceneFile scene )
+	{
+		var loadOptions = new SceneLoadOptions();
+		loadOptions.SetScene( scene );
+
+		return ChangeScene( loadOptions );
+	}
+
+	/// <summary>
+	/// Change the active scene and optionally bring all connected clients to
+	/// the new scene (broadcast the scene change.) If we're in a networking
+	/// session, then only the host can change the scene.
+	/// </summary>
+	/// <param name="scenePath">The relative path to the scene to load.</param>
+	/// <returns>Whether the scene was changed successfully.</returns>
+	public static bool ChangeScene( string scenePath )
+	{
+		var loadOptions = new SceneLoadOptions();
+		loadOptions.SetScene( scenePath );
+
+		return ChangeScene( loadOptions );
+	}
+
+	/// <summary>
+	/// Change the active scene and optionally bring all connected clients to
+	/// the new scene (broadcast the scene change.) If we're in a networking
+	/// session, then only the host can change the scene.
+	/// </summary>
 	/// <param name="options">The <see cref="SceneLoadOptions"/> to use which also specifies which scene to load.</param>
 	/// <returns>Whether the scene was changed successfully.</returns>
 	public static bool ChangeScene( SceneLoadOptions options )

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -8,7 +8,7 @@ public partial class Scene : GameObject
 {
 	/// <summary>
 	/// Load from the provided <see cref="SceneFile"/>. This will not load the scene for other clients in a
-	/// multiplayer session, you should instead use <see cref="Game.ChangeScene"/>
+	/// multiplayer session, you should instead use <see cref="Game.ChangeScene(SceneFile)"/>
 	/// if you want to bring other clients.
 	/// </summary>
 	public virtual bool Load( GameResource resource )
@@ -28,7 +28,7 @@ public partial class Scene : GameObject
 
 	/// <summary>
 	/// Load from the provided <see cref="SceneLoadOptions"/>. This will not load the scene for other clients in a
-	/// multiplayer session, you should instead use <see cref="Game.ChangeScene"/>
+	/// multiplayer session, you should instead use <see cref="Game.ChangeScene(SceneFile)"/>
 	/// if you want to bring other clients.
 	/// </summary>
 	public bool Load( SceneLoadOptions options )
@@ -158,7 +158,7 @@ public partial class Scene : GameObject
 
 	/// <summary>
 	/// Load from the provided file name. This will not load the scene for other clients in a
-	/// multiplayer session, you should instead use <see cref="Game.ChangeScene"/>
+	/// multiplayer session, you should instead use <see cref="Game.ChangeScene(SceneFile)"/>
 	/// if you want to bring other clients.
 	/// </summary>
 	public bool LoadFromFile( string filename )


### PR DESCRIPTION
## Summary
Adds `Game.ChangeScene( SceneFile )` and `Game.ChangeScene( string )` overloads. This behaviour now mirrors the obsoleted way of networking a scene change `Scene.Load`.

## Motivation & Context
Requiring `SceneLoadOptions` every time you want to change scenes is unnecessarily verbose in almost all cases. Users who need more granular control can still build and pass their own `SceneLoadOptions`.

## Implementation Details

Both overloads create `SceneLoadOptions`, set the requested scene and delegate to the existing `Game.ChangeScene( SceneLoadOptions )`

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂