### PR TITLE
Fix invalid exe path errors in launch configurations

### DIFF
--- a/engine/Sandbox.SolutionGenerator/Generator.cs
+++ b/engine/Sandbox.SolutionGenerator/Generator.cs
@@ -116,7 +116,7 @@ namespace Sandbox.SolutionGenerator
 					Directory.CreateDirectory( propertiesPath );
 
 					var absoluteExePath = Path.Combine( relativePath, "sbox-dev.exe" );
-					var relativeExePath = AttemptAbsoluteToRelative( propertiesPath, absoluteExePath );
+					var relativeExePath = AttemptAbsoluteToRelative( p.CsprojPath, absoluteExePath );
 
 					var launchSettings = new LaunchSettings { Profiles = new() };
 					launchSettings.Profiles.Add( "Editor", new LaunchSettings.Profile
@@ -124,6 +124,7 @@ namespace Sandbox.SolutionGenerator
 						CommandName = "Executable",
 						ExecutablePath = relativeExePath,
 						CommandLineArgs = $"-project \"{p.SandboxProjectFilePath}\"",
+						WorkingDirectory = "$(MSBuildProjectDirectory)",
 					} );
 
 					WriteTextIfChanged( Path.Combine( propertiesPath, "launchSettings.json" ), JsonSerializer.Serialize( launchSettings, JsonWriteIndented ) );

--- a/engine/Sandbox.SolutionGenerator/LaunchSettings.cs
+++ b/engine/Sandbox.SolutionGenerator/LaunchSettings.cs
@@ -15,6 +15,9 @@ namespace Sandbox.SolutionGenerator
 
 			[JsonPropertyName( "commandLineArgs" )]
 			public string CommandLineArgs { get; set; }
+
+			[JsonPropertyName( "workingDirectory" )]
+			public string WorkingDirectory { get; set; }
 		}
 
 		[JsonPropertyName( "profiles" )]


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

The generated launch configurations report invalid exe path errors currently in JetBrains Rider, preventing you from running the editor from the IDE. This applies to all launch configurations.

All launch configurations work based on my manual testing after applying these fixes, in both Rider and Visual Studio.

## Motivation & Context

https://sbox.game/f/devhelp/2736/1/

## Implementation Details

Applies the following fixes (based on limited understanding of the engine internals):
* Explicit workingDirectory property to fix invalid exe path error on JetBrains Rider.
* Use CsprojPath as base path instead of propertiesPath.

## Screenshots / Videos (if applicable)

<img width="1169" height="608" alt="image" src="https://github.com/user-attachments/assets/81a02117-93c2-4ba0-a6fc-8fffced9ea85" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂