### PR TITLE
Make stylesheet cache context aware to prevent bleeding between games

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Styles/StyleSheet.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Styles/StyleSheet.cs
@@ -28,6 +28,8 @@ public class StyleSheet
 	public Dictionary<string, KeyFrames> KeyFrames = new Dictionary<string, KeyFrames>( StringComparer.OrdinalIgnoreCase );
 	public Dictionary<string, MixinDefinition> Mixins = new Dictionary<string, MixinDefinition>( StringComparer.OrdinalIgnoreCase );
 
+	internal GlobalContext Context { get; private set; }
+
 	/// <summary>
 	/// Releases the filesystem watcher so we won't get file changed events.
 	/// </summary>
@@ -40,13 +42,15 @@ public class StyleSheet
 	public static StyleSheet FromFile( string filename, IEnumerable<(string key, string value)> variables = null, bool failSilently = false )
 	{
 		filename = BaseFileSystem.NormalizeFilename( filename );
+		var context = GlobalContext.Current;
 
-		var alreadyLoaded = Loaded.FirstOrDefault( x => x.FileName == filename );
+		var alreadyLoaded = Loaded.FirstOrDefault( x => x.FileName == filename && ReferenceEquals( x.Context, context ) );
 		if ( alreadyLoaded != null )
 			return alreadyLoaded;
 
 		var sheet = new StyleSheet();
-		sheet.UpdateFromFile( filename, failSilently );
+		sheet.Context = context;
+		sheet.UpdateFromFile( filename, failSilently, context );
 
 		sheet.AddVariables( variables );
 		sheet.FileName = filename;
@@ -158,7 +162,7 @@ public class StyleSheet
 		// Store the current context to pass through to the watcher because
 		// we might be in a different scope later, and won't be able to find the files
 		//
-		var context = GlobalContext.Current;
+		var context = Context ?? GlobalContext.Current;
 
 		Watcher = context.FileMount.Watch();
 		Watcher.OnChanges += x =>


### PR DESCRIPTION
## Summary
Make stylesheet cache context aware to prevent bleeding between games. 

## Motivation & Context
Games that share stylesheet names bleed styles into each other, exiting s&miner will cause the main menu to break its layout because s&miner also has a stylesheet named mainmenu

Fixes: 
https://github.com/Facepunch/sbox-public/issues/10778
https://github.com/Facepunch/sbox-public/issues/10711
https://github.com/Facepunch/sbox-public/issues/3807

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂