### PR TITLE
Fix CSS props misbehave when using dynamic values

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Yoga/YogaWrapper.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Yoga/YogaWrapper.cs
@@ -245,7 +245,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _top == value && !value.Value.Unit.IsDynamic() ) return;
 				_top = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, default, Yoga.YGNodeStyleSetPosition, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeTop );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, default, Yoga.YGNodeStyleSetPosition, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeTop );
 			}
 		}
 
@@ -256,7 +256,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _bottom == value && !value.Value.Unit.IsDynamic() ) return;
 				_bottom = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, default, Yoga.YGNodeStyleSetPosition, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeBottom );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, default, Yoga.YGNodeStyleSetPosition, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeBottom );
 			}
 		}
 
@@ -289,7 +289,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _margintop == value && !value.Value.Unit.IsDynamic() ) return;
 				_margintop = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, Yoga.YGNodeStyleSetMarginAuto, Yoga.YGNodeStyleSetMargin, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeTop );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, Yoga.YGNodeStyleSetMarginAuto, Yoga.YGNodeStyleSetMargin, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeTop );
 			}
 		}
 
@@ -300,7 +300,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _marginbottom == value && !value.Value.Unit.IsDynamic() ) return;
 				_marginbottom = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, Yoga.YGNodeStyleSetMarginAuto, Yoga.YGNodeStyleSetMargin, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeBottom );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, Yoga.YGNodeStyleSetMarginAuto, Yoga.YGNodeStyleSetMargin, Yoga.YGNodeStyleSetPositionPercent, YGEdge.YGEdgeBottom );
 			}
 		}
 
@@ -333,7 +333,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _paddingtop == value && !value.Value.Unit.IsDynamic() ) return;
 				_paddingtop = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, default, Yoga.YGNodeStyleSetPadding, Yoga.YGNodeStyleSetPaddingPercent, YGEdge.YGEdgeTop );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, default, Yoga.YGNodeStyleSetPadding, Yoga.YGNodeStyleSetPaddingPercent, YGEdge.YGEdgeTop );
 			}
 		}
 
@@ -344,7 +344,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _paddingbottom == value && !value.Value.Unit.IsDynamic() ) return;
 				_paddingbottom = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, default, Yoga.YGNodeStyleSetPadding, Yoga.YGNodeStyleSetPaddingPercent, YGEdge.YGEdgeBottom );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, default, Yoga.YGNodeStyleSetPadding, Yoga.YGNodeStyleSetPaddingPercent, YGEdge.YGEdgeBottom );
 			}
 		}
 
@@ -377,7 +377,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _bordertop == value && !value.Value.Unit.IsDynamic() ) return;
 				_bordertop = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, default, Yoga.YGNodeStyleSetBorder, default, YGEdge.YGEdgeTop );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, default, Yoga.YGNodeStyleSetBorder, default, YGEdge.YGEdgeTop );
 			}
 		}
 
@@ -388,7 +388,7 @@ namespace Sandbox.UI
 			{
 				if ( Initialized && _borderbottom == value && !value.Value.Unit.IsDynamic() ) return;
 				_borderbottom = value;
-				value.SetYoga( Node, () => Parent?.LayoutWidth ?? 0, default, Yoga.YGNodeStyleSetBorder, default, YGEdge.YGEdgeBottom );
+				value.SetYoga( Node, () => Parent?.LayoutHeight ?? 0, default, Yoga.YGNodeStyleSetBorder, default, YGEdge.YGEdgeBottom );
 			}
 		}
 

--- a/engine/Sandbox.System/UI/Calc/Calc.Parse.cs
+++ b/engine/Sandbox.System/UI/Calc/Calc.Parse.cs
@@ -55,6 +55,6 @@ partial class Calc
 		if ( operands.Count != 1 )
 			throw new Exception( "Invalid expression" );
 
-		return operands.Pop().Value.GetPixels( dimension );
+		return operands.Pop().Value.GetScaledPixels( dimension );
 	}
 }

--- a/engine/Sandbox.System/UI/Calc/Calc.cs
+++ b/engine/Sandbox.System/UI/Calc/Calc.cs
@@ -30,13 +30,18 @@ static partial class Calc
 		TreeNode result = new()
 		{
 			Type = TreeNodeType.Expression,
-			Value = operation switch
+			Value = new()
 			{
-				TokenType.Add => left.Value.GetScaledPixels( dimension ) + right.Value.GetScaledPixels( dimension ),
-				TokenType.Subtract => left.Value.GetScaledPixels( dimension ) - right.Value.GetScaledPixels( dimension ),
-				TokenType.Multiply => left.Value.GetScaledPixels( dimension ) * right.Value.GetScaledPixels( dimension ),
-				TokenType.Divide => left.Value.GetScaledPixels( dimension ) / right.Value.GetScaledPixels( dimension ),
-				_ => throw new Exception( "Invalid operation" )
+				// don't use LengthUnit.Pixels to avoid multiple scaling
+				Unit = LengthUnit.Auto,
+				Value = operation switch
+				{
+					TokenType.Add => left.Value.GetScaledPixels( dimension ) + right.Value.GetScaledPixels( dimension ),
+					TokenType.Subtract => left.Value.GetScaledPixels( dimension ) - right.Value.GetScaledPixels( dimension ),
+					TokenType.Multiply => left.Value.GetScaledPixels( dimension ) * right.Value.GetPixels( dimension ),
+					TokenType.Divide => left.Value.GetScaledPixels( dimension ) / right.Value.GetPixels( dimension ),
+					_ => throw new Exception( "Invalid operation" )
+				}
 			}
 		};
 


### PR DESCRIPTION
## Summary

Fix issues with certain CSS properties that misbehave when using dynamic values

## Motivation & Context
* top/bottom of position/margins used LayoutWidth instead of LayoutHeight
* * `top: calc(50%) == 50% pixels of Width`
* сalc() function applied pixel scaling each time the operand was used instead of just once
* * `calc(100% / 2) != 50%`
* * `calc(20px + 0 + 0) != 20px`
* сalc() function not applied pixel scaling for single param
* * `calc(20px) != 20px`
* * `calc(20px + 0) == 20px`

## Implementation Details
### YogaWrapper
Top/bottom of position/margins now uses `LayoutHeight`

### calc()
Operation result now uses `LengthUnit.Auto` instead of `LengthUnit.Pixels`, which prevents `GetScaledPixels()` from applying `* RootScale`.
For `*` & `/` only the left operand is scaled.
The final result is now also scaled for the single parameter case.

## Checklist
- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂