### PR TITLE
Props gibs should inherit velocity for most cases and prevelocity only for impact kills.

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -362,7 +362,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		if ( IsExplosive && damage.Tags.Contains( "impact" ) )
 		{
 			Health = 0;
-			Kill();
+			Kill( damage );
 			return;
 		}
 
@@ -386,7 +386,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 		if ( Health <= 0 )
 		{
-			Kill();
+			Kill( damage );
 			Health = 0;
 		}
 	}
@@ -428,19 +428,20 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		}
 	}
 
-	public void Kill()
+	public void Kill( DamageInfo damage = null )
 	{
-		OnBreak();
+		OnBreak( damage );
 		GameObject.Destroy();
 	}
 
-	void OnBreak()
+	void OnBreak( DamageInfo damage = null )
 	{
 		OnPropBreak?.Invoke();
 
 		PlayBreakSound();
 
-		NetworkCreateGibs();
+		var wasImpact = damage?.Tags.Contains( "impact" ) ?? false;
+		NetworkCreateGibs(wasImpact);
 
 		CreateExplosion();
 	}
@@ -512,15 +513,15 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 	/// Create the gibs for this prop breaking, over the network. This causes clients to spawn the gibs too.
 	/// </summary>
 	[Rpc.Broadcast( NetFlags.OwnerOnly )]
-	public void NetworkCreateGibs()
+	public void NetworkCreateGibs( bool wasImpact = false )
 	{
-		CreateGibs();
+		CreateGibs( wasImpact );
 	}
 
 	/// <summary>
 	/// Create the gibs and return them.
 	/// </summary>
-	public List<Gib> CreateGibs()
+	public List<Gib> CreateGibs( bool wasImpact = false )
 	{
 		var gibs = new List<Gib>();
 
@@ -594,19 +595,21 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		// Transfer velocity from us to the gibs.
 		if ( rb.IsValid() )
 		{
+			var linVel = wasImpact ? rb.PreVelocity : rb.Velocity;
+			var angVel = wasImpact ? rb.PreAngularVelocity : rb.AngularVelocity;
 			foreach ( var gib in gibs )
 			{
 				var phys = gib.Components.Get<Rigidbody>( true );
 				if ( !phys.IsValid() ) continue;
 
 				// Compute linear velocity at the gibs spawn point.
-				var velocity = rb.PreVelocity + Vector3.Cross( rb.PreAngularVelocity, phys.MassCenter - rb.MassCenter );
+				var velocity = linVel + Vector3.Cross( angVel, phys.MassCenter - rb.MassCenter );
 
 				// Apply 50% energy loss.
 				velocity *= 0.5f;
 
 				phys.Velocity = velocity;
-				phys.AngularVelocity = rb.PreAngularVelocity;
+				phys.AngularVelocity = angVel;
 			}
 		}
 

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -595,6 +595,10 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		// Transfer velocity from us to the gibs.
 		if ( rb.IsValid() )
 		{
+			// If the prop was thrown on the floor or a wall when broken, we want the gibs to inherit the velocity from before that impact
+			// that way they crash into the floor/wall nicely and stuff.
+			// HOWEVER, we don't want this for anything else
+			// else we'd be stomping whatever changes people might be wanting to make to the velocity themselves.
 			var linVel = wasImpact ? rb.PreVelocity : rb.Velocity;
 			var angVel = wasImpact ? rb.PreAngularVelocity : rb.AngularVelocity;
 			foreach ( var gib in gibs )

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -609,8 +609,11 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 				// Compute linear velocity at the gibs spawn point.
 				var velocity = linVel + Vector3.Cross( angVel, phys.MassCenter - rb.MassCenter );
 
-				// Apply 50% energy loss.
-				velocity *= 0.5f;
+				if ( wasImpact )
+				{
+					// Apply 50% energy loss from surface impact.
+					velocity *= 0.5f;
+				}
 
 				phys.Velocity = velocity;
 				phys.AngularVelocity = angVel;

--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -441,7 +441,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		PlayBreakSound();
 
 		var wasImpact = damage?.Tags.Contains( "impact" ) ?? false;
-		NetworkCreateGibs(wasImpact);
+		NetworkCreateGibs( wasImpact );
 
 		CreateExplosion();
 	}


### PR DESCRIPTION
## Summary

Currently, prop will not have any just applied velocity handed down to their gibs, which means in basically all cases, props shot by bullets have their gibs unnaturally drop in place.

## Motivation & Context

any just applied velocity is stomped by the impact damage prevelocity

## Implementation Details

I added a comment in code about why I thought prevelocity was probably chosen in the first place, and why we don't need it for most cases.
This is 100% human slop, no AI did the thinking or bug finding here.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/5e8dc69c-c801-4059-9438-7f5fcf0f172e
(This video implement another fix for sandbox gamemode, which reorders bullet impact forces to be applied before damage, http://github.com/Facepunch/sandbox/pull/274)

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing (N/A here)
- [X] I’m okay with this PR being rejected or requested to change 🙂