### PR TITLE
Don’t select the parent if the parent is the scene

### DIFF
--- a/game/addons/tools/Code/Scene/SceneEditorMenus.cs
+++ b/game/addons/tools/Code/Scene/SceneEditorMenus.cs
@@ -112,7 +112,7 @@ public static class SceneEditorMenus
 					nextSelect = nextSelect.GetNextSibling( false );
 
 				for ( var p = lastSelected.Parent; !nextSelect.IsValid() && p.IsValid(); p = p.Parent )
-					if ( !p.Flags.Contains( GameObjectFlags.Hidden ) )
+					if ( p is not Scene && !p.Flags.Contains( GameObjectFlags.Hidden ) )
 						nextSelect = p;
 
 				if ( SceneEditorSession.Active.Selection.Contains( lastSelected ) )


### PR DESCRIPTION
## Summary

When deleting an object from the scene, the next object or its parent is selected. If the parent is the scene, then the scene will be selected.

Fixes: #11162 

## Implementation Details

Do not select it if the parent type is Scene.
## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂