### PR TITLE
Added PropertyBlock/PropertyItem attribute system for grouped properties

### DIFF
--- a/engine/Sandbox.Generator/Units/PropertyBlock.cs
+++ b/engine/Sandbox.Generator/Units/PropertyBlock.cs
@@ -1,0 +1,114 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sandbox.Generator
+{
+	internal static class PropertyBlock
+	{
+		/// <summary>
+		/// Scans a class's members in source order and returns a map of PropertyItem nodes
+		/// to the attribute lists they should inherit from the preceding PropertyBlock.
+		/// </summary>
+		internal static Dictionary<SyntaxNode, SyntaxList<AttributeListSyntax>> ScanClass( ClassDeclarationSyntax classNode )
+		{
+			var map = new Dictionary<SyntaxNode, SyntaxList<AttributeListSyntax>>();
+			SyntaxList<AttributeListSyntax> currentBlock = default;
+			bool hasBlock = false;
+
+			foreach ( var member in classNode.Members )
+			{
+				if ( HasAttr( member.AttributeLists, "PropertyBlock" ) )
+				{
+					currentBlock = BuildInherited( member.AttributeLists );
+					hasBlock = true;
+				}
+
+				if ( hasBlock && HasAttr( member.AttributeLists, "PropertyItem" ) )
+					map[member] = currentBlock;
+			}
+
+			return map;
+		}
+
+		internal static void VisitProperty( ref PropertyDeclarationSyntax node, PropertyDeclarationSyntax original, Dictionary<SyntaxNode, SyntaxList<AttributeListSyntax>> map )
+		{
+			node = (PropertyDeclarationSyntax)Apply( node, original, map );
+		}
+
+		internal static void VisitField( ref FieldDeclarationSyntax node, FieldDeclarationSyntax original, Dictionary<SyntaxNode, SyntaxList<AttributeListSyntax>> map )
+		{
+			node = (FieldDeclarationSyntax)Apply( node, original, map );
+		}
+
+		static MemberDeclarationSyntax Apply( MemberDeclarationSyntax node, MemberDeclarationSyntax original, Dictionary<SyntaxNode, SyntaxList<AttributeListSyntax>> map )
+		{
+			bool hasMarkers = HasAttr( node.AttributeLists, "PropertyBlock" ) || HasAttr( node.AttributeLists, "PropertyItem" );
+			bool hasInherited = map.TryGetValue( original, out var inherited );
+
+			if ( !hasMarkers && !hasInherited ) return node;
+
+			if ( hasMarkers ) node = Strip( node );
+			if ( hasInherited ) node = node.WithAttributeLists( node.AttributeLists.AddRange( inherited ) );
+
+			return node;
+		}
+
+		// Removes [PropertyBlock] and [PropertyItem] markers from the compiled output.
+		// If the member is the PropertyBlock source, all attributes are cleared since
+		// Apply will re-add them correctly via the inherited path.
+		static MemberDeclarationSyntax Strip( MemberDeclarationSyntax node )
+		{
+			if ( HasAttr( node.AttributeLists, "PropertyBlock" ) )
+				return node.WithAttributeLists( SyntaxFactory.List<AttributeListSyntax>() );
+
+			var newLists = new List<AttributeListSyntax>();
+
+			foreach ( var list in node.AttributeLists )
+			{
+				var kept = list.Attributes.Where( a => !IsMarker( a ) ).ToArray();
+				if ( kept.Length == 0 ) continue;
+				newLists.Add( kept.Length == list.Attributes.Count
+					? list
+					: list.WithAttributes( SyntaxFactory.SeparatedList( kept ) ) );
+			}
+
+			return node.WithAttributeLists( SyntaxFactory.List( newLists ) );
+		}
+
+		// Builds the attribute lists to inject into PropertyItem members:
+		// replaces PropertyBlock with Property, drops PropertyItem
+		static SyntaxList<AttributeListSyntax> BuildInherited( SyntaxList<AttributeListSyntax> source )
+		{
+			var result = new List<AttributeListSyntax>();
+
+			foreach ( var list in source )
+			{
+				var attrs = list.Attributes
+					.Where( a => !IsPropertyItem( a ) )
+					.Select( a => IsPropertyBlock( a ) ? a.WithName( SyntaxFactory.ParseName( "Property" ) ) : a )
+					.ToArray();
+
+				if ( attrs.Length > 0 )
+					result.Add( list.WithAttributes( SyntaxFactory.SeparatedList( attrs ) ) );
+			}
+
+			return SyntaxFactory.List( result );
+		}
+
+		static bool HasAttr( SyntaxList<AttributeListSyntax> lists, string name )
+			=> lists.SelectMany( l => l.Attributes ).Any( a => Matches( a, name ) );
+
+		static bool IsMarker( AttributeSyntax a ) => IsPropertyBlock( a ) || IsPropertyItem( a );
+		static bool IsPropertyBlock( AttributeSyntax a ) => Matches( a, "PropertyBlock" );
+		static bool IsPropertyItem( AttributeSyntax a ) => Matches( a, "PropertyItem" );
+
+		static bool Matches( AttributeSyntax attr, string name )
+		{
+			var n = attr.Name.ToString();
+			return n == name || n == name + "Attribute";
+		}
+	}
+}

--- a/engine/Sandbox.Generator/Worker.cs
+++ b/engine/Sandbox.Generator/Worker.cs
@@ -90,6 +90,8 @@ namespace Sandbox.Generator
 		/// </summary>
 		internal static List<string> VisitedClasses = new List<string>();
 
+		Dictionary<SyntaxNode, SyntaxList<AttributeListSyntax>> _propertyBlockMap = new();
+
 		/// <summary>
 		/// Runs in the thread pool, processes the syntax tree and returns
 		/// </summary>
@@ -280,6 +282,7 @@ namespace Sandbox.Generator
 			var symbol = Model.GetDeclaredSymbol( _node );
 			var node = base.VisitFieldDeclaration( _node ) as FieldDeclarationSyntax;
 
+			PropertyBlock.VisitField( ref node, _node, _propertyBlockMap );
 			node = ClassFileLocation.VisitNode( node, _node, symbol, this, TreeInput ) as FieldDeclarationSyntax;
 
 			return node;
@@ -300,6 +303,7 @@ namespace Sandbox.Generator
 			var symbol = Model.GetDeclaredSymbol( _node );
 			var node = base.VisitPropertyDeclaration( _node ) as PropertyDeclarationSyntax;
 
+			PropertyBlock.VisitProperty( ref node, _node, _propertyBlockMap );
 			DefaultValue.VisitProperty( ref node, symbol, this );
 			Description.VisitProperty( ref node, symbol, this );
 			CodeGen.VisitProperty( ref node, symbol, this );
@@ -317,10 +321,12 @@ namespace Sandbox.Generator
 			var oldClassAdditions = ClassAdditions;
 			var oldClassModifiers = ClassModifiers;
 			var oldClassAttributes = ClassBaseTypes;
+			var oldPropertyBlockMap = _propertyBlockMap;
 
 			ClassAdditions = new List<string>();
 			ClassModifiers = new List<string>();
 			ClassBaseTypes = new List<string>();
+			_propertyBlockMap = PropertyBlock.ScanClass( _node );
 
 			var node = _node;
 
@@ -400,6 +406,7 @@ namespace Sandbox.Generator
 				ClassAdditions = oldClassAdditions;
 				ClassModifiers = oldClassModifiers;
 				ClassBaseTypes = oldClassAttributes;
+				_propertyBlockMap = oldPropertyBlockMap;
 			}
 
 			node = LinePreserve.AddLineNumber( node, _node, TreeInput, this );

--- a/engine/Sandbox.System/Attributes/Property.cs
+++ b/engine/Sandbox.System/Attributes/Property.cs
@@ -56,3 +56,23 @@ public class InlineEditorAttribute : Attribute
 public class AdvancedAttribute : Attribute
 {
 }
+
+/// <summary>
+/// Marks the start of a property group. All subsequent members marked with [PropertyItem] in the same
+/// file will inherit this attribute's parameters as if they had [Property] applied with the same arguments.
+/// </summary>
+[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field )]
+public class PropertyBlockAttribute : Attribute, IClassNameProvider, ITitleProvider
+{
+	public string Name { get; set; }
+	public string Title { get; set; }
+
+	string IClassNameProvider.Value => Name;
+	string ITitleProvider.Value => Title;
+}
+
+/// <summary>
+/// Marks a member as belonging to the nearest preceding [PropertyBlock] in the same file.
+/// </summary>
+[AttributeUsage( AttributeTargets.Property | AttributeTargets.Field )]
+public class PropertyItemAttribute : Attribute { }


### PR DESCRIPTION
## Summary

Adds [PropertyBlock] and [PropertyItem] attributes to reduce repetition when multiple members share the same property attributes.

## Motivation & Context

When a component has many properties belonging to the same group, every member requires the full attribute list repeated (e.g.  `[Property, Group("Movement"), Order(100), ... ]`). This makes organizing groups tedious (and ugly). [PropertyBlock] lets you declare the shared attributes once; any subsequent [PropertyItem] members in the same file inherit them automatically.

This was made in response to the following feature request.
Fixes: #10814

## Design Decisions & Implementation

The block syntax `[Property, Group("Speed"), ... ] { ... }` (like that described in the feature request) requires some non-trivial pre-processing of the source files since it's not valid C#. This would end up requiring a painful amount of work. And so, I decided to implement in this slightly less beautiful but still elegant and simpler way to have a block of [Property] attributes.

Here are some rough details of how it works:
- PropertyBlockAttribute and PropertyItemAttribute are defined in Sandbox.System. The generator handles the expansion in Worker.cs.
- On each VisitClassDeclaration, the class's members are scanned in source order to build a map of PropertyItem nodes and the attribute lists they should inherit from the nearest preceding PropertyBlock.
- PropertyBlock does not bleed across partial class files or into nested classes
- Members without [PropertyItem] are skipped with no allocation

Here are some examples of the new attributes in use. The comments on the right show the equivalent [Property] attributes each member compiles down to. Alternatively, you can think of the comments as what would have been written without these new attributes to achieve the same result.
```cs
  // 1. Basic
  public class Mover : Component
  {
      [PropertyBlock, Group( "Movement" ), Order( 0 )]
      [PropertyItem] public float WalkSpeed { get; set; } = 100f; // [Property, Group("Movement"), Order(0)]
      [PropertyItem] public float RunSpeed { get; set; } = 200f;  // [Property, Group("Movement"), Order(0)]
  }

  // 2. Multiple blocks
  public class Fighter : Component
  {
      [PropertyBlock, Group( "Movement" ), Order( 0 )]
      [PropertyItem] public float WalkSpeed { get; set; } = 100f; // [Property, Group("Movement"), Order(0)]
      [PropertyItem] public float RunSpeed { get; set; } = 200f;  // [Property, Group("Movement"), Order(0)]

      [PropertyBlock, Group( "Combat" ), Order( 100 )]
      [PropertyItem] public float Damage { get; set; } = 25f;     // [Property, Group("Combat"), Order(100)]
      [PropertyItem] public float AttackRate { get; set; } = 1f;  // [Property, Group("Combat"), Order(100)]
  }

  // 3. Non-PropertyItem members are untouched
  public class Example : Component
  {
      [PropertyBlock, Group( "Settings" ), Order( 50 )]
      [PropertyItem] public float Speed { get; set; } = 100f;     // [Property, Group("Settings"), Order(50)]
      private float _internal = 0f;                               // no [Property]
      [PropertyItem] public float Height { get; set; } = 1.8f;    // [Property, Group("Settings"), Order(50)]
  }

  // 4. Extra attributes on PropertyItem are preserved
  public class Clamped : Component
  {
      [PropertyBlock, Group( "Stats" ), Order( 10 )]
      [PropertyItem] public float Speed { get; set; } = 100f;                       // [Property, Group("Stats"), Order(10)]
      [PropertyItem, Range( 0, 500 )] public float MaxSpeed { get; set; }  // [Property, Group("Stats"), Order(10), Range(0, 500)]
  }

  // 5. PropertyItem with no preceding PropertyBlock is a no-op
  public class NoBlock : Component
  {
      [PropertyItem] public float Speed { get; set; } = 100f; // no [Property] injected
  }

  // 6. Nested class - outer PropertyBlock does not affect inner class members
  public class Outer : Component
  {
      [PropertyBlock, Group( "Outer" ), Order( 0 )]
      [PropertyItem] public float Speed { get; set; } = 100f; // [Property, Group("Outer"), Order(0)]

      public class Inner : Component
      {
          [PropertyItem] public float Speed { get; set; } = 50f; // no [Property] injected
      }
  }

  // 7. Fields
  public class WithFields : Component
  {
      [PropertyBlock, Group( "Config" ), Order( 200 )]
      [PropertyItem] public float Speed = 100f; // [Property, Group("Config"), Order(200)]
      [PropertyItem] public int Count = 5;      // [Property, Group("Config"), Order(200)]
  }

  // 8. PropertyBlock without PropertyItem - the member itself is not exposed
  public class MarkerOnly : Component
  {
      [PropertyBlock, Group( "Movement" ), Order( 0 )]
      public float NotExposed { get; set; } = 0f;         // no [Property]
      [PropertyItem] public float WalkSpeed { get; set; } // [Property, Group("Movement"), Order(0)]
  }
```

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂