### PR TITLE
[Linux] Fix Project sub path mismatch; resolve prefixes through LocalFileSystem in Sandbox.Engine

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -362,7 +362,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		if ( IsExplosive && damage.Tags.Contains( "impact" ) )
 		{
 			Health = 0;
-			Kill();
+			Kill( damage );
 			return;
 		}
 
@@ -386,7 +386,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 
 		if ( Health <= 0 )
 		{
-			Kill();
+			Kill( damage );
 			Health = 0;
 		}
 	}
@@ -428,19 +428,20 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		}
 	}
 
-	public void Kill()
+	public void Kill( DamageInfo damage = null )
 	{
-		OnBreak();
+		OnBreak( damage );
 		GameObject.Destroy();
 	}
 
-	void OnBreak()
+	void OnBreak( DamageInfo damage = null )
 	{
 		OnPropBreak?.Invoke();
 
 		PlayBreakSound();
 
-		NetworkCreateGibs();
+		var wasImpact = damage?.Tags.Contains( "impact" ) ?? false;
+		NetworkCreateGibs( wasImpact );
 
 		CreateExplosion();
 	}
@@ -512,15 +513,15 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 	/// Create the gibs for this prop breaking, over the network. This causes clients to spawn the gibs too.
 	/// </summary>
 	[Rpc.Broadcast( NetFlags.OwnerOnly )]
-	public void NetworkCreateGibs()
+	public void NetworkCreateGibs( bool wasImpact = false )
 	{
-		CreateGibs();
+		CreateGibs( wasImpact );
 	}
 
 	/// <summary>
 	/// Create the gibs and return them.
 	/// </summary>
-	public List<Gib> CreateGibs()
+	public List<Gib> CreateGibs( bool wasImpact = false )
 	{
 		var gibs = new List<Gib>();
 
@@ -594,19 +595,28 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		// Transfer velocity from us to the gibs.
 		if ( rb.IsValid() )
 		{
+			// If the prop was thrown on the floor or a wall when broken, we want the gibs to inherit the velocity from before that impact
+			// that way they crash into the floor/wall nicely and stuff.
+			// HOWEVER, we don't want this for anything else
+			// else we'd be stomping whatever changes people might be wanting to make to the velocity themselves.
+			var linVel = wasImpact ? rb.PreVelocity : rb.Velocity;
+			var angVel = wasImpact ? rb.PreAngularVelocity : rb.AngularVelocity;
 			foreach ( var gib in gibs )
 			{
 				var phys = gib.Components.Get<Rigidbody>( true );
 				if ( !phys.IsValid() ) continue;
 
 				// Compute linear velocity at the gibs spawn point.
-				var velocity = rb.PreVelocity + Vector3.Cross( rb.PreAngularVelocity, phys.MassCenter - rb.MassCenter );
+				var velocity = linVel + Vector3.Cross( angVel, phys.MassCenter - rb.MassCenter );
 
-				// Apply 50% energy loss.
-				velocity *= 0.5f;
+				if ( wasImpact )
+				{
+					// Apply 50% energy loss from surface impact.
+					velocity *= 0.5f;
+				}
 
 				phys.Velocity = velocity;
-				phys.AngularVelocity = rb.PreAngularVelocity;
+				phys.AngularVelocity = angVel;
 			}
 		}
 

--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.cs
@@ -17,7 +17,7 @@ public sealed partial class Project
 	internal object ProjectSourceObject { get; set; }
 
 	/// <summary>
-	/// Absolute path to the .addon file
+	/// Absolute path to the .sbproj file
 	/// </summary>
 	[JsonPropertyName( "Path" )]
 	public string ConfigFilePath { get; set; }
@@ -94,6 +94,11 @@ public sealed partial class Project
 	internal Action OnSaveProject { get; set; }
 
 	/// <summary>
+	/// A filesystem for sandbox projects
+	/// </summary>
+	internal LocalFileSystem ProjectFileSystem { get; set; }
+
+	/// <summary>
 	/// A filesystem into which compiled assemblies are written
 	/// </summary>
 	[JsonIgnore]
@@ -113,6 +118,8 @@ public sealed partial class Project
 		EditorCompiler = null;
 
 		AssemblyFileSystem?.Dispose();
+
+		ProjectFileSystem?.Dispose();
 	}
 
 	internal bool LoadMinimal()
@@ -130,6 +137,8 @@ public sealed partial class Project
 				// Turn Path from myproject/ into myproject/.sbproj
 				ConfigFilePath = System.IO.Path.Combine( RootDirectory.FullName, ".sbproj" );
 			}
+
+			ProjectFileSystem = new LocalFileSystem( RootDirectory.FullName );
 
 			var text = File.ReadAllText( ConfigFilePath );
 			Config = JsonSerializer.Deserialize<DataModel.ProjectConfig>( text );
@@ -167,49 +176,49 @@ public sealed partial class Project
 	/// <summary>
 	/// Absolute path to the location of the <c>.sbproj</c> file of the project.
 	/// </summary>
-	public string GetRootPath() => RootDirectory.FullName;
+	public string GetRootPath() => ProjectFileSystem?.GetFullPath( "/" );
 
 	/// <summary>
 	/// Gets the .sbproj file for this project
 	/// </summary>
 	/// <returns></returns>
-	public string GetProjectPath() => System.IO.Directory.EnumerateFiles( GetRootPath(), "*.sbproj" ).FirstOrDefault();
+	public string GetProjectPath() => ProjectFileSystem?.FindFile( "/", "*.sbproj" ).FirstOrDefault();
 
 	/// <summary>
 	/// Absolute path to the Code folder of the project.
 	/// </summary>
-	public string GetCodePath() => System.IO.Path.Combine( RootDirectory.FullName, "Code" );
+	public string GetCodePath() => ProjectFileSystem?.GetFullPath( "Code" );
 
 	/// <summary>
 	/// Returns true if the Code path exists
 	/// </summary>
-	public bool HasCodePath() => RootDirectory is not null && System.IO.Directory.Exists( GetCodePath() );
+	public bool HasCodePath() => System.IO.Directory.Exists( GetCodePath() );
 
 	/// <summary>
 	/// Absolute path to the Editor folder of the project.
 	/// </summary>
-	public string GetEditorPath() => System.IO.Path.Combine( RootDirectory.FullName, "Editor" );
+	public string GetEditorPath() => ProjectFileSystem?.GetFullPath( "Editor" );
 
 	/// <summary>
 	/// Returns true if the Editor path exists
 	/// </summary>
-	public bool HasEditorPath() => RootDirectory is not null && System.IO.Directory.Exists( GetEditorPath() );
+	public bool HasEditorPath() => System.IO.Directory.Exists( GetEditorPath() );
 
 	/// <summary>
 	/// Absolute path to the Assets folder of the project, or <see langword="null"/> if not set.
 	/// </summary>
-	public string GetAssetsPath() => System.IO.Path.Combine( RootDirectory.FullName, "Assets" );
+	public string GetAssetsPath() => ProjectFileSystem?.GetFullPath( "Assets" );
 
 	/// <summary>
 	/// Absolute path to the Localization folder of the project, or <see langword="null"/> if not set.
 	/// </summary>
 	/// <returns></returns>
-	public string GetLocalizationPath() => System.IO.Path.Combine( RootDirectory.FullName, "Localization" );
+	public string GetLocalizationPath() => ProjectFileSystem?.GetFullPath( "Localization" );
 
 	/// <summary>
 	/// Returns true if the Assets path exists
 	/// </summary>
-	public bool HasAssetsPath() => RootDirectory is not null && System.IO.Directory.Exists( GetAssetsPath() );
+	public bool HasAssetsPath() => System.IO.Directory.Exists( GetAssetsPath() );
 
 	internal void Save()
 	{

--- a/engine/Sandbox.Test/Project/Project.cs
+++ b/engine/Sandbox.Test/Project/Project.cs
@@ -36,6 +36,66 @@ public class ProjectTests
 	}
 
 	/// <summary>
+	/// GetRootPath returns a non-null absolute path
+	/// </summary>
+	[TestMethod]
+	public void GetRootPathIsAbsolute()
+	{
+		var project = Project.AddFromFile( "unittest/addons/testmap/.sbproj" );
+		var rootPath = project.GetRootPath();
+
+		Assert.IsNotNull( rootPath );
+		Assert.IsTrue( System.IO.Path.IsPathRooted( rootPath ) );
+	}
+
+	/// <summary>
+	/// Get*Path returns paths rooted under the project root
+	/// </summary>
+	[TestMethod]
+	public void GetPathsAreRootedUnderProject()
+	{
+		var project = Project.AddFromFile( "unittest/addons/testmap/.sbproj" );
+		var rootPath = project.GetRootPath();
+
+		Assert.IsTrue( project.GetCodePath().StartsWith( rootPath ) );
+		Assert.IsTrue( project.GetAssetsPath().StartsWith( rootPath ) );
+		Assert.IsTrue( project.GetEditorPath().StartsWith( rootPath ) );
+		Assert.IsTrue( project.GetLocalizationPath().StartsWith( rootPath ) );
+	}
+
+	/// <summary>
+	/// GetProjectPath finds the .sbproj file via the ProjectFileSystem
+	/// </summary>
+	[TestMethod]
+	public void GetProjectPathFindsSbproj()
+	{
+		var project = Project.AddFromFile( "unittest/addons/testmap/.sbproj" );
+		var projectPath = project.GetProjectPath();
+
+		// Check .sbproj as ending and as full filename
+		Assert.IsNotNull( projectPath );
+		Assert.IsTrue( projectPath.EndsWith( ".sbproj" ) );
+		Assert.AreEqual( ".sbproj", System.IO.Path.GetFileName( projectPath ) ); 
+	}
+
+	/// <summary>
+	/// Has*Path returns correct existence based on which folders are present
+	/// </summary>
+	[TestMethod]
+	public void HasPathReflectsActualFolders()
+	{
+		var project = Project.AddFromFile( "addons/base/.sbproj" );
+
+		// at the time of writing this, /base/code is lowercase, so a CIPFS
+		// test on Linux can do an existence check and should pass even when
+		// asking for /base/Code instead.
+
+		Assert.IsTrue( project.HasAssetsPath() );
+		Assert.IsTrue( project.HasCodePath() );
+		Assert.IsFalse( project.HasEditorPath() );
+	}
+
+	/// <summary>
 	/// Find and load a local package
 	/// </summary>
 	[TestMethod]

--- a/engine/Sandbox.Test/Project/Project.cs
+++ b/engine/Sandbox.Test/Project/Project.cs
@@ -75,7 +75,7 @@ public class ProjectTests
 		// Check .sbproj as ending and as full filename
 		Assert.IsNotNull( projectPath );
 		Assert.IsTrue( projectPath.EndsWith( ".sbproj" ) );
-		Assert.AreEqual( ".sbproj", System.IO.Path.GetFileName( projectPath ) ); 
+		Assert.AreEqual( ".sbproj", System.IO.Path.GetFileName( projectPath ) );
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Engine project paths we're relying on system path combines to find Assets, Code, Editor, and Localization sub paths. Since Zio can resolve case-insensitively on Linux and Windows, this just extends that to Project filesystems by having those paths using a LocalFileSystem object instead.

Reopen of https://github.com/Facepunch/sbox-public/pull/11062 to clean up ugly commit states

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Extends filesystem support to Linux systems for launching the game. Sub paths can be resolved case-insensitively, but Project File Systems don't take advantage of it yet.

## Implementation Details

* Add global internal `ProjectFileSystem` field, assigned `LocalFileSystem` with `RootDirectory` path in `LoadMinimal()`
* `Get*Path()` operators resolve full and subpaths with LocalFileSystem.
* Added Unit Tests

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂