### PR TITLE
DataTable not ready for IGameObjectNetworkEvents.NetworkOwnerChanged

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
@@ -121,6 +121,8 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 
 		_initialized = true;
 
+		CreateDataTable();
+
 		if ( owner is not null )
 		{
 			Creator = owner.Id;
@@ -131,8 +133,6 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 			Creator = Guid.Empty;
 			Owner = Guid.Empty;
 		}
-
-		CreateDataTable();
 
 		// Keep track of us
 		GameObject.Scene.RegisterNetworkedObject( this );
@@ -195,10 +195,11 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 
 		_initialized = true;
 
+		CreateDataTable();
+
 		Creator = msg.Creator;
 		Owner = msg.Owner;
 
-		CreateDataTable();
 		OnCreateMessage( msg );
 
 		GameObject.Scene.RegisterNetworkedObject( this );


### PR DESCRIPTION
## Summary

Currently, the CreateDataTable function is executed after the Owner setter, however, this setter triggers the IGameObjectNetworkEvents.NetworkOwnerChanged event. In this event, it is possible to set a sync variable because the network is active, but this causes a NullReferenceException because the data table has not yet been initialized

Fixes: #1265 

## Implementation Details

I initialize the DataTable before the owner setter, the initialization has nothing to do with the owner, so it’s possible.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂