### PR TITLE
DamageInfo: add Vector3? Force property; use it to push gibs on prop break

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -362,7 +362,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		if ( IsExplosive && damage.Tags.Contains( "impact" ) )
 		{
 			Health = 0;
-			Kill();
+			Kill( damage );
 			return;
 		}
 
@@ -386,7 +386,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 		if ( Health <= 0 )
 		{
-			Kill();
+			Kill( damage );
 			Health = 0;
 		}
 	}
@@ -428,19 +428,20 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		}
 	}
 
-	public void Kill()
+	public void Kill( DamageInfo damage = null )
 	{
-		OnBreak();
+		OnBreak( damage );
 		GameObject.Destroy();
 	}
 
-	void OnBreak()
+	void OnBreak( DamageInfo damage = null )
 	{
 		OnPropBreak?.Invoke();
 
 		PlayBreakSound();
 
-		NetworkCreateGibs();
+		var force = damage?.Force;
+		NetworkCreateGibs( force.HasValue, force ?? Vector3.Zero, damage?.Position ?? WorldPosition );
 
 		CreateExplosion();
 	}
@@ -512,15 +513,15 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 	/// Create the gibs for this prop breaking, over the network. This causes clients to spawn the gibs too.
 	/// </summary>
 	[Rpc.Broadcast( NetFlags.OwnerOnly )]
-	public void NetworkCreateGibs()
+	public void NetworkCreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default )
 	{
-		CreateGibs();
+		CreateGibs( hasForce, damageForce, damagePosition );
 	}
 
 	/// <summary>
 	/// Create the gibs and return them.
 	/// </summary>
-	public List<Gib> CreateGibs()
+	public List<Gib> CreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default )
 	{
 		var gibs = new List<Gib>();
 
@@ -607,6 +608,36 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 				phys.Velocity = velocity;
 				phys.AngularVelocity = rb.PreAngularVelocity;
+			}
+		}
+
+		// If the killing blow specified a damage force (velocity vector), add it to each gib.
+		// Applied as a centre-of-mass impulse so all gibs get consistent linear velocity
+		// regardless of where they are relative to the hit point — matching HL2 behaviour.
+		// Angular velocity is derived from r×F at the hit point on the prop's own body,
+		// so gibs spin in the physically correct direction for the hit.
+		if ( hasForce && !IsProxy )
+		{
+			// r = vector from prop mass centre to hit point (world space).
+			// Angular impulse = r × J where J = linear impulse (damageForce * gibMass).
+			// This is the exact formula ApplyImpulseAt uses internally; we apply it
+			// at the prop centre so all gibs get consistent direction without per-gib
+			// moment-arm scaling (which caused distant gibs to eject violently).
+			var r = Vector3.Zero;
+			if ( damagePosition != default && rb.IsValid() && rb.PhysicsBody.IsValid() )
+				r = damagePosition - rb.PhysicsBody.MassCenter;
+
+			foreach ( var gib in gibs )
+			{
+				var phys = gib.Components.Get<Rigidbody>( true );
+				if ( !phys.IsValid() ) continue;
+
+				var mass = phys.PhysicsBody.IsValid() ? phys.PhysicsBody.Mass : 1f;
+				var linearImpulse = damageForce * mass;
+				phys.ApplyImpulse( linearImpulse );
+
+				if ( r != Vector3.Zero && phys.PhysicsBody.IsValid() )
+					phys.PhysicsBody.ApplyAngularImpulse( Vector3.Cross( r, linearImpulse ) );
 			}
 		}
 

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -613,7 +613,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 		// If the killing blow specified a damage force (velocity vector), add it to each gib.
 		// Applied as a centre-of-mass impulse so all gibs get consistent linear velocity
-		// regardless of where they are relative to the hit point — matching HL2 behaviour.
+		// regardless of where they are relative to the hit point - matching HL2 behaviour.
 		// Angular velocity is derived from r×F at the hit point on the prop's own body,
 		// so gibs spin in the physically correct direction for the hit.
 		if ( hasForce && !IsProxy )

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -628,7 +628,6 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 			}
 		}
 
-		// impulse, so all gibs get consistent linear velocity regardless of where they
 		// If this prop was on fire, ignite the gibs so the fire carries over.
 		if ( IsOnFire )
 		{

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -441,7 +441,8 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		PlayBreakSound();
 
 		var force = damage?.Force;
-		NetworkCreateGibs( force.HasValue, force ?? Vector3.Zero, damage?.Position ?? WorldPosition );
+		var wasImpact = damage?.Tags.Contains( "impact" ) ?? false;
+		NetworkCreateGibs( force.HasValue, force ?? Vector3.Zero, damage?.Position ?? WorldPosition, wasImpact );
 
 		CreateExplosion();
 	}
@@ -513,15 +514,15 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 	/// Create the gibs for this prop breaking, over the network. This causes clients to spawn the gibs too.
 	/// </summary>
 	[Rpc.Broadcast( NetFlags.OwnerOnly )]
-	public void NetworkCreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default )
+	public void NetworkCreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default, bool wasImpact = false )
 	{
-		CreateGibs( hasForce, damageForce, damagePosition );
+		CreateGibs( hasForce, damageForce, damagePosition, wasImpact );
 	}
 
 	/// <summary>
 	/// Create the gibs and return them.
 	/// </summary>
-	public List<Gib> CreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default )
+	public List<Gib> CreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default, bool wasImpact = false )
 	{
 		var gibs = new List<Gib>();
 
@@ -600,14 +601,19 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 				var phys = gib.Components.Get<Rigidbody>( true );
 				if ( !phys.IsValid() ) continue;
 
-				// Compute linear velocity at the gibs spawn point.
-				var velocity = rb.PreVelocity + Vector3.Cross( rb.PreAngularVelocity, phys.MassCenter - rb.MassCenter );
+				// Impact damage fires after the collision has drained rb.Velocity to near zero.
+				// Use PreVelocity (captured before the collision) so gibs inherit the pre-impact
+				// motion. For all other damage types use the live velocity which reflects any
+				// impulses applied this tick (bullet, explosion).
+				var linVel = wasImpact ? rb.PreVelocity : rb.Velocity;
+				var angVel = wasImpact ? rb.PreAngularVelocity : rb.AngularVelocity;
+				var velocity = linVel + Vector3.Cross( angVel, phys.MassCenter - rb.MassCenter );
 
 				// Apply 50% energy loss.
 				velocity *= 0.5f;
 
 				phys.Velocity = velocity;
-				phys.AngularVelocity = rb.PreAngularVelocity;
+				phys.AngularVelocity = angVel;
 			}
 		}
 

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -354,6 +354,19 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 		if ( IsProxy ) return;
 
+		// Apply the damage's physics push to our own body. This runs before the health
+		// check so dead/unbreakable props (gibs, Health<=0) still react. If this hit
+		// breaks the prop, the impulse lands on the body before CreateGibs reads
+		// rb.Velocity, so gibs inherit it through the velocity transfer below.
+		if ( damage.Force.LengthSquared > 0.0f )
+		{
+			var rb = Components.Get<Rigidbody>();
+			if ( rb.IsValid() && rb.PhysicsBody.IsValid() )
+			{
+				rb.PhysicsBody.ApplyImpulseAt( damage.Position, damage.Force * rb.PhysicsBody.Mass );
+			}
+		}
+
 		// The dead feel nothing
 		if ( Health <= 0.0f )
 			return;
@@ -440,9 +453,8 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 		PlayBreakSound();
 
-		var force = damage?.Force;
 		var wasImpact = damage?.Tags.Contains( "impact" ) ?? false;
-		NetworkCreateGibs( force.HasValue, force ?? Vector3.Zero, damage?.Position ?? WorldPosition, wasImpact );
+		NetworkCreateGibs( wasImpact );
 
 		CreateExplosion();
 	}
@@ -514,15 +526,15 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 	/// Create the gibs for this prop breaking, over the network. This causes clients to spawn the gibs too.
 	/// </summary>
 	[Rpc.Broadcast( NetFlags.OwnerOnly )]
-	public void NetworkCreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default, bool wasImpact = false )
+	public void NetworkCreateGibs( bool wasImpact = false )
 	{
-		CreateGibs( hasForce, damageForce, damagePosition, wasImpact );
+		CreateGibs( wasImpact );
 	}
 
 	/// <summary>
 	/// Create the gibs and return them.
 	/// </summary>
-	public List<Gib> CreateGibs( bool hasForce = false, Vector3 damageForce = default, Vector3 damagePosition = default, bool wasImpact = false )
+	public List<Gib> CreateGibs( bool wasImpact = false )
 	{
 		var gibs = new List<Gib>();
 
@@ -594,22 +606,21 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		}
 
 		// Transfer velocity from us to the gibs.
+		// Impact damage fires after the collision has drained rb.Velocity to near zero;
+		// use PreVelocity (captured before the collision) so gibs inherit the pre-impact
+		// motion. For all other damage, rb.Velocity reflects any impulses applied this
+		// tick (bullet, explosion force from Prop.OnDamage or RadiusDamage).
 		if ( rb.IsValid() )
 		{
+			var linVel = wasImpact ? rb.PreVelocity : rb.Velocity;
+			var angVel = wasImpact ? rb.PreAngularVelocity : rb.AngularVelocity;
+
 			foreach ( var gib in gibs )
 			{
 				var phys = gib.Components.Get<Rigidbody>( true );
 				if ( !phys.IsValid() ) continue;
 
-				// Impact damage fires after the collision has drained rb.Velocity to near zero.
-				// Use PreVelocity (captured before the collision) so gibs inherit the pre-impact
-				// motion. For all other damage types use the live velocity which reflects any
-				// impulses applied this tick (bullet, explosion).
-				var linVel = wasImpact ? rb.PreVelocity : rb.Velocity;
-				var angVel = wasImpact ? rb.PreAngularVelocity : rb.AngularVelocity;
 				var velocity = linVel + Vector3.Cross( angVel, phys.MassCenter - rb.MassCenter );
-
-				// Apply 50% energy loss.
 				velocity *= 0.5f;
 
 				phys.Velocity = velocity;
@@ -617,37 +628,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 			}
 		}
 
-		// If the killing blow specified a damage force (velocity vector), add it to each gib.
-		// The linear impulse is applied to each gib's own rigidbody as a centre-of-mass
 		// impulse, so all gibs get consistent linear velocity regardless of where they
-		// are relative to the hit point - matching HL2 behaviour.
-		// Additional angular impulse is derived from r×J using the hit point on the
-		// original prop's body, so gibs spin in the physically correct direction.
-		if ( hasForce && !IsProxy )
-		{
-			// r = vector from the original prop mass centre to the hit point (world space).
-			// Angular impulse = r × J where J = the per-gib linear impulse
-			// (damageForce * gibMass). We apply the linear impulse directly to each gib's
-			// centre of mass, then apply this angular impulse separately so we avoid
-			// per-gib moment-arm scaling for the linear push.
-			var r = Vector3.Zero;
-			if ( damagePosition != default && rb.IsValid() && rb.PhysicsBody.IsValid() )
-				r = damagePosition - rb.PhysicsBody.MassCenter;
-
-			foreach ( var gib in gibs )
-			{
-				var phys = gib.Components.Get<Rigidbody>( true );
-				if ( !phys.IsValid() ) continue;
-
-				var mass = phys.PhysicsBody.IsValid() ? phys.PhysicsBody.Mass : 1f;
-				var linearImpulse = damageForce * mass;
-				phys.ApplyImpulse( linearImpulse );
-
-				if ( phys.PhysicsBody.IsValid() )
-					phys.PhysicsBody.ApplyAngularImpulse( Vector3.Cross( r, linearImpulse ) );
-			}
-		}
-
 		// If this prop was on fire, ignite the gibs so the fire carries over.
 		if ( IsOnFire )
 		{

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -612,17 +612,18 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		}
 
 		// If the killing blow specified a damage force (velocity vector), add it to each gib.
-		// Applied as a centre-of-mass impulse so all gibs get consistent linear velocity
-		// regardless of where they are relative to the hit point - matching HL2 behaviour.
-		// Angular velocity is derived from r×F at the hit point on the prop's own body,
-		// so gibs spin in the physically correct direction for the hit.
+		// The linear impulse is applied to each gib's own rigidbody as a centre-of-mass
+		// impulse, so all gibs get consistent linear velocity regardless of where they
+		// are relative to the hit point - matching HL2 behaviour.
+		// Additional angular impulse is derived from r×J using the hit point on the
+		// original prop's body, so gibs spin in the physically correct direction.
 		if ( hasForce && !IsProxy )
 		{
-			// r = vector from prop mass centre to hit point (world space).
-			// Angular impulse = r × J where J = linear impulse (damageForce * gibMass).
-			// This is the exact formula ApplyImpulseAt uses internally; we apply it
-			// at the prop centre so all gibs get consistent direction without per-gib
-			// moment-arm scaling (which caused distant gibs to eject violently).
+			// r = vector from the original prop mass centre to the hit point (world space).
+			// Angular impulse = r × J where J = the per-gib linear impulse
+			// (damageForce * gibMass). We apply the linear impulse directly to each gib's
+			// centre of mass, then apply this angular impulse separately so we avoid
+			// per-gib moment-arm scaling for the linear push.
 			var r = Vector3.Zero;
 			if ( damagePosition != default && rb.IsValid() && rb.PhysicsBody.IsValid() )
 				r = damagePosition - rb.PhysicsBody.MassCenter;

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -637,7 +637,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 				var linearImpulse = damageForce * mass;
 				phys.ApplyImpulse( linearImpulse );
 
-				if ( r != Vector3.Zero && phys.PhysicsBody.IsValid() )
+				if ( phys.PhysicsBody.IsValid() )
 					phys.PhysicsBody.ApplyAngularImpulse( Vector3.Cross( r, linearImpulse ) );
 			}
 		}

--- a/engine/Sandbox.Engine/Scene/Components/Game/RadiusDamage.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/RadiusDamage.cs
@@ -189,7 +189,9 @@ public sealed class RadiusDamage : Component
 			damage.Damage = damageAmount * distanceFalloff;
 			damage.Origin = sphere.Center;
 			damage.Position = occlusion ? traceHitPositions[rootIdx] : target.WorldPosition;
-			damage.Force = dir * damageAmount * physicsForce * distanceFalloff;
+			// Skip Force when the target is exactly at the explosion centre (zero-length offset produces NaN).
+			if ( dir.LengthSquared > 0.0001f )
+				damage.Force = dir * damageAmount * physicsForce * distanceFalloff;
 			damageable.OnDamage( damage );
 		}
 

--- a/engine/Sandbox.Engine/Scene/Components/Game/RadiusDamage.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/RadiusDamage.cs
@@ -185,9 +185,11 @@ public sealed class RadiusDamage : Component
 			var distance = target.WorldPosition.Distance( point );
 			var distanceFalloff = 1 - (distance / sphere.Radius).Clamp( 0, 1 );
 
+			var dir = (target.WorldPosition - point).Normal;
 			damage.Damage = damageAmount * distanceFalloff;
 			damage.Origin = sphere.Center;
 			damage.Position = occlusion ? traceHitPositions[rootIdx] : target.WorldPosition;
+			damage.Force = dir * damageAmount * physicsForce * distanceFalloff;
 			damageable.OnDamage( damage );
 		}
 

--- a/engine/Sandbox.Engine/Scene/DamageInfo.cs
+++ b/engine/Sandbox.Engine/Scene/DamageInfo.cs
@@ -44,11 +44,10 @@ public class DamageInfo
 	public PhysicsShape Shape { get; set; }
 
 	/// <summary>
-	/// The physics force vector to apply to whatever this damage hits.
-	/// Equivalent to HL2's m_vecDamageForce. Leave null if the damage should not push anything.
-	/// Applied as an impulse to each spawned gib (matching Source engine behaviour).
+	/// The physics force vector to apply to whatever this damage hits. Direction and magnitude
+	/// encode the intended push; consumers multiply by their own mass to derive an impulse.
 	/// </summary>
-	public Vector3? Force { get; set; }
+	public Vector3 Force { get; set; }
 
 	/// <summary>
 	/// Tags for this damage, allows you to enter and read different damage types etc

--- a/engine/Sandbox.Engine/Scene/DamageInfo.cs
+++ b/engine/Sandbox.Engine/Scene/DamageInfo.cs
@@ -44,6 +44,13 @@ public class DamageInfo
 	public PhysicsShape Shape { get; set; }
 
 	/// <summary>
+	/// The physics force vector to apply to whatever this damage hits.
+	/// Equivalent to HL2's m_vecDamageForce. Leave null if the damage should not push anything.
+	/// Applied as an impulse to each spawned gib (matching Source engine behaviour).
+	/// </summary>
+	public Vector3? Force { get; set; }
+
+	/// <summary>
 	/// Tags for this damage, allows you to enter and read different damage types etc
 	/// </summary>
 	public TagSet Tags { get; set; } = new();


### PR DESCRIPTION
## What

Adds `Vector3 Force` to `DamageInfo` (same idea as HL2's `CTakeDamageInfo::m_vecDamageForce`) and fixes gibs spawning with no velocity when a prop is killed.

## The bug

`CreateGibs` inherits velocity from `rb.PreVelocity`, which is captured at the start of the physics tick. Any impulse applied that same tick (bullet, explosion) hasn't been integrated yet so it's not in `PreVelocity` and gibs get nothing. Impact kills (collision damage) have the opposite problem, rb.Velocity has already been drained by the collision solver before gibs even spawn.

## Fix

Two things in `CreateGibs`:
- For **impact** kills (`damage.Tags.Contains("impact")`), use `rb.PreVelocity` - the pre-collision snapshot is what we want.
- For **everything else**, use `rb.Velocity` - which now reflects impulses applied this tick by `Prop.OnDamage` or `RadiusDamage`.

`Prop.OnDamage` also applies `damage.Force` as an impulse to its own prop

`RadiusDamage` sets `damage.Force` per-target in the damageables loop so explosions work without any extra code on the caller side.

force damage stuff like many games already use and expect

## Notes

`Force` is a plain `Vector3`, zero means no push. Convention is direction x magnitude, not mass-scaled; consumers multiply by their own mass when applying as an impulse.

Companion sandbox PR: https://github.com/Facepunch/sandbox/pull/273

Videos in the s&box discord because they're too big to upload here:
https://discord.com/channels/833983068468936704/833983416390385685/1509092234564337694