### PR TITLE
Add debug name to command list error message

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/CommandList/CommandList.cs
+++ b/engine/Sandbox.Engine/Systems/Render/CommandList/CommandList.cs
@@ -486,7 +486,7 @@ public sealed unsafe partial class CommandList
 			}
 			catch ( System.Exception e )
 			{
-				Log.Warning( e, "Error when executing CommandList" );
+				Log.Warning( e, $"Error when executing CommandList {_debugName ?? string.Empty}" );
 			}
 
 			Graphics.Context.EndPixEvent();

--- a/engine/Sandbox.Engine/Systems/Render/CommandList/CommandList.cs
+++ b/engine/Sandbox.Engine/Systems/Render/CommandList/CommandList.cs
@@ -486,7 +486,7 @@ public sealed unsafe partial class CommandList
 			}
 			catch ( System.Exception e )
 			{
-				Log.Warning( e, $"Error when executing CommandList {_debugName ?? string.Empty}" );
+				Log.Warning( e, $"Error when executing CommandList {_debugName}" );
 			}
 
 			Graphics.Context.EndPixEvent();


### PR DESCRIPTION
## Summary
Adds the command lists debug name to the error message if it fails, makes it a lot easier to figure out where the issue is
<img width="453" height="47" alt="image" src="https://github.com/user-attachments/assets/d5074cfe-ac51-4cc2-ad8f-bc991e85ff1d" />

## Motivation & Context
Was getting an error and it wasn't clear which command list was causing it

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂