### PR TITLE
Add clickable visibility toggle to scene hierarchy

### DIFF
--- a/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
+++ b/game/addons/tools/Code/Scene/SceneTree/GameObjectNode.cs
@@ -96,7 +96,7 @@ partial class GameObjectNode : TreeNode<GameObject>
 
 		float opacity = 0.9f;
 
-		if ( !Value.Active ) opacity *= 0.5f;
+		if ( !Value.Active || IsAncestorDisabled( Value ) ) opacity *= 0.5f;
 
 		Color pen = Theme.TextControl;
 		string icon = "layers";
@@ -310,14 +310,56 @@ partial class GameObjectNode : TreeNode<GameObject>
 
 		}
 
-		if ( Value.Tags.Has( "hidden" ) )
+		var disabled = !Value.Enabled;
+		if ( disabled || isHovered || selected )
 		{
-			var eyeRect = item.Rect;
-			eyeRect.Right -= 4;
-			eyeRect.Left = eyeRect.Right - 18;
+			var eyeRect = GetEyeRect( item.Rect );
+			float eyeAlpha = disabled ? 1.0f : (isHovered ? 0.7f : 0.4f);
+			Paint.Pen = Theme.TextControl.WithAlphaMultiplied( eyeAlpha );
+			Paint.DrawIcon( eyeRect, disabled ? "visibility_off" : "visibility", 14, TextFlag.Center );
+		}
+	}
 
-			Paint.Pen = Theme.TextControl;
-			Paint.DrawIcon( eyeRect, "visibility_off", 14, TextFlag.Center );
+	static bool IsAncestorDisabled( GameObject go )
+	{
+		for ( var p = go?.Parent; p.IsValid() && p is not Scene; p = p.Parent )
+		{
+			if ( !p.Enabled ) return true;
+		}
+		return false;
+	}
+
+	static Rect GetEyeRect( Rect row )
+	{
+		row.Right -= 4;
+		row.Left = row.Right - 18;
+		return row;
+	}
+
+	public override bool OnItemPressed( VirtualWidget item, MouseEvent e )
+	{
+		if ( e.LeftMouseButton && Value.IsValid() && Value is not Scene )
+		{
+			var eyeRect = GetEyeRect( item.Rect );
+			if ( eyeRect.IsInside( e.LocalPosition ) )
+			{
+				ToggleEnabled();
+				return false;
+			}
+		}
+
+		return base.OnItemPressed( item, e );
+	}
+
+	void ToggleEnabled()
+	{
+		using var scope = SceneEditorSession.Scope();
+
+		using ( SceneEditorSession.Active.UndoScope( Value.Enabled ? "Disable GameObject" : "Enable GameObject" )
+			.WithGameObjectChanges( new[] { Value }, GameObjectUndoFlags.All )
+			.Push() )
+		{
+			Value.Enabled = !Value.Enabled;
 		}
 	}
 

--- a/game/addons/tools/Code/Widgets/TreeView/TreeNode.cs
+++ b/game/addons/tools/Code/Widgets/TreeView/TreeNode.cs
@@ -477,6 +477,15 @@ public partial class TreeNode
 	{
 
 	}
+
+	/// <summary>
+	/// Called by the TreeView before its default press handling. Return false to consume the
+	/// press (skip expand/select); return true to let the TreeView handle it normally.
+	/// </summary>
+	public virtual bool OnItemPressed( VirtualWidget item, MouseEvent e )
+	{
+		return true;
+	}
 }
 
 /// <summary>

--- a/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
+++ b/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
@@ -419,6 +419,9 @@ public partial class TreeView : BaseItemWidget
 	{
 		var node = pressedItem.Object as TreeNode;
 
+		if ( node != null && !node.OnItemPressed( pressedItem, e ) )
+			return false;
+
 		bool recursive = Application.KeyboardModifiers.HasFlag( KeyboardModifiers.Shift );
 		if ( node?.ExpanderFills ?? false )
 		{


### PR DESCRIPTION
## Summary

Adds a Unity-style clickable eye icon to each row in the scene hierarchy that toggles `GameObject.Enabled` — the same property the inspector's enable checkbox controls — so the two stay in sync.

## What changed

- **TreeNode** — new virtual `OnItemPressed( VirtualWidget, MouseEvent )` hook so nodes can intercept presses before the `TreeView`'s default expand/select logic. Default impl returns `true` (no behavior change for existing nodes).
- **TreeView** — calls `node.OnItemPressed` first in `OnItemPressed`; consumes the press if the node returns `false`.
- **GameObjectNode**
  - Paints a visibility icon on the right of each row: `visibility_off` at full alpha when the object is disabled, faint `visibility` when the row is hovered or selected, nothing otherwise (keeps the hierarchy clean).
  - Overrides `OnItemPressed` to hit-test the eye rect and toggle `GameObject.Enabled` under an undo scope (`"Enable GameObject"` / `"Disable GameObject"`). Click is consumed so the row isn't also selected.
  - Row dim now also accounts for ancestor disabled state, so disabling a parent visibly cascades to all descendants in the tree.

## Why

The hierarchy already painted a `visibility_off` icon for objects with the `hidden` tag, but the icon wasn't clickable and the only way to disable an object from the tree was the right-click menu / `Alt+H` shortcut (which toggles the editor-only `hidden` tag, not the real enabled state). Wiring the eye to `GameObject.Enabled` matches Unity's hierarchy workflow and stays consistent with the inspector checkbox.

## Notes for reviewers

- The new `OnItemPressed` hook on `TreeNode` is additive — existing nodes get the default `return true` and behave exactly as before.
- The eye toggles `Enabled` (the inspector property), not the `hidden` tag. `Alt+H` and the right-click "Hide/Show" option still toggle the `hidden` tag independently, in case anyone relies on the editor-only hide.
- The cascading dim walks `Value.Parent` up to (but not including) the `Scene`. It's a per-paint check; if performance ever matters here we could cache it on `ValueHash`.

## Test plan

- [x] Click the eye on a visible GameObject → object disables, row dims, inspector checkbox flips off.
- [x] Click the eye again → re-enables, row brightens, checkbox flips on.
- [x] Toggle the inspector checkbox → eye icon in the hierarchy reflects the new state.
- [x] Disable a parent → parent dims **and** all descendants in the tree appear dimmed.
- [x] Undo (Ctrl+Z) after an eye click → reverts the enable/disable.
- [x] Confirm existing expand-chevron click, row selection, drag-and-drop, rename, and context menu still work.

Enabled state:
<img width="3839" height="2159" alt="image" src="https://github.com/user-attachments/assets/cfa50484-bdd8-493a-b124-b936825109e9" />

Disabled state:
<img width="3839" height="2159" alt="image" src="https://github.com/user-attachments/assets/b9cfa966-5cc5-4946-b3b8-3804e74d6049" />

