### PR TITLE
Add a TagSet for the PlayerController camera to ignore traces against

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Camera.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/PlayerController/PlayerController.Camera.cs
@@ -11,6 +11,10 @@ public sealed partial class PlayerController : Component
 	[Property, Feature( "Camera" )] public bool UseFovFromPreferences { get; set; } = true;
 	[Property, Feature( "Camera" )] public Vector3 CameraOffset { get; set; } = new Vector3( 256, 0, 12 );
 	[Property, Feature( "Camera" ), InputAction] public string ToggleCameraModeButton { get; set; } = "view";
+	/// <summary>
+	/// The set of tags to ignore during camera collision detection.
+	/// </summary>
+	[Property, Feature( "Camera" ), Title( "Collision Ignore" )] public TagSet CameraCollisionIgnore { get; set; } = [];
 
 	float _cameraDistance = 100;
 	float _eyez;
@@ -54,6 +58,7 @@ public sealed partial class PlayerController : Component
 			var tr = Scene.Trace.FromTo( eyePosition, eyePosition + cameraDelta )
 							.IgnoreGameObjectHierarchy( GameObject.Root )
 							.Radius( 8 )
+							.WithoutTags( CameraCollisionIgnore )
 							.Run();
 
 			// smooth the zoom in and out


### PR DESCRIPTION
## Summary

This PR adds a TagSet property under the Camera feature for the Player Controller, which is used in collision detection.

## Motivation & Context

I was annoyed that the camera was colliding with players in my game, and I thought there should be a TagSet property to customize this behaviour.

## Implementation Details

I used the same name for the TagSet that has been used in, for example, Particle Effects
https://github.com/Facepunch/sbox-public/blob/c5dc660ac70ea74df36ffe496a0f6605aaaff60f/engine/Sandbox.Engine/Scene/Components/Particles/ParticleEffect.cs#L249

## Screenshots / Videos (if applicable)

Sample project: [pccameracollide.zip](https://github.com/user-attachments/files/28873373/pccameracollide.zip)

https://github.com/user-attachments/assets/ca888730-d65a-4052-8dc4-b7eae2ae2722

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂