### PR TITLE
Fix Game.ChangeScene with additive not working

### DIFF
--- a/engine/Sandbox.Engine/Game/Game/Game.Scene.cs
+++ b/engine/Sandbox.Engine/Game/Game/Game.Scene.cs
@@ -35,20 +35,35 @@ public static partial class Game
 		if ( !Networking.IsHost )
 			return false;
 
-		// We don't want to send any networked messages to do with deletion or creation
-		// of GameObjects here. Because the client will destroy their scene locally
-		// anyway. This saves us sending a message for potentially 100s of objects.
-		using ( SceneNetworkSystem.SuppressSpawnMessages() )
+		if ( options.IsAdditive )
 		{
-			using ( SceneNetworkSystem.SuppressDestroyMessages() )
+			List<GameObject> sceneObjects;
+			using ( SceneNetworkSystem.SuppressSpawnMessages() )
 			{
-				if ( !ActiveScene.Load( options ) )
+				if ( !ActiveScene.Load( options, out sceneObjects ) )
 					return false;
 			}
+
+			SceneNetworkSystem.Instance?.LoadAdditiveSceneBroadcast( sceneObjects, options );
+		}
+		else
+		{
+			// We don't want to send any networked messages to do with deletion or creation
+			// of GameObjects here. Because the client will destroy their scene locally
+			// anyway. This saves us sending a message for potentially 100s of objects.
+			using ( SceneNetworkSystem.SuppressSpawnMessages() )
+			{
+				using ( SceneNetworkSystem.SuppressDestroyMessages() )
+				{
+					if ( !ActiveScene.Load( options ) )
+						return false;
+				}
+			}
+
+			// Conna: We want to send a new snapshot to every client.
+			SceneNetworkSystem.Instance?.LoadSceneBroadcast( options );
 		}
 
-		// Conna: We want to send a new snapshot to every client.
-		SceneNetworkSystem.Instance?.LoadSceneBroadcast( options );
 		return true;
 	}
 

--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -49,6 +49,7 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		AddHandler<LoadSceneSnapshotMsg>( OnLoadSceneSnapshotMsg );
 		AddHandler<LoadSceneRequestSnapshotMsg>( OnLoadSceneRequestSnapshotMsg );
 		AddHandler<SceneLoadedMsg>( OnSceneLoadedMsg );
+		AddHandler<LoadAdditiveSceneMsg>( OnLoadAdditiveScene );
 	}
 
 	internal void OnHotload()
@@ -123,6 +124,48 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 			PendingSceneLoads[c.Id] = loadMsg.Id;
 			c.SendStream( msg );
 			c.State = Connection.ChannelState.MountVPKs;
+		}
+
+		msg.Dispose();
+	}
+
+	internal void LoadAdditiveSceneBroadcast( List<GameObject> sceneObjects, SceneLoadOptions options )
+	{
+		if ( !Networking.IsActive || !Networking.IsHost )
+			return;
+
+		JsonArray gameObjects = [];
+		foreach ( var gameObject in sceneObjects )
+		{
+			var json = gameObject.Serialize();
+			if ( json is null )
+				continue;
+
+			gameObjects.Add( json );
+		}
+
+		var sceneFile = options.GetSceneFile();
+		var loadMsg = new LoadAdditiveSceneMsg
+		{
+			SceneFile = sceneFile,
+			GameObjects = Json.Serialize( gameObjects ),
+			ShowLoadingScreen = options.ShowLoadingScreen,
+		};
+
+		var msg = ByteStream.Create( 256 );
+		msg.Write( InternalMessageType.Packed );
+
+		Networking.System.Serialize( loadMsg, ref msg );
+
+		foreach ( var c in Connection.All )
+		{
+			if ( c == Connection.Local )
+				continue;
+
+			if ( c.State < Connection.ChannelState.Snapshot )
+				continue;
+
+			c.SendStream( msg );
 		}
 
 		msg.Dispose();
@@ -351,6 +394,37 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 
 		PendingSceneLoads.Remove( connection.Id );
 		Instance?.OnJoined( connection );
+	}
+
+	private void OnLoadAdditiveScene( LoadAdditiveSceneMsg msg, Connection source )
+	{
+		if ( !source.IsHost )
+			return;
+
+		var scene = Game.ActiveScene;
+		if ( !scene.IsValid() )
+			return;
+
+		var gameObjects = JsonNode.Parse( msg.GameObjects ).AsArray();
+		var sceneFile = new SceneFile
+		{
+			Id = msg.SceneFile.Id,
+			GameObjects = gameObjects.Select( x => x.AsObject() ).ToArray(),
+			SceneProperties = msg.SceneFile.SceneProperties
+		};
+
+		var loadOptions = new SceneLoadOptions
+		{
+			IsAdditive = true,
+			ShowLoadingScreen = msg.ShowLoadingScreen
+		};
+
+		loadOptions.SetScene( sceneFile );
+
+		using ( SuppressSpawnMessages() )
+		{
+			scene.Load( loadOptions );
+		}
 	}
 
 	/// <summary>
@@ -1420,6 +1494,14 @@ struct SceneLoadedMsg
 {
 	public Guid SceneId { get; set; }
 	public Guid Id { get; set; }
+}
+
+[Expose]
+struct LoadAdditiveSceneMsg
+{
+	public SceneFile SceneFile { get; set; }
+	public string GameObjects { get; set; }
+	public bool ShowLoadingScreen { get; set; }
 }
 
 [Expose]

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -33,6 +33,18 @@ public partial class Scene : GameObject
 	/// </summary>
 	public bool Load( SceneLoadOptions options )
 	{
+		return Load( options, out _ );
+	}
+
+	/// <summary>
+	/// Load from the provided <see cref="SceneLoadOptions"/>. This will not load the scene for other clients in a
+	/// multiplayer session, you should instead use <see cref="Game.ChangeScene"/>
+	/// if you want to bring other clients.
+	/// </summary>
+	public bool Load( SceneLoadOptions options, out List<GameObject> sceneObjects )
+	{
+		sceneObjects = [];
+
 		var sceneFile = options.GetSceneFile();
 
 		if ( !sceneFile.IsValid() )
@@ -108,6 +120,8 @@ public partial class Scene : GameObject
 				{
 					var go = CreateObject( false );
 					go.Deserialize( json );
+
+					sceneObjects.Add( go );
 				}
 			}
 


### PR DESCRIPTION
## Summary

When using `Game.ChangeScene`, whether a scene is additive is not handled for clients.

Fixes: #2050 

## Implementation Details

I retrieve the objects created when loading the additive scene (otherwise, if the same additive scene is loaded multiple times, ID collisions would occur). Using a custom network message, I send the scene path, the objects created by the host, and whether the loading screen should be displayed. On the client side, I reconstruct a `SceneFile` from that information and then call `scene.Loady` while blocking network object creation messages.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/0fa11b55-3810-4981-b605-6201990ea786

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂