### PR TITLE
[Scene Mesh] Draw a bicone when in the scene mesh editor Pivot MoveMode

### DIFF
--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -168,7 +168,7 @@ public static partial class Gizmo
 					using ( Scope() )
 					{
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.WithRotation( Rotation.Identity );
-						Sandbox.Gizmo.Draw.SolidBicone( 4.0f, 4.0f * 0.33f );
+						Sandbox.Gizmo.Draw.SolidBicone( 4.0f, 1.5f );
 					}
 					break;
 				default:

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -167,6 +167,7 @@ public static partial class Gizmo
 
 					using ( Scope() )
 					{
+						Sandbox.Gizmo.Hitbox.DepthBias = 0.01f;
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.WithRotation( Rotation.Identity );
 						Sandbox.Gizmo.Draw.SolidBicone( 4.0f, 1.5f );
 					}

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -168,10 +168,6 @@ public static partial class Gizmo
 						Sandbox.Gizmo.Draw.SolidBicone( 4.0f, 4.0f * 0.33f );
 					}
 					break;
-				case PositionCenterHandleStyle.Default:
-					Sandbox.Gizmo.Draw.LineThickness = 2.0f;
-					Sandbox.Gizmo.Draw.LineCircle( 0, Sandbox.Gizmo.IsHovered ? 0.6f : 0.5f, 8 );
-					break;
 				default:
 					Sandbox.Gizmo.Draw.LineThickness = 2.0f;
 					Sandbox.Gizmo.Draw.LineCircle( 0, Sandbox.Gizmo.IsHovered ? 0.6f : 0.5f, 8 );

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -165,7 +165,7 @@ public static partial class Gizmo
 
 					if ( !Sandbox.Gizmo.IsHovered ) Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Draw.Color.Darken( 0.33f );
 
-					using ( Scope() )
+					using ( Sandbox.Gizmo.Scope() )
 					{
 						Sandbox.Gizmo.Hitbox.DepthBias = 0.01f;
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.WithRotation( Rotation.Identity );

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -20,9 +20,24 @@ public static partial class Gizmo
 		}
 
 		/// <summary>
+		/// Visual style for the position center handle of the position gizmo.
+		/// </summary>
+		public enum PositionCenterHandleStyle
+		{
+			/// <summary>
+			/// Default position center handle style.
+			/// </summary>
+			Default = 0,
+			/// <summary>
+			/// Draw the position center handle as a bicone.
+			/// </summary>
+			Bicone = 1
+		}
+
+		/// <summary>
 		/// A front left up position movement widget. If widget was moved then will return true and out will return the new position.
 		/// </summary>
-		public bool Position( string name, Vector3 position, out Vector3 newPos, Rotation? axisRotation = null, float squareSize = 3.0f )
+		public bool Position( string name, Vector3 position, out Vector3 newPos, Rotation? axisRotation = null, float squareSize = 3.0f, PositionCenterHandleStyle centerHandleStyle = PositionCenterHandleStyle.Default )
 		{
 			if ( position.IsNaN )
 			{
@@ -79,7 +94,7 @@ public static partial class Gizmo
 					var camRot = Transform.RotationToLocal( Camera.Rotation );
 
 					Sandbox.Gizmo.Draw.Color = Color.White.WithAlpha( 1.1f );
-					if ( DragSquare( "drag-camera", squareSize, camRot, out var moved, DrawPositionCenter ) )
+					if ( DragSquare( "drag-camera", squareSize, camRot, out var moved, () => DrawPositionCenter( centerHandleStyle ) ) )
 					{
 						// movement is in camera space
 						movement += moved;
@@ -141,10 +156,27 @@ public static partial class Gizmo
 			return true;
 		}
 
-		static void DrawPositionCenter()
+		static void DrawPositionCenter( PositionCenterHandleStyle centerHandleStyle )
 		{
-			Sandbox.Gizmo.Draw.LineThickness = 2.0f;
-			Sandbox.Gizmo.Draw.LineCircle( 0, Sandbox.Gizmo.IsHovered ? 0.6f : 0.5f, 8 );
+			switch ( centerHandleStyle )
+			{
+				case PositionCenterHandleStyle.Bicone:
+					Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.IsHovered ? Sandbox.Gizmo.Colors.Selected : Sandbox.Gizmo.Colors.Pivot;
+					using ( Scope() )
+					{
+						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.WithRotation( Rotation.Identity );
+						Sandbox.Gizmo.Draw.SolidBicone( 4.0f, 4.0f * 0.33f );
+					}
+					break;
+				case PositionCenterHandleStyle.Default:
+					Sandbox.Gizmo.Draw.LineThickness = 2.0f;
+					Sandbox.Gizmo.Draw.LineCircle( 0, Sandbox.Gizmo.IsHovered ? 0.6f : 0.5f, 8 );
+					break;
+				default:
+					Sandbox.Gizmo.Draw.LineThickness = 2.0f;
+					Sandbox.Gizmo.Draw.LineCircle( 0, Sandbox.Gizmo.IsHovered ? 0.6f : 0.5f, 8 );
+					break;
+			}
 		}
 
 		/// <summary>

--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.cs
@@ -161,7 +161,10 @@ public static partial class Gizmo
 			switch ( centerHandleStyle )
 			{
 				case PositionCenterHandleStyle.Bicone:
-					Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.IsHovered ? Sandbox.Gizmo.Colors.Selected : Sandbox.Gizmo.Colors.Pivot;
+					Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Colors.Pivot;
+
+					if ( !Sandbox.Gizmo.IsHovered ) Sandbox.Gizmo.Draw.Color = Sandbox.Gizmo.Draw.Color.Darken( 0.33f );
+
 					using ( Scope() )
 					{
 						Sandbox.Gizmo.Transform = Sandbox.Gizmo.Transform.WithRotation( Rotation.Identity );

--- a/engine/Sandbox.Engine/Editor/Gizmos/Draw/Draw.Solid.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Draw/Draw.Solid.cs
@@ -7,7 +7,7 @@ public static partial class Gizmo
 		/// <summary>
 		/// Draw a solid cone shape
 		/// </summary>
-		public void SolidCone( Vector3 @base, Vector3 extent, float flRadius, int? segments = null )
+		public void SolidCone( Vector3 @base, Vector3 extent, float flRadius, int? segments = null, bool drawBase = true )
 		{
 			int nSegments = 10;
 
@@ -53,7 +53,7 @@ public static partial class Gizmo
 
 
 			// Draw the base.
-			if ( true )
+			if ( drawBase )
 			{
 				for ( int i = 1; i < nSegments - 1; i++ )
 				{
@@ -63,6 +63,15 @@ public static partial class Gizmo
 				}
 			}
 
+		}
+
+		/// <summary>
+		/// Draw a solid bicone shape
+		/// </summary>
+		public void SolidBicone( float coneLength, float flRadius )
+		{
+			SolidCone( 0, Vector3.Up * coneLength, flRadius, drawBase: false );
+			SolidCone( 0, Vector3.Down * coneLength, flRadius, drawBase: false );
 		}
 
 		/// <summary>

--- a/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.Colors.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.Colors.cs
@@ -25,6 +25,6 @@ public static partial class Gizmo
 		public static Color Selected { get; } = "#fbfbfb";
 		public static Color Hovered { get; } = "#90f1ef";
 		public static Color Active { get; } = "#ffc600";
-		public static Color Pivot { get; } = "#8b008b";
+		public static Color Pivot { get; } = "#c83cc8";
 	}
 }

--- a/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.Colors.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Gizmo.Colors.cs
@@ -25,5 +25,6 @@ public static partial class Gizmo
 		public static Color Selected { get; } = "#fbfbfb";
 		public static Color Hovered { get; } = "#90f1ef";
 		public static Color Active { get; } = "#ffc600";
+		public static Color Pivot { get; } = "#8b008b";
 	}
 }

--- a/game/addons/tools/Code/Scene/Mesh/MoveModes/PivotMode.cs
+++ b/game/addons/tools/Code/Scene/Mesh/MoveModes/PivotMode.cs
@@ -1,6 +1,4 @@
-﻿using static Sandbox.Gizmo.GizmoControls;
-
-namespace Editor.MeshEditor;
+﻿namespace Editor.MeshEditor;
 
 /// <summary>
 /// Set the location of the gizmo for the current selection.
@@ -46,7 +44,7 @@ public sealed class PivotMode : MoveMode
 		{
 			Gizmo.Hitbox.DepthBias = 0.01f;
 
-			if ( Gizmo.Control.Position( "position", Vector3.Zero, out var delta, _basis, centerHandleStyle: PositionCenterHandleStyle.Bicone ) )
+			if ( Gizmo.Control.Position( "position", Vector3.Zero, out var delta, _basis, centerHandleStyle: Gizmo.GizmoControls.PositionCenterHandleStyle.Bicone ) )
 			{
 				_moveDelta += delta;
 				tool.Pivot = Gizmo.Snap( (_pivot + _moveDelta) * _basis.Inverse, _moveDelta * _basis.Inverse ) * _basis;

--- a/game/addons/tools/Code/Scene/Mesh/MoveModes/PivotMode.cs
+++ b/game/addons/tools/Code/Scene/Mesh/MoveModes/PivotMode.cs
@@ -1,4 +1,6 @@
-﻿namespace Editor.MeshEditor;
+﻿using static Sandbox.Gizmo.GizmoControls;
+
+namespace Editor.MeshEditor;
 
 /// <summary>
 /// Set the location of the gizmo for the current selection.
@@ -39,7 +41,7 @@ public sealed class PivotMode : MoveMode
 		{
 			Gizmo.Hitbox.DepthBias = 0.01f;
 
-			if ( Gizmo.Control.Position( "position", Vector3.Zero, out var delta, _basis ) )
+			if ( Gizmo.Control.Position( "position", Vector3.Zero, out var delta, _basis, centerHandleStyle: PositionCenterHandleStyle.Bicone ) )
 			{
 				_pivot += delta;
 				tool.Pivot = Gizmo.Snap( _pivot * _basis.Inverse, delta * _basis.Inverse ) * _basis;


### PR DESCRIPTION
## Summary

This pr tweaks the Position gizmo so that you absolutely know that you in the pivot mode mode.

## Motivation & Context

Tweaked the Position gizmo so that a Bicone can be drawn instead of the standard LineCircle when in the pivot move mode so that there is a visable differnce between the position move mode and the pivot move mode.

## Implementation Details


* Modified the function `SolidCone` in  `Draw.Solid.cs` to be able to draw the base of a cone or not. 
* Added following the function   to  `Draw.Solid.cs` to draw a Bicone. Makes use of two `SolidCone` function calls to draw the top and bottom halfs. 
 ```cs
    public void SolidBicone( float coneLength, float flRadius )
 ```
* Modified the Position gizmo so that the Bicone could be drawn if set todo so via the `PositionCenterHandleStyle` enum.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/5bad2b0e-fca6-41db-bff4-cba7fc4b7437

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂