### PR TITLE
Clamp float drag value to range when slider is present

### DIFF
--- a/engine/Sandbox.Tools/ControlWidget/FloatControlWidget.cs
+++ b/engine/Sandbox.Tools/ControlWidget/FloatControlWidget.cs
@@ -341,7 +341,7 @@ public class FloatControlWidget : StringControlWidget
 			if ( e.ButtonState.Contains( MouseButtons.Right ) ) delta *= 0.1f;
 
 			dragValue += delta;
-			if ( HasRange && RangeClamped ) dragValue = dragValue.Clamp( Range.x, Range.y );
+			if ( HasRange && (RangeClamped || SliderWidget is not null) ) dragValue = dragValue.Clamp( Range.x, Range.y );
 
 			var steppedValue = (RangeStep != 0.0f) ? dragValue.SnapToGrid( RangeStep ) : dragValue;
 			SerializedProperty.As.Float = steppedValue;


### PR DESCRIPTION
When a float property has a slider, dragging the numeric label could push the value outside the slider's range. Now clamps to the range whenever a slider is shown, not just when RangeClamped is true.

# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
When a float property has a slider, dragging the numeric label could push the value outside the slider's range. Now clamps to the range whenever a slider is shown, not just when `RangeClamped` is true.

## Motivation & Context

If `[Range]` is set with `clamped: false` but a slider is still shown, the slider visually caps at the range bounds while the drag-edit on the label keeps going. That makes the displayed slider thumb and the underlying value disagree, and lets the user enter values the slider can't represent.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

One-line change in `FloatControlWidget.OnMouseMove`: extend the clamp condition so it also fires when `SliderWidget` is non-null. Manual entry into the line edit is untouched — users who want out-of-range values via typing still can, which preserves the original intent of `RangeClamped = false`.

## Screenshots / Videos (if applicable)

N/A - behavioural fix, no visual change beyond the value no longer drifting past the slider end.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂