### PR TITLE
Fix misc errors in built in assets

### DIFF
--- a/game/addons/citizen/Assets/models/citizen_clothes/hair/hair_looseblonde/hair.loose.grey.clothing
+++ b/game/addons/citizen/Assets/models/citizen_clothes/hair/hair_looseblonde/hair.loose.grey.clothing
@@ -11,7 +11,6 @@
   "Category": "Hair",
   "ConditionalModels": {},
   "Tags": null,
-  "Parent": "models/citizen_clothes/hair/hair_looseblonde/hair.loose.brown.clothing",
   "Model": "models/citizen_clothes/hair/hair_looseblonde/hair_looseblonde.vmdl",
   "HumanAltModel": "models/citizen_clothes/hair/hair_looseblonde/hair_looseblonde_m_hum.vmdl",
   "HumanAltFemaleModel": "models/citizen_clothes/hair/hair_looseblonde/hair_looseblonde_m_hum.vmdl",

--- a/game/addons/citizen/Assets/models/citizen_props/balloonears01.vmdl
+++ b/game/addons/citizen/Assets/models/citizen_props/balloonears01.vmdl
@@ -1,4 +1,4 @@
-<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc29:version{3cec427c-1b0e-4d48-a90a-0436f33a6041} -->
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc30:version{8c2d7a91-9c42-4bf0-883a-5a3b1762d4f1} -->
 {
 	rootNode = 
 	{
@@ -79,6 +79,14 @@
 						_class = "LODGroup"
 						name = "BalloonEars01_LOD0"
 						switch_threshold = 0.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonEars01_LOD0",
@@ -88,6 +96,14 @@
 						_class = "LODGroup"
 						name = "BalloonEars01_LOD1"
 						switch_threshold = 50.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonEars01_LOD1",
@@ -97,6 +113,14 @@
 						_class = "LODGroup"
 						name = "BalloonEars01_LOD2"
 						switch_threshold = 100.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonEars01_LOD2",
@@ -142,6 +166,7 @@
 						collision_tags = "solid"
 						faceMergeAngle = 20.0
 						maxHullVertices = 32
+						hull_mode = "SingleHull"
 					},
 				]
 			},
@@ -161,6 +186,11 @@
 							impact_damage = -1.0
 							parent_bodygroup_name = ""
 							parent_bodygroup_value = 0
+							flammable = false
+							explosive = false
+							explosive_damage = -1.0
+							explosive_radius = -1.0
+							explosive_force = -1.0
 						}
 					},
 					{
@@ -169,22 +199,6 @@
 						game_keys = 
 						{
 							gradient = "<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->\n{\n\tm_Stops = \n\t[\n\t\t{\n\t\t\tm_flPosition = 0.94832\n\t\t\tm_Color = [ 255, 0, 111, 255 ]\n\t\t},\n\t]\n}"
-						}
-					},
-					{
-						_class = "BreakCommand"
-						game_class = "break_create_particle"
-						game_keys = 
-						{
-							name = resource:"particles/break/break.cardboard.vpcf"
-							cp0_model = resource:""
-							cp0_snapshot = resource:""
-							damage_position_cp = -1
-							damage_direction_cp = -1
-							velocity_cp = -1
-							angular_velocity_cp = -1
-							local_gravity_cp = -1
-							tint_cp = -1
 						}
 					},
 					{

--- a/game/addons/citizen/Assets/models/citizen_props/balloonheart01.vmdl
+++ b/game/addons/citizen/Assets/models/citizen_props/balloonheart01.vmdl
@@ -1,4 +1,4 @@
-<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc29:version{3cec427c-1b0e-4d48-a90a-0436f33a6041} -->
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc30:version{8c2d7a91-9c42-4bf0-883a-5a3b1762d4f1} -->
 {
 	rootNode = 
 	{
@@ -79,6 +79,14 @@
 						_class = "LODGroup"
 						name = "BalloonHeart01_LOD0"
 						switch_threshold = 0.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonHeart01_LOD0",
@@ -88,6 +96,14 @@
 						_class = "LODGroup"
 						name = "BalloonHeart01_LOD1"
 						switch_threshold = 50.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonHeart01_LOD1",
@@ -97,6 +113,14 @@
 						_class = "LODGroup"
 						name = "BalloonHeart01_LOD2"
 						switch_threshold = 100.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonHeart01_LOD2",
@@ -142,6 +166,7 @@
 						collision_tags = "solid"
 						faceMergeAngle = 20.0
 						maxHullVertices = 32
+						hull_mode = "SingleHull"
 					},
 				]
 			},
@@ -172,6 +197,11 @@
 							impact_damage = -1.0
 							parent_bodygroup_name = ""
 							parent_bodygroup_value = 0
+							flammable = false
+							explosive = false
+							explosive_damage = -1.0
+							explosive_radius = -1.0
+							explosive_force = -1.0
 						}
 					},
 					{
@@ -180,22 +210,6 @@
 						game_keys = 
 						{
 							gradient = "<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->\n{\n\tm_Stops = \n\t[\n\t\t{\n\t\t\tm_flPosition = 0.426357\n\t\t\tm_Color = [ 0, 178, 255, 255 ]\n\t\t},\n\t]\n}"
-						}
-					},
-					{
-						_class = "BreakCommand"
-						game_class = "break_create_particle"
-						game_keys = 
-						{
-							name = resource:"particles/break/break.cardboard.vpcf"
-							cp0_model = resource:""
-							cp0_snapshot = resource:""
-							damage_position_cp = -1
-							damage_direction_cp = -1
-							velocity_cp = -1
-							angular_velocity_cp = -1
-							local_gravity_cp = -1
-							tint_cp = -1
 						}
 					},
 					{

--- a/game/addons/citizen/Assets/models/citizen_props/balloonregular01.vmdl
+++ b/game/addons/citizen/Assets/models/citizen_props/balloonregular01.vmdl
@@ -1,4 +1,4 @@
-<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc29:version{3cec427c-1b0e-4d48-a90a-0436f33a6041} -->
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc30:version{8c2d7a91-9c42-4bf0-883a-5a3b1762d4f1} -->
 {
 	rootNode = 
 	{
@@ -79,6 +79,14 @@
 						_class = "LODGroup"
 						name = "BalloonRegular01_LOD0"
 						switch_threshold = 0.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonRegular01_LOD0",
@@ -88,6 +96,14 @@
 						_class = "LODGroup"
 						name = "BalloonRegular01_LOD1"
 						switch_threshold = 50.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonRegular01_LOD1",
@@ -97,6 +113,14 @@
 						_class = "LODGroup"
 						name = "BalloonRegular01_LOD2"
 						switch_threshold = 100.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonRegular01_LOD2",
@@ -142,6 +166,7 @@
 						collision_tags = "solid"
 						faceMergeAngle = 20.0
 						maxHullVertices = 32
+						hull_mode = "SingleHull"
 					},
 				]
 			},
@@ -172,22 +197,11 @@
 							impact_damage = -1.0
 							parent_bodygroup_name = ""
 							parent_bodygroup_value = 0
-						}
-					},
-					{
-						_class = "BreakCommand"
-						game_class = "break_create_particle"
-						game_keys = 
-						{
-							name = resource:"particles/break/break.cardboard.vpcf"
-							cp0_model = resource:""
-							cp0_snapshot = resource:""
-							damage_position_cp = -1
-							damage_direction_cp = -1
-							velocity_cp = -1
-							angular_velocity_cp = -1
-							local_gravity_cp = -1
-							tint_cp = -1
+							flammable = false
+							explosive = false
+							explosive_damage = -1.0
+							explosive_radius = -1.0
+							explosive_force = -1.0
 						}
 					},
 				]

--- a/game/addons/citizen/Assets/models/citizen_props/balloontall01.vmdl
+++ b/game/addons/citizen/Assets/models/citizen_props/balloontall01.vmdl
@@ -1,4 +1,4 @@
-<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc29:version{3cec427c-1b0e-4d48-a90a-0436f33a6041} -->
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc30:version{8c2d7a91-9c42-4bf0-883a-5a3b1762d4f1} -->
 {
 	rootNode = 
 	{
@@ -79,6 +79,14 @@
 						_class = "LODGroup"
 						name = "BalloonTall01_LOD0"
 						switch_threshold = 0.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonTall01_LOD0",
@@ -88,6 +96,14 @@
 						_class = "LODGroup"
 						name = "BalloonTall01_LOD1"
 						switch_threshold = 50.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonTall01_LOD1",
@@ -97,6 +113,14 @@
 						_class = "LODGroup"
 						name = "BalloonTall01_LOD2"
 						switch_threshold = 100.0
+						auto_simplify_mode = 0
+						auto_reduction = 0.5
+						auto_max_error = 0.0
+						auto_lock_border_vertices = true
+						auto_permissive_simplification = false
+						auto_protect_uv_seams = true
+						auto_regularize = 1
+						auto_prune_isolated_components = false
 						meshes = 
 						[
 							"BalloonTall01_LOD2",
@@ -142,6 +166,7 @@
 						collision_tags = "solid"
 						faceMergeAngle = 20.0
 						maxHullVertices = 32
+						hull_mode = "SingleHull"
 					},
 				]
 			},
@@ -172,6 +197,11 @@
 							impact_damage = -1.0
 							parent_bodygroup_name = ""
 							parent_bodygroup_value = 0
+							flammable = false
+							explosive = false
+							explosive_damage = -1.0
+							explosive_radius = -1.0
+							explosive_force = -1.0
 						}
 					},
 					{
@@ -180,22 +210,6 @@
 						game_keys = 
 						{
 							gradient = "<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->\n{\n\tm_Stops = \n\t[\n\t\t{\n\t\t\tm_flPosition = 0.408269\n\t\t\tm_Color = [ 176, 255, 0, 255 ]\n\t\t},\n\t]\n}"
-						}
-					},
-					{
-						_class = "BreakCommand"
-						game_class = "break_create_particle"
-						game_keys = 
-						{
-							name = resource:"particles/break/break.cardboard.vpcf"
-							cp0_model = resource:""
-							cp0_snapshot = resource:""
-							damage_position_cp = -1
-							damage_direction_cp = -1
-							velocity_cp = -1
-							angular_velocity_cp = -1
-							local_gravity_cp = -1
-							tint_cp = -1
 						}
 					},
 				]

--- a/game/addons/menu/Assets/scenes/menu-main.scene
+++ b/game/addons/menu/Assets/scenes/menu-main.scene
@@ -5820,7 +5820,7 @@
                     ]
                   },
                   "OnReleased": null,
-                  "OnSound": "sounds/button1.sound",
+                  "OnSound": "sounds/kenney/ui/ui.button.press.sound",
                   "OnTurnedOff": null,
                   "OnTurnedOn": null,
                   "ResetTime": 2,

--- a/game/core/sounds/player_use_fail.sound
+++ b/game/core/sounds/player_use_fail.sound
@@ -1,12 +1,52 @@
 {
-	"volume": 0.500000,
-	"sounds":
-	[
-		"sounds/tools/sfm/denyundo.vsnd"
-	],
-	"VolumeRandom": 0.000000,
-	"Pitch": 1.000000,
-	"PitchRandom": 0.000000,
-	"DistanceMax": 500.000000,
-	"UI": false
+  "UI": false,
+  "Volume": "0.5",
+  "Pitch": "1",
+  "Decibels": 70,
+  "SelectionMode": "Random",
+  "Sounds": [
+    "sounds/editor/fail.vsnd"
+  ],
+  "Occlusion": true,
+  "AirAbsorption": true,
+  "Transmission": true,
+  "OcclusionRadius": 64,
+  "DistanceAttenuation": true,
+  "Distance": 15000,
+  "Falloff": [
+    {
+      "x": 0,
+      "y": 1,
+      "in": 0,
+      "out": -1.8,
+      "mode": "Mirrored"
+    },
+    {
+      "x": 0.05,
+      "y": 0.22,
+      "in": 3.5,
+      "out": -3.5,
+      "mode": "Mirrored"
+    },
+    {
+      "x": 0.2,
+      "y": 0.04,
+      "in": 0.16,
+      "out": -0.16,
+      "mode": "Mirrored"
+    },
+    {
+      "x": 1,
+      "y": 0,
+      "in": 0,
+      "out": 0,
+      "mode": "Mirrored"
+    }
+  ],
+  "DefaultMixer": {
+    "Name": "unknown",
+    "Id": "00000000-0000-0000-0000-000000000000"
+  },
+  "__references": [],
+  "__version": 1
 }


### PR DESCRIPTION
## Summary
Fixes some of the things ResourceSystem was complaining about on startup

## Motivation & Context
Annoyed me mildly.

## Implementation Details
In no particular order
- `models/citizen_clothes/hair/hair_looseblonde/hair.loose.brown.clothing` had a reference to a missing item in its `Parent` property, the property is obsolete and not referenced anywhere so I simply removed it from the file.
- `sounds/player_use_fail.sound` used `sounds/tools/sfm/denyundo.vsnd_c`, which no longer exists. It now uses `sounds/editor/fail.vsnd` which is a similar sound
- an object by the name of big_button on `scenes/menu-main.scene` used the nonexistent `sounds/button1.sound_c`, it now uses `sounds/kenney/ui/ui.button.press.sound`. Not entirely confident that that's a good replacement but at least its a valid sound event.
- `models/citizen_props/balloonregular01.vmdl` referenced a vpcf break particle that no longer exists, doesn't seem like break particles fire anyway so I just removed them from all of the balloon models (the balloons were the only remaining assets that reference vpcf particles).

## Issues that aren't fixed
- `templates/gameobject/3d object - decal.prefab` seems to mistakenly read the type name `Sandbox.Decal` as a reference to `sandbox.decal_c`
- `models/sbox_props/metal_wheely_bin/metal_wheely_bin_body_gib.vmdl` has an incorrect path on one of its materials (`props` instead of `sbox_props`) but it's not on the repo. Easy fix for someone at facepunch.
- `models/nature/grass_weeds/material/grass_weeds_01b.vmat` just needs to be recompiled I think

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂