### PR TITLE
Fix `AnyOfTypeControlWidget` inline properties not receiving mouse focus

### DIFF
--- a/game/addons/tools/Code/Widgets/ControlWidgets/AnyOfTypeControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/AnyOfTypeControlWidget.cs
@@ -51,6 +51,14 @@ sealed class AnyOfTypeControlWidget : DropdownControlWidget<TypeDescription>
 		}
 	}
 
+	protected override void OnMouseClick( MouseEvent e )
+	{
+		if ( e.LocalPosition.y > Theme.RowHeight )
+			return;
+
+		base.OnMouseClick( e );
+	}
+
 	protected override void OnItemSelected( object item )
 	{
 		var typeDesc = item is Entry e ? e.Value : item as TypeDescription;


### PR DESCRIPTION
## Summary

Fixes `AnyOfTypeControlWidget` opening its type-selection dropdown when clicking inline properties.

## Motivation & Context

`AnyOfTypeControlWidget` includes a dropdown row followed by inline property editors for the selected type. Because the widget grows to contain those editors, the inherited dropdown click handler treated clicks anywhere inside the expanded widget as dropdown clicks.

This prevented inline properties from receiving focus normally.

## Implementation Details

Added an `OnMouseClick` override to `AnyOfTypeControlWidget` that forwards clicks to the dropdown handler only when they occur within the top selector row.

Clicks below `Theme.RowHeight` are left for the embedded property controls.

## Screenshots / Videos (if applicable)

Before:

https://github.com/user-attachments/assets/0da9e44b-764e-43a8-80a6-17c05fc384c0



After:

https://github.com/user-attachments/assets/6b792fbd-61c8-4059-a87b-278c90ec4bfc






## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂