### PR TITLE
Fix F1–F12 shortcut being called twice

### DIFF
--- a/engine/Sandbox.Tools/ManagedTools.cs
+++ b/engine/Sandbox.Tools/ManagedTools.cs
@@ -201,9 +201,8 @@ internal static class ManagedTools
 					if ( modifiers.HasFlag( KeyboardModifiers.Ctrl ) && ev.Key != KeyCode.Control ) modifiedKey = "CTRL+" + modifiedKey;
 				}
 
-				// If we're "in game" these will be passed by the InputRouter whilst we're not focused
-				if ( EditorShortcuts._timeSinceGlobalShortcut <= 0.05f && ev.Key >= KeyCode.F1 && ev.Key <= KeyCode.F12 )
-					return false;
+				if ( ev.Key >= KeyCode.F1 && ev.Key <= KeyCode.F12 )
+					EditorShortcuts._timeSinceGlobalShortcut = 0;
 
 				// Try with modifier first.
 				if ( modifiers != KeyboardModifiers.None && EditorShortcuts.Invoke( modifiedKey ) )

--- a/engine/Sandbox.Tools/ToolsDll.cs
+++ b/engine/Sandbox.Tools/ToolsDll.cs
@@ -233,16 +233,17 @@ internal class ToolsDll : IToolsDll
 
 	public void OnFunctionKey( ButtonCode key, KeyboardModifiers modifiers )
 	{
+		// Rarely, OnFunctionKey and GlobalKeyPressed can receive the same key at the same time and therefore call EditorShortcuts.Invoke twice, 
+		// which cancels out the invoker event (e.g. Start + Stop).
+		if ( EditorShortcuts._timeSinceGlobalShortcut <= 0.05f )
+			return;
+
 		var keys = NativeEngine.InputSystem.CodeToString( key ).ToUpperInvariant();
 		if ( modifiers.HasFlag( KeyboardModifiers.Shift ) ) keys = "SHIFT+" + keys;
 		if ( modifiers.HasFlag( KeyboardModifiers.Alt ) ) keys = "ALT+" + keys;
 		if ( modifiers.HasFlag( KeyboardModifiers.Ctrl ) ) keys = "CTRL+" + keys;
 
 		EditorShortcuts.Invoke( keys, true );
-
-		// This is really just here for F5, if we stop the game session and defocus the game window, Qt is going to then run it's event
-		// The other option is, do we need to run EditorShortcuts from game mode? What is there other than F5?
-		EditorShortcuts._timeSinceGlobalShortcut = 0;
 	}
 
 	public void Spin()


### PR DESCRIPTION
## Summary

Rarely, the F1–F12 shortcuts are called twice, which cancels the action. For example, with F5, the first plays but the second stops it.

Fixes: #303 

## Implementation Details

The case was already handled, but in the wrong order, so I just changed the order.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂