### PR TITLE
Use high quality tangents for default sphere

### DIFF
--- a/game/core/models/dev/sphere.vmdl
+++ b/game/core/models/dev/sphere.vmdl
@@ -1,4 +1,4 @@
-<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc29:version{3cec427c-1b0e-4d48-a90a-0436f33a6041} -->
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:modeldoc30:version{8c2d7a91-9c42-4bf0-883a-5a3b1762d4f1} -->
 {
 	rootNode = 
 	{
@@ -12,6 +12,17 @@
 					{
 						_class = "RenderPrimitiveSphere"
 						name = "sphere"
+						children = 
+						[
+							{
+								_class = "RenderMeshMarkup"
+								material_search_path = ""
+								use_expensive_tangents = true
+								high_high_precision_texcoords = false
+								calc_per_vertex_curvature = false
+								prefer_high_density_tris_in_uv_density_calc = false
+							},
+						]
 						parent_bone = ""
 						material_name = "materials/default/white.vmat"
 						origin = [ 0.0, 0.0, 0.0 ]


### PR DESCRIPTION
## Summary
`models/dev/sphere.vmdl` had weird normals, enabling expensive tangents makes it nice and smooth. Makes the envmap gizmo look a lot nicer, generally more consistent with the assumption that spheres should be spherical.

## Screenshots
before:
<img width="870" height="749" alt="image" src="https://github.com/user-attachments/assets/f25d9148-f7be-473f-952a-54a31e541444" />
after:
<img width="819" height="747" alt="image" src="https://github.com/user-attachments/assets/0f20c275-af44-484b-a7e1-d3321d133f70" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂