### PR TITLE
Max Payne 2 mount

### DIFF
--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Assembly.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Assembly.cs
@@ -1,0 +1,6 @@
+global using Sandbox;
+global using Sandbox.Mounting;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
+global using System.Threading.Tasks;

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Kf2File.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Kf2File.cs
@@ -1,0 +1,524 @@
+using Sandbox;
+using System;
+using System.Collections.Generic;
+
+namespace RasLib;
+
+// Minimal KF2 reader: meshes + materials + texture file names. Animations/lights/skin skipped.
+public class Kf2File
+{
+	const uint ChunkTag = 0x0C;
+	const uint Node = 0x00010000;
+	const uint Camera = 0x00010001;
+	const uint Mesh = 0x00010005;
+	const uint Geometry = 0x00010006;
+	const uint Polygons = 0x00010007;
+	const uint Polygon = 0x00010008;
+	const uint Smoothing = 0x0001000B;
+	const uint PolygonMaterial = 0x0001000C;
+	const uint UvMapping = 0x0001000E;
+	const uint MaterialList = 0x0001000F;
+	const uint Material = 0x00010010;
+	const uint Texture = 0x00010011;
+	const uint KeyframeAnimation = 0x00010012;
+	const uint AnimationChunk = 0x00010013;
+	const uint SkinChunk = 0x00010014;
+	const uint ReferenceToData = 0x0001001A;
+
+	public class Primitive
+	{
+		public Vector3[] Positions;
+		public Vector3[] Normals;
+		public Vector2[] Uvs;
+		public int[] Indices;
+		public string MaterialName;
+		public string NodeName;
+		public int VertexStart;
+	}
+
+	public class SkinData
+	{
+		public string[] BoneNames;
+		public int[] Offsets;
+		public int[] Counts;
+		public int[] BoneIndices;
+		public float[] Weights;
+	}
+
+	public class MeshNode
+	{
+		public string Name;
+		public string Parent;
+		public bool HasParent;
+		public Mat43 Local;
+	}
+
+	public class NodeAnim
+	{
+		public string NodeName;
+		public string ParentName;
+		public float Fps;
+		public bool Looping;
+		public int TotalFrames;
+		public List<(int Frame, Mat43 Local)> Keys = [];
+	}
+
+	public class MaterialDef
+	{
+		public string Name;
+		public string DiffuseTexture;
+		public bool TwoSided;
+	}
+
+	public List<Primitive> Primitives { get; } = [];
+	public List<MeshNode> Nodes { get; } = [];
+	public List<NodeAnim> Animations { get; } = [];
+	public Dictionary<string, MaterialDef> Materials { get; } = new( StringComparer.OrdinalIgnoreCase );
+	public string TextureDirs { get; private set; }
+	public SkinData Skin { get; private set; }
+
+	readonly Dictionary<string, MeshNode> _nodesByName = new( StringComparer.OrdinalIgnoreCase );
+	readonly List<(MeshNode Node, int Start, int Count)> _meshRanges = [];
+	readonly MaxReader _r;
+
+	Kf2File( byte[] data )
+	{
+		_r = new MaxReader( data );
+	}
+
+	public static Kf2File Parse( byte[] data )
+	{
+		var kf2 = new Kf2File( data );
+		kf2.ReadTopLevel();
+		kf2.BakeNodeTransforms();
+		return kf2;
+	}
+
+	void ReadTopLevel()
+	{
+		while ( !_r.Eof )
+		{
+			var start = _r.Position;
+			if ( !TryReadHeader( out var id, out var version, out var size, out _ ) )
+				return;
+
+			switch ( id )
+			{
+				case Mesh: ReadMesh(); break;
+				case MaterialList: ReadMaterialList(); break;
+				case KeyframeAnimation: ReadKeyframeAnimation( version ); break;
+				case SkinChunk when version == 1: ReadSkin(); break;
+				default:
+					// chunk size includes the 13-byte header (NODE is the lone liar; never skipped here)
+					_r.Position = start + (int)size;
+					if ( !_r.Eof && _r.Peek != ChunkTag ) return;
+					break;
+			}
+		}
+	}
+
+	void BakeNodeTransforms()
+	{
+		foreach ( var (node, start, count) in _meshRanges )
+		{
+			var world = WorldOf( node );
+			for ( var p = start; p < start + count; p++ )
+			{
+				var prim = Primitives[p];
+				for ( var i = 0; i < prim.Positions.Length; i++ )
+					prim.Positions[i] = world.Point( prim.Positions[i] );
+
+				if ( prim.Normals is null )
+					continue;
+
+				for ( var i = 0; i < prim.Normals.Length; i++ )
+					prim.Normals[i] = world.Direction( prim.Normals[i] ).Normal;
+			}
+		}
+	}
+
+	public MeshNode FindNode( string name )
+		=> !string.IsNullOrEmpty( name ) && _nodesByName.TryGetValue( name, out var node ) ? node : null;
+
+	public Mat43 WorldOf( MeshNode node ) => WorldOf( node, 0 );
+
+	Mat43 WorldOf( MeshNode node, int depth )
+	{
+		if ( !node.HasParent || depth > 32 || string.IsNullOrEmpty( node.Parent ) || !_nodesByName.TryGetValue( node.Parent, out var parent ) )
+			return node.Local;
+
+		return node.Local.Then( WorldOf( parent, depth + 1 ) );
+	}
+
+	bool TryReadHeader( out uint id, out uint version, out uint size, out int payloadStart )
+	{
+		id = 0; version = 0; size = 0; payloadStart = 0;
+		if ( _r.Position + 13 > _r.Length ) return false;
+		if ( _r.RawByte() != ChunkTag ) { _r.Position--; return false; }
+		id = _r.RawUInt32();
+		version = _r.RawUInt32();
+		size = _r.RawUInt32();
+		payloadStart = _r.Position;
+		return true;
+	}
+
+	void ReadMesh()
+	{
+		Vector3[] verts = null, normals = null;
+		int[] vertsPerPrim = null;
+		ushort[] localIndices = null;
+		int[] trisPerPrim = null;
+		string[] materialNames = null;
+		Vector2[] uvs = null;
+		MeshNode node = null;
+		var primStart = Primitives.Count;
+		var done = false;
+
+		while ( !_r.Eof && !done )
+		{
+			var save = _r.Position;
+			if ( !TryReadHeader( out var id, out var version, out var size, out _ ) )
+				break;
+
+			switch ( id )
+			{
+				case Node:
+					node = ReadNode( version );
+					break;
+				case Geometry:
+					ReadGeometry( version, out verts, out normals, out vertsPerPrim );
+					break;
+				case Polygons:
+					ReadPolygons( version, out localIndices, out trisPerPrim );
+					break;
+				case PolygonMaterial:
+					ReadPolygonMaterial( version, out materialNames );
+					break;
+				case UvMapping:
+					ReadUvMapping( version, out var layerUvs, out var layer );
+					if ( layer == 0 ) uvs = layerUvs;
+					break;
+				case Smoothing:
+				case ReferenceToData:
+					_r.Position = save + (int)size;
+					break;
+				default:
+					_r.Position = save;
+					done = true;
+					break;
+			}
+		}
+
+		BuildPrimitives( verts, normals, uvs, vertsPerPrim, localIndices, trisPerPrim, materialNames );
+
+		if ( node is null )
+			return;
+
+		_nodesByName[node.Name] = node;
+		Nodes.Add( node );
+
+		if ( Primitives.Count > primStart )
+		{
+			_meshRanges.Add( (node, primStart, Primitives.Count - primStart) );
+			for ( var p = primStart; p < Primitives.Count; p++ )
+				Primitives[p].NodeName = node.Name;
+		}
+	}
+
+	MeshNode ReadNode( uint version )
+	{
+		var node = new MeshNode { Name = _r.String(), Parent = _r.String() };
+		node.Local = _r.Matrix4x3();
+		node.HasParent = _r.Bool();
+		if ( version > 0 ) _r.String(); // userDefinedString
+		return node;
+	}
+
+	// v1: eight arrays, each prefixed by 1 raw byte + typed count
+	void ReadSkin()
+	{
+		string[] StrArray()
+		{
+			_r.Skip( 1 );
+			var n = _r.Int();
+			var a = new string[n];
+			for ( var i = 0; i < n; i++ ) a[i] = _r.String();
+			return a;
+		}
+
+		int[] IntArray()
+		{
+			_r.Skip( 1 );
+			var n = _r.Int();
+			var a = new int[n];
+			for ( var i = 0; i < n; i++ ) a[i] = _r.Int();
+			return a;
+		}
+
+		float[] FloatArray()
+		{
+			_r.Skip( 1 );
+			var n = _r.Int();
+			var a = new float[n];
+			for ( var i = 0; i < n; i++ ) a[i] = _r.Float();
+			return a;
+		}
+
+		StrArray(); // skinObjectNames
+		var skin = new SkinData { BoneNames = StrArray() };
+		skin.Offsets = IntArray();
+		skin.Counts = IntArray();
+		skin.BoneIndices = IntArray();
+		skin.Weights = FloatArray();
+		IntArray(); // vertexNumPerPrimitive
+		IntArray(); // vertexStartIndexPerPrimitive
+
+		Skin = skin;
+	}
+
+	void ReadKeyframeAnimation( uint version )
+	{
+		if ( !TryReadHeader( out var id, out _, out _, out _ ) || id != AnimationChunk )
+			return;
+
+		var anim = new NodeAnim { NodeName = _r.String(), Fps = _r.Int() };
+		anim.Looping = _r.Bool();
+
+		// keys are local to THIS parent, which can differ from the skeleton hierarchy
+		anim.ParentName = _r.String();
+		_r.Bool(); // useLoopInterpolation
+
+		var totalFrames = _r.Int();
+		if ( version < 5 ) totalFrames++;
+		anim.TotalFrames = totalFrames;
+
+		var numKeys = _r.Int();
+		for ( var i = 0; i < numKeys; i++ )
+		{
+			var frame = _r.Int();
+			anim.Keys.Add( (frame, _r.Matrix4x3()) );
+		}
+
+		if ( version >= 1 )
+		{
+			var numVis = _r.Int();
+			for ( var i = 0; i < numVis; i++ ) { _r.Int(); _r.Float(); }
+		}
+
+		if ( version >= 2 ) _r.Int(); // loopToFrame
+		if ( version >= 3 ) _r.Int(); // interpolationMethod
+		if ( version >= 4 ) _r.Bool(); // maintainMatrixScaling
+
+		Animations.Add( anim );
+	}
+
+	void ReadGeometry( uint version, out Vector3[] verts, out Vector3[] normals, out int[] vertsPerPrim )
+	{
+		var numVertices = _r.Int();
+		verts = new Vector3[numVertices];
+		normals = null;
+
+		if ( version == 0 )
+		{
+			for ( var i = 0; i < numVertices; i++ ) verts[i] = _r.Vector3();
+			vertsPerPrim = [numVertices];
+			return;
+		}
+
+		var posFloats = _r.RawFloats( numVertices * 3 );
+		for ( var i = 0; i < numVertices; i++ )
+			verts[i] = new Vector3( posFloats[i * 3], posFloats[i * 3 + 1], posFloats[i * 3 + 2] );
+
+		var normFloats = _r.RawFloats( numVertices * 3 );
+		normals = new Vector3[numVertices];
+		for ( var i = 0; i < numVertices; i++ )
+			normals[i] = new Vector3( normFloats[i * 3], normFloats[i * 3 + 1], normFloats[i * 3 + 2] );
+
+		var numPrimitives = _r.Int();
+		vertsPerPrim = new int[numPrimitives];
+		for ( var i = 0; i < numPrimitives; i++ ) vertsPerPrim[i] = _r.Int();
+	}
+
+	void ReadPolygons( uint version, out ushort[] indices, out int[] trisPerPrim )
+	{
+		if ( version == 0 )
+		{
+			indices = [];
+			trisPerPrim = [];
+			throw new Exception( "KF2 mesh v1 (MP1) not supported" );
+		}
+
+		var numIndices = _r.Int();
+		indices = _r.RawUInt16s( numIndices );
+		var numPrimitives = _r.Int();
+		trisPerPrim = new int[numPrimitives];
+		for ( var i = 0; i < numPrimitives; i++ ) trisPerPrim[i] = _r.Int();
+	}
+
+	void ReadPolygonMaterial( uint version, out string[] names )
+	{
+		var numMaterials = _r.Int();
+		names = new string[numMaterials];
+		for ( var i = 0; i < numMaterials; i++ ) names[i] = _r.String();
+
+		if ( version == 0 )
+		{
+			var numPolygons = _r.Int();
+			for ( var i = 0; i < numPolygons; i++ ) _r.Int();
+		}
+	}
+
+	void ReadUvMapping( uint version, out Vector2[] uvs, out int layer )
+	{
+		layer = _r.Int();
+
+		if ( version == 0 )
+		{
+			var numPolygons = _r.Int();
+			for ( var i = 0; i < numPolygons; i++ )
+			{
+				TryReadHeader( out _, out _, out _, out _ );
+				var numVerts = _r.Int();
+				for ( var j = 0; j < numVerts; j++ ) _r.Int();
+			}
+			_r.SkipTyped();
+			_r.SkipTyped();
+		}
+
+		var numCoordinates = _r.Int();
+		uvs = new Vector2[numCoordinates];
+
+		if ( version == 0 )
+		{
+			for ( var i = 0; i < numCoordinates; i++ )
+			{
+				var v = _r.Vector3();
+				uvs[i] = new Vector2( v.x, v.y );
+			}
+			return;
+		}
+
+		var floats = _r.RawFloats( numCoordinates * 3 );
+		for ( var i = 0; i < numCoordinates; i++ )
+			uvs[i] = new Vector2( floats[i * 3], floats[i * 3 + 1] );
+
+		var numPrimitives = _r.Int();
+		for ( var i = 0; i < numPrimitives; i++ ) _r.Int();
+	}
+
+	void BuildPrimitives( Vector3[] verts, Vector3[] normals, Vector2[] uvs, int[] vertsPerPrim, ushort[] localIndices, int[] trisPerPrim, string[] materialNames )
+	{
+		if ( verts is null || localIndices is null || vertsPerPrim is null || trisPerPrim is null )
+			return;
+
+		var vertexStart = new int[vertsPerPrim.Length + 1];
+		for ( var p = 0; p < vertsPerPrim.Length; p++ )
+			vertexStart[p + 1] = vertexStart[p] + vertsPerPrim[p];
+
+		var indexCursor = 0;
+		for ( var p = 0; p < trisPerPrim.Length; p++ )
+		{
+			var count = vertsPerPrim[p];
+			var prim = new Primitive
+			{
+				Positions = new Vector3[count],
+				Normals = normals is null ? null : new Vector3[count],
+				Uvs = uvs is null ? null : new Vector2[count],
+				MaterialName = materialNames is not null && p < materialNames.Length ? materialNames[p] : null,
+				VertexStart = vertexStart[p],
+			};
+
+			Array.Copy( verts, vertexStart[p], prim.Positions, 0, count );
+			if ( prim.Normals is not null ) Array.Copy( normals, vertexStart[p], prim.Normals, 0, count );
+			if ( prim.Uvs is not null && vertexStart[p] + count <= uvs.Length ) Array.Copy( uvs, vertexStart[p], prim.Uvs, 0, count );
+
+			var tris = trisPerPrim[p];
+			prim.Indices = new int[tris * 3];
+			for ( var i = 0; i < tris * 3; i++ )
+				prim.Indices[i] = localIndices[indexCursor++];
+
+			Primitives.Add( prim );
+		}
+	}
+
+	void ReadMaterialList()
+	{
+		TextureDirs = _r.String();
+		var numMaterials = _r.Int();
+		for ( var i = 0; i < numMaterials; i++ )
+		{
+			if ( !TryReadHeader( out var id, out var version, out _, out _ ) || id != Material )
+				return;
+
+			ReadMaterial( version );
+		}
+	}
+
+	void ReadMaterial( uint version )
+	{
+		var name = _r.String();
+		var twoSided = _r.Bool();
+		for ( var i = 0; i < 4; i++ ) _r.Bool();
+		_r.Int(); _r.Int(); _r.Int();
+		for ( var i = 0; i < 12; i++ ) _r.Float();
+		_r.Float(); _r.Float();
+		_r.Int(); _r.Int();
+		_r.Float();
+
+		var def = new MaterialDef { Name = name, TwoSided = twoSided };
+
+		var hasDiffuse = _r.Bool();
+		if ( hasDiffuse )
+		{
+			if ( TryReadHeader( out _, out var texVer, out _, out _ ) )
+				def.DiffuseTexture = ReadTexture( texVer );
+		}
+
+		var hasReflection = _r.Bool();
+		if ( hasReflection && TryReadHeader( out _, out var rv, out _, out _ ) ) ReadTexture( rv );
+
+		var hasBump = _r.Bool();
+		if ( hasBump && TryReadHeader( out _, out var bv, out _, out _ ) ) ReadTexture( bv );
+
+		var hasOpacity = _r.Bool();
+		if ( hasOpacity && TryReadHeader( out _, out var ov, out _, out _ ) ) ReadTexture( ov );
+
+		if ( version >= 1 )
+		{
+			var hasMask = _r.Bool();
+			if ( hasMask && TryReadHeader( out _, out var mv, out _, out _ ) ) ReadTexture( mv );
+			_r.Int();
+			_r.Bool();
+		}
+
+		if ( version >= 2 )
+		{
+			_r.Bool(); _r.Bool(); _r.Int();
+		}
+
+		Materials[name] = def;
+	}
+
+	string ReadTexture( uint version )
+	{
+		_r.String(); // name
+		_r.Int(); // mipMapsNum
+		_r.Int(); // filteringType
+		var numTextures = _r.Int();
+
+		string first = null;
+		for ( var i = 0; i < numTextures; i++ )
+		{
+			var fn = _r.String();
+			first ??= fn;
+		}
+
+		if ( numTextures > 1 )
+		{
+			_r.Bool(); _r.Bool();
+			_r.Int(); _r.Int(); _r.Int();
+		}
+
+		return first;
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Kf2File.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Kf2File.cs
@@ -86,11 +86,11 @@ public class Kf2File
 		_r = new MaxReader( data );
 	}
 
-	public static Kf2File Parse( byte[] data )
+	public static Kf2File Parse( byte[] data, bool bakeNodeTransforms = true )
 	{
 		var kf2 = new Kf2File( data );
 		kf2.ReadTopLevel();
-		kf2.BakeNodeTransforms();
+		if ( bakeNodeTransforms ) kf2.BakeNodeTransforms();
 		return kf2;
 	}
 

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Ldb2File.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Ldb2File.cs
@@ -1,0 +1,451 @@
+using Sandbox;
+using System;
+using System.Collections.Generic;
+
+namespace RasLib;
+
+// Reads an LDB2 level: embedded textures, materials, and per-room static meshes.
+// Entity/FSM/trigger/dynamic-mesh sections are not parsed (rooms hold the static world).
+public class Ldb2File
+{
+	const uint Magic = 0x3242444C;
+	const int FormatVersion = 34;
+
+	public class TextureData
+	{
+		public int FileType;
+		public byte[] Data;
+	}
+
+	public class MaterialDef
+	{
+		public int FrameStart;
+		public int VisibleFrame;
+		public int LightmapId;
+		public int BlendMode;
+		public int SortPriority;
+		public bool DualSided;
+		public bool WritesZBuffer;
+
+		// Maya importer: these blend modes read transparency from the diffuse alpha channel
+		public bool UsesAlpha => BlendMode is 1 or 2 or 4 or 7 or 8 or 10 or 11;
+	}
+
+	public class SubMesh
+	{
+		public int MaterialId;
+		public Vector3[] Positions;
+		public Vector3[] Normals;
+		public Vector2[] Uvs;
+		public Vector2[] LightmapUvs;
+		public ushort[] Indices;
+	}
+
+	public class Room
+	{
+		public string Name;
+		public Mat43 Transform;
+		public List<SubMesh> Meshes = [];
+		public List<VolumeLight> VolumeLights = [];
+	}
+
+	public class VolumeLight
+	{
+		public Vector3 Min, Max;
+		public float R, G, B;
+	}
+
+	public class DynamicLight
+	{
+		public Mat43 Transform;
+		public int RoomId;
+		public float R, G, B, A, Falloff;
+	}
+
+	public class Fsm
+	{
+		public Mat43 Transform;
+		public int RoomId;
+	}
+
+	public class DynamicMesh
+	{
+		public int FsmId;
+		public Vector3 AabbPivot;
+		public List<SubMesh> Meshes;
+	}
+
+	public List<TextureData> Diffuse { get; } = [];
+	public List<TextureData> Lightmaps { get; } = [];
+	public List<MaterialDef> Materials { get; } = [];
+	public List<Room> Rooms { get; } = [];
+	public List<DynamicLight> Lights { get; } = [];
+	public List<Mat43> Flares { get; } = [];
+	public List<Fsm> Fsms { get; } = [];
+	public List<DynamicMesh> DynamicMeshes { get; } = [];
+
+	readonly MaxReader _r;
+
+	Ldb2File( byte[] data )
+	{
+		_r = new MaxReader( data );
+	}
+
+	public static bool IsLdb2( byte[] data )
+		=> data.Length >= 4 && BitConverter.ToUInt32( data, 0 ) == Magic;
+
+	public static Ldb2File Parse( byte[] data )
+	{
+		var ldb = new Ldb2File( data );
+		ldb.Read();
+		return ldb;
+	}
+
+	void Read()
+	{
+		if ( _r.RawUInt32() != Magic )
+			throw new Exception( "not an LDB2 file" );
+
+		var version = _r.Int();
+		if ( version != FormatVersion )
+			throw new Exception( $"unsupported LDB2 version {version}" );
+
+		var stringTableSize = _r.Int();
+		_r.Skip( stringTableSize );
+		_r.Float(); // physicalWorldSize
+
+		ReadTextureGroup( Diffuse );
+		ReadLightmaps();
+		ReadTextureGroup( null ); // detail
+		ReadTextureGroup( null ); // reflection
+		ReadTextureGroup( null ); // gloss
+
+		ReadMaterials();
+		ReadRooms();
+
+		try
+		{
+			ReadTrailingSections();
+		}
+		catch ( Exception )
+		{
+			// rooms are the critical content; entities/dynamic meshes degrade gracefully
+		}
+	}
+
+	// validated section order: lights, flares, levelItems, portals, jumpPoints, wayPoints,
+	// characters, FSMs, triggers, dynamicMeshes, mirrors
+	void ReadTrailingSections()
+	{
+		var lights = _r.Int();
+		for ( var i = 0; i < lights; i++ )
+		{
+			var light = new DynamicLight { Transform = _r.Matrix4x3(), RoomId = _r.Int() };
+			light.R = _r.Float(); light.G = _r.Float(); light.B = _r.Float(); light.A = _r.Float();
+			light.Falloff = _r.Float();
+			Lights.Add( light );
+		}
+
+		var flares = _r.Int();
+		for ( var i = 0; i < flares; i++ )
+		{
+			SkipName();
+			Flares.Add( _r.Matrix4x3() );
+			_r.Int(); // roomId
+		}
+
+		var items = _r.Int();
+		for ( var i = 0; i < items; i++ ) { SkipName(); SkipName(); _r.Matrix4x3(); _r.Int(); }
+
+		var portals = _r.Int();
+		for ( var i = 0; i < portals; i++ )
+		{
+			SkipName(); _r.Vector3(); _r.SkipTyped(); _r.SkipTyped();
+			var points = _r.Int();
+			for ( var p = 0; p < points; p++ ) _r.Vector3();
+		}
+
+		var jumps = _r.Int();
+		for ( var i = 0; i < jumps; i++ ) { SkipName(); _r.Matrix4x3(); _r.Int(); }
+
+		var ways = _r.Int();
+		for ( var i = 0; i < ways; i++ ) { SkipName(); _r.Matrix4x3(); _r.Int(); _r.SkipTyped(); }
+
+		_r.Skip( 1 );
+		var groups = _r.Int();
+		for ( var i = 0; i < groups; i++ ) { SkipName(); _r.Int(); }
+		var characters = _r.Int();
+		for ( var i = 0; i < characters; i++ ) { SkipName(); SkipName(); _r.Matrix4x3(); _r.Int(); _r.Int(); _r.SkipTyped(); }
+
+		var fsms = _r.Int();
+		for ( var i = 0; i < fsms; i++ )
+		{
+			SkipName();
+			var fsm = new Fsm { Transform = _r.Matrix4x3() };
+			_r.Int(); // parentId
+			_r.Matrix4x3(); // localTransform
+			fsm.RoomId = _r.Int();
+			Fsms.Add( fsm );
+
+			SkipName(); // defaultState
+			_r.Skip( 1 );
+			var custom = _r.Int();
+			for ( var c = 0; c < custom; c++ ) _r.SkipTyped();
+			_r.Int(); _r.Int(); _r.Int(); _r.Int();
+			var timers = _r.Int();
+			for ( var t = 0; t < timers; t++ ) { SkipName(); _r.SkipTyped(); _r.SkipTyped(); _r.SkipTyped(); _r.SkipTyped(); }
+		}
+
+		var triggers = _r.Int();
+		for ( var i = 0; i < triggers; i++ )
+		{
+			_r.Int(); _r.Float();
+			for ( var f = 0; f < 6; f++ ) Flag();
+			SkipName(); // activation state (not in the python spec)
+			if ( Flag() == 1 )
+			{
+				var parent = _r.Int();
+				if ( parent == -1 ) SkipCollisions();
+			}
+		}
+
+		var prefabMeshes = new Dictionary<int, List<SubMesh>>();
+		var dynCount = _r.Int();
+		for ( var i = 0; i < dynCount; i++ )
+		{
+			var dyn = new DynamicMesh { FsmId = _r.Int() };
+			var useLightMaps = Flag();
+			for ( var f = 0; f < 7; f++ ) Flag();
+			_r.Int(); // physicalMaterial
+			var prefabId = _r.Int();
+			var shareCollision = Flag();
+			_r.Vector3(); _r.Vector3();
+			dyn.AabbPivot = _r.Vector3();
+
+			bool readGeo, readColl;
+			if ( prefabId == -1 ) { readGeo = true; readColl = true; }
+			else if ( !prefabMeshes.ContainsKey( prefabId ) ) { readGeo = true; readColl = true; }
+			else if ( useLightMaps != 0 ) { readGeo = true; readColl = shareCollision == 0; }
+			else { readGeo = false; readColl = false; }
+
+			if ( readGeo )
+			{
+				var meshCount = _r.Int();
+				dyn.Meshes = new List<SubMesh>( meshCount );
+				for ( var m = 0; m < meshCount; m++ ) dyn.Meshes.Add( ReadSubMesh() );
+				if ( prefabId != -1 && !prefabMeshes.ContainsKey( prefabId ) ) prefabMeshes[prefabId] = dyn.Meshes;
+			}
+			else
+			{
+				dyn.Meshes = prefabMeshes[prefabId];
+			}
+
+			if ( readColl ) SkipCollisions();
+
+			var anims = _r.Int();
+			for ( var a = 0; a < anims; a++ )
+			{
+				SkipName(); _r.SkipTyped(); _r.Matrix4x3(); _r.Matrix4x3();
+				for ( var ch = 0; ch < 2; ch++ )
+				{
+					_r.SkipTyped(); _r.SkipTyped(); _r.SkipTyped();
+					_r.SkipTyped(); // sampleRate
+					var points = _r.Int();
+					_r.Skip( points * 4 );
+					_r.Skip( points * 4 );
+				}
+				_r.SkipTyped(); _r.SkipTyped(); _r.SkipTyped();
+			}
+
+			DynamicMeshes.Add( dyn );
+		}
+		// mirrors: last section, not consumed
+	}
+
+	int Flag() => _r.Peek == 0x0E ? (_r.Bool() ? 1 : 0) : _r.Int();
+
+	void SkipName()
+	{
+		if ( _r.Peek == 0x0D ) _r.String();
+		else _r.Int();
+	}
+
+	void ReadTextureGroup( List<TextureData> into )
+	{
+		var count = _r.Int();
+		for ( var i = 0; i < count; i++ )
+		{
+			var fileType = _r.Int();
+			var size = _r.Int();
+			_r.Int(); // filePathOffset
+			var data = _r.RawBytes( size );
+			into?.Add( new TextureData { FileType = fileType, Data = data } );
+		}
+	}
+
+	void ReadLightmaps()
+	{
+		_r.Bool(); // isDds
+		var count = _r.Int();
+		for ( var i = 0; i < count; i++ )
+		{
+			var size = _r.Int();
+			var data = _r.RawBytes( size );
+			Lightmaps.Add( new TextureData { FileType = 0, Data = data } );
+		}
+	}
+
+	void ReadMaterials()
+	{
+		var count = _r.Int();
+		for ( var i = 0; i < count; i++ )
+		{
+			var blendMode = _r.Int();
+			var frameStart = _r.Int();
+			_r.Int(); // frameEnd
+			var lightmapId = _r.Int();
+			_r.Int(); // detailTexId
+			_r.Int(); // reflectionTexId
+			_r.Int(); // glossTexId
+			_r.Int(); // alphaCompareReferenceValue
+			var sortPriority = _r.Int();
+			_r.Int(); // detailOffset
+			var dualSided = _r.Bool();
+			var writesZBuffer = _r.Bool();
+			_r.Int(); // framerate
+			var visibleFrame = _r.Int();
+
+			Materials.Add( new MaterialDef
+			{
+				FrameStart = frameStart,
+				VisibleFrame = visibleFrame,
+				LightmapId = lightmapId,
+				BlendMode = blendMode,
+				SortPriority = sortPriority,
+				DualSided = dualSided,
+				WritesZBuffer = writesZBuffer,
+			} );
+		}
+	}
+
+	void ReadRooms()
+	{
+		var count = _r.Int();
+		for ( var i = 0; i < count; i++ )
+		{
+			var room = new Room { Name = _r.String() };
+			room.Transform = _r.Matrix4x3();
+			_r.SkipTyped(); // unknown
+			_r.Vector3(); _r.Vector3(); _r.Vector3(); // aabb min/max/pivot
+
+			var meshCount = _r.Int();
+			for ( var m = 0; m < meshCount; m++ )
+				room.Meshes.Add( ReadSubMesh() );
+
+			SkipCollisions();
+			ReadVolumeLights( room );
+
+			Rooms.Add( room );
+		}
+	}
+
+	SubMesh ReadSubMesh()
+	{
+		var mesh = new SubMesh { MaterialId = _r.Int() };
+		var hasLightmapUvs = _r.Bool();
+		var hasDetailUvs = _r.Bool();
+		var polygonCount = _r.Int();
+		var vertexCount = _r.Int();
+
+		var pos = _r.RawFloats( vertexCount * 3 );
+		var norm = _r.RawFloats( vertexCount * 3 );
+		var uv = _r.RawFloats( vertexCount * 2 );
+
+		mesh.Positions = new Vector3[vertexCount];
+		mesh.Normals = new Vector3[vertexCount];
+		mesh.Uvs = new Vector2[vertexCount];
+		for ( var i = 0; i < vertexCount; i++ )
+		{
+			mesh.Positions[i] = new Vector3( pos[i * 3], pos[i * 3 + 1], pos[i * 3 + 2] );
+			mesh.Normals[i] = new Vector3( norm[i * 3], norm[i * 3 + 1], norm[i * 3 + 2] );
+			mesh.Uvs[i] = new Vector2( uv[i * 2], uv[i * 2 + 1] );
+		}
+
+		if ( hasLightmapUvs )
+		{
+			var lm = _r.RawFloats( vertexCount * 2 );
+			mesh.LightmapUvs = new Vector2[vertexCount];
+			for ( var i = 0; i < vertexCount; i++ )
+				mesh.LightmapUvs[i] = new Vector2( lm[i * 2], lm[i * 2 + 1] );
+		}
+
+		if ( hasDetailUvs )
+			_r.Skip( vertexCount * 2 * 4 );
+
+		mesh.Indices = _r.RawUInt16s( polygonCount * 3 );
+		return mesh;
+	}
+
+	void SkipCollisions()
+	{
+		var count = _r.Int();
+		for ( var i = 0; i < count; i++ )
+		{
+			var vertexCount = _r.Int();
+			var polygonCount = _r.Int();
+			_r.Skip( vertexCount * 3 * 4 ); // positions
+			_r.Skip( polygonCount * 3 * 2 ); // indices
+			_r.Skip( polygonCount ); // material indices
+			_r.Bool(); // isConvex
+			_r.Int(); // collisionMask
+			_r.Skip( 3 * 4 ); // origin
+			_r.Skip( 4 ); // reserved
+			var moppSize = (int)_r.RawUInt32();
+			_r.Skip( moppSize );
+		}
+	}
+
+	// 3D ambient grid per room, reduced to one average color per volume.
+	// Cell = 12 bytes: RGB8 ambient color, 5 unknown bytes, float32 intensity (0..~0.86).
+	// NOT 3 floats as the python spec claims - that decodes as garbage/NaN.
+	void ReadVolumeLights( Room room )
+	{
+		var count = _r.Int();
+		for ( var i = 0; i < count; i++ )
+		{
+			var w = _r.Int();
+			var h = _r.Int();
+			var d = _r.Int();
+			var min = _r.Vector3();
+			var max = _r.Vector3();
+
+			var cells = w * h * d;
+			var raw = _r.RawBytes( cells * 12 );
+
+			// average only the lit cells - cells buried in geometry are near-black and
+			// drag the mean down (characters stand in the open, not inside walls)
+			float meanIntensity = 0;
+			for ( var c = 0; c < cells; c++ )
+				meanIntensity += BitConverter.ToSingle( raw, c * 12 + 8 );
+			if ( cells > 0 ) meanIntensity /= cells;
+
+			float r = 0, g = 0, b = 0;
+			var lit = 0;
+			for ( var c = 0; c < cells; c++ )
+			{
+				var intensity = BitConverter.ToSingle( raw, c * 12 + 8 );
+				if ( intensity < meanIntensity )
+					continue;
+
+				r += raw[c * 12] / 255f * intensity;
+				g += raw[c * 12 + 1] / 255f * intensity;
+				b += raw[c * 12 + 2] / 255f * intensity;
+				lit++;
+			}
+
+			if ( lit > 0 ) { r /= lit; g /= lit; b /= lit; }
+
+			room.VolumeLights.Add( new VolumeLight { Min = min, Max = max, R = r, G = g, B = b } );
+		}
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxPayne2Mount.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxPayne2Mount.cs
@@ -1,0 +1,174 @@
+using Sandbox.Mounting;
+using System;
+using System.Threading.Tasks;
+
+/// <summary>
+/// A mounting implementation for Max Payne 2: The Fall of Max Payne
+/// </summary>
+public partial class MaxPayne2Mount : BaseGameMount
+{
+	public override string Ident => "maxpayne2";
+	public override string Title => "Max Payne 2";
+
+	const long appId = 12150;
+
+	readonly List<RasLib.Archive> archives = [];
+
+	protected override void Initialize( InitializeContext context )
+	{
+		if ( !context.IsAppInstalled( appId ) )
+			return;
+
+		var dir = context.GetAppDirectory( appId );
+		if ( string.IsNullOrEmpty( dir ) )
+			return;
+
+		foreach ( var rasPath in System.IO.Directory.EnumerateFiles( dir, "*.ras", System.IO.SearchOption.AllDirectories ) )
+		{
+			try
+			{
+				var archive = new RasLib.Archive( rasPath );
+				if ( archive.IsValid )
+				{
+					archives.Add( archive );
+					continue;
+				}
+
+				archive.Dispose();
+			}
+			catch ( Exception e )
+			{
+				Log.Warning( $"Failed to load RAS {rasPath}: {e.Message}" );
+			}
+		}
+
+		archives.Sort( ( a, b ) => string.Compare( a.Name, b.Name, StringComparison.OrdinalIgnoreCase ) );
+
+		IsInstalled = archives.Count > 0;
+	}
+
+	protected override Task Mount( MountContext context )
+	{
+		var added = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+
+		foreach ( var archive in archives )
+		{
+			foreach ( var file in archive.Files )
+			{
+				var ext = System.IO.Path.GetExtension( file.FileName )?.ToLowerInvariant();
+				if ( string.IsNullOrWhiteSpace( ext ) )
+					continue;
+
+				var path = file.FullPath;
+				if ( !added.Add( path ) )
+					continue;
+
+				switch ( ext )
+				{
+					case ".ldb":
+						context.Add( ResourceType.Scene, path, new MaxPayne2Map( path ) );
+						break;
+
+					case ".kf2":
+						// gn pages are placement quads for the comic player; their art is in Textures
+						if ( IsMeshlessKf2( path ) || path.Contains( "/graphicnovelpages/", StringComparison.OrdinalIgnoreCase ) ) continue;
+						if ( !HasMeshChunk( path ) ) continue;
+						context.Add( ResourceType.Model, path, new MaxPayne2Model( path ) );
+						break;
+
+					case ".dds":
+					case ".tga":
+					case ".pcx":
+					case ".jpg":
+						context.Add( ResourceType.Texture, path, new MaxPayne2Texture( path ) );
+						break;
+
+					case ".wav":
+						context.Add( ResourceType.Sound, path, new MaxPayne2Sound( path ) );
+						break;
+				}
+			}
+		}
+
+		IsMounted = true;
+		return Task.CompletedTask;
+	}
+
+	// skeletons hold keyframe animations, camerapaths hold cameras - neither has mesh data
+	static bool IsMeshlessKf2( string path )
+	{
+		return path.Contains( "/skeletons/", StringComparison.OrdinalIgnoreCase )
+			|| path.Contains( "/camerapaths/", StringComparison.OrdinalIgnoreCase );
+	}
+
+	// meshless kf2s hide everywhere (skins texture-set variants, projectile anims) - sniff the
+	// top-level chunks; only the nested NODE chunk lies about its size, outer chunks are reliable
+	bool HasMeshChunk( string path )
+	{
+		var data = GetFileBytes( path );
+		if ( data is null ) return false;
+
+		var pos = 0;
+		while ( pos + 13 <= data.Length )
+		{
+			if ( data[pos] != 0x0C ) return false;
+			if ( BitConverter.ToUInt32( data, pos + 1 ) == 0x00010005 ) return true;
+			var size = BitConverter.ToUInt32( data, pos + 9 );
+			if ( size < 13 ) return false;
+			pos += (int)size;
+		}
+
+		return false;
+	}
+
+	public byte[] GetFileBytes( string filename )
+	{
+		foreach ( var archive in archives )
+		{
+			var data = archive.GetFileBytes( filename );
+			if ( data != null )
+				return data;
+		}
+
+		return null;
+	}
+
+	public IEnumerable<string> FindFiles( string folderPrefix, string extension )
+	{
+		var seen = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+		foreach ( var archive in archives )
+		{
+			foreach ( var file in archive.Files )
+			{
+				var path = file.FullPath;
+				if ( !path.StartsWith( folderPrefix, StringComparison.OrdinalIgnoreCase ) )
+					continue;
+				if ( !path.EndsWith( extension, StringComparison.OrdinalIgnoreCase ) )
+					continue;
+				if ( seen.Add( path ) )
+					yield return path;
+			}
+		}
+	}
+
+	public bool FileExists( string filename )
+	{
+		foreach ( var archive in archives )
+		{
+			if ( archive.FileExists( filename ) )
+				return true;
+		}
+
+		return false;
+	}
+
+	protected override void Shutdown()
+	{
+		foreach ( var archive in archives )
+		{
+			archive.Dispose();
+		}
+
+		archives.Clear();
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxPayneImage.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxPayneImage.cs
@@ -1,0 +1,251 @@
+using Sandbox;
+using Sandbox.Mounting;
+using System;
+
+static class MaxPayneImage
+{
+	public static Texture Load( byte[] data )
+	{
+		if ( data is null || data.Length < 18 )
+			return null;
+
+		if ( data[0] == 'D' && data[1] == 'D' && data[2] == 'S' && data[3] == ' ' )
+			return TextureLoader.FromDds( data );
+
+		if ( data[0] == 0xFF && data[1] == 0xD8 )
+		{
+			using var bitmap = Bitmap.CreateFromBytes( data );
+			return bitmap?.ToTexture();
+		}
+
+		if ( data[0] == 0x0A && data[2] == 0x01 )
+			return FromPcx( data );
+
+		return FromTga( data );
+	}
+
+	static Texture FromTga( byte[] data )
+	{
+		var idLength = data[0];
+		var colorMapType = data[1];
+		var imageType = data[2];
+		var colorMapLength = BitConverter.ToUInt16( data, 5 );
+		var colorMapBits = data[7];
+		var width = BitConverter.ToUInt16( data, 12 );
+		var height = BitConverter.ToUInt16( data, 14 );
+		var bpp = data[16];
+		var topOrigin = (data[17] & 0x20) != 0;
+
+		if ( width <= 0 || height <= 0 )
+			return null;
+
+		var pos = 18 + idLength;
+
+		byte[] colorMap = null;
+		if ( colorMapType == 1 )
+		{
+			var colorMapBytes = colorMapLength * (colorMapBits / 8);
+			colorMap = new byte[colorMapBytes];
+			Array.Copy( data, pos, colorMap, 0, colorMapBytes );
+			pos += colorMapBytes;
+		}
+
+		var bytesPerPixel = bpp / 8;
+		var pixels = new byte[width * height * bytesPerPixel];
+
+		switch ( imageType )
+		{
+			case 1:
+			case 2:
+			case 3:
+				Array.Copy( data, pos, pixels, 0, pixels.Length );
+				break;
+
+			case 9:
+			case 10:
+			case 11:
+				DecodeTgaRle( data, pos, pixels, bytesPerPixel );
+				break;
+
+			default:
+				return null;
+		}
+
+		var rgba = new byte[width * height * 4];
+		for ( var i = 0; i < width * height; i++ )
+		{
+			var src = i * bytesPerPixel;
+			var dst = i * 4;
+
+			switch ( bpp )
+			{
+				case 8 when colorMap is not null:
+					var entry = pixels[src] * (colorMapBits / 8);
+					rgba[dst + 0] = colorMap[entry + 2];
+					rgba[dst + 1] = colorMap[entry + 1];
+					rgba[dst + 2] = colorMap[entry + 0];
+					rgba[dst + 3] = 255;
+					break;
+
+				case 8:
+					rgba[dst + 0] = pixels[src];
+					rgba[dst + 1] = pixels[src];
+					rgba[dst + 2] = pixels[src];
+					rgba[dst + 3] = 255;
+					break;
+
+				case 24:
+					rgba[dst + 0] = pixels[src + 2];
+					rgba[dst + 1] = pixels[src + 1];
+					rgba[dst + 2] = pixels[src + 0];
+					rgba[dst + 3] = 255;
+					break;
+
+				case 32:
+					rgba[dst + 0] = pixels[src + 2];
+					rgba[dst + 1] = pixels[src + 1];
+					rgba[dst + 2] = pixels[src + 0];
+					rgba[dst + 3] = pixels[src + 3];
+					break;
+
+				default:
+					return null;
+			}
+		}
+
+		if ( !topOrigin )
+			FlipVertical( rgba, width, height );
+
+		return Texture.Create( width, height )
+			.WithData( rgba )
+			.WithMips()
+			.Finish();
+	}
+
+	static void DecodeTgaRle( byte[] data, int pos, byte[] pixels, int bytesPerPixel )
+	{
+		var op = 0;
+		while ( op < pixels.Length && pos < data.Length )
+		{
+			var packet = data[pos++];
+			var count = (packet & 0x7F) + 1;
+
+			if ( (packet & 0x80) != 0 )
+			{
+				for ( var i = 0; i < count && op < pixels.Length; i++ )
+				{
+					Array.Copy( data, pos, pixels, op, bytesPerPixel );
+					op += bytesPerPixel;
+				}
+
+				pos += bytesPerPixel;
+			}
+			else
+			{
+				var bytes = count * bytesPerPixel;
+				Array.Copy( data, pos, pixels, op, Math.Min( bytes, pixels.Length - op ) );
+				op += bytes;
+				pos += bytes;
+			}
+		}
+	}
+
+	static Texture FromPcx( byte[] data )
+	{
+		var bitsPerPixel = data[3];
+		var xMin = BitConverter.ToUInt16( data, 4 );
+		var yMin = BitConverter.ToUInt16( data, 6 );
+		var xMax = BitConverter.ToUInt16( data, 8 );
+		var yMax = BitConverter.ToUInt16( data, 10 );
+		var planes = data[65];
+		var bytesPerLine = BitConverter.ToUInt16( data, 66 );
+
+		var width = xMax - xMin + 1;
+		var height = yMax - yMin + 1;
+
+		if ( width <= 0 || height <= 0 || bitsPerPixel != 8 )
+			return null;
+
+		var decoded = new byte[bytesPerLine * planes * height];
+		var pos = 128;
+		var op = 0;
+
+		while ( op < decoded.Length && pos < data.Length )
+		{
+			var b = data[pos++];
+			if ( (b & 0xC0) == 0xC0 )
+			{
+				var count = b & 0x3F;
+				var value = data[pos++];
+				for ( var i = 0; i < count && op < decoded.Length; i++ )
+					decoded[op++] = value;
+			}
+			else
+			{
+				decoded[op++] = b;
+			}
+		}
+
+		var rgba = new byte[width * height * 4];
+
+		if ( planes == 1 )
+		{
+			if ( data.Length < 769 || data[data.Length - 769] != 0x0C )
+				return null;
+
+			var palette = data.Length - 768;
+			for ( var y = 0; y < height; y++ )
+			{
+				for ( var x = 0; x < width; x++ )
+				{
+					var index = decoded[y * bytesPerLine + x] * 3;
+					var dst = (y * width + x) * 4;
+					rgba[dst + 0] = data[palette + index + 0];
+					rgba[dst + 1] = data[palette + index + 1];
+					rgba[dst + 2] = data[palette + index + 2];
+					rgba[dst + 3] = 255;
+				}
+			}
+		}
+		else if ( planes == 3 )
+		{
+			for ( var y = 0; y < height; y++ )
+			{
+				var row = y * bytesPerLine * 3;
+				for ( var x = 0; x < width; x++ )
+				{
+					var dst = (y * width + x) * 4;
+					rgba[dst + 0] = decoded[row + x];
+					rgba[dst + 1] = decoded[row + bytesPerLine + x];
+					rgba[dst + 2] = decoded[row + bytesPerLine * 2 + x];
+					rgba[dst + 3] = 255;
+				}
+			}
+		}
+		else
+		{
+			return null;
+		}
+
+		return Texture.Create( width, height )
+			.WithData( rgba )
+			.WithMips()
+			.Finish();
+	}
+
+	static void FlipVertical( byte[] rgba, int width, int height )
+	{
+		var stride = width * 4;
+		var row = new byte[stride];
+
+		for ( var y = 0; y < height / 2; y++ )
+		{
+			var top = y * stride;
+			var bottom = (height - 1 - y) * stride;
+
+			Array.Copy( rgba, top, row, 0, stride );
+			Array.Copy( rgba, bottom, rgba, top, stride );
+			Array.Copy( row, 0, rgba, bottom, stride );
+		}
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxPayneWav.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxPayneWav.cs
@@ -1,0 +1,142 @@
+using System;
+
+namespace RasLib;
+
+// MP2 ships most sounds as MS ADPCM (format tag 2). s&box's FromWav assumes PCM,
+// so decode ADPCM to PCM16 here and hand back raw little-endian samples.
+public static class MaxPayneWav
+{
+	public class Pcm
+	{
+		public byte[] Data;
+		public int Channels;
+		public int SampleRate;
+		public int BitsPerSample;
+	}
+
+	static readonly int[] AdaptationTable =
+	[
+		230, 230, 230, 230, 307, 409, 512, 614,
+		768, 614, 512, 409, 307, 230, 230, 230
+	];
+	static readonly int[] CoeffTable1 = [256, 512, 0, 192, 240, 460, 392];
+	static readonly int[] CoeffTable2 = [0, -256, 0, 64, 0, -208, -232];
+
+	// Returns null for PCM (caller should use the WAV as-is) or unsupported formats.
+	public static Pcm DecodeIfAdpcm( byte[] wav )
+	{
+		if ( wav.Length < 44 || wav[0] != 'R' || wav[1] != 'I' || wav[2] != 'F' || wav[3] != 'F' )
+			return null;
+
+		var pos = 12;
+		var fmtPos = -1;
+		var dataPos = -1;
+		var dataSize = 0;
+
+		while ( pos + 8 <= wav.Length )
+		{
+			var id = BitConverter.ToUInt32( wav, pos );
+			var size = (int)BitConverter.ToUInt32( wav, pos + 4 );
+			var body = pos + 8;
+
+			if ( id == 0x20746D66 ) fmtPos = body; // "fmt "
+			else if ( id == 0x61746164 ) { dataPos = body; dataSize = size; } // "data"
+
+			pos = body + size + (size & 1);
+		}
+
+		if ( fmtPos < 0 || dataPos < 0 )
+			return null;
+
+		var format = BitConverter.ToUInt16( wav, fmtPos );
+		if ( format != 2 )
+			return null; // PCM (1) or other - let the engine handle it
+
+		var channels = BitConverter.ToUInt16( wav, fmtPos + 2 );
+		var sampleRate = (int)BitConverter.ToUInt32( wav, fmtPos + 4 );
+		var blockAlign = BitConverter.ToUInt16( wav, fmtPos + 12 );
+
+		return DecodeMsAdpcm( wav, dataPos, dataSize, channels, sampleRate, blockAlign );
+	}
+
+	static Pcm DecodeMsAdpcm( byte[] src, int dataPos, int dataSize, int channels, int sampleRate, int blockAlign )
+	{
+		using var stream = new System.IO.MemoryStream();
+		var end = dataPos + dataSize;
+
+		for ( var block = dataPos; block < end; block += blockAlign )
+		{
+			var available = Math.Min( blockAlign, end - block );
+			if ( available < 7 * channels )
+				break;
+
+			DecodeBlock( src, block, available, channels, stream );
+		}
+
+		return new Pcm
+		{
+			Data = stream.ToArray(),
+			Channels = channels,
+			SampleRate = sampleRate,
+			BitsPerSample = 16,
+		};
+	}
+
+	static void DecodeBlock( byte[] src, int pos, int length, int channels, System.IO.MemoryStream output )
+	{
+		Span<int> predictor = stackalloc int[2];
+		Span<int> delta = stackalloc int[2];
+		Span<int> sample1 = stackalloc int[2];
+		Span<int> sample2 = stackalloc int[2];
+		Span<int> coeff1 = stackalloc int[2];
+		Span<int> coeff2 = stackalloc int[2];
+
+		var p = pos;
+
+		for ( var c = 0; c < channels; c++ )
+		{
+			predictor[c] = Math.Min( src[p++], (byte)6 );
+			coeff1[c] = CoeffTable1[predictor[c]];
+			coeff2[c] = CoeffTable2[predictor[c]];
+		}
+
+		for ( var c = 0; c < channels; c++ ) { delta[c] = BitConverter.ToInt16( src, p ); p += 2; }
+		for ( var c = 0; c < channels; c++ ) { sample1[c] = BitConverter.ToInt16( src, p ); p += 2; }
+		for ( var c = 0; c < channels; c++ ) { sample2[c] = BitConverter.ToInt16( src, p ); p += 2; }
+
+		Span<byte> pair = stackalloc byte[2];
+		for ( var c = 0; c < channels; c++ ) WriteSample( output, sample2[c], pair );
+		for ( var c = 0; c < channels; c++ ) WriteSample( output, sample1[c], pair );
+
+		var end = pos + length;
+		while ( p < end )
+		{
+			var b = src[p++];
+			DecodeNibble( b >> 4, 0, predictor, delta, sample1, sample2, coeff1, coeff2, channels, output, pair );
+			DecodeNibble( b & 0x0F, channels == 1 ? 0 : 1, predictor, delta, sample1, sample2, coeff1, coeff2, channels, output, pair );
+		}
+	}
+
+	static void DecodeNibble( int nibble, int c, Span<int> predictor, Span<int> delta, Span<int> sample1, Span<int> sample2, Span<int> coeff1, Span<int> coeff2, int channels, System.IO.MemoryStream output, Span<byte> pair )
+	{
+		var signed = nibble >= 8 ? nibble - 16 : nibble;
+		var predict = (sample1[c] * coeff1[c] + sample2[c] * coeff2[c]) / 256;
+		predict += signed * delta[c];
+		predict = Math.Clamp( predict, short.MinValue, short.MaxValue );
+
+		sample2[c] = sample1[c];
+		sample1[c] = predict;
+
+		delta[c] = AdaptationTable[nibble] * delta[c] / 256;
+		if ( delta[c] < 16 ) delta[c] = 16;
+
+		WriteSample( output, predict, pair );
+	}
+
+	static void WriteSample( System.IO.MemoryStream output, int sample, Span<byte> pair )
+	{
+		pair[0] = (byte)(sample & 0xFF);
+		pair[1] = (byte)((sample >> 8) & 0xFF);
+		output.Write( pair );
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxReader.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/MaxReader.cs
@@ -1,0 +1,228 @@
+using Sandbox;
+using System;
+using System.IO;
+using System.Text;
+
+namespace RasLib;
+
+// Row-vector 4x3: rows 0-2 basis, row 3 translation. point' = T + x*R + y*U + z*F.
+public struct Mat43
+{
+	public Vector3 Right, Up, Forward, Translation;
+
+	public static readonly Mat43 Identity = new() { Right = new( 1, 0, 0 ), Up = new( 0, 1, 0 ), Forward = new( 0, 0, 1 ) };
+
+	public readonly Vector3 Point( Vector3 v ) => Translation + v.x * Right + v.y * Up + v.z * Forward;
+	public readonly Vector3 Direction( Vector3 v ) => v.x * Right + v.y * Up + v.z * Forward;
+
+	// basis row lengths in converted axis order (sbox x=Right, y=Forward, z=Up)
+	public readonly Vector3 AxisScales => new( Right.Length, Forward.Length, Up.Length );
+
+	public readonly Mat43 Then( Mat43 parent ) => new()
+	{
+		Right = parent.Direction( Right ),
+		Up = parent.Direction( Up ),
+		Forward = parent.Direction( Forward ),
+		Translation = parent.Point( Translation ),
+	};
+
+	// MP2 (Y-up, mirrored) -> s&box (Z-up): conjugate by the (x,y,z)->(-x,-z,y) map.
+	// Quaternion built directly from the conjugated basis - LookAt reconstructs the frame
+	// from forward+up and can flip handedness for some orientations (mangled face/finger bones).
+	public readonly Transform ToSbox( float scale )
+	{
+		// columns of the converted rotation: images of s&box +X, +Y, +Z
+		var c0 = new Vector3( Right.x, Right.z, -Right.y ).Normal;
+		var c1 = new Vector3( Forward.x, Forward.z, -Forward.y );
+		// rebuild right-handed orthonormal: female Breast-R is a det=-1 mirror clone, which garbles quaternion extraction
+		var c2 = Vector3.Cross( c0, c1 ).Normal;
+		c1 = Vector3.Cross( c2, c0 );
+
+		float x, y, z, w;
+		var trace = c0.x + c1.y + c2.z;
+		if ( trace > 0f )
+		{
+			var s = MathF.Sqrt( trace + 1f ) * 2f;
+			w = 0.25f * s;
+			x = (c1.z - c2.y) / s;
+			y = (c2.x - c0.z) / s;
+			z = (c0.y - c1.x) / s;
+		}
+		else if ( c0.x > c1.y && c0.x > c2.z )
+		{
+			var s = MathF.Sqrt( 1f + c0.x - c1.y - c2.z ) * 2f;
+			w = (c1.z - c2.y) / s;
+			x = 0.25f * s;
+			y = (c1.x + c0.y) / s;
+			z = (c2.x + c0.z) / s;
+		}
+		else if ( c1.y > c2.z )
+		{
+			var s = MathF.Sqrt( 1f + c1.y - c0.x - c2.z ) * 2f;
+			w = (c2.x - c0.z) / s;
+			x = (c1.x + c0.y) / s;
+			y = 0.25f * s;
+			z = (c2.y + c1.z) / s;
+		}
+		else
+		{
+			var s = MathF.Sqrt( 1f + c2.z - c0.x - c1.y ) * 2f;
+			w = (c0.y - c1.x) / s;
+			x = (c2.x + c0.z) / s;
+			y = (c2.y + c1.z) / s;
+			z = 0.25f * s;
+		}
+
+		var rotation = new Rotation( x, y, z, w );
+		var position = new Vector3( -Translation.x, -Translation.z, Translation.y ) * scale;
+		return new Transform( position, rotation );
+	}
+}
+
+// Reads Max Payne's tagged-value stream (1 tag byte + width-compressed payload).
+public class MaxReader( byte[] data )
+{
+	readonly byte[] _data = data;
+
+	public int Position { get; set; }
+	public int Length => _data.Length;
+	public bool Eof => Position >= _data.Length;
+	public byte Peek => _data[Position];
+
+	public byte RawByte() => _data[Position++];
+
+	public uint RawUInt32()
+	{
+		var v = BitConverter.ToUInt32( _data, Position );
+		Position += 4;
+		return v;
+	}
+
+	public void Skip( int count ) => Position += count;
+
+	public float[] RawFloats( int count )
+	{
+		var result = new float[count];
+		Buffer.BlockCopy( _data, Position, result, 0, count * 4 );
+		Position += count * 4;
+		return result;
+	}
+
+	public ushort[] RawUInt16s( int count )
+	{
+		var result = new ushort[count];
+		Buffer.BlockCopy( _data, Position, result, 0, count * 2 );
+		Position += count * 2;
+		return result;
+	}
+
+	public byte[] RawBytes( int count )
+	{
+		var result = new byte[count];
+		Array.Copy( _data, Position, result, 0, count );
+		Position += count;
+		return result;
+	}
+
+	public int Int()
+	{
+		var tag = _data[Position++];
+		switch ( tag )
+		{
+			case 0x00: case 0x02: { var v = BitConverter.ToInt32( _data, Position ); Position += 4; return v; }
+			case 0x01: case 0x03: { var v = (int)BitConverter.ToUInt32( _data, Position ); Position += 4; return v; }
+			case 0x04: { var v = BitConverter.ToInt16( _data, Position ); Position += 2; return v; }
+			case 0x05: { var v = BitConverter.ToUInt16( _data, Position ); Position += 2; return v; }
+			case 0x06: case 0x07: return (sbyte)_data[Position++];
+			case 0x08: return _data[Position++];
+			case 0x0F: { int v = _data[Position] | (_data[Position + 1] << 8) | (_data[Position + 2] << 16); Position += 3; return v; }
+			case 0x10: { var v = BitConverter.ToUInt16( _data, Position ); Position += 2; return v; }
+			case 0x11: return _data[Position++];
+			case 0x12: { int v = _data[Position] | (_data[Position + 1] << 8) | (_data[Position + 2] << 16); if ( (v & 0x800000) != 0 ) v |= unchecked((int)0xFF000000); Position += 3; return v; }
+			case 0x13: { var v = BitConverter.ToInt16( _data, Position ); Position += 2; return v; }
+			case 0x14: return (sbyte)_data[Position++];
+			default: throw new Exception( $"unexpected int tag 0x{tag:X2} at {Position - 1}" );
+		}
+	}
+
+	public float Float()
+	{
+		var tag = _data[Position++];
+		switch ( tag )
+		{
+			case 0x09: { var v = BitConverter.ToSingle( _data, Position ); Position += 4; return v; }
+			case 0x0A: { var v = (float)BitConverter.ToDouble( _data, Position ); Position += 8; return v; }
+			case 0x26: { var v = (float)BitConverter.ToHalf( _data, Position ); Position += 2; return v; }
+			default: throw new Exception( $"unexpected float tag 0x{tag:X2} at {Position - 1}" );
+		}
+	}
+
+	public bool Bool()
+	{
+		Position++; // 0x0E
+		return _data[Position++] != 0;
+	}
+
+	public string String()
+	{
+		Position++; // 0x0D
+		var count = Int();
+		var s = Encoding.Latin1.GetString( _data, Position, count );
+		Position += count;
+		return s;
+	}
+
+	public Vector3 Vector3()
+	{
+		Position++; // 0x16
+		var v = new Vector3( BitConverter.ToSingle( _data, Position ), BitConverter.ToSingle( _data, Position + 4 ), BitConverter.ToSingle( _data, Position + 8 ) );
+		Position += 12;
+		return v;
+	}
+
+	public Mat43 Matrix4x3()
+	{
+		Position++; // 0x1A
+		return new Mat43
+		{
+			Right = new Vector3( ReadF(), ReadF(), ReadF() ),
+			Up = new Vector3( ReadF(), ReadF(), ReadF() ),
+			Forward = new Vector3( ReadF(), ReadF(), ReadF() ),
+			Translation = new Vector3( ReadF(), ReadF(), ReadF() ),
+		};
+	}
+
+	float ReadF()
+	{
+		var v = BitConverter.ToSingle( _data, Position );
+		Position += 4;
+		return v;
+	}
+
+	// Consume a typed value of any kind, return nothing - for fields parsed only to advance.
+	public void SkipTyped()
+	{
+		var tag = _data[Position];
+		switch ( tag )
+		{
+			case 0x0D: String(); return;
+			case 0x0E: Bool(); return;
+			case 0x09: case 0x0A: case 0x26: Float(); return;
+			case 0x15: Position += 1 + 8; return;
+			case 0x16: Position += 1 + 12; return;
+			case 0x17: Position += 1 + 16; return;
+			case 0x18: Position += 1 + 16; return;
+			case 0x19: Position += 1 + 36; return;
+			case 0x1A: Position += 1 + 48; return;
+			case 0x1B: Position += 1 + 64; return;
+			default: Int(); return;
+		}
+	}
+
+	public string StringAt( int offset )
+	{
+		var end = offset;
+		while ( end < _data.Length && _data[end] != 0 ) end++;
+		return Encoding.Latin1.GetString( _data, offset, end - offset );
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/RagdollFile.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/RagdollFile.cs
@@ -1,0 +1,117 @@
+using Sandbox;
+using System;
+using System.Globalization;
+
+namespace RasLib;
+
+// data/database/ragdolls/<set>.txt: hull geometry kf2 + weighted bones + per-joint swing/twist limits
+public class RagdollFile
+{
+	public class BoneDef
+	{
+		public string Name;
+		public float Weight = 1f;
+	}
+
+	public class JointDef
+	{
+		public string Bone1;
+		public string Bone2;
+		public Vector3 TwistAxis = new( 1, 0, 0 );
+		public float TwistMin, TwistMax, ConeMin, ConeMax, PlaneMin, PlaneMax;
+	}
+
+	public string GeometryFile { get; private set; }
+	public List<BoneDef> Bones { get; } = [];
+	public List<JointDef> Joints { get; } = [];
+
+	public static RagdollFile Parse( string text )
+	{
+		var ragdoll = new RagdollFile();
+		var section = "";
+		BoneDef bone = null;
+		JointDef joint = null;
+
+		foreach ( var rawLine in text.Split( '\n' ) )
+		{
+			var line = rawLine;
+			var comment = line.IndexOf( "//", StringComparison.Ordinal );
+			if ( comment >= 0 ) line = line[..comment];
+			line = line.Trim();
+			if ( line.Length == 0 ) continue;
+
+			if ( line.StartsWith( '[' ) )
+			{
+				var name = line.Trim( '[', ']' );
+				switch ( name )
+				{
+					case "ParticipatingBones":
+					case "Joints":
+					case "Ragdoll":
+					case "Geometry":
+					case "Properties":
+						section = name;
+						break;
+					case "Bone" when section == "ParticipatingBones":
+						bone = new BoneDef();
+						ragdoll.Bones.Add( bone );
+						break;
+					case "Joint" when section == "Joints":
+						joint = new JointDef();
+						ragdoll.Joints.Add( joint );
+						break;
+				}
+				continue;
+			}
+
+			var eq = line.IndexOf( '=' );
+			if ( eq < 0 ) continue;
+
+			var key = line[..eq].Trim();
+			var value = line[(eq + 1)..].Trim().TrimEnd( ';' ).Trim();
+
+			if ( section == "Geometry" && key == "ExportData" )
+			{
+				ragdoll.GeometryFile = value.Split( ';' )[0].Trim().Trim( '"' );
+				continue;
+			}
+
+			if ( bone is not null && section == "ParticipatingBones" )
+			{
+				switch ( key )
+				{
+					case "Name": bone.Name = value.Trim( '"' ); break;
+					case "RelativeWeight": bone.Weight = Float( value ); break;
+				}
+				continue;
+			}
+
+			if ( joint is not null && section == "Joints" )
+			{
+				switch ( key )
+				{
+					case "Bone1": joint.Bone1 = value.Trim( '"' ); break;
+					case "Bone2": joint.Bone2 = value.Trim( '"' ); break;
+					case "TwistAxis": joint.TwistAxis = Vec( value ); break;
+					case "TwistMin": joint.TwistMin = Float( value ); break;
+					case "TwistMax": joint.TwistMax = Float( value ); break;
+					case "ConeMin": joint.ConeMin = Float( value ); break;
+					case "ConeMax": joint.ConeMax = Float( value ); break;
+					case "PlaneMin": joint.PlaneMin = Float( value ); break;
+					case "PlaneMax": joint.PlaneMax = Float( value ); break;
+				}
+			}
+		}
+
+		return ragdoll;
+	}
+
+	static float Float( string value )
+		=> float.TryParse( value, NumberStyles.Float, CultureInfo.InvariantCulture, out var f ) ? f : 0f;
+
+	static Vector3 Vec( string value )
+	{
+		var parts = value.Trim( '(', ')' ).Split( ',', StringSplitOptions.TrimEntries );
+		return parts.Length == 3 ? new Vector3( Float( parts[0] ), Float( parts[1] ), Float( parts[2] ) ) : Vector3.Zero;
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Ras.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Ras.cs
@@ -1,0 +1,239 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace RasLib;
+
+public class RasFile
+{
+	public string FileName;
+	public string FilePath;
+	public long FilePosition;
+	public int FileLength;
+	public int StoredLength;
+
+	public string FullPath => System.IO.Path.Combine( FilePath, FileName ).Replace( '\\', '/' );
+}
+
+public class Archive : IDisposable
+{
+	private readonly FileStream rasStream;
+
+	private readonly Dictionary<string, RasFile> fileLookup = new( StringComparer.OrdinalIgnoreCase );
+
+	public List<RasFile> Files { get; private set; } = [];
+	public string Path { get; }
+	public string Name => System.IO.Path.GetFileName( Path );
+
+	public int NumFiles => Files.Count;
+	public bool IsValid { get; private set; }
+
+	public Archive( string path )
+	{
+		Path = path;
+		rasStream = File.OpenRead( path );
+
+		if ( !ReadArchive() )
+			return;
+
+		IsValid = true;
+	}
+
+	private bool ReadArchive()
+	{
+		using var br = new BinaryReader( rasStream, Encoding.Latin1, leaveOpen: true );
+
+		rasStream.Seek( 0, SeekOrigin.Begin );
+		if ( br.ReadUInt32() != 0x00534152 )
+			return false;
+
+		var seed = br.ReadInt32();
+
+		var header = br.ReadBytes( 0x24 );
+		Decrypt( header, seed );
+
+		var numFiles = BitConverter.ToInt32( header, 0 );
+		var numFolders = BitConverter.ToInt32( header, 4 );
+		var fileTableLength = BitConverter.ToInt32( header, 8 );
+		var folderTableLength = BitConverter.ToInt32( header, 12 );
+		var version = BitConverter.ToSingle( header, 16 );
+
+		if ( numFiles < 0 || numFolders <= 0 || fileTableLength <= 0 || folderTableLength <= 0 )
+			return false;
+
+		var fileTable = br.ReadBytes( fileTableLength );
+		Decrypt( fileTable, seed );
+
+		var folderTable = br.ReadBytes( folderTableLength );
+		Decrypt( folderTable, seed );
+
+		var dataStart = rasStream.Position;
+		var legacy = version < 1.25f;
+
+		var folders = new string[numFolders];
+		var pos = 0;
+		for ( var i = 0; i < numFolders; i++ )
+		{
+			folders[i] = ReadString( folderTable, ref pos );
+			if ( legacy ) pos += 16;
+		}
+
+		Files = new List<RasFile>( numFiles );
+		pos = 0;
+		var runningOffset = dataStart;
+
+		for ( var i = 0; i < numFiles; i++ )
+		{
+			var name = ReadString( fileTable, ref pos );
+			var file = new RasFile { FileName = name };
+
+			if ( legacy )
+			{
+				file.FileLength = BitConverter.ToInt32( fileTable, pos );
+				file.StoredLength = BitConverter.ToInt32( fileTable, pos + 4 );
+				file.FilePath = FolderName( folders, BitConverter.ToInt32( fileTable, pos + 12 ) );
+				file.FilePosition = runningOffset;
+				runningOffset += file.StoredLength;
+				pos += 40;
+			}
+			else
+			{
+				file.FileLength = BitConverter.ToInt32( fileTable, pos );
+				file.FilePosition = BitConverter.ToUInt32( fileTable, pos + 4 );
+				file.FilePath = FolderName( folders, BitConverter.ToInt32( fileTable, pos + 8 ) );
+				file.StoredLength = file.FileLength;
+				pos += 12;
+			}
+
+			Files.Add( file );
+			fileLookup[file.FullPath] = file;
+		}
+
+		return true;
+	}
+
+	private static string ReadString( byte[] data, ref int pos )
+	{
+		var start = pos;
+		while ( data[pos] != 0 ) pos++;
+		return Encoding.ASCII.GetString( data, start, pos++ - start );
+	}
+
+	private static string FolderName( string[] folders, int index )
+	{
+		if ( index < 0 || index >= folders.Length )
+			return string.Empty;
+
+		return folders[index].Trim( '\\', '/' ).Replace( '\\', '/' );
+	}
+
+	public byte[] GetFileBytes( string filename )
+	{
+		if ( !IsValid || string.IsNullOrEmpty( filename ) )
+			return null;
+
+		if ( !fileLookup.TryGetValue( filename, out var file ) )
+			return null;
+
+		return GetFileBytes( file );
+	}
+
+	public byte[] GetFileBytes( RasFile file )
+	{
+		var stored = new byte[file.StoredLength];
+		rasStream.Seek( file.FilePosition, SeekOrigin.Begin );
+		rasStream.ReadExactly( stored, 0, file.StoredLength );
+
+		if ( stored.Length >= 12 && stored[0] == 'R' && stored[1] == 'A' && stored[2] == '-' && stored[3] == '>' )
+		{
+			var length = BitConverter.ToInt32( stored, 4 );
+			return Decompress( stored, 12, stored.Length - 12, length );
+		}
+
+		return stored;
+	}
+
+	public bool FileExists( string filename )
+	{
+		if ( !IsValid || string.IsNullOrEmpty( filename ) )
+			return false;
+
+		return fileLookup.ContainsKey( filename );
+	}
+
+	// Stream cipher reverse engineered by Ekey (zenhax.com/viewtopic.php?t=2717)
+	private static void Decrypt( byte[] data, int seed )
+	{
+		if ( seed == 0 )
+			seed = 1;
+
+		unchecked
+		{
+			for ( var i = 0; i < data.Length; i++ )
+			{
+				seed = -2 * (seed / 177) + 171 * (seed % 177);
+
+				var rot = i % 5;
+				var rolled = (byte)((data[i] << rot) | (data[i] >> (8 - rot)));
+				var mixed = (byte)(rolled ^ (byte)((i + 3) * 6));
+
+				data[i] = (byte)(mixed + (byte)seed);
+			}
+		}
+	}
+
+	// LZSS with a zero-initialized 4KB ring buffer ("RA->" blocks)
+	private static byte[] Decompress( byte[] src, int srcOffset, int srcLength, int dstLength )
+	{
+		var dst = new byte[dstLength];
+		var ring = new byte[4096];
+		var r = 4096 - 18;
+
+		var ip = srcOffset;
+		var end = srcOffset + srcLength;
+		var op = 0;
+		var flags = 0;
+
+		while ( op < dstLength && ip < end )
+		{
+			flags >>= 1;
+			if ( (flags & 0x100) == 0 )
+				flags = src[ip++] | 0xFF00;
+
+			if ( (flags & 1) != 0 )
+			{
+				var b = src[ip++];
+				dst[op++] = b;
+				ring[r] = b;
+				r = (r + 1) & 0xFFF;
+			}
+			else
+			{
+				if ( ip + 1 >= end )
+					break;
+
+				int low = src[ip++];
+				int high = src[ip++];
+
+				var offset = low | ((high & 0xF0) << 4);
+				var length = (high & 0x0F) + 3;
+
+				for ( var i = 0; i < length && op < dstLength; i++ )
+				{
+					var b = ring[(offset + i) & 0xFFF];
+					dst[op++] = b;
+					ring[r] = b;
+					r = (r + 1) & 0xFFF;
+				}
+			}
+		}
+
+		return dst;
+	}
+
+	public void Dispose()
+	{
+		rasStream.Dispose();
+		GC.SuppressFinalize( this );
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Map.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Map.cs
@@ -1,0 +1,301 @@
+using Sandbox;
+using Sandbox.Mounting;
+using RasLib;
+using System;
+using System.Collections.Generic;
+
+partial class MaxPayne2Map( string fileName ) : SceneLoader<MaxPayne2Mount>
+{
+	public string FileName { get; set; } = fileName;
+
+	const float Scale = 39.37f; // meters -> inches
+
+	Ldb2File _ldb;
+	readonly Dictionary<int, Texture> _diffuseCache = [];
+	readonly Dictionary<int, Texture> _lightmapCache = [];
+
+	protected override void BuildScene()
+	{
+		var data = Host.GetFileBytes( FileName );
+		if ( data is null )
+			return;
+
+		_ldb = Ldb2File.Parse( data );
+
+		var world = new GameObject( true, "worldspawn" );
+
+		foreach ( var room in _ldb.Rooms )
+		{
+			var model = BuildMeshListModel( room.Name, room.Meshes, room.Transform );
+			if ( model is null )
+				continue;
+
+			SpawnModel( world, room.Name, model, Transform.Zero );
+		}
+
+		SpawnDynamicMeshes( world );
+		SpawnLights( world );
+	}
+
+	void SpawnDynamicMeshes( GameObject world )
+	{
+		var modelCache = new Dictionary<List<Ldb2File.SubMesh>, Model>();
+
+		for ( var i = 0; i < _ldb.DynamicMeshes.Count; i++ )
+		{
+			var dyn = _ldb.DynamicMeshes[i];
+			if ( dyn.Meshes is null || dyn.Meshes.Count == 0 )
+				continue;
+
+			if ( dyn.FsmId < 0 || dyn.FsmId >= _ldb.Fsms.Count )
+				continue;
+
+			if ( !modelCache.TryGetValue( dyn.Meshes, out var model ) )
+			{
+				model = BuildMeshListModel( $"dynamic_{i}", dyn.Meshes, Mat43.Identity );
+				modelCache[dyn.Meshes] = model;
+			}
+
+			if ( model is null )
+				continue;
+
+			// geometry is centered on itself; pivot = center offset from the FSM origin
+			// (door hinge) in FSM-LOCAL axes, so it must rotate with the basis
+			var placement = _ldb.Fsms[dyn.FsmId].Transform;
+			placement.Translation = placement.Point( dyn.AabbPivot );
+
+			SpawnModel( world, $"dynamic_{i}", model, placement.ToSbox( Scale ) );
+		}
+	}
+
+	void SpawnLights( GameObject world )
+	{
+		foreach ( var light in _ldb.Lights )
+		{
+			var go = new GameObject( true, "light" );
+			go.SetParent( world );
+			go.WorldTransform = light.Transform.ToSbox( Scale );
+
+			var point = go.AddComponent<PointLight>();
+			point.LightColor = new Color( light.R / 255f, light.G / 255f, light.B / 255f, 1f ) * (light.A / 255f);
+			point.Radius = light.Falloff * Scale;
+		}
+
+		// flares mark the visible lamp props; their illumination is baked into lightmaps,
+		// so give each a real light to shine on characters and props
+		foreach ( var flare in _ldb.Flares )
+		{
+			var go = new GameObject( true, "flare_light" );
+			go.SetParent( world );
+			go.WorldTransform = flare.ToSbox( Scale );
+
+			var point = go.AddComponent<PointLight>();
+			point.LightColor = new Color( 1f, 0.92f, 0.78f, 1f );
+			point.Radius = 350f;
+			point.Shadows = false;
+		}
+
+		float ambR = 0, ambG = 0, ambB = 0, ambWeight = 0;
+
+		foreach ( var room in _ldb.Rooms )
+		{
+			foreach ( var vol in room.VolumeLights )
+			{
+				var center = room.Transform.Point( (vol.Min + vol.Max) * 0.5f );
+				var size = (vol.Max - vol.Min) * Scale;
+
+				var go = new GameObject( true, $"ambient_{room.Name}" );
+				go.SetParent( world );
+				go.WorldPosition = new Vector3( -center.x, -center.z, center.y ) * Scale;
+
+				// x2 compensates for point falloff standing in for a uniform ambient grid
+				var point = go.AddComponent<PointLight>();
+				point.LightColor = new Color( MathF.Min( vol.R * 2f, 1f ), MathF.Min( vol.G * 2f, 1f ), MathF.Min( vol.B * 2f, 1f ), 1f );
+				point.Radius = MathF.Max( size.Length, 256f );
+				point.Shadows = false;
+
+				var weight = MathF.Max( size.Length, 1f );
+				ambR += vol.R * weight; ambG += vol.G * weight; ambB += vol.B * weight;
+				ambWeight += weight;
+			}
+		}
+
+		// distance-independent floor so characters stay visible everywhere in the level
+		if ( ambWeight > 0 )
+		{
+			var go = new GameObject( true, "mp2_ambient" );
+			go.SetParent( world );
+			go.AddComponent<AmbientLight>().Color = new Color(
+				MathF.Min( ambR / ambWeight, 1f ),
+				MathF.Min( ambG / ambWeight, 1f ),
+				MathF.Min( ambB / ambWeight, 1f ), 1f );
+		}
+	}
+
+	static void SpawnModel( GameObject world, string name, Model model, Transform transform )
+	{
+		var go = new GameObject( true, name );
+		go.SetParent( world );
+		go.WorldTransform = transform;
+		go.AddComponent<ModelRenderer>().Model = model;
+
+		var collider = go.AddComponent<ModelCollider>();
+		collider.Model = model;
+		collider.Static = true;
+	}
+
+	Model BuildMeshListModel( string name, List<Ldb2File.SubMesh> meshes, Mat43 transform )
+	{
+		var builder = Model.Builder.WithName( $"{Path}#{name}" );
+		var collisionVerts = new List<Vector3>();
+		var collisionIndices = new List<int>();
+		var any = false;
+
+		foreach ( var sub in meshes )
+		{
+			if ( sub.Positions.Length == 0 || sub.Indices.Length == 0 )
+				continue;
+
+			var mesh = BuildSubMesh( sub, transform, out var positions, out var indices );
+			if ( mesh is null )
+				continue;
+
+			var baseIndex = collisionVerts.Count;
+			collisionVerts.AddRange( positions );
+			for ( var i = 0; i < indices.Length; i++ )
+				collisionIndices.Add( baseIndex + indices[i] );
+
+			builder.AddMesh( mesh );
+			any = true;
+		}
+
+		if ( !any )
+			return null;
+
+		builder.AddCollisionMesh( collisionVerts, collisionIndices );
+		builder.AddTraceMesh( collisionVerts, collisionIndices );
+		return builder.Create();
+	}
+
+	Mesh BuildSubMesh( Ldb2File.SubMesh sub, Mat43 roomToWorld, out Vector3[] positions, out int[] indices )
+	{
+		var count = sub.Positions.Length;
+		positions = new Vector3[count];
+		var normals = new Vector3[count];
+		for ( var i = 0; i < count; i++ )
+		{
+			var p = roomToWorld.Point( sub.Positions[i] );
+			var n = roomToWorld.Direction( sub.Normals[i] );
+			positions[i] = new Vector3( -p.x, -p.z, p.y ) * Scale;
+			normals[i] = new Vector3( -n.x, -n.z, n.y ).Normal;
+		}
+
+		var matDef = sub.MaterialId >= 0 && sub.MaterialId < _ldb.Materials.Count ? _ldb.Materials[sub.MaterialId] : null;
+		var dualSided = matDef?.DualSided ?? false;
+
+		// coplanar layers: MP2 orders them by sortPriority with decals not writing z;
+		// nudge along the normal so they separate in a plain z-buffered renderer
+		var nudge = (matDef is { WritesZBuffer: false } ? 0.6f : 0f) + (matDef?.SortPriority ?? 0) * 0.3f;
+		if ( nudge > 0f )
+		{
+			for ( var i = 0; i < count; i++ )
+				positions[i] += normals[i] * nudge;
+		}
+
+		var tris = sub.Indices.Length;
+		indices = new int[dualSided ? tris * 2 : tris];
+		for ( var i = 0; i < tris; i += 3 )
+		{
+			indices[i] = sub.Indices[i];
+			indices[i + 1] = sub.Indices[i + 2];
+			indices[i + 2] = sub.Indices[i + 1];
+		}
+
+		if ( dualSided )
+		{
+			for ( var i = 0; i < tris; i++ )
+				indices[tris + i] = sub.Indices[i];
+		}
+
+		var lightmap = sub.LightmapUvs is not null && matDef is not null ? ResolveLightmap( matDef.LightmapId ) : null;
+
+		var usesAlpha = matDef?.UsesAlpha ?? false;
+
+		Mesh mesh;
+		if ( lightmap is not null )
+		{
+			var material = Material.Create( "mp2_world", "shaders/mp2_world.shader" );
+			material?.Set( "g_tColor", ResolveDiffuse( sub.MaterialId ) ?? Texture.White );
+			material?.Set( "g_tLightmap", lightmap );
+			if ( usesAlpha ) material?.SetFeature( "F_ALPHA_TEST", 1 );
+
+			mesh = new Mesh( material );
+			var vertices = new MapVertex[count];
+			for ( var i = 0; i < count; i++ )
+				vertices[i] = new MapVertex( positions[i], normals[i], sub.Uvs[i], sub.LightmapUvs[i] );
+			mesh.CreateVertexBuffer( count, vertices );
+		}
+		else
+		{
+			var material = Material.Create( "mp2_model", "shaders/mp2_model.shader" );
+			material?.Set( "g_tColor", ResolveDiffuse( sub.MaterialId ) ?? Texture.White );
+			if ( usesAlpha ) material?.SetFeature( "F_ALPHA_TEST", 1 );
+
+			mesh = new Mesh( material );
+			var vertices = new SimpleVertex[count];
+			for ( var i = 0; i < count; i++ )
+				vertices[i] = new SimpleVertex( positions[i], normals[i], Vector3.Zero, sub.Uvs[i] );
+			mesh.CreateVertexBuffer( count, vertices );
+		}
+
+		mesh.CreateIndexBuffer( indices.Length, indices );
+		mesh.Bounds = BBox.FromPoints( positions );
+		return mesh;
+	}
+
+	Texture ResolveLightmap( int lightmapId )
+	{
+		if ( lightmapId < 0 || lightmapId >= _ldb.Lightmaps.Count )
+			return null;
+
+		if ( _lightmapCache.TryGetValue( lightmapId, out var cached ) )
+			return cached;
+
+		var tex = MaxPayneImage.Load( _ldb.Lightmaps[lightmapId].Data );
+		_lightmapCache[lightmapId] = tex;
+		return tex;
+	}
+
+	Texture ResolveDiffuse( int materialId )
+	{
+		if ( materialId < 0 || materialId >= _ldb.Materials.Count )
+			return null;
+
+		var mat = _ldb.Materials[materialId];
+		var index = mat.VisibleFrame >= 0 ? mat.FrameStart + mat.VisibleFrame : mat.FrameStart;
+		if ( index < 0 || index >= _ldb.Diffuse.Count )
+			return null;
+
+		if ( _diffuseCache.TryGetValue( index, out var cached ) )
+			return cached;
+
+		var tex = MaxPayneImage.Load( _ldb.Diffuse[index].Data );
+		_diffuseCache[index] = tex;
+		return tex;
+	}
+}
+
+file struct MapVertex( Vector3 position, Vector3 normal, Vector2 texcoord, Vector2 lightmapUv )
+{
+	[VertexLayout.Position]
+	public Vector3 Position = position;
+
+	[VertexLayout.Normal]
+	public Vector3 Normal = normal;
+
+	[VertexLayout.TexCoord]
+	public Vector2 Texcoord = texcoord;
+
+	[VertexLayout.TexCoord( 1 )]
+	public Vector2 LightmapUv = lightmapUv;
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Model.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Model.cs
@@ -23,7 +23,6 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 		var dir = System.IO.Path.GetDirectoryName( FileName )?.Replace( '\\', '/' );
 		var searchDirs = BuildSearchDirs( dir, kf2.TextureDirs );
 		var builder = Model.Builder.WithName( Path );
-		var textureCache = new Dictionary<string, Texture>( StringComparer.OrdinalIgnoreCase );
 
 		var rig = LoadRig( dir );
 		var animatedNodes = rig is null && kf2.Animations.Count > 0 && kf2.Nodes.Count > 0;
@@ -44,10 +43,10 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 			var indices = BuildIndices( kf2, prim );
 
 			var mesh = rig is not null
-				? BuildRigMesh( kf2, prim, positions, indices, searchDirs, textureCache, rig )
+				? BuildRigMesh( kf2, prim, positions, indices, searchDirs, rig )
 				: animatedNodes
-					? BuildSkinnedMesh( kf2, prim, positions, indices, searchDirs, textureCache, boneIndexByNode )
-					: BuildMesh( kf2, prim, positions, indices, searchDirs, textureCache );
+					? BuildSkinnedMesh( kf2, prim, positions, indices, searchDirs, boneIndexByNode )
+					: BuildMesh( kf2, prim, positions, indices, searchDirs );
 
 			var baseIndex = collisionVerts.Count;
 			collisionVerts.AddRange( positions );
@@ -190,9 +189,9 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 		builder.AddBones( bones );
 	}
 
-	Mesh BuildRigMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Dictionary<string, Texture> cache, Rig rig )
+	Mesh BuildRigMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Rig rig )
 	{
-		var material = CreateMaterial( kf2, prim, searchDirs, cache );
+		var material = CreateMaterial( kf2, prim, searchDirs );
 		var mesh = new Mesh( material );
 
 		var skin = rig.Skin;
@@ -542,9 +541,9 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 		return string.Join( '/', parts );
 	}
 
-	Mesh BuildMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Dictionary<string, Texture> cache )
+	Mesh BuildMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs )
 	{
-		var material = CreateMaterial( kf2, prim, searchDirs, cache );
+		var material = CreateMaterial( kf2, prim, searchDirs );
 
 		var mesh = new Mesh( material );
 
@@ -566,9 +565,9 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 		return mesh;
 	}
 
-	Mesh BuildSkinnedMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Dictionary<string, Texture> cache, Dictionary<string, int> boneIndexByNode )
+	Mesh BuildSkinnedMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Dictionary<string, int> boneIndexByNode )
 	{
-		var material = CreateMaterial( kf2, prim, searchDirs, cache );
+		var material = CreateMaterial( kf2, prim, searchDirs );
 
 		var mesh = new Mesh( material );
 
@@ -616,16 +615,16 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 		return indices;
 	}
 
-	Material CreateMaterial( Kf2File kf2, Kf2File.Primitive prim, List<string> searchDirs, Dictionary<string, Texture> cache )
+	Material CreateMaterial( Kf2File kf2, Kf2File.Primitive prim, List<string> searchDirs )
 	{
 		var material = Material.Create( "mp2_model", "shaders/mp2_model.shader" );
-		material?.Set( "g_tColor", ResolveTexture( kf2, prim.MaterialName, searchDirs, cache ) ?? Texture.White );
+		material?.Set( "g_tColor", ResolveTexture( kf2, prim.MaterialName, searchDirs ) ?? Texture.White );
 		// opaque DXT1 decodes a=1 everywhere, so the cutout never fires on solid models
 		material?.SetFeature( "F_ALPHA_TEST", 1 );
 		return material;
 	}
 
-	Texture ResolveTexture( Kf2File kf2, string materialName, List<string> searchDirs, Dictionary<string, Texture> cache )
+	Texture ResolveTexture( Kf2File kf2, string materialName, List<string> searchDirs )
 	{
 		if ( string.IsNullOrEmpty( materialName ) || !kf2.Materials.TryGetValue( materialName, out var mat ) )
 			return null;
@@ -633,12 +632,7 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 		if ( string.IsNullOrEmpty( mat.DiffuseTexture ) )
 			return null;
 
-		if ( cache.TryGetValue( mat.DiffuseTexture, out var cached ) )
-			return cached;
-
-		var tex = LoadTexture( searchDirs, mat.DiffuseTexture );
-		cache[mat.DiffuseTexture] = tex;
-		return tex;
+		return LoadTexture( searchDirs, mat.DiffuseTexture );
 	}
 
 	Texture LoadTexture( List<string> searchDirs, string fileName )
@@ -650,9 +644,10 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 			foreach ( var ext in new[] { ".dds", ".tga", ".jpg", ".pcx" } )
 			{
 				var candidate = string.IsNullOrEmpty( dir ) ? name + ext : $"{dir}/{name}{ext}";
-				var data = Host.GetFileBytes( candidate );
-				if ( data is not null )
-					return MaxPayneImage.Load( data );
+				if ( !Host.FileExists( candidate ) )
+					continue;
+
+				return Texture.Load( $"mount://{Host.Ident}/{candidate}.vtex" );
 			}
 		}
 

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Model.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Model.cs
@@ -1,0 +1,670 @@
+using Sandbox;
+using Sandbox.Mounting;
+using RasLib;
+using System;
+using System.Collections.Generic;
+
+class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
+{
+	public string FileName { get; set; } = fileName;
+
+	const float Scale = 39.37f; // meters -> inches
+
+	protected override object Load()
+	{
+		var data = Host.GetFileBytes( FileName );
+		if ( data is null )
+			return null;
+
+		var kf2 = Kf2File.Parse( data );
+		if ( kf2.Primitives.Count == 0 )
+			return null;
+
+		var dir = System.IO.Path.GetDirectoryName( FileName )?.Replace( '\\', '/' );
+		var searchDirs = BuildSearchDirs( dir, kf2.TextureDirs );
+		var builder = Model.Builder.WithName( Path );
+		var textureCache = new Dictionary<string, Texture>( StringComparer.OrdinalIgnoreCase );
+
+		var rig = LoadRig( dir );
+		var animatedNodes = rig is null && kf2.Animations.Count > 0 && kf2.Nodes.Count > 0;
+
+		Dictionary<string, int> boneIndexByNode = null;
+		if ( rig is not null ) AddRigBones( builder, rig );
+		else if ( animatedNodes ) boneIndexByNode = AddBones( kf2, builder );
+
+		var collisionVerts = new List<Vector3>();
+		var collisionIndices = new List<int>();
+		var any = false;
+		foreach ( var prim in kf2.Primitives )
+		{
+			if ( prim.Positions.Length == 0 || prim.Indices.Length == 0 )
+				continue;
+
+			var positions = ConvertPositions( prim );
+			var indices = BuildIndices( kf2, prim );
+
+			var mesh = rig is not null
+				? BuildRigMesh( kf2, prim, positions, indices, searchDirs, textureCache, rig )
+				: animatedNodes
+					? BuildSkinnedMesh( kf2, prim, positions, indices, searchDirs, textureCache, boneIndexByNode )
+					: BuildMesh( kf2, prim, positions, indices, searchDirs, textureCache );
+
+			var baseIndex = collisionVerts.Count;
+			collisionVerts.AddRange( positions );
+			for ( var i = 0; i < indices.Length; i++ )
+				collisionIndices.Add( baseIndex + indices[i] );
+
+			builder.AddMesh( mesh );
+			any = true;
+		}
+
+		if ( !any )
+			return null;
+
+		builder.AddCollisionMesh( collisionVerts, collisionIndices );
+		builder.AddTraceMesh( collisionVerts, collisionIndices );
+
+		if ( rig is not null ) AddRigAnimations( builder, rig );
+		else if ( animatedNodes ) AddAnimations( kf2, builder );
+
+		return builder.Create();
+	}
+
+	class Rig
+	{
+		public string[] BoneNames;
+		public string[] ParentNames;
+		public Transform[] BindLocals;
+		public Vector3[] BindScales;
+		public Kf2File.SkinData Skin;
+		public string AnimFolder;
+	}
+
+	Rig LoadRig( string dir )
+	{
+		var skdData = Host.GetFileBytes( System.IO.Path.ChangeExtension( FileName, ".skd" )?.Replace( '\\', '/' ) );
+		if ( skdData is null )
+			return null;
+
+		Kf2File skd;
+		try { skd = Kf2File.Parse( skdData ); }
+		catch { return null; }
+
+		if ( skd.Skin?.BoneNames is not { Length: > 0 } boneNames )
+			return null;
+
+		// skins/<char>/<lod>.kf2 -> skins/<char>.txt declares Skeleton = "male"|"female"
+		var skeletonName = "male";
+		var txt = Host.GetFileBytes( $"{dir}.txt" );
+		if ( txt is not null )
+		{
+			var match = System.Text.RegularExpressions.Regex.Match(
+				System.Text.Encoding.Latin1.GetString( txt ), "Skeleton\\s*=\\s*\"([^\"]+)\"" );
+			if ( match.Success ) skeletonName = match.Groups[1].Value.ToLowerInvariant();
+		}
+
+		var skelDir = $"data/database/skeletons/{skeletonName}";
+		var skelData = Host.GetFileBytes( $"{skelDir}/skeleton_{skeletonName}.kf2" );
+		if ( skelData is null )
+			return null;
+
+		Kf2File skeleton;
+		try { skeleton = Kf2File.Parse( skelData ); }
+		catch { return null; }
+
+		var poseLocals = new Dictionary<string, Mat43>( StringComparer.OrdinalIgnoreCase );
+		var poseData = Host.GetFileBytes( $"{skelDir}/pose_{skeletonName}.kf2" );
+		if ( poseData is not null )
+		{
+			try
+			{
+				foreach ( var anim in Kf2File.Parse( poseData ).Animations )
+				{
+					if ( anim.Keys.Count > 0 )
+						poseLocals[anim.NodeName] = anim.Keys[0].Local;
+				}
+			}
+			catch { }
+		}
+
+		var boneSet = new HashSet<string>( boneNames, StringComparer.OrdinalIgnoreCase );
+		var rig = new Rig
+		{
+			BoneNames = boneNames,
+			ParentNames = new string[boneNames.Length],
+			BindLocals = new Transform[boneNames.Length],
+			BindScales = new Vector3[boneNames.Length],
+			Skin = skd.Skin,
+			AnimFolder = $"{skelDir}/anim/",
+		};
+
+		for ( var i = 0; i < boneNames.Length; i++ )
+		{
+			var node = skeleton.FindNode( boneNames[i] );
+			if ( node is null )
+			{
+				rig.BindLocals[i] = Transform.Zero;
+				rig.BindScales[i] = Vector3.One;
+				continue;
+			}
+
+			// skeleton casing, not skd casing: MaxPayne skd says 'ForeArm', skeleton 'Forearm' - children
+			// declare skeleton-cased parents and the engine must match them to the bone names
+			rig.BoneNames[i] = node.Name;
+			var local = poseLocals.TryGetValue( node.Name, out var pose ) ? pose : node.Local;
+			rig.BindLocals[i] = local.ToSbox( Scale );
+			rig.BindScales[i] = local.AxisScales;
+			rig.ParentNames[i] = node.HasParent && !string.IsNullOrEmpty( node.Parent ) && boneSet.Contains( node.Parent )
+				? node.Parent : null;
+		}
+
+		return rig;
+	}
+
+	// GoldSrc mount standard: Bone takes MODEL-SPACE transforms, AddFrame takes parent-local
+	static void AddRigBones( ModelBuilder builder, Rig rig )
+	{
+		var count = rig.BoneNames.Length;
+		var indexByName = new Dictionary<string, int>( count, StringComparer.OrdinalIgnoreCase );
+		for ( var i = 0; i < count; i++ ) indexByName[rig.BoneNames[i]] = i;
+
+		var worlds = new Transform?[count];
+
+		Transform WorldOf( int i )
+		{
+			if ( worlds[i] is { } cached ) return cached;
+			var world = rig.ParentNames[i] is { } p && indexByName.TryGetValue( p, out var pi ) && pi != i
+				? WorldOf( pi ).ToWorld( rig.BindLocals[i] )
+				: rig.BindLocals[i];
+			worlds[i] = world;
+			return world;
+		}
+
+		var bones = new ModelBuilder.Bone[count];
+		for ( var i = 0; i < count; i++ )
+		{
+			var world = WorldOf( i );
+			bones[i] = new ModelBuilder.Bone( rig.BoneNames[i], rig.ParentNames[i], world.Position, world.Rotation );
+		}
+
+		builder.AddBones( bones );
+	}
+
+	Mesh BuildRigMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Dictionary<string, Texture> cache, Rig rig )
+	{
+		var material = CreateMaterial( kf2, prim, searchDirs, cache );
+		var mesh = new Mesh( material );
+
+		var skin = rig.Skin;
+		var vertices = new SkinnedVertex[positions.Length];
+		Span<int> bones = stackalloc int[4];
+		Span<float> weights = stackalloc float[4];
+		Span<byte> wb = stackalloc byte[4];
+
+		for ( var i = 0; i < vertices.Length; i++ )
+		{
+			var n = prim.Normals is not null ? prim.Normals[i] : Vector3.Up;
+			var uv = prim.Uvs is not null ? prim.Uvs[i] : Vector2.Zero;
+
+			bones.Clear();
+			weights.Clear();
+			var used = 0;
+
+			var global = prim.VertexStart + i;
+			if ( global < skin.Offsets.Length )
+			{
+				var offset = skin.Offsets[global];
+				var boneCount = skin.Counts[global];
+				for ( var b = 0; b < boneCount && offset + b < skin.Weights.Length; b++ )
+				{
+					var bone = skin.BoneIndices[offset + b];
+					var weight = skin.Weights[offset + b];
+					if ( weight <= 0f || bone < 0 || bone > 255 ) continue;
+
+					if ( used < 4 ) { bones[used] = bone; weights[used] = weight; used++; }
+					else
+					{
+						var min = 0;
+						for ( var k = 1; k < 4; k++ ) if ( weights[k] < weights[min] ) min = k;
+						if ( weight > weights[min] ) { bones[min] = bone; weights[min] = weight; }
+					}
+				}
+			}
+
+			Color32 blendIndices, blendWeights;
+			if ( used == 0 )
+			{
+				blendIndices = new Color32( 0, 0, 0, 0 );
+				blendWeights = new Color32( 255, 0, 0, 0 );
+			}
+			else
+			{
+				float total = 0;
+				for ( var k = 0; k < used; k++ ) total += weights[k];
+
+				wb.Clear();
+				var sum = 0;
+				for ( var k = 0; k < used; k++ )
+				{
+					wb[k] = (byte)Math.Clamp( (int)MathF.Round( weights[k] / total * 255f ), 0, 255 );
+					sum += wb[k];
+				}
+
+				// engine expects bytes summing exactly 255 (MD5 mount precedent) - dump the diff on the largest
+				if ( sum != 255 )
+				{
+					var max = 0;
+					for ( var k = 1; k < used; k++ ) if ( wb[k] > wb[max] ) max = k;
+					wb[max] = (byte)(wb[max] + (255 - sum));
+				}
+
+				blendIndices = new Color32( (byte)bones[0], (byte)bones[1], (byte)bones[2], (byte)bones[3] );
+				blendWeights = new Color32( wb[0], wb[1], wb[2], wb[3] );
+			}
+
+			vertices[i] = new SkinnedVertex(
+				positions[i],
+				new Vector3( -n.x, -n.z, n.y ),
+				uv, blendIndices, blendWeights );
+		}
+
+		mesh.CreateVertexBuffer( vertices.Length, vertices );
+		mesh.CreateIndexBuffer( indices.Length, indices );
+		mesh.Bounds = BBox.FromPoints( positions );
+		return mesh;
+	}
+
+	void AddRigAnimations( ModelBuilder builder, Rig rig )
+	{
+		var indexByName = new Dictionary<string, int>( StringComparer.OrdinalIgnoreCase );
+		for ( var i = 0; i < rig.BoneNames.Length; i++ ) indexByName[rig.BoneNames[i]] = i;
+
+		foreach ( var path in Host.FindFiles( rig.AnimFolder, ".kf2" ) )
+		{
+			if ( path.EndsWith( "_mov.kf2", StringComparison.OrdinalIgnoreCase ) )
+				continue;
+
+			var data = Host.GetFileBytes( path );
+			if ( data is null ) continue;
+
+			Kf2File animFile;
+			try { animFile = Kf2File.Parse( data ); }
+			catch { continue; }
+
+			if ( animFile.Animations.Count == 0 ) continue;
+
+			BakeClip( builder, System.IO.Path.GetFileNameWithoutExtension( path ), rig, indexByName, animFile.Animations );
+		}
+	}
+
+	// anim tracks are local to the track's OWN parentName, which can differ from the skeleton
+	// (AI_Shoot anims key clavicles to Neck, thighs to Spine). Rebuild worlds per frame through
+	// the anim's parent graph, then re-localize to the skeleton hierarchy for the engine.
+	void BakeClip( ModelBuilder builder, string name, Rig rig, Dictionary<string, int> indexByName, List<Kf2File.NodeAnim> anims )
+	{
+		var fps = 30f;
+		var totalFrames = 0;
+		var looping = false;
+		var boneCount = rig.BoneNames.Length;
+
+		var skelParent = new int[boneCount];
+		for ( var i = 0; i < boneCount; i++ )
+			skelParent[i] = rig.ParentNames[i] is not null && indexByName.TryGetValue( rig.ParentNames[i], out var sp ) ? sp : -1;
+
+		var keysPerBone = new List<(int Frame, Transform Local)>[boneCount];
+		var animParent = new int[boneCount];
+		Array.Copy( skelParent, animParent, boneCount );
+
+		foreach ( var a in anims )
+		{
+			if ( a.Fps > 0 ) fps = a.Fps;
+			if ( a.TotalFrames > totalFrames ) totalFrames = a.TotalFrames;
+			looping |= a.Looping;
+
+			if ( !indexByName.TryGetValue( a.NodeName, out var bone ) || a.Keys.Count == 0 )
+				continue;
+
+			var keys = new List<(int Frame, Transform Local)>( a.Keys.Count );
+			foreach ( var (frame, local) in a.Keys )
+			{
+				// MP2 animates faces via matrix scale (blinks, lips) - carried as scale relative to bind
+				var t = local.ToSbox( Scale );
+				t.Scale = RelativeScale( local.AxisScales, rig.BindScales[bone] );
+				keys.Add( (frame, t) );
+				if ( frame + 1 > totalFrames ) totalFrames = frame + 1;
+			}
+			keys.Sort( ( x, y ) => x.Frame.CompareTo( y.Frame ) );
+			keysPerBone[bone] = keys;
+
+			// empty parentName = "skeleton parent" (Sub_* face tracks), NOT root
+			animParent[bone] = string.IsNullOrEmpty( a.ParentName )
+				? skelParent[bone]
+				: indexByName.TryGetValue( a.ParentName, out var ap ) ? ap : skelParent[bone];
+		}
+
+		if ( totalFrames <= 0 )
+			return;
+
+		var animation = builder.AddAnimation( name, fps ).WithLooping( looping );
+		var frameTransforms = new Transform[boneCount];
+		var locals = new Transform[boneCount];
+		var worlds = new Transform?[boneCount];
+
+		Transform WorldAt( int i, int f, int depth )
+		{
+			if ( worlds[i] is { } cached ) return cached;
+
+			var local = locals[i];
+			var parent = keysPerBone[i] is not null ? animParent[i] : skelParent[i];
+
+			var world = parent < 0 || depth > 128
+				? new Transform( local.Position, local.Rotation )
+				: WorldAt( parent, f, depth + 1 ).ToWorld( new Transform( local.Position, local.Rotation ) );
+			worlds[i] = world;
+			return world;
+		}
+
+		for ( var f = 0; f < totalFrames; f++ )
+		{
+			Array.Clear( worlds, 0, worlds.Length );
+
+			for ( var i = 0; i < boneCount; i++ )
+				locals[i] = keysPerBone[i] is not null ? SampleLocal( keysPerBone[i], rig.BindLocals[i], f ) : rig.BindLocals[i];
+
+			for ( var i = 0; i < boneCount; i++ )
+			{
+				var world = WorldAt( i, f, 0 );
+				if ( skelParent[i] < 0 )
+				{
+					frameTransforms[i] = world;
+				}
+				else
+				{
+					var parent = WorldAt( skelParent[i], f, 0 );
+					var invRot = parent.Rotation.Inverse;
+					frameTransforms[i] = new Transform( invRot * (world.Position - parent.Position), invRot * world.Rotation );
+				}
+
+				frameTransforms[i].Scale = locals[i].Scale;
+			}
+
+			animation.AddFrame( frameTransforms.AsSpan() );
+		}
+	}
+
+	static Vector3 RelativeScale( Vector3 key, Vector3 bind )
+	{
+		static float S( float k, float b ) => b > 0.0001f ? k / b : 1f;
+		return new Vector3( S( key.x, bind.x ), S( key.y, bind.y ), S( key.z, bind.z ) );
+	}
+
+	static Vector3[] ConvertPositions( Kf2File.Primitive prim )
+	{
+		var positions = new Vector3[prim.Positions.Length];
+		for ( var i = 0; i < positions.Length; i++ )
+		{
+			var p = prim.Positions[i];
+			positions[i] = new Vector3( -p.x, -p.z, p.y ) * Scale;
+		}
+
+		return positions;
+	}
+
+	// GoldSrc mount standard: Bone takes MODEL-SPACE transforms, AddFrame takes parent-local
+	static Dictionary<string, int> AddBones( Kf2File kf2, ModelBuilder builder )
+	{
+		var byName = new Dictionary<string, int>( StringComparer.OrdinalIgnoreCase );
+		var bones = new ModelBuilder.Bone[kf2.Nodes.Count];
+
+		for ( var i = 0; i < kf2.Nodes.Count; i++ )
+		{
+			var node = kf2.Nodes[i];
+			var parent = node.HasParent ? kf2.FindNode( node.Parent ) : null;
+			var world = kf2.WorldOf( node ).ToSbox( Scale );
+			bones[i] = new ModelBuilder.Bone( node.Name, parent?.Name, world.Position, world.Rotation );
+			byName[node.Name] = i;
+		}
+
+		builder.AddBones( bones );
+		return byName;
+	}
+
+	void AddAnimations( Kf2File kf2, ModelBuilder builder )
+	{
+		var fps = 30f;
+		var totalFrames = 0;
+		var looping = false;
+		var animByNode = new Dictionary<string, Kf2File.NodeAnim>( StringComparer.OrdinalIgnoreCase );
+
+		foreach ( var a in kf2.Animations )
+		{
+			animByNode[a.NodeName] = a;
+			if ( a.Fps > 0 ) fps = a.Fps;
+			if ( a.TotalFrames > totalFrames ) totalFrames = a.TotalFrames;
+			foreach ( var k in a.Keys )
+				if ( k.Frame + 1 > totalFrames ) totalFrames = k.Frame + 1;
+			looping |= a.Looping;
+		}
+
+		if ( totalFrames <= 0 )
+			return;
+
+		var nodeCount = kf2.Nodes.Count;
+		var bindLocals = new Transform[nodeCount];
+		var keysPerNode = new List<(int Frame, Transform Local)>[nodeCount];
+
+		for ( var i = 0; i < nodeCount; i++ )
+		{
+			var node = kf2.Nodes[i];
+			bindLocals[i] = node.Local.ToSbox( Scale );
+
+			if ( !animByNode.TryGetValue( node.Name, out var anim ) || anim.Keys.Count == 0 )
+				continue;
+
+			var bindScales = node.Local.AxisScales;
+			var keys = new List<(int Frame, Transform Local)>( anim.Keys.Count );
+			foreach ( var (frame, local) in anim.Keys )
+			{
+				var t = local.ToSbox( Scale );
+				t.Scale = RelativeScale( local.AxisScales, bindScales );
+				keys.Add( (frame, t) );
+			}
+			keys.Sort( ( x, y ) => x.Frame.CompareTo( y.Frame ) );
+			keysPerNode[i] = keys;
+		}
+
+		var animation = builder.AddAnimation( "scene", fps ).WithLooping( looping );
+
+		var frameTransforms = new Transform[nodeCount];
+		for ( var f = 0; f < totalFrames; f++ )
+		{
+			for ( var i = 0; i < nodeCount; i++ )
+				frameTransforms[i] = SampleLocal( keysPerNode[i], bindLocals[i], f );
+			animation.AddFrame( frameTransforms.AsSpan() );
+		}
+	}
+
+	static Transform SampleLocal( List<(int Frame, Transform Local)> keys, Transform bind, int f )
+	{
+		if ( keys is null || keys.Count == 0 )
+			return bind;
+
+		if ( f <= keys[0].Frame )
+			return keys[0].Local;
+
+		for ( var i = 1; i < keys.Count; i++ )
+		{
+			if ( f == keys[i].Frame )
+				return keys[i].Local;
+
+			if ( f < keys[i].Frame )
+			{
+				var a = keys[i - 1];
+				var b = keys[i];
+				var t = (f - a.Frame) / (float)(b.Frame - a.Frame);
+				return new Transform(
+					Vector3.Lerp( a.Local.Position, b.Local.Position, t ),
+					Rotation.Slerp( a.Local.Rotation, b.Local.Rotation, t ),
+					Vector3.Lerp( a.Local.Scale, b.Local.Scale, t ) );
+			}
+		}
+
+		return keys[^1].Local;
+	}
+
+	static List<string> BuildSearchDirs( string dir, string textureDirs )
+	{
+		var dirs = new List<string> { dir ?? "" };
+		foreach ( var entry in (textureDirs ?? "").Split( ';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries ) )
+		{
+			var resolved = ResolveRelative( dir, entry );
+			if ( !dirs.Exists( d => string.Equals( d, resolved, StringComparison.OrdinalIgnoreCase ) ) )
+				dirs.Add( resolved );
+		}
+
+		return dirs;
+	}
+
+	static string ResolveRelative( string baseDir, string rel )
+	{
+		var parts = new List<string>( (baseDir ?? "").Split( '/', StringSplitOptions.RemoveEmptyEntries ) );
+		foreach ( var seg in rel.Replace( '\\', '/' ).Split( '/', StringSplitOptions.RemoveEmptyEntries ) )
+		{
+			if ( seg == "." ) continue;
+			if ( seg == ".." )
+			{
+				if ( parts.Count > 0 ) parts.RemoveAt( parts.Count - 1 );
+				continue;
+			}
+			parts.Add( seg );
+		}
+
+		return string.Join( '/', parts );
+	}
+
+	Mesh BuildMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Dictionary<string, Texture> cache )
+	{
+		var material = CreateMaterial( kf2, prim, searchDirs, cache );
+
+		var mesh = new Mesh( material );
+
+		var vertices = new SimpleVertex[positions.Length];
+		for ( var i = 0; i < vertices.Length; i++ )
+		{
+			var n = prim.Normals is not null ? prim.Normals[i] : Vector3.Up;
+			var uv = prim.Uvs is not null ? prim.Uvs[i] : Vector2.Zero;
+			vertices[i] = new SimpleVertex(
+				positions[i],
+				new Vector3( -n.x, -n.z, n.y ),
+				Vector3.Zero,
+				uv );
+		}
+
+		mesh.CreateVertexBuffer( vertices.Length, vertices );
+		mesh.CreateIndexBuffer( indices.Length, indices );
+		mesh.Bounds = BBox.FromPoints( positions );
+		return mesh;
+	}
+
+	Mesh BuildSkinnedMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Dictionary<string, Texture> cache, Dictionary<string, int> boneIndexByNode )
+	{
+		var material = CreateMaterial( kf2, prim, searchDirs, cache );
+
+		var mesh = new Mesh( material );
+
+		var bone = prim.NodeName is not null && boneIndexByNode.TryGetValue( prim.NodeName, out var bi ) ? bi : 0;
+		var blendIndices = new Color32( (byte)bone, 255, 255, 255 );
+		var blendWeights = new Color32( 255, 0, 0, 0 );
+
+		var vertices = new SkinnedVertex[positions.Length];
+		for ( var i = 0; i < vertices.Length; i++ )
+		{
+			var n = prim.Normals is not null ? prim.Normals[i] : Vector3.Up;
+			var uv = prim.Uvs is not null ? prim.Uvs[i] : Vector2.Zero;
+			vertices[i] = new SkinnedVertex(
+				positions[i],
+				new Vector3( -n.x, -n.z, n.y ),
+				uv, blendIndices, blendWeights );
+		}
+
+		mesh.CreateVertexBuffer( vertices.Length, vertices );
+		mesh.CreateIndexBuffer( indices.Length, indices );
+		mesh.Bounds = BBox.FromPoints( positions );
+		return mesh;
+	}
+
+	static int[] BuildIndices( Kf2File kf2, Kf2File.Primitive prim )
+	{
+		var twoSided = prim.MaterialName is not null
+			&& kf2.Materials.TryGetValue( prim.MaterialName, out var matDef ) && matDef.TwoSided;
+
+		var tris = prim.Indices.Length;
+		var indices = new int[twoSided ? tris * 2 : tris];
+		for ( var i = 0; i < tris; i += 3 )
+		{
+			indices[i] = prim.Indices[i];
+			indices[i + 1] = prim.Indices[i + 2];
+			indices[i + 2] = prim.Indices[i + 1];
+		}
+
+		if ( twoSided )
+		{
+			for ( var i = 0; i < tris; i++ )
+				indices[tris + i] = prim.Indices[i];
+		}
+
+		return indices;
+	}
+
+	Material CreateMaterial( Kf2File kf2, Kf2File.Primitive prim, List<string> searchDirs, Dictionary<string, Texture> cache )
+	{
+		var material = Material.Create( "mp2_model", "shaders/mp2_model.shader" );
+		material?.Set( "g_tColor", ResolveTexture( kf2, prim.MaterialName, searchDirs, cache ) ?? Texture.White );
+		// opaque DXT1 decodes a=1 everywhere, so the cutout never fires on solid models
+		material?.SetFeature( "F_ALPHA_TEST", 1 );
+		return material;
+	}
+
+	Texture ResolveTexture( Kf2File kf2, string materialName, List<string> searchDirs, Dictionary<string, Texture> cache )
+	{
+		if ( string.IsNullOrEmpty( materialName ) || !kf2.Materials.TryGetValue( materialName, out var mat ) )
+			return null;
+
+		if ( string.IsNullOrEmpty( mat.DiffuseTexture ) )
+			return null;
+
+		if ( cache.TryGetValue( mat.DiffuseTexture, out var cached ) )
+			return cached;
+
+		var tex = LoadTexture( searchDirs, mat.DiffuseTexture );
+		cache[mat.DiffuseTexture] = tex;
+		return tex;
+	}
+
+	Texture LoadTexture( List<string> searchDirs, string fileName )
+	{
+		var name = System.IO.Path.GetFileNameWithoutExtension( fileName );
+
+		foreach ( var dir in searchDirs )
+		{
+			foreach ( var ext in new[] { ".dds", ".tga", ".jpg", ".pcx" } )
+			{
+				var candidate = string.IsNullOrEmpty( dir ) ? name + ext : $"{dir}/{name}{ext}";
+				var data = Host.GetFileBytes( candidate );
+				if ( data is not null )
+					return MaxPayneImage.Load( data );
+			}
+		}
+
+		return null;
+	}
+}
+
+file struct SkinnedVertex( Vector3 position, Vector3 normal, Vector2 texcoord, Color32 blendIndices, Color32 blendWeights )
+{
+	[VertexLayout.Position] public Vector3 Position = position;
+	[VertexLayout.Normal] public Vector3 Normal = normal;
+	[VertexLayout.TexCoord] public Vector2 Texcoord = texcoord;
+	[VertexLayout.BlendIndices] public Color32 BlendIndices = blendIndices;
+	[VertexLayout.BlendWeight] public Color32 BlendWeights = blendWeights;
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Model.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Model.cs
@@ -63,7 +63,11 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 		builder.AddCollisionMesh( collisionVerts, collisionIndices );
 		builder.AddTraceMesh( collisionVerts, collisionIndices );
 
-		if ( rig is not null ) AddRigAnimations( builder, rig );
+		if ( rig is not null )
+		{
+			AddRigAnimations( builder, rig );
+			AddRagdoll( builder, rig );
+		}
 		else if ( animatedNodes ) AddAnimations( kf2, builder );
 
 		return builder.Create();
@@ -163,6 +167,18 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 	// GoldSrc mount standard: Bone takes MODEL-SPACE transforms, AddFrame takes parent-local
 	static void AddRigBones( ModelBuilder builder, Rig rig )
 	{
+		var worlds = ComputeBindWorlds( rig );
+		var bones = new ModelBuilder.Bone[worlds.Length];
+		for ( var i = 0; i < worlds.Length; i++ )
+		{
+			bones[i] = new ModelBuilder.Bone( rig.BoneNames[i], rig.ParentNames[i], worlds[i].Position, worlds[i].Rotation );
+		}
+
+		builder.AddBones( bones );
+	}
+
+	static Transform[] ComputeBindWorlds( Rig rig )
+	{
 		var count = rig.BoneNames.Length;
 		var indexByName = new Dictionary<string, int>( count, StringComparer.OrdinalIgnoreCase );
 		for ( var i = 0; i < count; i++ ) indexByName[rig.BoneNames[i]] = i;
@@ -179,14 +195,114 @@ class MaxPayne2Model( string fileName ) : ResourceLoader<MaxPayne2Mount>
 			return world;
 		}
 
-		var bones = new ModelBuilder.Bone[count];
+		var result = new Transform[count];
 		for ( var i = 0; i < count; i++ )
 		{
-			var world = WorldOf( i );
-			bones[i] = new ModelBuilder.Bone( rig.BoneNames[i], rig.ParentNames[i], world.Position, world.Rotation );
+			result[i] = WorldOf( i );
 		}
 
-		builder.AddBones( bones );
+		return result;
+	}
+
+	const float RagdollMass = 90f;
+
+	// data/database/ragdolls: a convex hull per bone (geometry kf2 node names match bone names)
+	// plus swing/twist joint limits, shared by every humanoid character
+	void AddRagdoll( ModelBuilder builder, Rig rig )
+	{
+		var text = Host.GetFileBytes( "data/database/ragdolls/highdetail.txt" );
+		if ( text is null )
+			return;
+
+		RasLib.RagdollFile ragdoll;
+		Kf2File geometry;
+		try
+		{
+			ragdoll = RasLib.RagdollFile.Parse( System.Text.Encoding.Latin1.GetString( text ) );
+
+			var geoData = Host.GetFileBytes( $"data/database/ragdolls/highdetail/{ragdoll.GeometryFile}" );
+			if ( geoData is null )
+				return;
+
+			geometry = Kf2File.Parse( geoData, bakeNodeTransforms: false );
+		}
+		catch
+		{
+			return;
+		}
+
+		var hulls = new Dictionary<string, Vector3[]>( StringComparer.OrdinalIgnoreCase );
+		foreach ( var prim in geometry.Primitives )
+		{
+			if ( prim.NodeName is null || prim.Positions.Length < 3 )
+				continue;
+
+			var points = new Vector3[prim.Positions.Length];
+			for ( var i = 0; i < points.Length; i++ )
+			{
+				var p = prim.Positions[i];
+				points[i] = new Vector3( -p.x, -p.z, p.y ) * Scale;
+			}
+
+			hulls[prim.NodeName] = points;
+		}
+
+		var boneIndexByName = new Dictionary<string, int>( StringComparer.OrdinalIgnoreCase );
+		for ( var i = 0; i < rig.BoneNames.Length; i++ ) boneIndexByName[rig.BoneNames[i]] = i;
+
+		var bindWorlds = ComputeBindWorlds( rig );
+
+		var totalWeight = 0f;
+		foreach ( var bone in ragdoll.Bones ) totalWeight += bone.Weight;
+		if ( totalWeight <= 0f )
+			return;
+
+		var bodyCount = 0;
+		var bodyByBone = new Dictionary<string, int>( StringComparer.OrdinalIgnoreCase );
+		foreach ( var bone in ragdoll.Bones )
+		{
+			if ( !boneIndexByName.TryGetValue( bone.Name, out var boneIndex ) )
+				continue;
+			if ( !hulls.TryGetValue( bone.Name, out var points ) )
+				continue;
+
+			builder.AddBody( RagdollMass * bone.Weight / totalWeight, boneName: rig.BoneNames[boneIndex] )
+				.SetBindPose( bindWorlds[boneIndex] )
+				.AddHull( points );
+			bodyByBone[bone.Name] = bodyCount++;
+		}
+
+		foreach ( var joint in ragdoll.Joints )
+		{
+			if ( !bodyByBone.TryGetValue( joint.Bone1, out var body1 ) )
+				continue;
+			if ( !bodyByBone.TryGetValue( joint.Bone2, out var body2 ) )
+				continue;
+
+			var parentWorld = bindWorlds[boneIndexByName[joint.Bone1]];
+			var childWorld = bindWorlds[boneIndexByName[joint.Bone2]];
+
+			// pivot at the child bone, joint frames built from the same world transform so the
+			// rig is strain-free at bind; twist axis is authored in the child bone's local space
+			var axis = childWorld.Rotation * new Vector3( -joint.TwistAxis.x, -joint.TwistAxis.z, joint.TwistAxis.y );
+			var jointWorld = new Transform( childWorld.Position, Rotation.LookAt( axis ) );
+			var frame1 = parentWorld.ToLocal( jointWorld );
+			var frame2 = childWorld.ToLocal( jointWorld );
+
+			var swing = MathF.Max(
+				MathF.Max( MathF.Abs( joint.ConeMin ), MathF.Abs( joint.ConeMax ) ),
+				MathF.Max( MathF.Abs( joint.PlaneMin ), MathF.Abs( joint.PlaneMax ) ) );
+
+			if ( swing <= 0.01f && joint.TwistMax - joint.TwistMin <= 0.01f )
+			{
+				builder.AddFixedJoint( body1, body2, frame1, frame2 );
+				continue;
+			}
+
+			builder.AddBallJoint( body1, body2, frame1, frame2 )
+				.WithSwingLimit( swing )
+				.WithTwistLimit( joint.TwistMin, joint.TwistMax );
+		}
 	}
 
 	Mesh BuildRigMesh( Kf2File kf2, Kf2File.Primitive prim, Vector3[] positions, int[] indices, List<string> searchDirs, Rig rig )

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Sound.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Sound.cs
@@ -1,0 +1,30 @@
+using RasLib;
+using System;
+
+class MaxPayne2Sound( string fileName ) : ResourceLoader<MaxPayne2Mount>
+{
+	public string FileName { get; set; } = fileName;
+
+	protected override object Load()
+	{
+		var data = Host.GetFileBytes( FileName );
+		if ( data is null )
+			return null;
+
+		var loop = FileName.Contains( "_loop", StringComparison.OrdinalIgnoreCase );
+
+		var adpcm = MaxPayneWav.DecodeIfAdpcm( data );
+		if ( adpcm is not null )
+		{
+			return SoundFile.FromPcm( Path, adpcm.Data, new SoundFile.PcmOptions
+			{
+				Channels = adpcm.Channels,
+				Rate = (uint)adpcm.SampleRate,
+				Bits = adpcm.BitsPerSample,
+				Loop = loop,
+			} );
+		}
+
+		return SoundFile.FromWav( Path, data, new SoundFile.LoadOptions { Loop = loop } );
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Texture.cs
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Resource/MaxPayne2Texture.cs
@@ -1,0 +1,13 @@
+class MaxPayne2Texture( string fileName ) : ResourceLoader<MaxPayne2Mount>
+{
+	public string FileName { get; set; } = fileName;
+
+	protected override object Load()
+	{
+		var data = Host.GetFileBytes( FileName );
+		if ( data is null )
+			return null;
+
+		return MaxPayneImage.Load( data );
+	}
+}

--- a/engine/Mounting/Sandbox.Mounting.MaxPayne2/Sandbox.Mounting.MaxPayne2.csproj
+++ b/engine/Mounting/Sandbox.Mounting.MaxPayne2/Sandbox.Mounting.MaxPayne2.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionPrefix>1.0.1</VersionPrefix>
+    <TargetFramework>net10.0</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1591</NoWarn>
+	<LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Sandbox.Engine\Sandbox.Engine.csproj" />
+    <ProjectReference Include="..\..\Sandbox.Filesystem\Sandbox.Filesystem.csproj" />
+    <ProjectReference Include="..\..\Sandbox.System\Sandbox.System.csproj" />
+    <ProjectReference Include="..\Sandbox.Mounting\Sandbox.Mounting.csproj"/>
+  </ItemGroup>
+
+	<Target Name="CopyOutputDll" AfterTargets="Build">
+		<Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFiles="..\..\..\game\mount\maxpayne2\maxpayne2.dll" />
+	</Target>
+
+</Project>

--- a/engine/Sandbox-Engine.slnx
+++ b/engine/Sandbox-Engine.slnx
@@ -47,6 +47,7 @@
   </Folder>
   <Folder Name="/Engine/Tier0/Mounting/">
     <Project Path="Mounting/Sandbox.Mounting.GoldSrc/Sandbox.Mounting.GoldSrc.csproj" />
+    <Project Path="Mounting/Sandbox.Mounting.MaxPayne2/Sandbox.Mounting.MaxPayne2.csproj" />
     <Project Path="Mounting/Sandbox.Mounting.NS2/Sandbox.Mounting.NS2.csproj" />
     <Project Path="Mounting/Sandbox.Mounting.Quake/Sandbox.Mounting.Quake.csproj" />
     <Project Path="Mounting/Sandbox.Mounting/Sandbox.Mounting.csproj" />

--- a/game/mount/maxpayne2/Assets/shaders/mp2_model.shader
+++ b/game/mount/maxpayne2/Assets/shaders/mp2_model.shader
@@ -1,0 +1,79 @@
+HEADER
+{
+	Description = "Max Payne 2 model / unlightmapped surface";
+}
+
+FEATURES
+{
+	#include "common/features.hlsl"
+	Feature( F_ALPHA_TEST, 0..1, "Rendering" );
+}
+
+MODES
+{
+	Forward();
+	Depth();
+}
+
+COMMON
+{
+	#include "common/shared.hlsl"
+
+	#define CUSTOM_MATERIAL_INPUTS
+}
+
+struct VertexInput
+{
+	#include "common/vertexinput.hlsl"
+};
+
+struct PixelInput
+{
+	#include "common/pixelinput.hlsl"
+};
+
+VS
+{
+	#include "common/vertex.hlsl"
+
+	PixelInput MainVs( VertexInput v )
+	{
+		PixelInput i = ProcessVertex( v );
+		return FinalizeVertex( i );
+	}
+}
+
+PS
+{
+	#include "common/pixel.hlsl"
+
+	StaticCombo( S_ALPHA_TEST, F_ALPHA_TEST, Sys( ALL ) );
+
+	SamplerState g_sSampler0 < Filter( Anisotropic ); AddressU( WRAP ); AddressV( WRAP ); >;
+	CreateInputTexture2D( Color, Srgb, 8, "None", "_color", ",0/,0/0", Default4( 1.00, 1.00, 1.00, 1.00 ) );
+	Texture2D g_tColor < Channel( RGBA, Box( Color ), Srgb ); OutputFormat( DXT5 ); SrgbRead( true ); >;
+
+	float4 MainPs( PixelInput i ) : SV_Target0
+	{
+		Material m = Material::Init();
+
+		float4 albedo = Tex2DS( g_tColor, g_sSampler0, i.vTextureCoords.xy );
+
+		#if ( S_ALPHA_TEST )
+			clip( albedo.a - 0.5 );
+		#endif
+
+		m.Albedo = albedo.rgb;
+		m.Normal = i.vNormalWs;
+		m.Roughness = 1;
+		m.Metalness = 0;
+		m.AmbientOcclusion = 1;
+		m.TintMask = 1;
+		m.Opacity = albedo.a;
+		m.Emission = 0;
+		m.Transmission = 0;
+		m.TextureCoords = i.vTextureCoords.xy;
+
+		return ShadingModelStandard::Shade( i, m );
+	}
+}

--- a/game/mount/maxpayne2/Assets/shaders/mp2_world.shader
+++ b/game/mount/maxpayne2/Assets/shaders/mp2_world.shader
@@ -1,0 +1,85 @@
+HEADER
+{
+	Description = "Max Payne 2 lightmapped world geometry";
+}
+
+FEATURES
+{
+	#include "common/features.hlsl"
+	Feature( F_ALPHA_TEST, 0..1, "Rendering" );
+}
+
+MODES
+{
+	Forward();
+	Depth();
+}
+
+COMMON
+{
+	#include "common/shared.hlsl"
+
+	#define S_UV2 1
+	#define CUSTOM_MATERIAL_INPUTS
+}
+
+struct VertexInput
+{
+	#include "common/vertexinput.hlsl"
+};
+
+struct PixelInput
+{
+	#include "common/pixelinput.hlsl"
+};
+
+VS
+{
+	#include "common/vertex.hlsl"
+
+	PixelInput MainVs( VertexInput v )
+	{
+		PixelInput i = ProcessVertex( v );
+		return FinalizeVertex( i );
+	}
+}
+
+PS
+{
+	#include "common/pixel.hlsl"
+
+	StaticCombo( S_ALPHA_TEST, F_ALPHA_TEST, Sys( ALL ) );
+
+	SamplerState g_sSampler0 < Filter( Anisotropic ); AddressU( WRAP ); AddressV( WRAP ); >;
+	SamplerState g_sSampler1 < Filter( Bilinear ); AddressU( CLAMP ); AddressV( CLAMP ); >;
+	CreateInputTexture2D( Color, Srgb, 8, "None", "_color", ",0/,0/0", Default4( 1.00, 1.00, 1.00, 1.00 ) );
+	CreateInputTexture2D( Lightmap, Linear, 8, "None", "_color", ",0/,0/0", Default4( 1.00, 1.00, 1.00, 1.00 ) );
+	Texture2D g_tColor < Channel( RGBA, Box( Color ), Srgb ); OutputFormat( DXT5 ); SrgbRead( true ); >;
+	Texture2D g_tLightmap < Channel( RGBA, Box( Lightmap ), Linear ); OutputFormat( DXT5 ); SrgbRead( false ); >;
+
+	float4 MainPs( PixelInput i ) : SV_Target0
+	{
+		Material m = Material::Init();
+
+		float4 albedo = Tex2DS( g_tColor, g_sSampler0, i.vTextureCoords.xy );
+
+		#if ( S_ALPHA_TEST )
+			clip( albedo.a - 0.5 );
+		#endif
+
+		float3 lightmap = Tex2DS( g_tLightmap, g_sSampler1, i.vTextureCoords.zw ).rgb;
+
+		m.Albedo = albedo.rgb;
+		m.Normal = i.vNormalWs;
+		m.Roughness = 1;
+		m.Metalness = 0;
+		m.AmbientOcclusion = 1;
+		m.TintMask = 1;
+		m.Opacity = albedo.a;
+		m.Emission = albedo.rgb * lightmap * 2.0;
+		m.Transmission = 0;
+		m.TextureCoords = i.vTextureCoords.xy;
+
+		return ShadingModelStandard::Shade( i, m );
+	}
+}


### PR DESCRIPTION
## Summary

 Adds a mount for **Max Payne 2: The Fall of Max Payne** (Steam app `12150`), structured to mirror the Quake mount (`Sandbox.Mounting.Quake`): a `BaseGameMount` that indexes the game's
  archives, with `ResourceLoader<T>` / `SceneLoader<T>` implementations per resource type, and mount shaders under `game/mount/maxpayne2/Assets/shaders`.

  What it surfaces:

  | Resource | Source | Notes |
  |---|---|---|
  | Scene | `.ldb` levels | static world per room, lightmaps, baked ambient lighting, collision |
  | Model | `.kf2` | static props and fully skinned characters with the game's animation library as model sequences |
  | Texture | `.dds .tga .pcx .jpg` | TGA normalized to top-down, PCX/JPG via Bitmap |
  | Sound | `.wav` | most of the game's audio is MS-ADPCM, decoded to PCM16 |

  ## Motivation & Context

- I love max payne

  Fixes: N/A

  ## Implementation Details

- **RAS archives**: the container is XOR-enciphered (header, file table and folder table each encrypted independently with a per-archive seed) with per-file LZSS compression. `Ras.cs`
  decrypts and inflates on demand.
- **KF2 models**: tagged-value stream with chunked layout. Chunk sizes include their own 13-byte header; the nested NODE chunk reports an unreliable size, so it is parsed field by
  field. Mesh node transforms are baked into vertices before coordinate conversion.
- **Skeletal characters** are a four-file system (mesh `.kf2` + skin `.skd` + shared per-sex skeleton/pose + an animation library of ~350 clips). The loader stitches these together and
  bakes every library clip as a named model sequence. Notable format quirks handled:
    - Bones are passed to `ModelBuilder` in model space with parent-local frames to `AnimationBuilder`, matching what the Quake/GoldSrc mounts do.
    - Every female skeleton has one mirrored bone (`Bip01 Breast-R`, a det = -1 mirror clone). The matrix-to-quaternion conversion rebuilds an orthonormal right-handed basis first,
  otherwise that bone garbles into a non-unit quaternion.
    - Animation tracks with an empty parent name are local to their skeleton parent, not the root (facial tracks rely on this).
    - Facial animation uses matrix scale (blinks and lip movement squash helper bones); frames carry per-axis scale relative to the bind so unkeyed bones stay identity.
    - One skin (`MaxPayne.skd`) names bones with different casing than the skeleton file; bone names are normalized to the skeleton's casing.
  - **LDB2 levels**: rooms hold the full static world. Lightmaps render through `mp2_world.shader` (same pattern as `quake_generic`: diffuse from uv0, lightmap atlas from uv1). MP2 has no  dynamic lights; lighting is baked lightmaps plus per-room volume-light grids, which are reduced to shadowless point lights as an ambient approximation. Render geometry is also used for
  collision.
  - **Coordinate conversion**: MP2 is meters, Y-up, opposite handedness. Positions map `(x, y, z) -> (-x, -z, y)` with a winding flip, scaled to inches.
  - **Meshless `.kf2` files** (animation libraries, camera paths, texture-set variants) are filtered at registration by sniffing top-level chunks for mesh data, so the asset browser only
  lists real models.
  - **Sounds**: `SoundFile.FromWav` passes ADPCM through as raw PCM, so format tag 2 files are decoded to PCM16 first and loaded with `FromPcm`.

  ## Screenshots / Videos (if applicable)
<img width="1505" height="562" alt="image" src="https://github.com/user-attachments/assets/4cf74a88-3966-4aae-a75d-dbba194bb0c3" />
<img width="814" height="428" alt="image" src="https://github.com/user-attachments/assets/6b0c4f17-a6eb-464f-9fef-f24b69338e45" />
<img width="1128" height="857" alt="image" src="https://github.com/user-attachments/assets/a6b062f6-5664-434c-9bef-d2279cf00369" />


https://github.com/user-attachments/assets/5f67c566-75be-4538-a683-f244516da57e

  ## Checklist

  - [x] Code follows existing style and conventions
  - [x] No unnecessary formatting or unrelated changes
  - [x] Public APIs are documented (if applicable)
  - [x] Unit tests added where applicable and all passing
  - [x] I'm okay with this PR being rejected or requested to change 🙂