### PR TITLE
Add Hide attribute to HeightMap and ControlMap

### DIFF
--- a/engine/Sandbox.Engine/Resources/Terrain/TerrainStorage.cs
+++ b/engine/Sandbox.Engine/Resources/Terrain/TerrainStorage.cs
@@ -123,6 +123,7 @@ public partial class TerrainStorage : GameResource
 {
 	[JsonInclude, JsonPropertyName( "Maps" )] private TerrainMapBlob Maps { get; set; } = new();
 
+	[Hide]
 	[JsonIgnore]
 	public ushort[] HeightMap
 	{
@@ -130,6 +131,7 @@ public partial class TerrainStorage : GameResource
 		set => Maps.HeightMap = value;
 	}
 
+	[Hide]
 	[JsonIgnore]
 	public UInt32[] ControlMap
 	{


### PR DESCRIPTION
## Summary

By opening the details of the embedded terrain, a crash occurs because the editor is trying to display the values of the HeightMap and ControlMap

Fixes: #11220 

## Implementation Details

Use of the Hide attribute

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂