### PR TITLE
Add missing escape behaviours to menu

### DIFF
--- a/game/addons/menu/Code/AvatarEditor/AvatarUI.razor
+++ b/game/addons/menu/Code/AvatarEditor/AvatarUI.razor
@@ -91,7 +91,13 @@
 
         SetClass( "hide", Input.Keyboard.Down( "SPACE" ) );
 
-		if (returnToMainMenu)
+		if ( Input.EscapePressed && InputFocus.Current is null )
+		{
+			Input.EscapePressed = false;
+			BackToMainMenu();
+		}
+
+		if ( returnToMainMenu )
 		{
 			var options = new SceneLoadOptions();
 			options.ShowLoadingScreen = true;
@@ -110,5 +116,4 @@
 	{
 
 	}
-
 }

--- a/game/addons/menu/Code/MainMenu.razor
+++ b/game/addons/menu/Code/MainMenu.razor
@@ -4,6 +4,7 @@
 @using System;
 @using Menu;
 @using MenuProject.Modals;
+@using MenuProject.MenuUI.Components.Notifications;
 @inherits PanelComponent
 
 <div class="mainmenu">
@@ -58,6 +59,27 @@
         _ = ShowWelcomeScreenIfNeeded();
     }
 
+    void MonitorEscape()
+    {
+        if ( !Input.EscapePressed || InputFocus.Current is not null ) 
+            return;
+
+        if ( ModalSystem.Instance?.IsModalOpen == true )
+            return;
+
+        if ( NotificationList.CloseCurrent() )
+        {
+            Input.EscapePressed = false;
+            return;
+        }
+
+        if ( Navigator is null || Navigator.CurrentUrl == "/home" ) 
+            return;
+
+        Input.EscapePressed = false;
+        Navigator.Navigate( "/home" );
+    }
+
     async Task ShowWelcomeScreenIfNeeded()
     {
         await Task.DelayRealtime(1500);
@@ -78,5 +100,7 @@
 
         var isInGame = Application.IsEditor ? false : Game.InGame;
         Background.Enabled = Navigator?.CurrentUrl == "/home" && !isInGame;
+
+        MonitorEscape();
     }
 }

--- a/game/addons/menu/Code/MenuUI/Components/New/MainSearchBar.razor
+++ b/game/addons/menu/Code/MenuUI/Components/New/MainSearchBar.razor
@@ -22,7 +22,7 @@
             </div>
         </div>
 
-        <TextEntry @ref="SearchText" onfocus=@SearchTextFocus onblur=@SearchTextBlur 
+        <TextEntry @ref="SearchText" onfocus=@SearchTextFocus onblur=@SearchTextBlur oncancel=@ClearSearch
             OnTextEdited=@SearchTextEdited Placeholder="Search for games..." onsubmit=@Submit Icon="search" />
 
     </div>
@@ -58,6 +58,21 @@
     void SearchTextBlur()
     {
         SetClass("autocomplete-active", false);
+    }
+
+    void ClearSearch()
+    {
+        if ( SearchText is null )
+            return;
+
+        Input.EscapePressed = false;
+
+        SearchText.Text = "";
+        SearchText.CaretPosition = 0;
+        SearchText.OnValueChanged();
+
+        AutocompleteResult = null;
+        awaitingAutocomplete = false;
     }
 
     protected override async Task OnParametersSetAsync()

--- a/game/addons/menu/Code/MenuUI/Components/Notifications/NotificationList.razor
+++ b/game/addons/menu/Code/MenuUI/Components/Notifications/NotificationList.razor
@@ -35,7 +35,37 @@
 
 @code 
 {
+    static NotificationList Current;
+
     Sandbox.Services.Notification[] Notices;
+
+    public NotificationList()
+    {
+        Current = this;
+    }
+
+    public static bool CloseCurrent()
+    {
+        if ( !Current.IsValid() )
+            return false;
+
+        Current.Close();
+        return true;
+    }
+
+    public override void OnDeleted()
+    {
+        base.OnDeleted();
+
+        if ( Current == this )
+            Current = null;
+    }
+
+    void Close()
+    {
+        Delete();
+        Current = null;
+    }
 
     protected override async Task OnParametersSetAsync()
     {

--- a/game/addons/menu/Code/MenuUI/GamesPage.razor
+++ b/game/addons/menu/Code/MenuUI/GamesPage.razor
@@ -20,7 +20,7 @@
                     <GamePackageSortOrder Value:bind="@filterOrder"></GamePackageSortOrder>
                 </div>
 
-                <TextEntry @ref="SearchEntry" placeholder="Search games..."></TextEntry>
+                <TextEntry @ref="SearchEntry" placeholder="Search games..." oncancel=@ClearSearch></TextEntry>
 
                 @if (Result?.Properties is not null && Result.Properties.Length > 0)
                 {
@@ -106,6 +106,21 @@
     void OnOrderChanged(string value)
     {
         filterOrder = value;
+    }
+
+    void ClearSearch()
+    {
+        if ( !SearchEntry.IsValid() )
+            return;
+
+        Input.EscapePressed = false;
+
+        SearchEntry.Text = "";
+        SearchEntry.CaretPosition = 0;
+        SearchEntry.OnValueChanged();
+
+        NeedsSetQuery = false;
+        StateHasChanged();
     }
 
     string GetQuery()

--- a/game/addons/menu/Code/Modals/BaseModal.cs
+++ b/game/addons/menu/Code/Modals/BaseModal.cs
@@ -25,6 +25,7 @@ public class BaseModal : Panel
 	protected override void OnEscape( PanelEvent e )
 	{
 		CloseModal( false );
+		Sandbox.Input.EscapePressed = false;
 		e.StopPropagation();
 	}
 


### PR DESCRIPTION
## Summary
Add missing escape behaviours to main menu. Return to menu with escape, close notification popup, clear search bar.

Fixes: 
https://github.com/Facepunch/sbox-public/issues/8925

## Screenshots / Videos (if applicable)
Before:

https://github.com/user-attachments/assets/e08e45c4-793c-465a-a120-4cd236d80543



After:

https://github.com/user-attachments/assets/15df6916-7cff-491b-a091-c806748369b1



## Checklist
- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂