### PR TITLE
Fix Asset Browser locations tree freezing when a pinned folder is missing

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/Local/LocalAssetLocations.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/Local/LocalAssetLocations.cs
@@ -157,10 +157,11 @@ public class LocalAssetLocations : AssetLocations
 	[EditorEvent.Frame]
 	public void OnFrame()
 	{
-		if ( PinsNode?.Children.Count() == Pins.Count() && !_pinsDirty )
+		if ( !_pinsDirty && _lastBuiltPins is not null && Pins.SequenceEqual( _lastBuiltPins ) )
 			return;
 
 		_pinsDirty = false;
+		_lastBuiltPins = Pins.ToList();
 
 		PinsNode?.Clear();
 
@@ -198,6 +199,7 @@ public class LocalAssetLocations : AssetLocations
 	}
 
 	private bool _pinsDirty = false;
+	private List<string> _lastBuiltPins;
 
 	void RefreshPins()
 	{


### PR DESCRIPTION
## Summary

Fixes the Local Asset Browser's locations tree becoming unresponsive to clicks when a pinned folder no longer exists on disk.

## Motivation & Context

`LocalAssetLocations.OnFrame()` short-circuits when the pin list is unchanged, guarded by `PinsNode.Children.Count() == Pins.Count()`. But the rebuild loop skips pins whose folder is missing (`if ( !di.Exists ) continue;`), so once a pin points at a deleted/renamed folder the counts never match and `Rebuild()` runs every frame.

Each `Rebuild()` replaces the tree's `VirtualWidget` instances, and `BaseItemWidget` only registers a click when the press-time `pressedItem` still matches `hovered` at release. The per-frame rebuild orphans that widget mid-click, so clicks get dropped. (`OnFrame` calls `Rebuild()` directly, bypassing the `pressedItem` guard in `UpdateIfDirty`.)

## Implementation Details
Guard on a content snapshot of the pin list (`SequenceEqual`) instead of the child count. `Pins` is `internal static` and shared across instances, so this still picks up changes made elsewhere, but no longer mismatches forever when a folder is missing.

## Screenshots / Videos (if applicable)
N/A

## Repro

Pin a folder in the Local asset browser, delete or rename it on disk, then click items in the locations tree.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂
