### PR TITLE
Add Networking.GetLobby and Networking.GetLobbyId

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/Networking.LobbyQuery.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Networking.LobbyQuery.cs
@@ -200,26 +200,7 @@ public static partial class Networking
 			return found;
 
 		foreach ( var l in lobbies )
-		{
-			var item = new LobbyInformation();
-			item.LobbyId = l.Id;
-			item.OwnerId = l.Owner.Id;
-			item.Ping = -1;
-
-			item.MaxMembers = l.MaxMembers;
-			item.Members = l.MemberCount;
-			item.Data = l.Data.ToDictionary( x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase );
-
-			item.Data.Remove( "name", out item.Name );
-			item.Data.Remove( "map", out item.Map );
-			item.Data.Remove( "game", out item.Game );
-
-			if ( string.IsNullOrEmpty( item.Name ) ) item.Name = $"{item.LobbyId}";
-			if ( string.IsNullOrEmpty( item.Map ) ) item.Map = "";
-			if ( string.IsNullOrEmpty( item.Game ) ) item.Game = "";
-
-			found.Add( item );
-		}
+			found.Add( new LobbyInformation( l ) );
 
 		return found;
 	}

--- a/engine/Sandbox.Engine/Systems/Networking/Networking.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Networking.cs
@@ -586,6 +586,36 @@ public static partial class Networking
 	}
 
 	/// <summary>
+	/// Returns the id of the steam lobby.
+	/// </summary>
+	public static ulong? GetLobbyId()
+	{
+		if ( System is null )
+			return null;
+
+		foreach ( var socket in System.Sockets )
+			if ( socket is SteamLobbySocket lobbySocket )
+				return lobbySocket.LobbySteamId;
+
+		return null;
+	}
+
+	/// <summary>
+	/// Returns informations about the steam lobby.
+	/// </summary>
+	public static LobbyInformation? GetLobby()
+	{
+		if ( System is null )
+			return null;
+
+		foreach ( var socket in System.Sockets )
+			if ( socket is SteamLobbySocket lobbySocket )
+				return new LobbyInformation( lobbySocket.SteamLobby );
+
+		return null;
+	}
+
+	/// <summary>
 	/// Disconnect from current multiplayer session.
 	/// </summary>
 	public static void Disconnect()

--- a/engine/Sandbox.Engine/Systems/Networking/System/GameNetworkSystem/GameNetworkSystem.Static.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/GameNetworkSystem/GameNetworkSystem.Static.cs
@@ -121,6 +121,25 @@ public struct LobbyInformation
 	/// </summary>
 	internal bool ContainsFriends => false;
 
+	internal LobbyInformation( Lobby lobby )
+	{
+		LobbyId = lobby.Id;
+		OwnerId = lobby.Owner.Id;
+		Ping = -1;
+
+		MaxMembers = lobby.MaxMembers;
+		Members = lobby.MemberCount;
+		Data = lobby.Data.ToDictionary( x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase );
+
+		Data.Remove( "name", out Name );
+		Data.Remove( "map", out Map );
+		Data.Remove( "game", out Game );
+
+		if ( string.IsNullOrEmpty( Name ) ) Name = $"{LobbyId}";
+		if ( string.IsNullOrEmpty( Map ) ) Map = "";
+		if ( string.IsNullOrEmpty( Game ) ) Game = "";
+	}
+
 	public string Get( string key, string defaultValue = "" )
 	{
 		return Data.GetValueOrDefault( key, defaultValue );


### PR DESCRIPTION
## Summary

Addition of the Networking.GetLobby and Networking.GetLobbyId functions #3493 

## Implementation Details

The two functions iterate over the network sockets, if a socket corresponds to a steam lobby, its id or information is returned. Otherwise, null is returned.

## Screenshots / Videos (if applicable)

<img width="1274" height="247" alt="image" src="https://github.com/user-attachments/assets/971fe515-475d-4cfb-acf9-467763069de9" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂