### PR TITLE
Add manual exposure to Tonemapper

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
@@ -86,12 +86,15 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 	[Property, Group( "Auto Exposure" ), Range( 0.0f, 5.0f ), ShowIf( nameof( AutoExposureEnabled ), true )]
 	public float MaximumExposure { get; set; } = 3.0f;
 
-	[Property, Group( "Auto Exposure" ), Range( -5.0f, 5.0f ), ShowIf( nameof( AutoExposureEnabled ), true )]
-	public float ExposureCompensation { get; set; } = 0.0f;
-
 	[Property, Group( "Auto Exposure" ), Range( 1.0f, 10.0f ), ShowIf( nameof( AutoExposureEnabled ), true )]
 	public float Rate { get; set; } = 1.0f;
 
+	[Obsolete("Use Exposure instead.")]
+	public float ExposureCompensation {
+		get => Exposure;
+		set => Exposure = value;
+	}
+	
 	void UpdateExposure( CameraComponent camera )
 	{
 		if ( !camera.IsValid() ) return;

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
@@ -54,6 +54,9 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 
 	[ShowIf( nameof( Mode ), TonemappingMode.HableFilmic )]
 	[Property] public ExposureColorSpaceEnum ExposureMethod { get; set; } = ExposureColorSpaceEnum.RGB;
+	
+	[Property, Range( -5.0f, 5.0f )]
+	public float Exposure { get; set; } = 0.0f;
 
 	private static Material Shader = Material.FromShader( "shaders/tonemapping/tonemapping.shader" );
 
@@ -63,6 +66,8 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 
 		Attributes.SetComboEnum( "D_TONEMAPPING", Mode );
 		Attributes.SetComboEnum( "D_EXPOSUREMETHOD", ExposureMethod );
+		Attributes.Set( "Exposure", MathF.Pow( 2, GetWeighted( x => x.Exposure ) ) );
+		Attributes.Set( "ExposureMix", GetWeighted(x => x.AutoExposureEnabled ? 1f : 0f ) );
 
 		var blit = BlitMode.WithBackbuffer( Shader, Stage.Tonemapping, 0 );
 		Blit( blit, "Tonemapping" );
@@ -91,8 +96,8 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 	{
 		if ( !camera.IsValid() ) return;
 
-		camera.AutoExposure.Enabled = AutoExposureEnabled;
-		camera.AutoExposure.Compensation = GetWeighted( x => x.ExposureCompensation, 0 );
+		camera.AutoExposure.Enabled = true;
+		camera.AutoExposure.Compensation = GetWeighted( x => x.Exposure, 0 );
 		camera.AutoExposure.MinimumExposure = GetWeighted( x => x.MinimumExposure, 1 );
 		camera.AutoExposure.MaximumExposure = GetWeighted( x => x.MaximumExposure, 3 );
 		camera.AutoExposure.Rate = GetWeighted( x => x.Rate, 1 );

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
@@ -54,7 +54,7 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 
 	[ShowIf( nameof( Mode ), TonemappingMode.HableFilmic )]
 	[Property] public ExposureColorSpaceEnum ExposureMethod { get; set; } = ExposureColorSpaceEnum.RGB;
-	
+
 	[Property, Range( -5.0f, 5.0f )]
 	public float Exposure { get; set; } = 0.0f;
 
@@ -67,7 +67,7 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 		Attributes.SetComboEnum( "D_TONEMAPPING", Mode );
 		Attributes.SetComboEnum( "D_EXPOSUREMETHOD", ExposureMethod );
 		Attributes.Set( "Exposure", MathF.Pow( 2, GetWeighted( x => x.Exposure ) ) );
-		Attributes.Set( "ExposureMix", GetWeighted(x => x.AutoExposureEnabled ? 1f : 0f ) );
+		Attributes.Set( "ExposureMix", GetWeighted( x => x.AutoExposureEnabled ? 1f : 0f ) );
 
 		var blit = BlitMode.WithBackbuffer( Shader, Stage.Tonemapping, 0 );
 		Blit( blit, "Tonemapping" );
@@ -89,12 +89,13 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 	[Property, Group( "Auto Exposure" ), Range( 1.0f, 10.0f ), ShowIf( nameof( AutoExposureEnabled ), true )]
 	public float Rate { get; set; } = 1.0f;
 
-	[Obsolete("Use Exposure instead.")]
-	public float ExposureCompensation {
+	[Obsolete( "Use Exposure instead." )]
+	public float ExposureCompensation
+	{
 		get => Exposure;
 		set => Exposure = value;
 	}
-	
+
 	void UpdateExposure( CameraComponent camera )
 	{
 		if ( !camera.IsValid() ) return;
@@ -112,13 +113,14 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 	/// Remap Exposure Compensation to just Exposure
 	/// </summary>
 	[Expose, JsonUpgrader( typeof( Tonemapping ), 4 )]
-	static void Upgrader_v4(JsonObject obj) {
+	static void Upgrader_v4( JsonObject obj )
+	{
 		if ( obj.TryGetPropertyValue( "ExposureCompensation", out var compensation ) )
 		{
 			obj["Exposure"] = (float)compensation;
 		}
 	}
-	
+
 	/// <summary>
 	/// Remove Exposure Bias
 	/// this doesn't make much sense since it's tied to only HableFilmic and does the same thing as ExposureCompensation

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
@@ -106,8 +106,19 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 		camera.AutoExposure.Rate = GetWeighted( x => x.Rate, 1 );
 	}
 
-	public override int ComponentVersion => 3;
+	public override int ComponentVersion => 4;
 
+	/// <summary>
+	/// Remap Exposure Compensation to just Exposure
+	/// </summary>
+	[Expose, JsonUpgrader( typeof( Tonemapping ), 4 )]
+	static void Upgrader_v4(JsonObject obj) {
+		if ( obj.TryGetPropertyValue( "ExposureCompensation", out var compensation ) )
+		{
+			obj["Exposure"] = (float)compensation;
+		}
+	}
+	
 	/// <summary>
 	/// Remove Exposure Bias
 	/// this doesn't make much sense since it's tied to only HableFilmic and does the same thing as ExposureCompensation

--- a/game/addons/base/Assets/shaders/tonemapping/tonemapping.shader
+++ b/game/addons/base/Assets/shaders/tonemapping/tonemapping.shader
@@ -61,6 +61,8 @@ PS
     DynamicCombo( D_EXPOSUREMETHOD, 0..1, Sys( PC ) );   
      
     Texture2D g_tColorBuffer < Attribute( "ColorBuffer" ); SrgbRead( false ); >;
+    float fl_Exposure < Attribute( "Exposure" ); >;
+    float fl_ExposureMix < Attribute( "ExposureMix" ); >;
          
     float CalculateLuminance(float3 color)
     { 
@@ -213,7 +215,7 @@ PS
     {   
         float4 color = g_tColorBuffer.Sample( g_sPointClamp, i.vTexCoord );
 
-        float3 rgb = max(0.0.xxx, color.rgb) * g_flToneMapScalarLinear;
+        float3 rgb = max(0.0.xxx, color.rgb) * lerp( fl_Exposure, g_flToneMapScalarLinear, fl_ExposureMix );
 
         #if ( D_TONEMAPPING == TONEMAPPING_LINEAR ) 
             // it's already linear


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR adds a generic `Exposure` option to the Tonemapping Postprocess component.
The new property is not related to Auto Exposure and will allow artists to easily set a single exposure of a scene.
There are also changes to allow transitioning between non-auto exposure volumes and auto exposure volumes.

## Motivation & Context

This gives artists simpler and clearer control over the exposure of the scene.
Transitions between auto and non-auto exposed volumes also did not exist.

## Implementation Details

When using auto exposure, `Exposure` is used where `ExposureCompensation` previously was.
`ExposureCompensation` has been made obsolete and modifies the `Exposure` property.
An upgrader was also added to remap `ExposureCompensation` to `Exposure`.

Two float attributes were added to `tonemapping.shader`
- `fl_Exposure`, the new exposure property as `2^exposure`
- `fl_ExposureMix`, a value to mix between auto and non-auto exposure.
These values are used to modify the `rgb` variable in the pixel shader.

## Screenshots / Videos (if applicable)

Video to verify expected behaviors.
https://github.com/user-attachments/assets/cd1cdf39-1ec5-4116-9885-57f83a873b55

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂