### PR TITLE
Add missing OnMenu binding

### DIFF
--- a/game/addons/menu/Code/MenuUI/MapsPage.razor
+++ b/game/addons/menu/Code/MenuUI/MapsPage.razor
@@ -47,7 +47,7 @@
         </Left>
 
 		<Body>
-            <PackageList @ref=PackageList ShowFilters="@false" Query=@($"type:map sort:{filterOrder} {GetQuery()}") OnSelected="@OnPackageSelected" Take=@(200)></PackageList>
+            <PackageList @ref=PackageList ShowFilters="@false" Query=@($"type:map sort:{filterOrder} {GetQuery()}") OnSelected="@OnPackageSelected" OnMenu=@OnMenu Take=@(200)></PackageList>
 		</Body>
 	</Page>
 </root>


### PR DESCRIPTION
## Summary

Currently, right-clicking on a map in the map list does nothing; the PR fixes this

## Implementation Details

Just bind the function

## Screenshots / Videos (if applicable)

<img width="460" height="343" alt="image" src="https://github.com/user-attachments/assets/ce4c1cf1-f419-423a-a3d8-cdf838610ef5" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂