### PR TITLE
Fix "No valid Scene was found in SceneLoadOptions"

### DIFF
--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -394,4 +394,12 @@ public partial class Scene : GameObject
 		target.SceneProperties = SerializeProperties();
 		target.BinaryData = blobs.ToByteArray();
 	}
+
+	internal SceneFile ToSceneFile()
+	{
+		var target = (Source as SceneFile) ?? new SceneFile();
+		ToSceneFile( target );
+
+		return target;
+	}
 }

--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
@@ -325,7 +325,8 @@ public partial class SceneEditorSession : Scene.ISceneEditorSession
 		string fileType = isPrefab ? "Prefab" : "Scene";
 
 		var saveLocation = string.Empty;
-		if ( !saveAs && Scene.Source is not null && AssetSystem.FindByPath( Scene.Source.ResourcePath ) is Asset sourceAsset )
+		var existingAsset = Scene.Source is not null ? AssetSystem.FindByPath( Scene.Source.ResourcePath ) : null;
+		if ( !saveAs && existingAsset is Asset sourceAsset )
 		{
 			saveLocation = sourceAsset.AbsolutePath;
 		}
@@ -359,7 +360,11 @@ public partial class SceneEditorSession : Scene.ISceneEditorSession
 		var asset = AssetSystem.CreateResource( extension, saveLocation );
 		Assert.NotNull( asset, $"Failed to CreateResource for {fileType} at {saveLocation}" );
 
-		GameResource resource = Scene is PrefabScene prefabScene ? prefabScene.ToPrefabFile() : Scene.CreateSceneFile();
+		// Drop the resource if the asset changes; otherwise, the old asset will point to the new one
+		if ( saveAs && existingAsset != asset )
+			Scene.Source = null;
+
+		GameResource resource = Scene is PrefabScene prefabScene ? prefabScene.ToPrefabFile() : Scene.ToSceneFile();
 		asset.SaveToDisk( resource );
 
 		// Update this scene's path


### PR DESCRIPTION
## Summary

In order for `SceneLoadOptions` to find a scene, it uses a hashmap that maps the resource path to the resource. This hashmap is updated when a `GameResource` instance is created or destroyed. For destruction, it relies on the garbage collector. However, before the garbage collector runs, it is possible for another `GameResource` with the same path to be registered. Then, once the garbage collector executes, the cache removes that mapping, causing the scene to become unfindable.

The issue is that every time the scene is saved, a new instance of `SceneFile` is created. And `SceneFile` is a `GameResource`.

Fixes: #10130 #10492 

## Implementation Details

I avoid initializing a `SceneFile` as much as possible when saving.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂