### PR TITLE
Add Khronos PBR neutral mode to tonemapper

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
@@ -38,7 +38,12 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 		/// Similar to ACES - very realistic, but handles lower and higher brightness ranges better.
 		/// Uses the Punchy AgX look.
 		/// </summary>
-		AgX
+		AgX,
+		/// <summary>
+		/// Khronos' neutral tonemapper, preserves color as much as possible while eliminating artifacts.
+		/// </summary>
+		[Title("Khronos PBR Neutral")]
+		KhronosPBRNeutral
 	}
 
 	public enum ExposureColorSpaceEnum

--- a/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
+++ b/engine/Sandbox.Engine/Scene/Components/PostProcessing/Effects/Tonemapping.cs
@@ -42,7 +42,7 @@ public class Tonemapping : BasePostProcess<Tonemapping>
 		/// <summary>
 		/// Khronos' neutral tonemapper, preserves color as much as possible while eliminating artifacts.
 		/// </summary>
-		[Title("Khronos PBR Neutral")]
+		[Title( "Khronos PBR Neutral" )]
 		KhronosPBRNeutral
 	}
 

--- a/game/addons/base/Assets/shaders/tonemapping/tonemapping.shader
+++ b/game/addons/base/Assets/shaders/tonemapping/tonemapping.shader
@@ -52,8 +52,9 @@ PS
     #define TONEMAPPING_REINHARDJODIE 3
     #define TONEMAPPING_LINEAR 4
     #define TONEMAPPING_AGX 5
+    #define TONEMAPPING_KHRONOS 6
 
-    DynamicCombo( D_TONEMAPPING, 0..5, Sys( PC ) ); 
+    DynamicCombo( D_TONEMAPPING, 0..6, Sys( PC ) ); 
    
     #define ExposureMethod_RGB        0
     #define ExposureMethod_LUM        1
@@ -209,6 +210,26 @@ PS
         vColor = max( vColor, 0.0.xxx );
     }
 
+    void ToneMapping_Khronos( in out float3 color )
+    {
+        const float startCompression = 0.8 - 0.04;
+        const float desaturation = 0.15;
+
+        float x = min( color.r, min( color.g, color.b ) );
+        float offset = x < 0.08 ? x - 6.25 * x * x : 0.04;
+        color -= offset;
+
+        float peak = max( color.r, min( color.g, color.b ) );
+        if ( peak < startCompression ) return;
+
+        const float d = 1.0 - startCompression;
+        float newPeak = 1.0 - d * d / ( peak + d - startCompression );
+        color *= newPeak / peak;
+
+        float g = 1.0 - 1.0 / ( desaturation * ( peak - newPeak ) + 1.0 );
+        color = lerp( color, newPeak * float3( 1, 1, 1 ), g );
+    }
+
     float4 MainPs( PixelInput i ) : SV_Target0
     {   
         float4 color = g_tColorBuffer.Sample( g_sPointClamp, i.vTexCoord );
@@ -225,6 +246,8 @@ PS
               ToneMapping_Aces( rgb );
         #elif ( D_TONEMAPPING == TONEMAPPING_AGX )
               ToneMapping_Agx( rgb );
+        #elif ( D_TONEMAPPING == TONEMAPPING_KHRONOS )
+              ToneMapping_Khronos( rgb );
         #endif
 
         return float4( rgb, color.a ); 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This adds the Khronos PBR Neutral tonemapper as a mode in the `Tonemapping` component.

## Motivation & Context

This tonemapper gives people an option that handles highlights while maintaining their color choices.
I use the Linear mode in my game but need an option that handles bright lights better.

## Implementation Details

This adds a new combo in `tonemapping.shader`
Implementation is based off the [reference GLSL implementation](https://github.com/KhronosGroup/ToneMapping/blob/main/PBR_Neutral/pbrNeutral.glsl) provided by Khronos.

## Screenshots / Videos (if applicable)

Linear:
<img width="1920" height="1080" alt="linear" src="https://github.com/user-attachments/assets/a4cb7030-e531-4417-85f7-40fcf33c9c5c" />

Khronos PBR Neutral:
<img width="1920" height="1080" alt="neutral" src="https://github.com/user-attachments/assets/6d56968f-69a1-4796-9209-ac7778f25e27" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂