### PR TITLE
Requires at least one valid splatmap

### DIFF
--- a/game/addons/tools/Code/Scene/Terrain/TerrainComponentWidget.Settings.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainComponentWidget.Settings.cs
@@ -248,7 +248,7 @@ partial class TerrainComponentWidget : ComponentEditorWidget
 			{
 				if ( bitmap.Width != resolution || bitmap.Height != resolution )
 				{
-					Log.Warning( $"Skipping {Path.GetFileName( file )}:  does not match terrain resolution " );
+					Log.Warning( $"Skipping {Path.GetFileName( file )}: does not match terrain resolution" );
 					continue;
 				}
 
@@ -270,6 +270,9 @@ partial class TerrainComponentWidget : ComponentEditorWidget
 
 			materialIndexOffset += 4;
 		}
+
+		if ( materialIndexOffset == 0 )
+			return;
 
 		// find top 2 contributors across all splatmaps, we dont care about the rest
 		for ( int i = 0; i < numPixels; i++ )


### PR DESCRIPTION
## Summary

Currently, if no valid splatmap is available, the process continues regardless, which causes errors (such as ‘index was out of range’)

## Implementation Details

If no splatmap is valid, i.e. materialIndexOffset = 0, then if materialIndexOffset = 0, return

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂