### PR TITLE
Log error when font load fails and falls back to system font

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/TextRendering/FontManager.cs
+++ b/engine/Sandbox.Engine/Systems/Render/TextRendering/FontManager.cs
@@ -150,7 +150,7 @@ internal class FontManager : FontMapper
 		// Fallback on system font
 		if ( f is null )
 		{
-			Log.Error( $"FontManager: Font '{style.FontFamily}' not found, falling back to system font" );
+			Log.Warning( $"FontManager: Font '{style.FontFamily}' not found, falling back to system font" );
 			f = Default.TypefaceFromStyle( style, ignoreFontVariants );
 		}
 

--- a/engine/Sandbox.Engine/Systems/Render/TextRendering/FontManager.cs
+++ b/engine/Sandbox.Engine/Systems/Render/TextRendering/FontManager.cs
@@ -148,7 +148,11 @@ internal class FontManager : FontMapper
 		var f = GetBestTypeface( style );
 
 		// Fallback on system font
-		f ??= Default.TypefaceFromStyle( style, ignoreFontVariants );
+		if ( f is null )
+		{
+			Log.Error( $"FontManager: Font '{style.FontFamily}' not found, falling back to system font" );
+			f = Default.TypefaceFromStyle( style, ignoreFontVariants );
+		}
 
 		lock ( Cache )
 		{


### PR DESCRIPTION
## Summary

Displays a brief error message when loading a font fails and falls back to system font. 

## Motivation & Context

Previously loading a font would fail silently and fall back to the system font. This made using custom fonts confusing since it was unclear if the custom font was failing to load or wasn't even being loaded at all. Users may also just not even notice their font failed to load.

This addition was made in response to an issue mentioned on discord.

## Screenshots

<img width="510" height="120" alt="image" src="https://github.com/user-attachments/assets/3b649afe-8c17-4ec2-a93c-87635de784bb" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂