### PR TITLE
Fix missing styles when dragging item over folder. Clicking empty space blurs current focus.

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
@@ -157,20 +157,22 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		AssetList.OnViewModeChanged += () => { UpdateViewModeIcon(); SaveSettings(); };
 		AssetList.OnHighlight = ( entries ) =>
 		{
-			var assets = entries.OfType<AssetEntry>().ToList();
-			if ( assets.Count == entries.Count() )
+			var highlightedEntries = entries.ToList();
+			var assets = highlightedEntries.OfType<AssetEntry>().ToList();
+
+			if ( assets.Count == highlightedEntries.Count )
 			{
 				if ( assets.Count > 1 )
 				{
 					OnAssetsHighlight?.Invoke( assets.Select( x => x.Asset ).ToArray() );
 				}
-				else
+				else if ( assets.Count == 1 )
 				{
 					OnAssetHighlight?.Invoke( assets.First().Asset );
 				}
 			}
 
-			OnHighlight?.Invoke( entries );
+			OnHighlight?.Invoke( highlightedEntries );
 		};
 
 		Chips = new ChipsWidget();
@@ -750,7 +752,7 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		{
 			PixmapIcon = x.Icon16,
 			Title = x.FriendlyName,
-			Group = (string.IsNullOrEmpty( x.Category ) ? "Other" : x.Category),
+			Group = string.IsNullOrEmpty( x.Category ) ? "Other" : x.Category,
 			Column = 0,
 			Count = () => AssetSystem.All.Where( y => y.AssetType == x ).Count(),
 			Color = x.Color

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.cs
@@ -1,5 +1,4 @@
-﻿using Sandbox.UI;
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -238,7 +237,7 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 
 		bool active = Paint.HasPressed;
 		bool highlight = !active && (Paint.HasSelected || Paint.HasPressed);
-		bool hover = !highlight && Paint.HasMouseOver;
+		bool hover = !highlight && (Paint.HasMouseOver || item.Dropping);
 
 		var rect = item.Rect.Shrink( 2 );
 
@@ -328,7 +327,7 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 		{
 			DrawSelectedBackground( item );
 		}
-		else if ( Paint.HasMouseOver )
+		else if ( Paint.HasMouseOver || item.Dropping )
 		{
 			DrawHoverBackground( item );
 		}
@@ -419,7 +418,7 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 
 	private void DrawColumns( VirtualWidget item, Dictionary<string, string> columns )
 	{
-		int columnCount = (SingleColumnMode ? 1 : columns.Count());
+		int columnCount = SingleColumnMode ? 1 : columns.Count();
 
 		var defaultColWidth = item.Rect.Width / columnCount;
 		var textRect = item.Rect;
@@ -528,7 +527,7 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 	{
 		if ( e.HasCtrl )
 		{
-			var d = (e.Delta > 0 ? 1 : -1);
+			var d = e.Delta > 0 ? 1 : -1;
 			var lastViewMode = ViewMode;
 
 			if ( d == 1 && ViewMode == AssetListViewMode.LargeIcons )
@@ -544,6 +543,17 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 		}
 
 		base.OnMouseWheel( e );
+	}
+
+	protected override void OnMousePress( MouseEvent e )
+	{
+		if ( e.LeftMouseButton && GetItemAt( e.LocalPosition ) is null )
+		{
+			UnselectAll();
+			Update();
+		}
+
+		base.OnMousePress( e );
 	}
 
 	void BuildAllIcons()
@@ -798,6 +808,19 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 		// Prevent OnDragDrop from trying to move the files again
 		hasJustMoved = true;
 		return;
+	}
+
+	protected override void OnDragHoverItem( DragEvent ev, VirtualWidget item )
+	{
+		ev.Action = DropAction.Ignore;
+
+		if ( !ev.Data.HasFileOrFolder )
+			return;
+
+		if ( item.Object is not DirectoryEntry )
+			return;
+
+		ev.Action = ev.HasCtrl ? DropAction.Copy : DropAction.Move;
 	}
 
 	[Shortcut( "editor.select-all", "CTRL+A" )]

--- a/game/addons/tools/Code/Editor/CloudBrowser/CloudBrowser.cs
+++ b/game/addons/tools/Code/Editor/CloudBrowser/CloudBrowser.cs
@@ -149,8 +149,10 @@ public partial class CloudAssetBrowser : Widget, IBrowser
 		AssetList.OnViewModeChanged += () => SaveSettings();
 		AssetList.OnHighlight = ( entries ) =>
 		{
-			var packages = entries.OfType<PackageEntry>().ToList();
-			if ( packages.Count == entries.Count() )
+			var highlightedEntries = entries.ToList();
+			var packages = highlightedEntries.OfType<PackageEntry>().ToList();
+
+			if ( packages.Count == 1 && packages.Count == highlightedEntries.Count )
 			{
 				OnPackageHighlight?.Invoke( packages.First().Package );
 			}


### PR DESCRIPTION
## Summary

Fix missing styles when dragging item over folder. 
Clicking empty space blurs current focus.

Fixes: 
https://github.com/Facepunch/sbox-public/issues/10950

## Screenshots / Videos (if applicable)
Before:

https://github.com/user-attachments/assets/f414b95a-a756-49be-b819-367addd56972

After:

https://github.com/user-attachments/assets/f5fc08cf-0c29-45ad-aadc-fd0be68142f0

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂