### PR TITLE
Bug Fix: Index out of bounds error when subSetloopEdges.Count > 0

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Mesh/PolygonMesh.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Mesh/PolygonMesh.cs
@@ -3153,6 +3153,7 @@ public sealed partial class PolygonMesh : IJsonConvert
 			int nNumSubsetLoopEdges = subSetLoopEdges.Count;
 			loopEdges.Clear();
 			loopEdges.EnsureCapacity( nNumSubsetLoopEdges );
+			index = 0;
 			for ( int iEdge = 0; iEdge < nNumSubsetLoopEdges; ++iEdge )
 			{
 				if ( !loopEdges.ContainsKey( subSetLoopEdges[iEdge] ) )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
After clearing the loop edges when trying to select edge loops with multiple edges selected, the index count was not reset before adding remaining edges to the edge loop dictionary. This would cause index out of bounds exceptions in certain scenarios, such as trying to select edge loops from a selected edge ring.
<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

## Motivation & Context
To ensure the mesh editor tools function well.
<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->


## Implementation Details
Just reset the index after clearing the loop edges dict.
<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂