### PR TITLE
Fix cleanup null resources when leaving a dedicated server (via sbproj)

### DIFF
--- a/engine/Sandbox.Engine/Resources/ResourceLibrary.cs
+++ b/engine/Sandbox.Engine/Resources/ResourceLibrary.cs
@@ -122,7 +122,7 @@ public class ResourceSystem
 		foreach ( var resource in toDispose )
 		{
 			// Don't wait/rely for finalizer get rid of this immediately
-			resource.Destroy();
+			resource?.Destroy();
 		}
 
 		ResourceIndex.Clear();


### PR DESCRIPTION
## Summary

  `ResourceSystem.Clear()` iterates `ResourceIndex.Values.ToArray()` and calls
  `resource.Destroy()` on each entry. 
  
  On dedicated servers running a sbproj, the native resource
  system can leave null entries in the index for assets that failed to load or randomly?, causing a NRE on
  `resource.Destroy()`, but I couldn't find the root cause, but this fixes my main issue.
  
  The first loop already used `OfType<GameResource>()` which silently skips nulls.
  
  The second loop did not, causing the bricked state. When the exception occurred mid-Clear(),
  `ResourceSystem = new ResourceSystem()` in `GlobalContext.Reset()` was never
  reached, leaving the old broken ResourceSystem in place,  which caused every
  subsequent game join attempt to hit the same NRE until the client was restarted.
  
## Motivation & Context

I'm trying to run a dedicated server via a .sbproj, but whenever a client left, it would brick their s&box game. Why there's null in this loop, I have no idea, but there is and I couldn't find a path why.

Fixes: #11301

## Implementation Details

Just a simple null-conditional operator which protects against calling destroy on null resources.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂