### PR TITLE
[Doo] Return not showing if args < 1

### DIFF
--- a/game/editor/DooEditor/Code/DooEditor/BlockEditors/InvokeBlock.cs
+++ b/game/editor/DooEditor/Code/DooEditor/BlockEditors/InvokeBlock.cs
@@ -111,28 +111,26 @@ public class InvokeBlock : InspectorWidget
 				}
 			}
 
-			if ( methodDesc.Parameters.Length == 0 )
+			if ( methodDesc.Parameters.Length > 0 )
 			{
-				return;
-			}
+				Layout.Add( new Label.Header( $"Parameters" ) );
 
-			Layout.Add( new Label.Header( $"Parameters" ) );
+				cs = new ControlSheet();
+				Layout.Add( cs );
 
-			cs = new ControlSheet();
-			Layout.Add( cs );
+				var array = obj.ToArray();
+				int i = 0;
+				foreach ( var param in methodDesc.Parameters )
+				{
+					var prop = array[i];
 
-			var array = obj.ToArray();
-			int i = 0;
-			foreach ( var param in methodDesc.Parameters )
-			{
-				var prop = array[i];
+					var csp = prop.GetCustomizable();
+					csp.SetDisplayName( $"{param.Name.ToTitleCase()}" );
+					csp.AddAttribute( new TypeHintAttribute( param.ParameterType ) );
 
-				var csp = prop.GetCustomizable();
-				csp.SetDisplayName( $"{param.Name.ToTitleCase()}" );
-				csp.AddAttribute( new TypeHintAttribute( param.ParameterType ) );
-
-				cs.AddRow( csp );
-				i++;
+					cs.AddRow( csp );
+					i++;
+				}
 			}
 		}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

If you have a function ex: public GameObject GetHead()

and you try to call it, then since it has no args, you wont be able to put a return assignation
<img width="906" height="786" alt="image" src="https://github.com/user-attachments/assets/6127d96f-45e8-49cf-9b33-8bf60dfc4df7" />

## Motivation & Context

use doo on a fight system

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

Garry just did a too early return

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂