### PR TITLE
Bulk create prefabs when dragging multiple GameObjects into Asset Browser

### DIFF
--- a/game/addons/tools/Code/Editor/AssetList/AssetList.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.cs
@@ -746,24 +746,32 @@ public partial class AssetList : ListView, AssetSystem.IEventListener
 	private void OnDropGameObject( DragEvent ev )
 	{
 		if ( Browser?.CurrentLocation == null ) return;
-		if ( ev.Data.Object is not GameObject[] gos || gos.Length != 1 ) return;
+		if ( ev.Data.Object is not GameObject[] gos ) return;
 
-		var target = gos[0];
-		var location = Path.Combine( Browser.CurrentLocation.Path, $"{target.Name}.prefab" );
+		bool assetListRequiresRefresh = false;
 
-		if ( AssetSystem.FindByPath( location ) != null )
+		foreach ( GameObject target in gos )
 		{
-			Log.Warning( "A prefab already exists at " + location );
-			return;
+			var location = Path.Combine( Browser.CurrentLocation.Path, $"{target.Name}.prefab" );
+
+			if ( AssetSystem.FindByPath( location ) != null )
+			{
+				Log.Warning( "A prefab already exists at " + location );
+				continue;
+			}
+
+			var session = SceneEditorSession.Resolve( target );
+			using var scene = session.Scene.Push();
+			using ( session.UndoScope( "Convert GameObject To Prefab" ).WithGameObjectChanges( target, GameObjectUndoFlags.All ).Push() )
+			{
+				EditorUtility.Prefabs.ConvertGameObjectToPrefab( target, location );
+				EditorUtility.InspectorObject = target;
+			}
+
+			assetListRequiresRefresh = true;
 		}
 
-		var session = SceneEditorSession.Resolve( target );
-		using var scene = session.Scene.Push();
-		using ( session.UndoScope( "Convert GameObject To Prefab" ).WithGameObjectChanges( target, GameObjectUndoFlags.All ).Push() )
-		{
-			EditorUtility.Prefabs.ConvertGameObjectToPrefab( target, location );
-			EditorUtility.InspectorObject = target;
-		}
+		if ( !assetListRequiresRefresh ) return;
 
 		Refresh();
 	}


### PR DESCRIPTION
## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

A small quality of life feature that lets you create multiple prefabs by dragging multiple GameObjects.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

I've noticed that we can only create one prefab at a time by dragging GameObjects into Asset Browser window. I sometimes find myself setting up multiple GameObjects at a time before converting them into prefabs. 

This is one of the QoL features that's present in other engines so I thought it would be nice to have it here as well.

## Implementation Details

- There was an explicit check that returned early if you dragged multiple GameObjects. I simply got rid of that check and iterated list in a loop where I created a prefab and registered Undo/Redo separately.
- I've also made sure that we refresh the list only once and only when there's at least one successful prefab creation from dragging.

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

https://github.com/user-attachments/assets/8e80fcff-d6e1-4219-b154-3d4943b8844e

Undo works as well.

https://github.com/user-attachments/assets/404a5cc7-0018-4c28-9aea-9fc34a701215

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂