### PR TITLE
Restore changing the GameResource's color via the `[AssetType]` attribute

### DIFF
--- a/engine/Sandbox.Engine/Game/Avatar/Clothing.cs
+++ b/engine/Sandbox.Engine/Game/Avatar/Clothing.cs
@@ -5,7 +5,7 @@ namespace Sandbox;
 /// <summary>
 /// Describes an item of clothing and implicitly which other items it can be worn with
 /// </summary>
-[AssetType( Name = "Clothing Definition", Extension = "clothing", Category = "citizen", Flags = AssetTypeFlags.IncludeThumbnails )]
+[AssetType( Name = "Clothing Definition", Extension = "clothing", Category = "citizen", Flags = AssetTypeFlags.IncludeThumbnails, IconColor = "#fdea60" )]
 public sealed partial class Clothing : GameResource
 {
 

--- a/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
+++ b/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
@@ -36,6 +36,11 @@ public class AssetTypeAttribute : System.Attribute, ITypeAttribute, IUninheritab
 	public AssetTypeFlags Flags { get; set; }
 
 	/// <summary>
+	/// Color of the bottom line and background gradient for this resource's thumbnail.
+	/// </summary>
+	public string IconColor { get; set; } = "#67ac5c";
+
+	/// <summary>
 	/// Find a resource type by its extension. The extension should have no period.
 	/// </summary>
 	public static TypeDescription FindTypeByExtension( string extension )

--- a/engine/Sandbox.Engine/Resources/Scene/PrefabFile.cs
+++ b/engine/Sandbox.Engine/Resources/Scene/PrefabFile.cs
@@ -7,7 +7,7 @@ namespace Sandbox;
 /// A GameObject which is saved to a file.
 /// </summary>
 [Expose]
-[AssetType( Name = "Prefab", Extension = "prefab", Category = "World", Flags = AssetTypeFlags.NoEmbedding )]
+[AssetType( Name = "Prefab", Extension = "prefab", Category = "World", Flags = AssetTypeFlags.NoEmbedding, IconColor = "#86c4fe" )]
 public partial class PrefabFile : GameResource
 {
 	/// <summary>

--- a/engine/Sandbox.Engine/Resources/Scene/SceneFile.cs
+++ b/engine/Sandbox.Engine/Resources/Scene/SceneFile.cs
@@ -5,7 +5,7 @@ namespace Sandbox;
 /// <summary>
 /// A scene file contains a collection of GameObject with Components and their properties.
 /// </summary>
-[AssetType( Name = "Scene", Extension = "scene", Category = "World", Flags = AssetTypeFlags.NoEmbedding )]
+[AssetType( Name = "Scene", Extension = "scene", Category = "World", Flags = AssetTypeFlags.NoEmbedding, IconColor = "#4596ec" )]
 public partial class SceneFile : GameResource
 {
 	[JsonPropertyName( "__guid" )]

--- a/engine/Sandbox.Engine/Resources/Surface.cs
+++ b/engine/Sandbox.Engine/Resources/Surface.cs
@@ -7,7 +7,7 @@ namespace Sandbox;
 /// <summary>
 /// A physics surface. This is applied to each <see cref="PhysicsShape">PhysicsShape</see> and controls its physical properties and physics related sounds.
 /// </summary>
-[AssetType( Name = "Surface Description", Extension = "surface", Category = "Physics", Flags = AssetTypeFlags.NoEmbedding )]
+[AssetType( Name = "Surface Description", Extension = "surface", Category = "Physics", Flags = AssetTypeFlags.NoEmbedding, IconColor = "#4596ec" )]
 public partial class Surface : GameResource
 {
 	/// <summary>

--- a/engine/Sandbox.Tools/Assets/AssetType.cs
+++ b/engine/Sandbox.Tools/Assets/AssetType.cs
@@ -270,7 +270,7 @@ public class AssetType
 		GenerateGlyphs( attribute );
 
 		// For game resources, use the background color specified in the attribute
-		Color = "#67ac5c";
+		Color = attribute.IconColor;
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
Restored the old functionality of `[GameResource]` attribute where `IconBgColor` also affected the color of the bottom horizontal line and the background gradient as well. But with the switch to `[AssetType]` attribute that functionality got lost, due to icon color being derrived from `CreateAssetTypeIcon()` override, which meant there was no color property on the new attribute.

## Motivation & Context

With the switch to `[AssetType]` attribute, there was no way to set the color due to it being expected to come from the attribute, which has nothing in it. This resulted in some engine resources becoming green, even if their `CreateAssetTypeIcon()` icon was not green.

## Implementation Details

A string property was added to `[AssetType]` attribute to mirror the old behavior of `[GameResource]`, which is passed to the expected spot. It is defaulting to the same green, so no breaking changes.

I have also restored old colors that were there before `[AssetType]` introduction, but I may have missed some.

## Screenshots / Videos (if applicable)
Current broken colors:
<img width="658" height="161" alt="sbox-dev_zZ11B4y8az" src="https://github.com/user-attachments/assets/83cbff33-6962-4be2-bb72-4bd2562f2956" />

Fixed colors:
<img width="626" height="143" alt="sbox-dev_xpC1pSI9dd" src="https://github.com/user-attachments/assets/22535cd1-b2ef-466b-aad7-0587c6bd7ed8" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂