### PR TITLE
[Scene Mesh] Convert Selection Toggle

### DIFF
--- a/game/addons/tools/Code/Scene/Mesh/Tools/MeshTool.Toolbar.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/MeshTool.Toolbar.cs
@@ -83,7 +83,7 @@ partial class MeshTool
 		AddCheckboxOption( menu, "Backface Selection", "flip_to_back", "Allow selection of backfacing elements",
 			EditorPreferences.BackfaceSelection, ( v ) => { EditorPreferences.BackfaceSelection = v; } );
 
-		AddCheckboxOption( menu, "Transfer Selection", "swap_horizontal_circle", "Convert current selection when changing between tools.",
+		AddCheckboxOption( menu, "Convert Selection", "swap_horizontal_circle", "Convert current selection when changing between tools.",
 			ConvertSelection, ( v ) => { ConvertSelection = v; } );
 
 		menu.OpenAtCursor();

--- a/game/addons/tools/Code/Scene/Mesh/Tools/MeshTool.Toolbar.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/MeshTool.Toolbar.cs
@@ -9,6 +9,7 @@ partial class MeshTool
 	public bool OverlaySelection { get; set; } = true;
 	public bool LassoPartialSelection { get; set; } = true;
 	public bool SelectionThrough { get; set; } = true;
+	public bool ConvertSelection { get; set; } = false;
 
 	public override Widget CreateToolbarWidget()
 	{
@@ -81,6 +82,9 @@ partial class MeshTool
 
 		AddCheckboxOption( menu, "Backface Selection", "flip_to_back", "Allow selection of backfacing elements",
 			EditorPreferences.BackfaceSelection, ( v ) => { EditorPreferences.BackfaceSelection = v; } );
+
+		AddCheckboxOption( menu, "Transfer Selection", "swap_horizontal_circle", "Convert current selection when changing between tools.",
+			ConvertSelection, ( v ) => { ConvertSelection = v; } );
 
 		menu.OpenAtCursor();
 	}

--- a/game/addons/tools/Code/Scene/Mesh/Tools/SelectionTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/SelectionTool.cs
@@ -518,7 +518,7 @@ public abstract class SelectionTool<T>( MeshTool tool ) : SelectionTool where T 
 	{
 		var elements = Selection.OfType<T>().ToArray();
 
-		bool isConverting = Application.KeyboardModifiers.Contains( KeyboardModifiers.Alt );
+		bool isConverting = Application.KeyboardModifiers.Contains( KeyboardModifiers.Alt ) || Tool.ConvertSelection;
 		var convertedElements = isConverting ?
 			ConvertSelectionToCurrentType().ToArray() : [];
 

--- a/game/addons/tools/Code/Scene/Mesh/Tools/SelectionTool.cs
+++ b/game/addons/tools/Code/Scene/Mesh/Tools/SelectionTool.cs
@@ -518,7 +518,7 @@ public abstract class SelectionTool<T>( MeshTool tool ) : SelectionTool where T 
 	{
 		var elements = Selection.OfType<T>().ToArray();
 
-		bool isConverting = Application.KeyboardModifiers.Contains( KeyboardModifiers.Alt ) || Tool.ConvertSelection;
+		bool isConverting = Tool.ConvertSelection ^ Application.KeyboardModifiers.Contains( KeyboardModifiers.Alt );
 		var convertedElements = isConverting ?
 			ConvertSelectionToCurrentType().ToArray() : [];
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Adds a button in selection options to always transfer selection. This was previously done by holding alt when changing tools.

Holding alt will now invert the current setting.

## Motivation & Context

I don't think many people know it exists and is hidden behind hotkeys. It is a very useful selection option that I think is worth having a toggle for. It is on by default in other modelling programs like Blender.

Fixes: N/A

## Implementation Details

Adds a toggle button. Off by default to maintain current tool behavior.

## Screenshots / Videos (if applicable)

<img width="1331" height="696" alt="convert" src="https://github.com/user-attachments/assets/283d392c-2ee9-4e57-b09c-819bb6b4a179" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂