### PR TITLE
Don't show viewport context menu if the camera has moved

### DIFF
--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
@@ -130,6 +130,7 @@ public partial class SceneViewportWidget : Widget
 	bool mouseWasPressed = false;
 	int framesAfterRelease = 0;
 	Vector2 initialMousePosition = Vector2.Zero;
+	Vector3 initialCameraPosition = Vector3.Zero;
 
 	/// <summary>
 	/// When the mouse is pressed, don't change the input enabled state
@@ -328,6 +329,7 @@ public partial class SceneViewportWidget : Widget
 		if ( e.Button == MouseButtons.Right )
 		{
 			initialMousePosition = e.LocalPosition;
+			initialCameraPosition = cameraTargetPosition ?? GizmoInstance.GetValue<Vector3?>( "CameraTarget" ) ?? _activeCamera.WorldPosition;
 		}
 	}
 
@@ -414,7 +416,8 @@ public partial class SceneViewportWidget : Widget
 
 		// Unity does a 6 pixel deadzone to trigger the context menu
 		if ( e.KeyboardModifiers == KeyboardModifiers.None && e.Button == MouseButtons.Right &&
-			 Vector2.DistanceBetween( initialMousePosition, e.LocalPosition ) < 6 )
+			 Vector2.DistanceBetween( initialMousePosition, e.LocalPosition ) < 6 &&
+			 initialCameraPosition == (cameraTargetPosition ?? GizmoInstance.GetValue<Vector3?>( "CameraTarget" ) ?? _activeCamera.WorldPosition) )
 		{
 			var menu = new ContextMenu( this ) { Searchable = true };
 			bool HasSelection = Session.Selection.OfType<GameObject>().Any();


### PR DESCRIPTION
## Summary
Previously if the camera was moved positionally but not rotated while holding right click the context menu would still appear.

## Motivation & Context
Annoyed me, shows up a lot when making small movements.

## Implementation Details
Tries to check against the target position rather than the current (smoothed) position, so that the menu is only disabled if the user has actually pressed the movement keys.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/7c0071f2-4f07-41dd-9c92-fce37c411910

(previously the menu would be created each time right click is released in this video despite the camera being moved)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂