### PR TITLE
[Linux] Add SubFileSystem resolve sub paths case-insensitively; update Zio to latest version

### DIFF
--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -321,7 +321,7 @@ public class BaseFileSystem
 	{
 		// Log.Trace( $"CreateFileSystem( {path} ) [{GetFullPath(path)}]" );
 
-		var sub = new Zio.FileSystems.SubFileSystem( system, FixPath( path ), false );
+		var sub = new Zio.FileSystems.SubFileSystem( system, FixPath( path ), false, false );
 		return new BaseFileSystem( sub );
 	}
 

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -222,7 +222,7 @@ public class BaseFileSystem
 	internal string GetRelativePath( string path )
 	{
 		if ( string.IsNullOrWhiteSpace( path ) ) return null;
-		return GetRelativePath( system, path.ToLowerInvariant() );
+		return GetRelativePath( system, path )?.ToLowerInvariant();
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Filesystem/Sandbox.Filesystem.csproj
+++ b/engine/Sandbox.Filesystem/Sandbox.Filesystem.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Sandbox.Generator\Sandbox.Generator.csproj" />
     <ProjectReference Include="..\Sandbox.System\Sandbox.System.csproj" />
-    <PackageReference Include="Zio" Version="0.22.2" />
+    <PackageReference Include="Zio" Version="0.23.0" />
   </ItemGroup>
   
 </Project>

--- a/engine/Sandbox.Test/Filesystem/FileSystem.cs
+++ b/engine/Sandbox.Test/Filesystem/FileSystem.cs
@@ -280,4 +280,52 @@ public partial class FileSystem
 		var data = Sandbox.EngineFileSystem.Root.ReadAllBytes( "Addons/Green/green.txt" );
 		Assert.AreNotEqual( 0, data.Length );
 	}
+
+	[TestMethod]
+	public void GetRelativePathCaseInsensitive()
+	{
+		// GetRelativePath lowercases the physical path before calling ConvertPathFromInternal.
+		// SubFileSystem(isCaseSensitive:false) is required so the base prefix "/Addons/Red"
+		// is stripped from the lowercased input "/addons/red/red.txt" without throwing.
+		var sub = Sandbox.EngineFileSystem.Root.CreateSubSystem( "Addons/Red" );
+		var fullPath = Sandbox.EngineFileSystem.Root.GetFullPath( "Addons/Red/red.txt" );
+
+		var relative = sub.GetRelativePath( fullPath );
+
+		Assert.AreEqual( "/red.txt", relative );
+	}
+
+	[TestMethod]
+	public void SubFileSystemCaseInsensitivePath()
+	{
+		// SubFileSystem is created with isCaseSensitive=false so the subpath prefix is stripped
+		// case-insensitively. Without this, on Linux the physical FS resolves to actual disk
+		// casing (e.g. /Addons/Red/…) but the SubFileSystem base was /addons/red, causing
+		// ConvertPathFromDelegate to fail with an ordinal compare.
+		var sub = Sandbox.EngineFileSystem.Root.CreateSubSystem( "addons/red" );
+
+		Assert.IsTrue( sub.FileExists( "red.txt" ) );
+		Assert.IsTrue( sub.FileExists( "common.txt" ) );
+		Assert.AreEqual( "Red", sub.ReadAllText( "red.txt" ) );
+		Assert.AreEqual( 2, sub.FindFile( "/", "*", false ).Count() );
+	}
+
+	[TestMethod]
+	public void MountedFoldersCaseInsensitivePaths()
+	{
+		var fs = new Sandbox.AggregateFileSystem();
+
+		fs.CreateAndMount( Sandbox.EngineFileSystem.Root, "addons/blue" );
+		fs.CreateAndMount( Sandbox.EngineFileSystem.Root, "addons/red" );
+		fs.CreateAndMount( Sandbox.EngineFileSystem.Root, "addons/green" );
+
+		Assert.IsTrue( fs.FileExists( "red.txt" ) );
+		Assert.IsTrue( fs.FileExists( "green.txt" ) );
+		Assert.IsTrue( fs.FileExists( "blue.txt" ) );
+
+		Assert.AreEqual( "Red", fs.ReadAllText( "red.txt" ) );
+		Assert.AreEqual( "Green", fs.ReadAllText( "green.txt" ) );
+		Assert.AreEqual( "Blue", fs.ReadAllText( "blue.txt" ) );
+		Assert.AreEqual( "Green", fs.ReadAllText( "common.txt" ) );
+	}
 }

--- a/engine/Sandbox.Test/Filesystem/Watch.cs
+++ b/engine/Sandbox.Test/Filesystem/Watch.cs
@@ -146,4 +146,48 @@ public partial class FileSystem
 			Assert.IsTrue( detectedChanges, "Callbacks should have been triggered now" );
 		}
 	}
+
+	[TestMethod]
+	public async Task WatchMountedCaseInsensitivePath()
+	{
+		var fs = new Sandbox.AggregateFileSystem();
+		fs.UnMountAll();
+
+		// Wrong-case mount paths: SubFileSystem(isCaseSensitive:false) must strip the base
+		// prefix case-insensitively when routing physical change events back to virtual paths,
+		// otherwise the watcher silently drops events on Linux.
+		fs.CreateAndMount( Sandbox.EngineFileSystem.Root, "addons/blue" );
+
+		Sandbox.EngineFileSystem.Root.CreateDirectory( "Addons/Blue/UI" );
+		System.IO.File.WriteAllText( Sandbox.EngineFileSystem.Root.GetFullPath( "Addons/Blue/UI/hello.txt" ), "initial" );
+
+		using ( var watcher = fs.Watch( "/UI/hello.txt" ) )
+		{
+			bool detectedChanges = false;
+
+			watcher.OnChanges += w =>
+			{
+				Console.WriteLine( $"{string.Join( ",", w.Changes )} has changes" );
+				detectedChanges = true;
+			};
+
+			await Task.Delay( 200 );
+
+			Assert.IsFalse( detectedChanges, "No changes made yet - should be false" );
+
+			Sandbox.FileWatch.Tick();
+
+			Assert.IsFalse( detectedChanges, "No changes made yet - should be false" );
+
+			System.IO.File.WriteAllText( Sandbox.EngineFileSystem.Root.GetFullPath( "Addons/Blue/UI/hello.txt" ), "changed" );
+
+			await Task.Delay( 2000 );
+
+			Assert.IsFalse( detectedChanges, "Not triggered yet - should be false" );
+
+			Sandbox.FileWatch.Tick();
+
+			Assert.IsTrue( detectedChanges, "Callbacks should have been triggered now" );
+		}
+	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

https://github.com/xoofx/zio/pull/106
I submitted a PR to Zio so that SubFileSystem objects can take a fourth argument to set case sensitivity comparison to false. It is approved and Zio has been updated to 0.23.0.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Instead of doing something like:
<img width="893" height="386" alt="Screenshot_From_2026-05-31_23-36-43" src="https://github.com/user-attachments/assets/78ed8603-6e89-4289-9612-67c5952f0921" />

We can instead do:
<img width="584" height="167" alt="Screenshot 2026-06-08 072611" src="https://github.com/user-attachments/assets/e967050d-1d8d-40b7-ae36-16708d1eedf7" />

We no longer need a whole new inherited class to handle when the subpath differs in casing from resolved paths in the delegate. Plus Windows is already case-insensitive so it's a bonus that we don't need separate operations to handle the filesystem anymore for this.

## Implementation Details

See Zio release 0.23.0 for updates to the library.

* Update Zio
* Set SubFileSystem case-insensitive : `new SubFileSystem( system, path, false )` -> `new SubFileSystem( system, path, false, false )`
* Fix `GetRelativePath` normalizing lowercase physical paths, and instead returning them after they are resolved.

### Needs Review
I added a Unit Test for `GetRelativePath()`. I found out it was casting the entire physical path ToLowerInvariant() internally, which causes ConvertPathFromDelegate() to strip the entire physical path, and an ordinal compare throws an error on it. So `GetRelativePath` now just casts `ToLowerInvariant()` after it's made its trip through `ConvertPathFromDelegate.` See review.

## Added Unit Tests
* `GetRelativePathCaseInsensitive()` - `GetRelativePath` lowercases the physical path before calling `ConvertPathFromInternal`, so `isCaseSensitive=false` is required so base prefix is stripped from lowercases input without throwing.
* `SubFileSystemCaseInsensitivePath()` - `SubFileSystem` sub paths have their prefix's stripped, so they need to be resolved-case-insensitively.
* `MountedFoldersCaseInsensitivePaths()` - Same thing but with multiple paths being tested on an `AggregateFileSystem`.
* `WatchMountedCaseInsensitivePath()` - Tests to make sure watcher events do not silently drop on Linux when the stripped prefix do not match the physical.

## Screenshots / Videos (if applicable)

Fixing the subpath stops this menu.maps stuff from happening and prevents SubFileSystem from throwing an error.
<img width="1606" height="356" alt="Screenshot_From_2026-06-01_02-11-55" src="https://github.com/user-attachments/assets/8526cb52-3248-4bdf-9975-a94c9b2bb993" />

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂