### PR TITLE
Qol/external scene change prompt

### DIFF
--- a/engine/Sandbox.Tools/EditorPreferences.cs
+++ b/engine/Sandbox.Tools/EditorPreferences.cs
@@ -48,6 +48,27 @@ public static class EditorPreferences
 		set => EditorCookie.Set( "CompileNotifications", value );
 	}
 
+	public enum ExternalSceneChangeAction
+	{
+		[Title( "Always Ask" )]
+		Ask,
+		[Title( "Reload If Saved" )]
+		ReloadIfSaved,
+		[Title( "Always Reload" )]
+		AlwaysReload
+	}
+
+	/// <summary>
+	/// What to do when an open scene's file is modified outside the editor.
+	/// "Reload If Saved" reloads automatically only when you have no unsaved changes, otherwise it asks.
+	/// </summary>
+	[Title( "Scene Changed On Disk" )]
+	public static ExternalSceneChangeAction ExternalSceneChange
+	{
+		get => EditorCookie.Get( "ExternalSceneChange", ExternalSceneChangeAction.Ask );
+		set => EditorCookie.Set( "ExternalSceneChange", value );
+	}
+
 	/// <summary>
 	/// The amount of seconds to keep a notification open if it's an error
 	/// </summary>

--- a/game/addons/tools/Code/Editor/EditorPreferences/PageGeneral.cs
+++ b/game/addons/tools/Code/Editor/EditorPreferences/PageGeneral.cs
@@ -18,6 +18,17 @@ internal class PageGeneral : Widget
 			sheet.AddProperty( () => EditorPreferences.FastHotload );
 
 			Layout.Add( sheet );
+		}
+
+		{
+			Layout.AddSpacingCell( 16 );
+			Layout.Add( new Label.Subtitle( "Scene" ) );
+
+			var sceneSheet = new ControlSheet();
+
+			sceneSheet.AddProperty( () => EditorPreferences.ExternalSceneChange );
+
+			Layout.Add( sceneSheet );
 			Layout.AddStretchCell();
 		}
 	}

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.Events.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.Events.cs
@@ -11,6 +11,25 @@ public partial class SceneViewWidget : ResourceLibrary.IEventListener
 		if ( _externalChangesDialog.IsValid() ) // already showing one
 			return;
 
+		switch ( EditorPreferences.ExternalSceneChange )
+		{
+			case EditorPreferences.ExternalSceneChangeAction.AlwaysReload:
+				Session.Reload();
+				return;
+
+			case EditorPreferences.ExternalSceneChangeAction.ReloadIfSaved:
+				if ( !Session.HasUnsavedChanges )
+				{
+					Session.Reload();
+					return;
+				}
+				break; // unsaved work -> fall through and prompt
+
+			case EditorPreferences.ExternalSceneChangeAction.Ask:
+			default:
+				break; // show prompt as before
+		}
+
 		Session.MakeActive();
 
 		var popup = new PopupDialogWidget( "published_with_changes" );

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.Events.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewWidget.Events.cs
@@ -14,15 +14,14 @@ public partial class SceneViewWidget : ResourceLibrary.IEventListener
 		switch ( EditorPreferences.ExternalSceneChange )
 		{
 			case EditorPreferences.ExternalSceneChangeAction.AlwaysReload:
-				Session.Reload();
+				// The source resource isn't reloaded from disk until OnExternalChangesPostLoad,
+				// so we have to defer the reload until then or we'd just load the stale data back.
 				return;
 
 			case EditorPreferences.ExternalSceneChangeAction.ReloadIfSaved:
 				if ( !Session.HasUnsavedChanges )
-				{
-					Session.Reload();
-					return;
-				}
+					return; // auto-reload handled in OnExternalChangesPostLoad
+
 				break; // unsaved work -> fall through and prompt
 
 			case EditorPreferences.ExternalSceneChangeAction.Ask:
@@ -66,5 +65,27 @@ public partial class SceneViewWidget : ResourceLibrary.IEventListener
 		popup.SetModal( true, true );
 		popup.Hide();
 		popup.Show();
+	}
+
+	void ResourceLibrary.IEventListener.OnExternalChangesPostLoad( GameResource resource )
+	{
+		if ( resource != Session.Scene.Source ) return;
+
+		// A prompt is up - let the user decide what to do.
+		if ( _externalChangesDialog.IsValid() )
+			return;
+
+		// By now the source resource has been fully reloaded from disk, so it's safe to reload.
+		switch ( EditorPreferences.ExternalSceneChange )
+		{
+			case EditorPreferences.ExternalSceneChangeAction.AlwaysReload:
+				Session.Reload();
+				break;
+
+			case EditorPreferences.ExternalSceneChangeAction.ReloadIfSaved:
+				if ( !Session.HasUnsavedChanges )
+					Session.Reload();
+				break;
+		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

When you change a scene file on disk underneath the editor it always pops up a prompt to ask if you want to keep the editor's version or reload the scene. This can be jarring if you like typing in an editor instead of clicking on boxes or dragging sliders/etc.

This adds an editor preference with 3 options:
* Always ask: Default, current behavior.
* Reload if Saved: If the editor isn't holding changes not written to disk, reload as if the reload button is clicked.
* Always reload: Lose editor state and trust the disk

## Motivation & Context

I've only been using sbox for like 5 days and I'm already really really really tired of this.


## Implementation Details

It builds against master and works, idk...

## Screenshots / Videos (if applicable)

<img width="742" height="472" alt="image" src="https://github.com/user-attachments/assets/d88fd7c4-c6bd-4449-a5d4-1922eb63d90e" />

## Checklist

- [Y] Code follows existing style and conventions
- [Y] No unnecessary formatting or unrelated changes
- [N/A] Public APIs are documented (if applicable)
- [Y] Unit tests added where applicable and all passing
- [Y] I’m okay with this PR being rejected or requested to change 🙂