### PR TITLE
whitelist compiler generated InlineArrayAttribute

### DIFF
--- a/engine/Sandbox.Access/Rules/CompilerGenerated.cs
+++ b/engine/Sandbox.Access/Rules/CompilerGenerated.cs
@@ -9,7 +9,7 @@ internal static partial class Rules
 		"System.Private.CoreLib/System.Runtime.CompilerServices.Unsafe.Add*",
 		"System.Private.CoreLib/System.Runtime.CompilerServices.Unsafe.As*",
 		"System.Private.CoreLib/System.Runtime.CompilerServices.Unsafe.AsRef*",
-		"System.Private.CoreLib/System.Runtime.CompilerServices.InlineArrayAttribute",
+		"System.Private.CoreLib/System.Runtime.CompilerServices.InlineArray*",
 		"System.Private.CoreLib/System.Runtime.CompilerServices.DecimalConstantAttribute",
 		"System.Private.CoreLib/System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan*",
 


### PR DESCRIPTION
# Pull Request

## Summary

this pull request fixes https://github.com/Facepunch/sbox-public/issues/11228

## Motivation & Context

after swapping from cll to dll players couldn't join updated game servers due to this issue

Fixes: #11228

## Implementation Details
After the CLL → DLL transition, access control scans loaded assemblies and rejects packages that reference compiler-generated InlineArrayN1types (e.g.InlineArray41). The old rule only allowed InlineArrayAttribute, so DLLs using [InlineArray(N)] failed to load with a whitelist error.
[InlineArray(N)] produces two things: the attribute (metadata) and a compiler-generated struct (InlineArray41`, etc.) used in IL. The failure was on the struct type, not the attribute.

## Checklist

- [ +] Code follows existing style and conventions
- [ +] No unnecessary formatting or unrelated changes
- [ +] Public APIs are documented (if applicable)
- [ +] Unit tests added where applicable and all passing
- [ +] I’m okay with this PR being rejected or requested to change 🙂