### PR TITLE
Support adding, editing, and removing multiple terrain materials

### DIFF
--- a/game/addons/tools/Code/Scene/Terrain/TerrainComponentWidget.Settings.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainComponentWidget.Settings.cs
@@ -68,10 +68,17 @@ partial class TerrainComponentWidget : ComponentEditorWidget
 			cloudMats.Clicked += () =>
 			{
 				var picker = AssetPicker.Create( null, AssetType.FromExtension( "tmat" ) );
-				picker.OnAssetPicked = x =>
+				picker.OnAssetPicked = assets =>
 				{
-					var material = x.First().LoadResource<TerrainMaterial>();
-					terrain.Storage.Materials.Add( material );
+					foreach ( var asset in assets )
+					{
+						var material = asset.LoadResource<TerrainMaterial>();
+						if ( terrain.Storage.Materials.Contains( material ) )
+							continue;
+
+						terrain.Storage.Materials.Add( material );
+					}
+
 					terrain.UpdateMaterialsBuffer();
 					MaterialList?.BuildItems();
 				};

--- a/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
@@ -101,10 +101,17 @@ public class TerrainEditorTool : EditorTool
 				cloudMats.Clicked += () =>
 				{
 					var picker = AssetPicker.Create( null, AssetType.FromExtension( "tmat" ) );
-					picker.OnAssetPicked = x =>
+					picker.OnAssetPicked = assets =>
 					{
-						var material = x.First().LoadResource<TerrainMaterial>();
-						terrain.Storage.Materials.Add( material );
+						foreach ( var asset in assets )
+						{
+							var material = asset.LoadResource<TerrainMaterial>();
+							if ( terrain.Storage.Materials.Contains( material ) )
+								continue;
+
+							terrain.Storage.Materials.Add( material );
+						}
+
 						terrain.UpdateMaterialsBuffer();
 						materialList?.BuildItems();
 					};

--- a/game/addons/tools/Code/Scene/Terrain/TerrainMaterialList.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainMaterialList.cs
@@ -5,6 +5,8 @@ namespace Editor.TerrainEditor;
 
 public class TerrainMaterialList : ListView
 {
+	static List<TerrainMaterialList> All = [];
+
 	Terrain Terrain;
 	Drag dragData;
 	int dragOverIndex = -1;
@@ -21,9 +23,17 @@ public class TerrainMaterialList : ListView
 		ItemAlign = Sandbox.UI.Align.FlexStart;
 		Margin = 8;
 
+		All.Add(this);
 		Terrain = terrain;
 
 		BuildItems();
+	}
+
+	public override void OnDestroyed()
+	{
+		base.OnDestroyed();
+
+		All.Remove( this );
 	}
 
 	protected override bool OnDragItem( VirtualWidget item )
@@ -147,19 +157,31 @@ public class TerrainMaterialList : ListView
 
 	private void ShowItemContext( object obj )
 	{
-		if ( obj is not TerrainMaterial entry ) return;
-
 		var m = new ContextMenu( this );
 		m.AddOption( "Open In Editor", "edit", () =>
 		{
-			var asset = AssetSystem.FindByPath( entry.ResourcePath );
-			asset?.OpenInEditor();
+			foreach ( var entry in SelectedItems )
+			{
+				if ( entry is TerrainMaterial material )
+				{
+					var asset = AssetSystem.FindByPath( material.ResourcePath );
+					asset?.OpenInEditor();
+				}
+			}
 		} );
 
 		m.AddOption( "Remove", "delete", () =>
 		{
-			Terrain.Storage.Materials.Remove( entry );
+			foreach ( var entry in SelectedItems )
+			{
+				if ( entry is TerrainMaterial material )
+				{
+					Terrain.Storage.Materials.Remove( material );
+				}
+			}
+
 			Terrain.UpdateMaterialsBuffer();
+
 			BuildItems();
 		} );
 
@@ -168,7 +190,10 @@ public class TerrainMaterialList : ListView
 
 	public void BuildItems()
 	{
-		SetItems( Terrain.Storage.Materials.Cast<object>() );
+		foreach ( var materialList in All )
+		{
+			materialList.SetItems( Terrain.Storage.Materials.Cast<object>() );
+		}
 	}
 
 	protected override void PaintItem( VirtualWidget item )


### PR DESCRIPTION
## Summary

This PR adds support for adding, editing, and removing multiple terrain materials. It also synchronizes both material lists. I also prevented the same material from being added twice.

## Implementation Details

Instead of simply taking the first element, I iterate through all elements in the list depending on the context.

For synchronization, I added the material list components to a static collection. Whenever a modification occurs, I iterate through that collection and rebuild all material lists.

To prevent duplicate materials, I check whether the material already exists before adding it.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/393b6a78-721b-436e-be60-d3b3a147bedf

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂