### PR TITLE
[Scene Mesh] Quadrangulate Tool

### DIFF
--- a/game/addons/tools/Code/Scene/Mesh/Tools/FaceTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/FaceTool.UI.cs
@@ -131,6 +131,7 @@ partial class FaceTool
 				CreateButton( "Clipping Tool", "content_cut", "mesh.open-clipping-tool", OpenClippingTool, _faces.Length > 0, grid );
 				CreateButton( "Bridge", "device_hub", "mesh.bridge-tool", OpenBridgeTool, CanBridgeFaces(), grid );
 				CreateButton( "Inset", "filter_center_focus", "mesh.inset-tool", OpenInsetTool, _faces.Length > 0, grid );
+				CreateButton( "Quadrangulate", "crop_square", "mesh.quadrangulate-tool", OpenQuadrangulateTool, _faces.Length > 1, grid );
 
 				grid.AddStretchCell();
 
@@ -218,6 +219,17 @@ partial class FaceTool
 				return;
 
 			var tool = new InsetTool( _faces );
+			tool.Manager = _meshTool.Manager;
+			_meshTool.CurrentTool = tool;
+		}
+
+		[Shortcut( "mesh.quadrangulate-tool", "ALT+J", typeof( SceneViewWidget ) )]
+		void OpenQuadrangulateTool()
+		{
+			if ( _faces.Length <= 1 )
+				return;
+
+			var tool = new QuadrangulateTool( _faces );
 			tool.Manager = _meshTool.Manager;
 			_meshTool.CurrentTool = tool;
 		}

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
@@ -2,14 +2,14 @@
 
 public partial class QuadrangulateTool
 {
-	public static float QuadrangulateMaxFaceAngle { get; set { field = value.Clamp( 0, 180f ); } } = 40.0f;
-	public static float QuadrangulateMaxShapeAngle { get; set { field = value.Clamp( 0, 180f ); } } = 40.0f;
+	public static float QuadrangulateMaxFaceAngle { get; set => field = value.Clamp( 0, 180f ); } = 40.0f;
+	public static float QuadrangulateMaxShapeAngle { get; set => field = value.Clamp( 0, 180f ); } = 40.0f;
 	public static bool QuadrangulateCompareUVs { get; set; } = true;
 	public static bool QuadrangulateCompareVertexColor { get; set; } = true;
 	public static bool QuadrangulateCompareVertexBlend { get; set; } = true;
 	public static bool QuadrangulateCompareFaceMaterial { get; set; } = true;
 	public static bool QuadrangulateCompareSmoothing { get; set; } = true;
-	
+
 	public override Widget CreateToolSidebar()
 	{
 		return new QuadrangulateToolWidget( this );
@@ -17,60 +17,36 @@ public partial class QuadrangulateTool
 
 	public class QuadrangulateToolWidget : ToolSidebarWidget
 	{
+		[InlineEditor( Label = false )] private readonly QuadrangulateProperties _quadrangulateProperties = new();
+
 		private readonly QuadrangulateTool _tool;
 
-		private struct QuadrangulateProperties()
-		{
-			[Title( "Max Face Angle" ), Range( 0.0f, 180.0f, true, true ), Step( 0.1f ), WideMode, Description( "The tolerance for difference in face normals in order to be quadrangulated.")]
-			public readonly float MaxFaceAngle { get => QuadrangulateMaxFaceAngle; set => QuadrangulateMaxFaceAngle = value; }
-			
-			[Title( "Max Shape Angle" ), Range( 0.0f, 180.0f, true, true ), Step( 0.1f ), WideMode, Description( "The interior angle tolerance for created quads. 0 means only perfect 90 degree interior angles are processed." )]
-			public readonly float MaxShapeAngle { get => QuadrangulateMaxShapeAngle; set => QuadrangulateMaxShapeAngle = value; }
-			
-			[Title( "Compare UVs" ), Description( "Limit by non-contiguous UVs" )]
-			public readonly bool CompareUVs { get => QuadrangulateCompareUVs; set => QuadrangulateCompareUVs = value; }
-			
-			[Title( "Compare Vertex Color" ), Description( "Limit by vertex color." )]
-			public readonly bool CompareVertexColor { get => QuadrangulateCompareVertexColor; set => QuadrangulateCompareVertexColor = value; }
-			
-			[Title( "Compare Vertex Blend" ), Description( "Limit by vertex blending." )]
-			public readonly bool CompareVertexBlend { get => QuadrangulateCompareVertexBlend; set => QuadrangulateCompareVertexBlend = value; }
-			
-			[Title( "Compare Material" ), Description( "Limit by different face materials.")]
-			public readonly bool CompareFaceMaterial { get => QuadrangulateCompareFaceMaterial; set => QuadrangulateCompareFaceMaterial = value; }
-			
-			[Title( "Compare Smoothing" ), Description( "Limit by edges marked as hard normals." )]
-			public readonly bool CompareSmoothing { get => QuadrangulateCompareSmoothing; set => QuadrangulateCompareSmoothing = value; }
-		}
-		
-		[InlineEditor( Label = false )]
-		readonly QuadrangulateProperties _quadrangulateProperties = new();
-		
-		public QuadrangulateToolWidget( QuadrangulateTool tool ) : base()
+		public QuadrangulateToolWidget( QuadrangulateTool tool )
 		{
 			_tool = tool;
-			
+
 			AddTitle( "Quadrangulate Tool", "crop_square" );
-			
+
 			{
-				var group = AddGroup( "Properties" );
-				var row = group.AddRow();
+				Layout group = AddGroup( "Properties" );
+				Layout row = group.AddRow();
 				row.Spacing = 8;
 
-				var sheet = new ControlSheet();
-				var control = sheet.AddRow( this.GetSerialized().GetProperty( nameof( _quadrangulateProperties ) ) );
+				ControlSheet sheet = new();
+				ControlWidget control =
+					sheet.AddRow( this.GetSerialized().GetProperty( nameof(_quadrangulateProperties) ) );
 				control.OnChildValuesChanged += _ => UpdateMesh();
 				row.Add( sheet );
 
 				row = group.AddRow();
 				row.Spacing = 4;
 
-				var apply = new Button( "Apply", "done" );
+				Button apply = new("Apply", "done");
 				apply.Clicked = Apply;
 				apply.ToolTip = "[Apply " + EditorShortcuts.GetKeys( "mesh.quadrangulate-apply" ) + "]";
 				row.Add( apply );
 
-				var cancel = new Button( "Cancel", "close" );
+				Button cancel = new("Cancel", "close");
 				cancel.Clicked = Cancel;
 				cancel.ToolTip = "[Cancel " + EditorShortcuts.GetKeys( "mesh.quadrangulate-cancel" ) + "]";
 				row.Add( cancel );
@@ -80,23 +56,86 @@ public partial class QuadrangulateTool
 
 			UpdateMesh();
 		}
-		
-		void UpdateMesh()
+
+		private void UpdateMesh()
 		{
-			_tool.UpdateQuadrangulate( QuadrangulateMaxFaceAngle, QuadrangulateMaxShapeAngle, QuadrangulateCompareUVs, QuadrangulateCompareVertexColor, 
+			_tool.UpdateQuadrangulate( QuadrangulateMaxFaceAngle, QuadrangulateMaxShapeAngle, QuadrangulateCompareUVs,
+				QuadrangulateCompareVertexColor,
 				QuadrangulateCompareVertexBlend, QuadrangulateCompareFaceMaterial, QuadrangulateCompareSmoothing );
 		}
 
 		[Shortcut( "mesh.quadrangulate-apply", "enter", ShortcutType.Application )]
-		void Apply()
+		private void Apply()
 		{
 			_tool.Apply();
 		}
 
 		[Shortcut( "mesh.quadrangulate-cancel", "ESC", ShortcutType.Application )]
-		void Cancel()
+		private void Cancel()
 		{
 			_tool.Cancel();
+		}
+
+		private struct QuadrangulateProperties
+		{
+			[Title( "Max Face Angle" )]
+			[Range( 0.0f, 180.0f, true )]
+			[Step( 0.1f )]
+			[WideMode]
+			[Description( "The tolerance for difference in face normals in order to be quadrangulated." )]
+			public readonly float MaxFaceAngle
+			{
+				get => QuadrangulateMaxFaceAngle;
+				set => QuadrangulateMaxFaceAngle = value;
+			}
+
+			[Title( "Max Shape Angle" )]
+			[Range( 0.0f, 180.0f, true )]
+			[Step( 0.1f )]
+			[WideMode]
+			[Description(
+				"The interior angle tolerance for created quads. 0 means only perfect 90 degree interior angles are processed." )]
+			public readonly float MaxShapeAngle
+			{
+				get => QuadrangulateMaxShapeAngle;
+				set => QuadrangulateMaxShapeAngle = value;
+			}
+
+			[Title( "Compare UVs" )]
+			[Description( "Limit by non-contiguous UVs" )]
+			public readonly bool CompareUVs { get => QuadrangulateCompareUVs; set => QuadrangulateCompareUVs = value; }
+
+			[Title( "Compare Vertex Color" )]
+			[Description( "Limit by vertex color." )]
+			public readonly bool CompareVertexColor
+			{
+				get => QuadrangulateCompareVertexColor;
+				set => QuadrangulateCompareVertexColor = value;
+			}
+
+			[Title( "Compare Vertex Blend" )]
+			[Description( "Limit by vertex blending." )]
+			public readonly bool CompareVertexBlend
+			{
+				get => QuadrangulateCompareVertexBlend;
+				set => QuadrangulateCompareVertexBlend = value;
+			}
+
+			[Title( "Compare Material" )]
+			[Description( "Limit by different face materials." )]
+			public readonly bool CompareFaceMaterial
+			{
+				get => QuadrangulateCompareFaceMaterial;
+				set => QuadrangulateCompareFaceMaterial = value;
+			}
+
+			[Title( "Compare Smoothing" )]
+			[Description( "Limit by edges marked as hard normals." )]
+			public readonly bool CompareSmoothing
+			{
+				get => QuadrangulateCompareSmoothing;
+				set => QuadrangulateCompareSmoothing = value;
+			}
 		}
 	}
 }

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
@@ -34,19 +34,19 @@ public partial class QuadrangulateTool
 
 				ControlSheet sheet = new();
 				ControlWidget control =
-					sheet.AddRow( this.GetSerialized().GetProperty( nameof(_quadrangulateProperties) ) );
+					sheet.AddRow( this.GetSerialized().GetProperty( nameof( _quadrangulateProperties ) ) );
 				control.OnChildValuesChanged += _ => UpdateMesh();
 				row.Add( sheet );
 
 				row = group.AddRow();
 				row.Spacing = 4;
 
-				Button apply = new("Apply", "done");
+				Button apply = new( "Apply", "done" );
 				apply.Clicked = Apply;
 				apply.ToolTip = "[Apply " + EditorShortcuts.GetKeys( "mesh.quadrangulate-apply" ) + "]";
 				row.Add( apply );
 
-				Button cancel = new("Cancel", "close");
+				Button cancel = new( "Cancel", "close" );
 				cancel.Clicked = Cancel;
 				cancel.ToolTip = "[Cancel " + EditorShortcuts.GetKeys( "mesh.quadrangulate-cancel" ) + "]";
 				row.Add( cancel );

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
@@ -1,0 +1,107 @@
+﻿namespace Editor.MeshEditor;
+
+public partial class QuadrangulateTool
+{
+	public static float QuadrangulateMaxFaceAngle { get; set { field = value.Clamp( 0, 180f ); } } = 40.0f;
+	public static float QuadrangulateMaxShapeAngle { get; set { field = value.Clamp( 0, 180f ); } } = 40.0f;
+	public static float QuadrangulateTopologyInfluence { get; set { field = value.Clamp( 0.0f, 2.0f ); } } = 1.0f;
+	public static bool QuadrangulateCompareUVs { get; set; } = true;
+	public static bool QuadrangulateCompareVertexColor { get; set; } = true;
+	public static bool QuadrangulateCompareVertexBlend { get; set; } = true;
+	public static bool QuadrangulateCompareFaceMaterial { get; set; } = true;
+	public static bool QuadrangulateCompareSmoothing { get; set; } = true;
+	
+	public override Widget CreateToolSidebar()
+	{
+		return new QuadrangulateToolWidget( this );
+	}
+
+	public class QuadrangulateToolWidget : ToolSidebarWidget
+	{
+		private readonly QuadrangulateTool _tool;
+
+		private struct QuadrangulateProperties()
+		{
+			[Title( "Max Face Angle" ), Range( 0.0f, 180.0f, true, true ), Step( 0.1f ), WideMode, Description( "The tolerance for difference in face normals in order to be quadrangulated.")]
+			public readonly float MaxFaceAngle { get => QuadrangulateMaxFaceAngle; set => QuadrangulateMaxFaceAngle = value; }
+			
+			[Title( "Max Shape Angle" ), Range( 0.0f, 180.0f, true, true ), Step( 0.1f ), WideMode, Description( "The interior angle tolerance for created quads. 0 means only perfect 90 degree interior angles." )]
+			public readonly float MaxShapeAngle { get => QuadrangulateMaxShapeAngle; set => QuadrangulateMaxShapeAngle = value; }
+			
+			[Title( "Topology Influence" ), Range( 0.0f, 2.0f, true, true ), Step( 0.001f ), WideMode, Description( "How heavily to prioritize keeping faces planar.")]
+			public readonly float TopologyInfluence { get => QuadrangulateTopologyInfluence; set => QuadrangulateTopologyInfluence = value; }
+			
+			[Title( "Compare UVs" ), Description( "Limit by UV seams" )]
+			public readonly bool CompareUVs { get => QuadrangulateCompareUVs; set => QuadrangulateCompareUVs = value; }
+			
+			[Title( "Compare Vertex Color" ), Description( "Limit by vertex color split" )]
+			public readonly bool CompareVertexColor { get => QuadrangulateCompareVertexColor; set => QuadrangulateCompareVertexColor = value; }
+			
+			[Title( "Compare Vertex Blend" ), Description( "Limit by vertex material blend." )]
+			public readonly bool CompareVertexBlend { get => QuadrangulateCompareVertexBlend; set => QuadrangulateCompareVertexBlend = value; }
+			
+			[Title( "Compare Material" ), Description( "Limit by different face materials.")]
+			public readonly bool CompareFaceMaterial { get => QuadrangulateCompareFaceMaterial; set => QuadrangulateCompareFaceMaterial = value; }
+			
+			[Title( "Compare Smoothing" ), Description( "Limit by hard edge smoothing." )]
+			public readonly bool CompareSmoothing { get => QuadrangulateCompareSmoothing; set => QuadrangulateCompareSmoothing = value; }
+		}
+		
+		[InlineEditor( Label = false )]
+		readonly QuadrangulateProperties _quadrangulateProperties = new();
+		
+		public QuadrangulateToolWidget( QuadrangulateTool tool ) : base()
+		{
+			_tool = tool;
+			
+			AddTitle( "Quadrangulate Tool", "crop_square" );
+			
+			{
+				var group = AddGroup( "Properties" );
+				var row = group.AddRow();
+				row.Spacing = 8;
+
+				var sheet = new ControlSheet();
+				var control = sheet.AddRow( this.GetSerialized().GetProperty( nameof( _quadrangulateProperties ) ) );
+				control.OnChildValuesChanged += _ => UpdateMesh();
+				row.Add( sheet );
+
+				row = group.AddRow();
+				row.Spacing = 4;
+
+				var apply = new Button( "Apply", "done" );
+				apply.Clicked = Apply;
+				apply.ToolTip = "[Apply " + EditorShortcuts.GetKeys( "mesh.quadrangulate-apply" ) + "]";
+				row.Add( apply );
+
+				var cancel = new Button( "Cancel", "close" );
+				cancel.Clicked = Cancel;
+				cancel.ToolTip = "[Cancel " + EditorShortcuts.GetKeys( "mesh.quadrangulate-cancel" ) + "]";
+				row.Add( cancel );
+			}
+
+			Layout.AddStretchCell();
+
+			UpdateMesh();
+		}
+		
+		void UpdateMesh()
+		{
+			_tool.UpdateQuadrangulate( QuadrangulateMaxFaceAngle, QuadrangulateMaxShapeAngle, 
+				QuadrangulateTopologyInfluence, QuadrangulateCompareUVs, QuadrangulateCompareVertexColor, 
+				QuadrangulateCompareVertexBlend, QuadrangulateCompareFaceMaterial, QuadrangulateCompareSmoothing );
+		}
+
+		[Shortcut( "mesh.quadrangulate-apply", "enter", ShortcutType.Application )]
+		void Apply()
+		{
+			_tool.Apply();
+		}
+
+		[Shortcut( "mesh.quadrangulate-cancel", "ESC", ShortcutType.Application )]
+		void Cancel()
+		{
+			_tool.Cancel();
+		}
+	}
+}

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.UI.cs
@@ -4,7 +4,6 @@ public partial class QuadrangulateTool
 {
 	public static float QuadrangulateMaxFaceAngle { get; set { field = value.Clamp( 0, 180f ); } } = 40.0f;
 	public static float QuadrangulateMaxShapeAngle { get; set { field = value.Clamp( 0, 180f ); } } = 40.0f;
-	public static float QuadrangulateTopologyInfluence { get; set { field = value.Clamp( 0.0f, 2.0f ); } } = 1.0f;
 	public static bool QuadrangulateCompareUVs { get; set; } = true;
 	public static bool QuadrangulateCompareVertexColor { get; set; } = true;
 	public static bool QuadrangulateCompareVertexBlend { get; set; } = true;
@@ -25,25 +24,22 @@ public partial class QuadrangulateTool
 			[Title( "Max Face Angle" ), Range( 0.0f, 180.0f, true, true ), Step( 0.1f ), WideMode, Description( "The tolerance for difference in face normals in order to be quadrangulated.")]
 			public readonly float MaxFaceAngle { get => QuadrangulateMaxFaceAngle; set => QuadrangulateMaxFaceAngle = value; }
 			
-			[Title( "Max Shape Angle" ), Range( 0.0f, 180.0f, true, true ), Step( 0.1f ), WideMode, Description( "The interior angle tolerance for created quads. 0 means only perfect 90 degree interior angles." )]
+			[Title( "Max Shape Angle" ), Range( 0.0f, 180.0f, true, true ), Step( 0.1f ), WideMode, Description( "The interior angle tolerance for created quads. 0 means only perfect 90 degree interior angles are processed." )]
 			public readonly float MaxShapeAngle { get => QuadrangulateMaxShapeAngle; set => QuadrangulateMaxShapeAngle = value; }
 			
-			[Title( "Topology Influence" ), Range( 0.0f, 2.0f, true, true ), Step( 0.001f ), WideMode, Description( "How heavily to prioritize keeping faces planar.")]
-			public readonly float TopologyInfluence { get => QuadrangulateTopologyInfluence; set => QuadrangulateTopologyInfluence = value; }
-			
-			[Title( "Compare UVs" ), Description( "Limit by UV seams" )]
+			[Title( "Compare UVs" ), Description( "Limit by non-contiguous UVs" )]
 			public readonly bool CompareUVs { get => QuadrangulateCompareUVs; set => QuadrangulateCompareUVs = value; }
 			
-			[Title( "Compare Vertex Color" ), Description( "Limit by vertex color split" )]
+			[Title( "Compare Vertex Color" ), Description( "Limit by vertex color." )]
 			public readonly bool CompareVertexColor { get => QuadrangulateCompareVertexColor; set => QuadrangulateCompareVertexColor = value; }
 			
-			[Title( "Compare Vertex Blend" ), Description( "Limit by vertex material blend." )]
+			[Title( "Compare Vertex Blend" ), Description( "Limit by vertex blending." )]
 			public readonly bool CompareVertexBlend { get => QuadrangulateCompareVertexBlend; set => QuadrangulateCompareVertexBlend = value; }
 			
 			[Title( "Compare Material" ), Description( "Limit by different face materials.")]
 			public readonly bool CompareFaceMaterial { get => QuadrangulateCompareFaceMaterial; set => QuadrangulateCompareFaceMaterial = value; }
 			
-			[Title( "Compare Smoothing" ), Description( "Limit by hard edge smoothing." )]
+			[Title( "Compare Smoothing" ), Description( "Limit by edges marked as hard normals." )]
 			public readonly bool CompareSmoothing { get => QuadrangulateCompareSmoothing; set => QuadrangulateCompareSmoothing = value; }
 		}
 		
@@ -87,8 +83,7 @@ public partial class QuadrangulateTool
 		
 		void UpdateMesh()
 		{
-			_tool.UpdateQuadrangulate( QuadrangulateMaxFaceAngle, QuadrangulateMaxShapeAngle, 
-				QuadrangulateTopologyInfluence, QuadrangulateCompareUVs, QuadrangulateCompareVertexColor, 
+			_tool.UpdateQuadrangulate( QuadrangulateMaxFaceAngle, QuadrangulateMaxShapeAngle, QuadrangulateCompareUVs, QuadrangulateCompareVertexColor, 
 				QuadrangulateCompareVertexBlend, QuadrangulateCompareFaceMaterial, QuadrangulateCompareSmoothing );
 		}
 

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
@@ -1,0 +1,236 @@
+﻿using HalfEdgeMesh;
+
+namespace Editor.MeshEditor;
+
+public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
+{
+	readonly Dictionary<MeshComponent, PolygonMesh> _originalMeshes = [];
+	readonly Dictionary<MeshComponent, List<FaceHandle>> _remappedFaces = [];
+	
+	readonly Dictionary<MeshComponent, List<FaceHandle>> _quadFaces = [];
+	readonly Dictionary<MeshComponent, List<Line>> _removedEdgeLines = [];
+	
+	public override void OnEnabled()
+	{
+		if ( faces is not { Length: > 0 } ) return;
+
+		foreach ( var group in faces.GroupBy( f => f.Component ) )
+		{
+			var component = group.Key;
+			if ( !component.IsValid() ) continue;
+
+			var originalMesh = new PolygonMesh { Transform = component.Mesh.Transform };
+			originalMesh.MergeMesh( component.Mesh, Transform.Zero, out _, out _, out var faceMap );
+
+			_originalMeshes[component] = originalMesh;
+			_remappedFaces[component] = group
+				.Select( f => faceMap.TryGetValue( f.Handle, out var mapped ) ? mapped : default )
+				.Where( f => f.IsValid )
+				.ToList();
+		}
+	}
+	
+	public override void OnDisabled() => RestoreOriginals();
+	
+	public override void OnUpdate()
+	{
+		foreach ( var (component, lines) in _removedEdgeLines )
+		{
+			if ( !component.IsValid() || lines.Count == 0 ) continue;
+			
+			using ( Gizmo.ObjectScope( component.GameObject, component.WorldTransform ) )
+			{
+				using ( Gizmo.Scope( "QuadrangulatePreview" ) )
+				{
+					Gizmo.Draw.Color = new Color( 1.0f, 0.0f, 0f, 0.5f );
+					Gizmo.Draw.LineThickness = 2;
+
+					foreach ( var line in lines )
+						Gizmo.Draw.Line( line );
+				}
+			}
+		}
+	}
+	
+	public void UpdateQuadrangulate( float faceAngle, float shapeAngle, float topology, bool uv, bool color, bool blend, bool material, bool smooth )
+	{
+		_quadFaces.Clear();
+		_removedEdgeLines.Clear();
+
+		foreach ( var (component, originalMesh) in _originalMeshes )
+		{
+			if ( !component.IsValid() ) continue;
+
+			var mesh = new PolygonMesh { Transform = originalMesh.Transform };
+			mesh.MergeMesh( originalMesh, Transform.Zero, out _, out _, out var faceMap );
+
+			var facesToQuad = _remappedFaces[component]
+				.Select( f => faceMap.GetValueOrDefault(f) )
+				.Where( f => f.IsValid )
+				.ToArray();
+
+			if ( facesToQuad.Length == 0 )
+			{
+				component.Mesh = mesh;
+				continue;
+			}
+			
+			QuadrangulateFaces( mesh, facesToQuad, faceAngle, shapeAngle, topology, uv, color, blend, material, smooth, out var newFaces, out var removedEdges );
+
+			_quadFaces[component] = newFaces;
+			_removedEdgeLines[component] = removedEdges;
+			
+			component.Mesh = mesh;
+		}
+	}
+	
+	public void Apply()
+	{
+		var components = _originalMeshes.Keys.Where( c => c.IsValid() ).ToArray();
+		if ( components.Length == 0 ) return;
+
+		var resultMeshes = components.ToDictionary( c => c, c => c.Mesh );
+		RestoreOriginals();
+
+		using var scope = SceneEditorSession.Scope();
+
+		using ( SceneEditorSession.Active.UndoScope( "Quadrangulate Faces" )
+			       .WithComponentChanges( components )
+			       .Push() )
+		{
+			var selection = SceneEditorSession.Active.Selection;
+			selection.Clear();
+
+			foreach ( var component in components )
+			{
+				component.Mesh = resultMeshes[component];
+
+				if ( !_quadFaces.TryGetValue( component, out var insetFaces ) ) continue;
+
+				foreach ( var face in insetFaces.Where( f => f.IsValid ) )
+					selection.Add( new MeshFace( component, face ) );
+			}
+		}
+
+		Cleanup();
+		EditorToolManager.SetSubTool( nameof( FaceTool ) );
+	}
+
+	public void Cancel()
+	{
+		RestoreOriginals();
+		Cleanup();
+		EditorToolManager.SetSubTool( nameof( FaceTool ) );
+	}
+
+	void RestoreOriginals()
+	{
+		foreach ( var (component, originalMesh) in _originalMeshes )
+		{
+			if ( component.IsValid() )
+				component.Mesh = originalMesh;
+		}
+	}
+
+	void Cleanup()
+	{
+		_originalMeshes.Clear();
+		_remappedFaces.Clear();
+		_quadFaces.Clear();
+		_removedEdgeLines.Clear();
+	}
+
+	static void QuadrangulateFaces( PolygonMesh mesh, FaceHandle[] faces, float faceAngle, float shapeAngle,
+		float topology, bool uv, bool color, bool blend, bool material, bool smooth, out List<FaceHandle> newFaces, out List<Line> removedEdges )
+	{
+		newFaces = [];
+		removedEdges = [];
+
+		// Get faces that share an edge, score them based on how viable they are to quadrangulate.
+		foreach ( var face in faces )
+		{
+			// Get neighbouring faces that were selected during the operation.
+			List<FaceHandle> neighbourFaces = [];
+			
+			mesh.GetFacesConnectedToFace( face, out var connectedFaces );
+			neighbourFaces.AddRange( connectedFaces.Where( connectedFace => faces.Contains( connectedFace ) ) );
+
+			foreach ( var neighbourFace in neighbourFaces )
+			{
+				mesh.GetEdgesConnectedToFace( face, out var faceEdges );
+				mesh.GetEdgesConnectedToFace( neighbourFace, out var neighbourEdges );
+
+				var sharedEdge = faceEdges.First( edge => neighbourEdges.Contains( edge ) );
+				
+				// Check if faces are valid for scoring according to properties.
+				if ( smooth && mesh.GetEdgeSmoothing( sharedEdge ) == PolygonMesh.EdgeSmoothMode.Hard ) continue;
+				
+				if ( uv )
+				{
+					mesh.GetEdgeVertices( sharedEdge, out var sharedVertA, out var sharedVertB );
+					
+					var faceUVs = mesh.GetFaceTextureCoords( face );
+					var faceVerts = mesh.GetFaceVertices( face );
+					
+					int faceIndexA = Array.IndexOf( faceVerts, sharedVertA );
+					int faceIndexB = Array.IndexOf( faceVerts, sharedVertB );
+					
+					var neighbourUVs = mesh.GetFaceTextureCoords( neighbourFace );
+					var neighbourVerts = mesh.GetFaceVertices( neighbourFace );
+					
+					int neighbourIndexA = Array.IndexOf( neighbourVerts, sharedVertA );
+					int neighbourIndexB = Array.IndexOf( neighbourVerts, sharedVertB );
+					
+					const float margin = 0.0001f;
+					
+					bool matchA = faceUVs[faceIndexA].AlmostEqual( neighbourUVs[neighbourIndexA], margin );
+					bool matchB = faceUVs[faceIndexB].AlmostEqual( neighbourUVs[neighbourIndexB], margin );
+
+					bool match = matchA && matchB;
+					
+					if ( !match ) continue;
+				}
+
+				if ( color )
+				{
+					bool match = mesh.GetVertexColor( sharedEdge ) ==
+					             mesh.GetVertexColor( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
+					             mesh.GetVertexColor( sharedEdge.OppositeEdge ) ==
+					             mesh.GetVertexColor( sharedEdge.NextEdge.NextEdge );
+					if ( !match ) continue;
+				}
+
+				if ( blend )
+				{
+					bool match = mesh.GetVertexBlend( sharedEdge ) ==
+					             mesh.GetVertexBlend( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
+					             mesh.GetVertexBlend( sharedEdge.OppositeEdge ) ==
+					             mesh.GetVertexBlend( sharedEdge.NextEdge.NextEdge );
+					if ( !match ) continue;
+				}
+				
+				if ( material && mesh.GetFaceMaterial( face ) != mesh.GetFaceMaterial( neighbourFace ) ) continue;
+
+				var faceNormal = GetFaceNormal( face );
+				var neighbourNormal = GetFaceNormal( neighbourFace );
+
+				float degree = MathF.Acos( Vector3.Dot( faceNormal, neighbourNormal ) ).RadianToDegree();
+				if ( degree >= QuadrangulateMaxFaceAngle ) continue;
+				
+				removedEdges.Add( mesh.GetEdgeLine( sharedEdge ) );
+			}
+		}
+
+		Vector3 GetFaceNormal( FaceHandle face )
+		{
+			var vhs = mesh.GetFaceVertices( face );
+			
+			Vector3 a = mesh.GetVertexPosition( vhs[0] );
+			Vector3 b = mesh.GetVertexPosition( vhs[1] );
+			Vector3 c = mesh.GetVertexPosition( vhs[2] );
+
+			Vector3 normal = Vector3.Cross( b - a, c - a ).Normal;
+			return normal;
+		}
+	}
+}

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
@@ -119,8 +119,8 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		using IDisposable scope = SceneEditorSession.Scope();
 
 		using ( SceneEditorSession.Active.UndoScope( "Quadrangulate Faces" )
-			       .WithComponentChanges( components )
-			       .Push() )
+				   .WithComponentChanges( components )
+				   .Push() )
 		{
 			SelectionSystem selection = SceneEditorSession.Active.Selection;
 			selection.Clear();
@@ -142,14 +142,14 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		}
 
 		Cleanup();
-		EditorToolManager.SetSubTool( nameof(FaceTool) );
+		EditorToolManager.SetSubTool( nameof( FaceTool ) );
 	}
 
 	public void Cancel()
 	{
 		RestoreOriginals();
 		Cleanup();
-		EditorToolManager.SetSubTool( nameof(FaceTool) );
+		EditorToolManager.SetSubTool( nameof( FaceTool ) );
 	}
 
 	private void RestoreOriginals()
@@ -252,9 +252,9 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 				if ( color )
 				{
 					bool match = mesh.GetVertexColor( sharedEdge ) ==
-					             mesh.GetVertexColor( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
-					             mesh.GetVertexColor( sharedEdge.OppositeEdge ) ==
-					             mesh.GetVertexColor( sharedEdge.NextEdge.NextEdge );
+								 mesh.GetVertexColor( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
+								 mesh.GetVertexColor( sharedEdge.OppositeEdge ) ==
+								 mesh.GetVertexColor( sharedEdge.NextEdge.NextEdge );
 					if ( !match )
 					{
 						continue;
@@ -264,9 +264,9 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 				if ( blend )
 				{
 					bool match = mesh.GetVertexBlend( sharedEdge ) ==
-					             mesh.GetVertexBlend( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
-					             mesh.GetVertexBlend( sharedEdge.OppositeEdge ) ==
-					             mesh.GetVertexBlend( sharedEdge.NextEdge.NextEdge );
+								 mesh.GetVertexBlend( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
+								 mesh.GetVertexBlend( sharedEdge.OppositeEdge ) ==
+								 mesh.GetVertexBlend( sharedEdge.NextEdge.NextEdge );
 					if ( !match )
 					{
 						continue;

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
@@ -12,7 +12,7 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 	
 	public override void OnEnabled()
 	{
-		if ( faces is not { Length: > 0 } ) return;
+		if ( faces is not { Length: > 1 } ) return;
 
 		foreach ( var group in faces.GroupBy( f => f.Component ) )
 		{
@@ -340,11 +340,11 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		}
 	}
 	
-	private struct FacePair( FaceHandle face, FaceHandle neighbourFace, HalfEdgeHandle edge )
+	private record struct FacePair( FaceHandle Face, FaceHandle NeighbourFace, HalfEdgeHandle Edge )
 	{
-		public FaceHandle FaceA { get; } = face;
-		public FaceHandle FaceB { get; } = neighbourFace;
-		public HalfEdgeHandle SharedEdge { get; } = edge;
+		public FaceHandle FaceA { get; } = Face;
+		public FaceHandle FaceB { get; } = NeighbourFace;
+		public HalfEdgeHandle SharedEdge { get; } = Edge;
 		
 		public float Shape { get; set; }
 		public float Normal { get; set; }

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
@@ -236,8 +236,6 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 					int neighbourIndexA = Array.IndexOf( neighbourVerts, sharedVertA );
 					int neighbourIndexB = Array.IndexOf( neighbourVerts, sharedVertB );
 
-					float margin = 0.0001f;
-
 					bool matchA = faceUVs[faceIndexA].AlmostEqual( neighbourUVs[neighbourIndexA] );
 					bool matchB = faceUVs[faceIndexB].AlmostEqual( neighbourUVs[neighbourIndexB] );
 

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
@@ -52,7 +52,7 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		}
 	}
 	
-	public void UpdateQuadrangulate( float faceAngle, float shapeAngle, float topology, bool uv, bool color, bool blend, bool material, bool smooth )
+	public void UpdateQuadrangulate( float faceAngle, float shapeAngle, bool uv, bool color, bool blend, bool material, bool smooth )
 	{
 		_quadFaces.Clear();
 		_removedEdgeLines.Clear();
@@ -75,7 +75,7 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 				continue;
 			}
 			
-			QuadrangulateFaces( mesh, facesToQuad, faceAngle, shapeAngle, topology, uv, color, blend, material, smooth, out var newFaces, out var removedEdges );
+			QuadrangulateFaces( mesh, facesToQuad, faceAngle, shapeAngle, uv, color, blend, material, smooth, out var newFaces, out var removedEdges);
 
 			_quadFaces[component] = newFaces;
 			_removedEdgeLines[component] = removedEdges;
@@ -105,9 +105,9 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 			{
 				component.Mesh = resultMeshes[component];
 
-				if ( !_quadFaces.TryGetValue( component, out var insetFaces ) ) continue;
+				if ( !_quadFaces.TryGetValue( component, out var quadFaces ) ) continue;
 
-				foreach ( var face in insetFaces.Where( f => f.IsValid ) )
+				foreach ( var face in quadFaces.Where( f => f.IsValid ) )
 					selection.Add( new MeshFace( component, face ) );
 			}
 		}
@@ -140,35 +140,45 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		_removedEdgeLines.Clear();
 	}
 
-	static void QuadrangulateFaces( PolygonMesh mesh, FaceHandle[] faces, float faceAngle, float shapeAngle,
-		float topology, bool uv, bool color, bool blend, bool material, bool smooth, out List<FaceHandle> newFaces, out List<Line> removedEdges )
+	static void QuadrangulateFaces( PolygonMesh mesh, FaceHandle[] faces, float faceAngle, float shapeAngle, bool uv, bool color, bool blend, bool material, bool smooth, out List<FaceHandle> newFaces, out List<Line> removedEdges )
 	{
 		newFaces = [];
 		removedEdges = [];
 
+		List<FacePair> facePairs = [];
+
 		// Get faces that share an edge, score them based on how viable they are to quadrangulate.
 		foreach ( var face in faces )
 		{
-			// Get neighbouring faces that were selected during the operation.
+			if (mesh.GetFaceEdges( face ).Length > 3) continue;
+			
+			// Get neighbouring faces that were selected when opening the tool.
 			List<FaceHandle> neighbourFaces = [];
 			
 			mesh.GetFacesConnectedToFace( face, out var connectedFaces );
 			neighbourFaces.AddRange( connectedFaces.Where( connectedFace => faces.Contains( connectedFace ) ) );
 
+			// Get the edge shared between the faces.
 			foreach ( var neighbourFace in neighbourFaces )
 			{
-				mesh.GetEdgesConnectedToFace( face, out var faceEdges );
-				mesh.GetEdgesConnectedToFace( neighbourFace, out var neighbourEdges );
+				if (mesh.GetFaceEdges( neighbourFace ).Length > 3) continue;
+				
+				// Skip checks if processed two faces in an earlier loop.
+				if (facePairs.Exists( x => x.FaceB == face && x.FaceA == neighbourFace )) continue;
+				
+				var faceEdges = mesh.GetFaceEdges( face );
+				var neighbourEdges = mesh.GetFaceEdges( neighbourFace );
 
 				var sharedEdge = faceEdges.First( edge => neighbourEdges.Contains( edge ) );
+				mesh.GetEdgeVertices( sharedEdge, out var sharedVertA, out var sharedVertB );
 				
-				// Check if faces are valid for scoring according to properties.
-				if ( smooth && mesh.GetEdgeSmoothing( sharedEdge ) == PolygonMesh.EdgeSmoothMode.Hard ) continue;
+				// Check if faces pass checks prior to scoring.
+				{
+					if ( smooth && mesh.GetEdgeSmoothing( sharedEdge ) == PolygonMesh.EdgeSmoothMode.Hard ) continue;
+				}
 				
 				if ( uv )
 				{
-					mesh.GetEdgeVertices( sharedEdge, out var sharedVertA, out var sharedVertB );
-					
 					var faceUVs = mesh.GetFaceTextureCoords( face );
 					var faceVerts = mesh.GetFaceVertices( face );
 					
@@ -208,19 +218,81 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 					             mesh.GetVertexBlend( sharedEdge.NextEdge.NextEdge );
 					if ( !match ) continue;
 				}
-				
-				if ( material && mesh.GetFaceMaterial( face ) != mesh.GetFaceMaterial( neighbourFace ) ) continue;
 
-				var faceNormal = GetFaceNormal( face );
-				var neighbourNormal = GetFaceNormal( neighbourFace );
+				{
+					if ( material && mesh.GetFaceMaterial( face ) != mesh.GetFaceMaterial( neighbourFace ) ) continue;
+				}
 
-				float degree = MathF.Acos( Vector3.Dot( faceNormal, neighbourNormal ) ).RadianToDegree();
-				if ( degree >= QuadrangulateMaxFaceAngle ) continue;
+				float normal;
+				{
+					var faceNormal = GetFaceNormal( face );
+					var neighbourNormal = GetFaceNormal( neighbourFace );
+
+					float degree = MathF.Acos( Vector3.Dot( faceNormal, neighbourNormal ) ).RadianToDegree();
+					if ( degree >= faceAngle ) continue;
+					
+					normal = ( degree / faceAngle );
+				}
+
+				float shape;
+				{
+					(float a, float b) = GetFaceShape( sharedEdge );
+
+					var maxAngle = 90 + shapeAngle;
+					var minAngle = 90 - shapeAngle;
+
+					if ( a < minAngle || a > maxAngle ) continue;
+					if ( b < minAngle || b > maxAngle ) continue;
+
+					var limitA = Math.Min( Math.Abs( maxAngle - a ), Math.Abs( minAngle - a ) );
+					var limitB = Math.Min( Math.Abs( maxAngle - b ), Math.Abs( minAngle - b ) );
+
+					var max = Math.Min( limitA, limitB );
+					shape = ( max / shapeAngle );
+				}
+
+				float area;
+				{
+					area = GetSharedFaceArea( face, neighbourFace );
+				}
 				
-				removedEdges.Add( mesh.GetEdgeLine( sharedEdge ) );
+				facePairs.Add( new FacePair( face, neighbourFace, sharedEdge ) { Normal = normal, Shape = shape, Area = area } );
 			}
 		}
 
+		// Order face pairs by score, start removing the highest scoring until there is no more.
+		List<HalfEdgeHandle> edgesToRemove = [];
+		while ( facePairs.Count > 0 )
+		{
+			var e = facePairs.OrderBy( x => x.Score ).Last();
+			edgesToRemove.Add( e.SharedEdge );
+
+			facePairs.RemoveAll(x =>
+				x.FaceA == e.FaceA || x.FaceA == e.FaceB ||
+				x.FaceB == e.FaceA || x.FaceB == e.FaceB
+			);
+			
+			facePairs.Remove( e );
+		}
+
+		removedEdges.AddRange( edgesToRemove.Select( e => mesh.GetEdgeLine( e ) ) );
+		mesh.DissolveEdges( edgesToRemove, false, PolygonMesh.DissolveRemoveVertexCondition.None );
+
+		float GetFaceArea( FaceHandle face )
+		{
+			var vhs = mesh.GetFaceVertices( face );
+			
+			Vector3 a = mesh.GetVertexPosition( vhs[0] );
+			Vector3 b = mesh.GetVertexPosition( vhs[1] );
+			Vector3 c = mesh.GetVertexPosition( vhs[2] );
+
+			float area = Vector3.Cross( b - a, c - a ).Length * 0.5f;
+			return area;
+		}
+
+		float GetSharedFaceArea( FaceHandle face, FaceHandle neighbourFace ) =>
+			GetFaceArea( face ) + GetFaceArea( neighbourFace );
+		
 		Vector3 GetFaceNormal( FaceHandle face )
 		{
 			var vhs = mesh.GetFaceVertices( face );
@@ -229,8 +301,55 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 			Vector3 b = mesh.GetVertexPosition( vhs[1] );
 			Vector3 c = mesh.GetVertexPosition( vhs[2] );
 
-			Vector3 normal = Vector3.Cross( b - a, c - a ).Normal;
+			var normal = Vector3.Cross( b - a, c - a ).Normal;
 			return normal;
 		}
+		
+		(float a, float b) GetFaceShape ( HalfEdgeHandle edge )
+		{
+			mesh.GetEdgeVertices( edge, out var hVertexA, out var hVertexB );
+			var hVertexC = mesh.GetNextVertexInFace( edge ).Vertex;
+			var hVertexD = mesh.GetNextVertexInFace( edge.OppositeEdge ).Vertex;
+
+			float a;
+			float b;
+
+			// Corner A
+			{
+				var quadADirA = ( mesh.GetVertexPosition( hVertexC ) - mesh.GetVertexPosition( hVertexA )).Normal;
+				var quadADirB = ( mesh.GetVertexPosition( hVertexD ) - mesh.GetVertexPosition( hVertexA )).Normal;
+				
+				var dot = Vector3.Dot(  quadADirA, quadADirB ).Clamp( -1.0f, 1.0f );
+				var sharedVertADegrees = MathF.Acos( dot) * 180.0f / MathF.PI;
+				
+				a = sharedVertADegrees;
+			}
+			
+			// Corner B
+			{
+				var quadBDirA = ( mesh.GetVertexPosition( hVertexC ) - mesh.GetVertexPosition( hVertexB )).Normal;
+				var quadBDirB = ( mesh.GetVertexPosition( hVertexD ) - mesh.GetVertexPosition( hVertexB )).Normal;
+				
+				var dot = Vector3.Dot(  quadBDirA, quadBDirB ).Clamp( -1.0f, 1.0f );
+				var sharedVertBDegrees = MathF.Acos( dot) * 180.0f / MathF.PI;
+				
+				b = sharedVertBDegrees;
+			}
+
+			return (a, b);
+		}
+	}
+	
+	private struct FacePair( FaceHandle face, FaceHandle neighbourFace, HalfEdgeHandle edge )
+	{
+		public FaceHandle FaceA { get; } = face;
+		public FaceHandle FaceB { get; } = neighbourFace;
+		public HalfEdgeHandle SharedEdge { get; } = edge;
+		
+		public float Shape { get; set; }
+		public float Normal { get; set; }
+		public float Area { get; set; }
+		
+		public float Score => (Shape + Normal);
 	}
 }

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
@@ -4,40 +4,53 @@ namespace Editor.MeshEditor;
 
 public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 {
-	readonly Dictionary<MeshComponent, PolygonMesh> _originalMeshes = [];
-	readonly Dictionary<MeshComponent, List<FaceHandle>> _remappedFaces = [];
-	
-	readonly Dictionary<MeshComponent, List<FaceHandle>> _quadFaces = [];
-	readonly Dictionary<MeshComponent, List<Line>> _removedEdgeLines = [];
-	
+	private readonly Dictionary<MeshComponent, PolygonMesh> _originalMeshes = [];
+
+	private readonly Dictionary<MeshComponent, List<FaceHandle>> _quadFaces = [];
+	private readonly Dictionary<MeshComponent, List<FaceHandle>> _remappedFaces = [];
+	private readonly Dictionary<MeshComponent, List<Line>> _removedEdgeLines = [];
+
 	public override void OnEnabled()
 	{
-		if ( faces is not { Length: > 1 } ) return;
-
-		foreach ( var group in faces.GroupBy( f => f.Component ) )
+		if ( faces is not { Length: > 1 } )
 		{
-			var component = group.Key;
-			if ( !component.IsValid() ) continue;
+			return;
+		}
 
-			var originalMesh = new PolygonMesh { Transform = component.Mesh.Transform };
-			originalMesh.MergeMesh( component.Mesh, Transform.Zero, out _, out _, out var faceMap );
+		foreach ( IGrouping<MeshComponent, MeshFace> group in faces.GroupBy( f => f.Component ) )
+		{
+			MeshComponent component = group.Key;
+			if ( !component.IsValid() )
+			{
+				continue;
+			}
+
+			PolygonMesh originalMesh = new() { Transform = component.Mesh.Transform };
+			originalMesh.MergeMesh( component.Mesh, Transform.Zero, out _, out _,
+				out Dictionary<FaceHandle, FaceHandle> faceMap );
 
 			_originalMeshes[component] = originalMesh;
 			_remappedFaces[component] = group
-				.Select( f => faceMap.TryGetValue( f.Handle, out var mapped ) ? mapped : default )
+				.Select( f => faceMap.TryGetValue( f.Handle, out FaceHandle mapped ) ? mapped : default )
 				.Where( f => f.IsValid )
 				.ToList();
 		}
 	}
-	
-	public override void OnDisabled() => RestoreOriginals();
-	
+
+	public override void OnDisabled()
+	{
+		RestoreOriginals();
+	}
+
 	public override void OnUpdate()
 	{
-		foreach ( var (component, lines) in _removedEdgeLines )
+		foreach ( (MeshComponent component, List<Line> lines) in _removedEdgeLines )
 		{
-			if ( !component.IsValid() || lines.Count == 0 ) continue;
-			
+			if ( !component.IsValid() || lines.Count == 0 )
+			{
+				continue;
+			}
+
 			using ( Gizmo.ObjectScope( component.GameObject, component.WorldTransform ) )
 			{
 				using ( Gizmo.Scope( "QuadrangulatePreview" ) )
@@ -45,27 +58,34 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 					Gizmo.Draw.Color = new Color( 1.0f, 0.0f, 0f, 0.5f );
 					Gizmo.Draw.LineThickness = 2;
 
-					foreach ( var line in lines )
+					foreach ( Line line in lines )
+					{
 						Gizmo.Draw.Line( line );
+					}
 				}
 			}
 		}
 	}
-	
-	public void UpdateQuadrangulate( float faceAngle, float shapeAngle, bool uv, bool color, bool blend, bool material, bool smooth )
+
+	public void UpdateQuadrangulate( float faceAngle, float shapeAngle, bool uv, bool color, bool blend, bool material,
+		bool smooth )
 	{
 		_quadFaces.Clear();
 		_removedEdgeLines.Clear();
 
-		foreach ( var (component, originalMesh) in _originalMeshes )
+		foreach ( (MeshComponent component, PolygonMesh originalMesh) in _originalMeshes )
 		{
-			if ( !component.IsValid() ) continue;
+			if ( !component.IsValid() )
+			{
+				continue;
+			}
 
-			var mesh = new PolygonMesh { Transform = originalMesh.Transform };
-			mesh.MergeMesh( originalMesh, Transform.Zero, out _, out _, out var faceMap );
+			PolygonMesh mesh = new() { Transform = originalMesh.Transform };
+			mesh.MergeMesh( originalMesh, Transform.Zero, out _, out _,
+				out Dictionary<FaceHandle, FaceHandle> faceMap );
 
-			var facesToQuad = _remappedFaces[component]
-				.Select( f => faceMap.GetValueOrDefault(f) )
+			FaceHandle[] facesToQuad = _remappedFaces[component]
+				.Select( f => faceMap.GetValueOrDefault( f ) )
 				.Where( f => f.IsValid )
 				.ToArray();
 
@@ -74,65 +94,76 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 				component.Mesh = mesh;
 				continue;
 			}
-			
-			QuadrangulateFaces( mesh, facesToQuad, faceAngle, shapeAngle, uv, color, blend, material, smooth, out var newFaces, out var removedEdges);
+
+			QuadrangulateFaces( mesh, facesToQuad, faceAngle, shapeAngle, uv, color, blend, material, smooth,
+				out List<FaceHandle> newFaces, out List<Line> removedEdges );
 
 			_quadFaces[component] = newFaces;
 			_removedEdgeLines[component] = removedEdges;
-			
+
 			component.Mesh = mesh;
 		}
 	}
-	
+
 	public void Apply()
 	{
-		var components = _originalMeshes.Keys.Where( c => c.IsValid() ).ToArray();
-		if ( components.Length == 0 ) return;
+		MeshComponent[] components = _originalMeshes.Keys.Where( c => c.IsValid() ).ToArray();
+		if ( components.Length == 0 )
+		{
+			return;
+		}
 
-		var resultMeshes = components.ToDictionary( c => c, c => c.Mesh );
+		Dictionary<MeshComponent, PolygonMesh> resultMeshes = components.ToDictionary( c => c, c => c.Mesh );
 		RestoreOriginals();
 
-		using var scope = SceneEditorSession.Scope();
+		using IDisposable scope = SceneEditorSession.Scope();
 
 		using ( SceneEditorSession.Active.UndoScope( "Quadrangulate Faces" )
 			       .WithComponentChanges( components )
 			       .Push() )
 		{
-			var selection = SceneEditorSession.Active.Selection;
+			SelectionSystem selection = SceneEditorSession.Active.Selection;
 			selection.Clear();
 
-			foreach ( var component in components )
+			foreach ( MeshComponent component in components )
 			{
 				component.Mesh = resultMeshes[component];
 
-				if ( !_quadFaces.TryGetValue( component, out var quadFaces ) ) continue;
+				if ( !_quadFaces.TryGetValue( component, out List<FaceHandle> quadFaces ) )
+				{
+					continue;
+				}
 
-				foreach ( var face in quadFaces.Where( f => f.IsValid ) )
+				foreach ( FaceHandle face in quadFaces.Where( f => f.IsValid ) )
+				{
 					selection.Add( new MeshFace( component, face ) );
+				}
 			}
 		}
 
 		Cleanup();
-		EditorToolManager.SetSubTool( nameof( FaceTool ) );
+		EditorToolManager.SetSubTool( nameof(FaceTool) );
 	}
 
 	public void Cancel()
 	{
 		RestoreOriginals();
 		Cleanup();
-		EditorToolManager.SetSubTool( nameof( FaceTool ) );
+		EditorToolManager.SetSubTool( nameof(FaceTool) );
 	}
 
-	void RestoreOriginals()
+	private void RestoreOriginals()
 	{
-		foreach ( var (component, originalMesh) in _originalMeshes )
+		foreach ( (MeshComponent component, PolygonMesh originalMesh) in _originalMeshes )
 		{
 			if ( component.IsValid() )
+			{
 				component.Mesh = originalMesh;
+			}
 		}
 	}
 
-	void Cleanup()
+	private void Cleanup()
 	{
 		_originalMeshes.Clear();
 		_remappedFaces.Clear();
@@ -140,7 +171,9 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		_removedEdgeLines.Clear();
 	}
 
-	static void QuadrangulateFaces( PolygonMesh mesh, FaceHandle[] faces, float faceAngle, float shapeAngle, bool uv, bool color, bool blend, bool material, bool smooth, out List<FaceHandle> newFaces, out List<Line> removedEdges )
+	private static void QuadrangulateFaces( PolygonMesh mesh, FaceHandle[] faces, float faceAngle, float shapeAngle,
+		bool uv, bool color, bool blend, bool material, bool smooth, out List<FaceHandle> newFaces,
+		out List<Line> removedEdges )
 	{
 		newFaces = [];
 		removedEdges = [];
@@ -148,57 +181,72 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		List<FacePair> facePairs = [];
 
 		// Get faces that share an edge, score them based on how viable they are to quadrangulate.
-		foreach ( var face in faces )
+		foreach ( FaceHandle face in faces )
 		{
-			if (mesh.GetFaceEdges( face ).Length > 3) continue;
-			
+			if ( mesh.GetFaceEdges( face ).Length > 3 )
+			{
+				continue;
+			}
+
 			// Get neighbouring faces that were selected when opening the tool.
 			List<FaceHandle> neighbourFaces = [];
-			
-			mesh.GetFacesConnectedToFace( face, out var connectedFaces );
+
+			mesh.GetFacesConnectedToFace( face, out List<FaceHandle> connectedFaces );
 			neighbourFaces.AddRange( connectedFaces.Where( connectedFace => faces.Contains( connectedFace ) ) );
 
 			// Get the edge shared between the faces.
-			foreach ( var neighbourFace in neighbourFaces )
+			foreach ( FaceHandle neighbourFace in neighbourFaces )
 			{
-				if (mesh.GetFaceEdges( neighbourFace ).Length > 3) continue;
-				
-				// Skip checks if processed two faces in an earlier loop.
-				if (facePairs.Exists( x => x.FaceB == face && x.FaceA == neighbourFace )) continue;
-				
-				var faceEdges = mesh.GetFaceEdges( face );
-				var neighbourEdges = mesh.GetFaceEdges( neighbourFace );
+				if ( mesh.GetFaceEdges( neighbourFace ).Length > 3 )
+				{
+					continue;
+				}
 
-				var sharedEdge = faceEdges.First( edge => neighbourEdges.Contains( edge ) );
-				mesh.GetEdgeVertices( sharedEdge, out var sharedVertA, out var sharedVertB );
-				
+				// Skip checks if processed two faces in an earlier loop.
+				if ( facePairs.Exists( x => x.FaceB == face && x.FaceA == neighbourFace ) )
+				{
+					continue;
+				}
+
+				HalfEdgeHandle[] faceEdges = mesh.GetFaceEdges( face );
+				HalfEdgeHandle[] neighbourEdges = mesh.GetFaceEdges( neighbourFace );
+
+				HalfEdgeHandle sharedEdge = faceEdges.First( edge => neighbourEdges.Contains( edge ) );
+				mesh.GetEdgeVertices( sharedEdge, out VertexHandle sharedVertA, out VertexHandle sharedVertB );
+
 				// Check if faces pass checks prior to scoring.
 				{
-					if ( smooth && mesh.GetEdgeSmoothing( sharedEdge ) == PolygonMesh.EdgeSmoothMode.Hard ) continue;
+					if ( smooth && mesh.GetEdgeSmoothing( sharedEdge ) == PolygonMesh.EdgeSmoothMode.Hard )
+					{
+						continue;
+					}
 				}
-				
+
 				if ( uv )
 				{
-					var faceUVs = mesh.GetFaceTextureCoords( face );
-					var faceVerts = mesh.GetFaceVertices( face );
-					
+					Vector2[] faceUVs = mesh.GetFaceTextureCoords( face );
+					VertexHandle[] faceVerts = mesh.GetFaceVertices( face );
+
 					int faceIndexA = Array.IndexOf( faceVerts, sharedVertA );
 					int faceIndexB = Array.IndexOf( faceVerts, sharedVertB );
-					
-					var neighbourUVs = mesh.GetFaceTextureCoords( neighbourFace );
-					var neighbourVerts = mesh.GetFaceVertices( neighbourFace );
-					
+
+					Vector2[] neighbourUVs = mesh.GetFaceTextureCoords( neighbourFace );
+					VertexHandle[] neighbourVerts = mesh.GetFaceVertices( neighbourFace );
+
 					int neighbourIndexA = Array.IndexOf( neighbourVerts, sharedVertA );
 					int neighbourIndexB = Array.IndexOf( neighbourVerts, sharedVertB );
-					
+
 					const float margin = 0.0001f;
-					
-					bool matchA = faceUVs[faceIndexA].AlmostEqual( neighbourUVs[neighbourIndexA], margin );
-					bool matchB = faceUVs[faceIndexB].AlmostEqual( neighbourUVs[neighbourIndexB], margin );
+
+					bool matchA = faceUVs[faceIndexA].AlmostEqual( neighbourUVs[neighbourIndexA] );
+					bool matchB = faceUVs[faceIndexB].AlmostEqual( neighbourUVs[neighbourIndexB] );
 
 					bool match = matchA && matchB;
-					
-					if ( !match ) continue;
+
+					if ( !match )
+					{
+						continue;
+					}
 				}
 
 				if ( color )
@@ -207,7 +255,10 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 					             mesh.GetVertexColor( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
 					             mesh.GetVertexColor( sharedEdge.OppositeEdge ) ==
 					             mesh.GetVertexColor( sharedEdge.NextEdge.NextEdge );
-					if ( !match ) continue;
+					if ( !match )
+					{
+						continue;
+					}
 				}
 
 				if ( blend )
@@ -216,47 +267,64 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 					             mesh.GetVertexBlend( sharedEdge.OppositeEdge.NextEdge.NextEdge ) &&
 					             mesh.GetVertexBlend( sharedEdge.OppositeEdge ) ==
 					             mesh.GetVertexBlend( sharedEdge.NextEdge.NextEdge );
-					if ( !match ) continue;
+					if ( !match )
+					{
+						continue;
+					}
 				}
 
 				{
-					if ( material && mesh.GetFaceMaterial( face ) != mesh.GetFaceMaterial( neighbourFace ) ) continue;
+					if ( material && mesh.GetFaceMaterial( face ) != mesh.GetFaceMaterial( neighbourFace ) )
+					{
+						continue;
+					}
 				}
 
 				float normal;
 				{
-					var faceNormal = GetFaceNormal( face );
-					var neighbourNormal = GetFaceNormal( neighbourFace );
+					Vector3 faceNormal = GetFaceNormal( face );
+					Vector3 neighbourNormal = GetFaceNormal( neighbourFace );
 
 					float degree = MathF.Acos( Vector3.Dot( faceNormal, neighbourNormal ) ).RadianToDegree();
-					if ( degree >= faceAngle ) continue;
-					
-					normal = ( degree / faceAngle );
+					if ( degree >= faceAngle )
+					{
+						continue;
+					}
+
+					normal = degree / faceAngle;
 				}
 
 				float shape;
 				{
 					(float a, float b) = GetFaceShape( sharedEdge );
 
-					var maxAngle = 90 + shapeAngle;
-					var minAngle = 90 - shapeAngle;
+					float maxAngle = 90 + shapeAngle;
+					float minAngle = 90 - shapeAngle;
 
-					if ( a < minAngle || a > maxAngle ) continue;
-					if ( b < minAngle || b > maxAngle ) continue;
+					if ( a < minAngle || a > maxAngle )
+					{
+						continue;
+					}
 
-					var limitA = Math.Min( Math.Abs( maxAngle - a ), Math.Abs( minAngle - a ) );
-					var limitB = Math.Min( Math.Abs( maxAngle - b ), Math.Abs( minAngle - b ) );
+					if ( b < minAngle || b > maxAngle )
+					{
+						continue;
+					}
 
-					var max = Math.Min( limitA, limitB );
-					shape = ( max / shapeAngle );
+					float limitA = Math.Min( Math.Abs( maxAngle - a ), Math.Abs( minAngle - a ) );
+					float limitB = Math.Min( Math.Abs( maxAngle - b ), Math.Abs( minAngle - b ) );
+
+					float max = Math.Min( limitA, limitB );
+					shape = max / shapeAngle;
 				}
 
 				float area;
 				{
 					area = GetSharedFaceArea( face, neighbourFace );
 				}
-				
-				facePairs.Add( new FacePair( face, neighbourFace, sharedEdge ) { Normal = normal, Shape = shape, Area = area } );
+
+				facePairs.Add(
+					new FacePair( face, neighbourFace, sharedEdge ) { Normal = normal, Shape = shape, Area = area } );
 			}
 		}
 
@@ -264,14 +332,14 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 		List<HalfEdgeHandle> edgesToRemove = [];
 		while ( facePairs.Count > 0 )
 		{
-			var e = facePairs.OrderBy( x => x.Score ).Last();
+			FacePair e = facePairs.OrderBy( x => x.Score ).Last();
 			edgesToRemove.Add( e.SharedEdge );
 
-			facePairs.RemoveAll(x =>
+			facePairs.RemoveAll( x =>
 				x.FaceA == e.FaceA || x.FaceA == e.FaceB ||
 				x.FaceB == e.FaceA || x.FaceB == e.FaceB
 			);
-			
+
 			facePairs.Remove( e );
 		}
 
@@ -280,8 +348,8 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 
 		float GetFaceArea( FaceHandle face )
 		{
-			var vhs = mesh.GetFaceVertices( face );
-			
+			VertexHandle[] vhs = mesh.GetFaceVertices( face );
+
 			Vector3 a = mesh.GetVertexPosition( vhs[0] );
 			Vector3 b = mesh.GetVertexPosition( vhs[1] );
 			Vector3 c = mesh.GetVertexPosition( vhs[2] );
@@ -290,66 +358,68 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 			return area;
 		}
 
-		float GetSharedFaceArea( FaceHandle face, FaceHandle neighbourFace ) =>
-			GetFaceArea( face ) + GetFaceArea( neighbourFace );
-		
+		float GetSharedFaceArea( FaceHandle face, FaceHandle neighbourFace )
+		{
+			return GetFaceArea( face ) + GetFaceArea( neighbourFace );
+		}
+
 		Vector3 GetFaceNormal( FaceHandle face )
 		{
-			var vhs = mesh.GetFaceVertices( face );
-			
+			VertexHandle[] vhs = mesh.GetFaceVertices( face );
+
 			Vector3 a = mesh.GetVertexPosition( vhs[0] );
 			Vector3 b = mesh.GetVertexPosition( vhs[1] );
 			Vector3 c = mesh.GetVertexPosition( vhs[2] );
 
-			var normal = Vector3.Cross( b - a, c - a ).Normal;
+			Vector3 normal = Vector3.Cross( b - a, c - a ).Normal;
 			return normal;
 		}
-		
-		(float a, float b) GetFaceShape ( HalfEdgeHandle edge )
+
+		(float a, float b) GetFaceShape( HalfEdgeHandle edge )
 		{
-			mesh.GetEdgeVertices( edge, out var hVertexA, out var hVertexB );
-			var hVertexC = mesh.GetNextVertexInFace( edge ).Vertex;
-			var hVertexD = mesh.GetNextVertexInFace( edge.OppositeEdge ).Vertex;
+			mesh.GetEdgeVertices( edge, out VertexHandle hVertexA, out VertexHandle hVertexB );
+			VertexHandle hVertexC = mesh.GetNextVertexInFace( edge ).Vertex;
+			VertexHandle hVertexD = mesh.GetNextVertexInFace( edge.OppositeEdge ).Vertex;
 
 			float a;
 			float b;
 
 			// Corner A
 			{
-				var quadADirA = ( mesh.GetVertexPosition( hVertexC ) - mesh.GetVertexPosition( hVertexA )).Normal;
-				var quadADirB = ( mesh.GetVertexPosition( hVertexD ) - mesh.GetVertexPosition( hVertexA )).Normal;
-				
-				var dot = Vector3.Dot(  quadADirA, quadADirB ).Clamp( -1.0f, 1.0f );
-				var sharedVertADegrees = MathF.Acos( dot) * 180.0f / MathF.PI;
-				
+				Vector3 quadADirA = (mesh.GetVertexPosition( hVertexC ) - mesh.GetVertexPosition( hVertexA )).Normal;
+				Vector3 quadADirB = (mesh.GetVertexPosition( hVertexD ) - mesh.GetVertexPosition( hVertexA )).Normal;
+
+				float dot = Vector3.Dot( quadADirA, quadADirB ).Clamp( -1.0f, 1.0f );
+				float sharedVertADegrees = MathF.Acos( dot ) * 180.0f / MathF.PI;
+
 				a = sharedVertADegrees;
 			}
-			
+
 			// Corner B
 			{
-				var quadBDirA = ( mesh.GetVertexPosition( hVertexC ) - mesh.GetVertexPosition( hVertexB )).Normal;
-				var quadBDirB = ( mesh.GetVertexPosition( hVertexD ) - mesh.GetVertexPosition( hVertexB )).Normal;
-				
-				var dot = Vector3.Dot(  quadBDirA, quadBDirB ).Clamp( -1.0f, 1.0f );
-				var sharedVertBDegrees = MathF.Acos( dot) * 180.0f / MathF.PI;
-				
+				Vector3 quadBDirA = (mesh.GetVertexPosition( hVertexC ) - mesh.GetVertexPosition( hVertexB )).Normal;
+				Vector3 quadBDirB = (mesh.GetVertexPosition( hVertexD ) - mesh.GetVertexPosition( hVertexB )).Normal;
+
+				float dot = Vector3.Dot( quadBDirA, quadBDirB ).Clamp( -1.0f, 1.0f );
+				float sharedVertBDegrees = MathF.Acos( dot ) * 180.0f / MathF.PI;
+
 				b = sharedVertBDegrees;
 			}
 
 			return (a, b);
 		}
 	}
-	
+
 	private record struct FacePair( FaceHandle Face, FaceHandle NeighbourFace, HalfEdgeHandle Edge )
 	{
 		public FaceHandle FaceA { get; } = Face;
 		public FaceHandle FaceB { get; } = NeighbourFace;
 		public HalfEdgeHandle SharedEdge { get; } = Edge;
-		
+
 		public float Shape { get; set; }
 		public float Normal { get; set; }
 		public float Area { get; set; }
-		
-		public float Score => (Shape + Normal);
+
+		public float Score => Shape + Normal;
 	}
 }

--- a/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/QuadrangulateTool.cs
@@ -236,7 +236,7 @@ public partial class QuadrangulateTool( MeshFace[] faces ) : EditorTool
 					int neighbourIndexA = Array.IndexOf( neighbourVerts, sharedVertA );
 					int neighbourIndexB = Array.IndexOf( neighbourVerts, sharedVertB );
 
-					const float margin = 0.0001f;
+					float margin = 0.0001f;
 
 					bool matchA = faceUVs[faceIndexA].AlmostEqual( neighbourUVs[neighbourIndexA] );
 					bool matchB = faceUVs[faceIndexB].AlmostEqual( neighbourUVs[neighbourIndexB] );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Converts selected triangle faces into quads.

## Motivation & Context

A highly requested feature and one that I use regularly when importing level meshes from Blender. Can also be used in models that have been converted to scene mesh to clean them up and make them a bit easier to work with. Can be paired with my PR for triangulating scene mesh.

Fixes: N/A

## Implementation Details

Loops through neighboring triangle faces and scored them based on how planar they are and how parallel the edges of the new quad will be (more square the better). 

Can be restricted by non-contiguous UVs, edges with hard normals, vertex painting and blending, and face materials.

## Screenshots / Videos (if applicable)

<img width="1331" height="696" alt="quad" src="https://github.com/user-attachments/assets/efc36c9f-57b3-4910-93c7-4cc52e2dac06" />

<img width="1331" height="696" alt="quad2" src="https://github.com/user-attachments/assets/dff3be58-60cf-4f35-9e96-2bc280d522b7" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂