### PR TITLE
[Doo] Fix never being dirty if modified after being created

### DIFF
--- a/game/editor/DooEditor/Code/DooEditor/BlockTree.cs
+++ b/game/editor/DooEditor/Code/DooEditor/BlockTree.cs
@@ -56,6 +56,7 @@ public class BlockTree : TreeView
 			if ( ev.IsDrop )
 			{
 				_doo.Body.Add( block );
+				GetAncestor<DooEditorWidget>()?.NoteDirty();
 			}
 
 			return DropAction.Copy;

--- a/game/editor/DooEditor/Code/DooEditor/BlockTreeNode.cs
+++ b/game/editor/DooEditor/Code/DooEditor/BlockTreeNode.cs
@@ -126,6 +126,7 @@ public class BlockTreeNode : TreeNode<Doo.Block>
 	void Menu_Delete()
 	{
 		_doo.DeleteBlock( Value );
+		TreeView.GetAncestor<DooEditorWidget>()?.NoteDirty();
 	}
 
 	public override bool OnDragStart()
@@ -184,6 +185,8 @@ public class BlockTreeNode : TreeNode<Doo.Block>
 		{
 			_doo.InsertAfter( Value, block );
 		}
+
+		TreeView.GetAncestor<DooEditorWidget>()?.NoteDirty();
 	}
 
 	bool IsDescendantOf( BlockTreeNode potentialAncestor )

--- a/game/editor/DooEditor/Code/DooEditor/DooEditorWidget.cs
+++ b/game/editor/DooEditor/Code/DooEditor/DooEditorWidget.cs
@@ -42,6 +42,15 @@ public class DooEditorWidget : PopupWidget
 		RebuildUI();
 	}
 
+	/// <summary>
+	/// Notify the parent resource that this Doo was modified and needs saving.
+	/// </summary>
+	public void NoteDirty()
+	{
+		if ( SerializedObject?.ParentProperty is { } parent )
+			SerializedObject.NoteChanged( parent );
+	}
+
 	Layout _rightColumn;
 
 	void RebuildUI()

--- a/game/editor/DooEditor/Code/DooEditor/DooInspector.cs
+++ b/game/editor/DooEditor/Code/DooEditor/DooInspector.cs
@@ -37,15 +37,29 @@ public class DooInspector : Widget
 	}
 
 	Doo.Block _target;
+	SerializedObject _targetSubscription;
 
 	public void SetTarget( Doo.Block target ) // todo support multi-select
 	{
 		if ( _target == target )
 			return;
 
+		if ( _targetSubscription is not null )
+			_targetSubscription.OnPropertyChanged -= OnBlockPropertyChanged;
+
 		_target = target;
 		Target = target?.GetSerialized();
+		_targetSubscription = Target;
+
+		if ( _targetSubscription is not null )
+			_targetSubscription.OnPropertyChanged += OnBlockPropertyChanged;
+
 		RebuildContent();
+	}
+
+	void OnBlockPropertyChanged( SerializedProperty _ )
+	{
+		Editor?.NoteDirty();
 	}
 
 	void RebuildContent()

--- a/game/editor/DooEditor/Code/DooEditor/DooToolbox.cs
+++ b/game/editor/DooEditor/Code/DooEditor/DooToolbox.cs
@@ -71,9 +71,11 @@ public class ToolboxItem<T> : Widget where T : Doo.Block, new()
 	{
 		if ( e.LeftMouseButton )
 		{
+			var editor = GetAncestor<DooEditorWidget>();
 			var block = CreateBlock();
-			GetAncestor<DooEditorWidget>().Target.Body.Add( block );
-			GetAncestor<DooEditorWidget>().BlockTree.SelectItem( block );
+			editor.Target.Body.Add( block );
+			editor.NoteDirty();
+			editor.BlockTree.SelectItem( block );
 		}
 	}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

I use Doo into a gameresource, the issue was after adding a doo and place a block etc it would trigger a save, i can save my resource no issue, but if i quit, reopen it and just modify my doo, the gameresource think nothing has changed

## Motivation & Context

Painful to use

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

Just call NoteDirty after any block modification

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂