### PR TITLE
Added a way to restore grounding : PlayerController.RestoreGrounding()

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Ground.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Ground.cs
@@ -49,6 +49,14 @@ public sealed partial class PlayerController : Component
 	}
 
 	/// <summary>
+	/// Restores grounding, meant to be called during PreventGrounding( float seconds )
+	/// </summary>
+	public void RestoreGrounding()
+	{
+		_timeUntilAllowedGround = 0;
+	}
+
+	/// <summary>
 	/// Lift player up and place a skin level above the ground
 	/// </summary>
 	internal void Reground( float stepSize )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Added a way to restore grounding, during the time period in which PlayerController.PreventGrounding( float seconds ) is active.
The function is called PlayerController.RestoreGrounding().

## Motivation & Context

I needed this in order to restore grounding after an event (collision in my case).

## Implementation Details

## Screenshots / Videos (if applicable)

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂