### PR TITLE
[NodeUI] Extra position check to make sure we don't mark the item as moved when we haven't moved at all

### DIFF
--- a/game/addons/tools/Code/NodeGraph/NodeUI.cs
+++ b/game/addons/tools/Code/NodeGraph/NodeUI.cs
@@ -682,7 +682,7 @@ public partial class NodeUI : GraphicsItem
 	{
 		Position = Position.SnapToGrid( Graph.GridSize );
 
-		if ( Node != null )
+		if ( Node != null && !object.Equals( Node.Position, Position ) )
 		{
 			Graph?.MoveableMoved();
 			Node.Position = Position;

--- a/game/addons/tools/Code/NodeGraph/NodeUI.cs
+++ b/game/addons/tools/Code/NodeGraph/NodeUI.cs
@@ -686,8 +686,8 @@ public partial class NodeUI : GraphicsItem
 		{
 			Graph?.MoveableMoved();
 			Node.Position = Position;
-		}
 
-		Graph?.NodePositionChanged( this );
+			Graph?.NodePositionChanged( this );
+		}
 	}
 }


### PR DESCRIPTION

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This pr tweaks `NodeUI.OnPositionChanged()` so that most of it doesn't execute if the position hasn't actually changed.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

This change fixes a bug where in shadergraph for example sometimes when clicking on the node without moving it. It will mark the graph as dirty.

## Implementation Details

Simple equality check to avoid doing the rest of the function if the position hasn't actually changed.

```cs
	protected override void OnPositionChanged()
	{
		Position = Position.SnapToGrid( Graph.GridSize );

		if ( Node != null && !object.Equals( Node.Position, Position ) )
		{
			Graph?.MoveableMoved();
			Node.Position = Position;

			Graph?.NodePositionChanged( this );
		}
	}
```

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂