### PR TITLE
Assign a proper name to dragged decal GameObjects

### DIFF
--- a/game/addons/tools/Code/Scene/SceneView/DropObjects/DecalDropObject.cs
+++ b/game/addons/tools/Code/Scene/SceneView/DropObjects/DecalDropObject.cs
@@ -26,6 +26,7 @@ partial class DecalDropObject : BaseDropObject
 			undoScope = SceneEditorSession.Active.UndoScope( "Drop Prefab" ).WithGameObjectCreations().Push();
 
 			GameObject = new GameObject( false );
+			GameObject.Name = d.ResourceName;
 			GameObject.Flags = GameObjectFlags.NotSaved | GameObjectFlags.Hidden;
 			GameObject.Tags.Add( "isdragdrop" );
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This is a very small change ensuring that all decal resources dropped onto scene will have a proper name assigned to it. 

<img width="1037" height="176" alt="image" src="https://github.com/user-attachments/assets/1b45bf83-9e85-4bd1-895d-fa2b31d3ba53" />

## Motivation & Context

By default, all decals dragged and dropped onto scene will be spawned with a default name, "GameObject". 

This issue wasn't the end of the world, but when you're placing dozens of decals on scene, you end up with dozens of nameless gameobjects that are somewhat annoying to sort in hierarchy list. Makes a lot more sense when they are named after it's resource file. 

## Implementation Details

My change simply assigns a gameobject name in `DecalDropObject` during `Initialize`:
```GameObject.Name = d.ResourceName;```

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂