### PR TITLE
Fix Steam.SteamId for Dedicated Server

### DIFF
--- a/engine/Sandbox.Engine/Core/Bootstrap.cs
+++ b/engine/Sandbox.Engine/Core/Bootstrap.cs
@@ -282,7 +282,9 @@ internal static class Bootstrap
 	{
 		Environment.CurrentDirectory = rootFolder;
 
-		Sandbox.Utility.Steam.InitializeClient();
+		if ( !Application.IsDedicatedServer )
+			Sandbox.Utility.Steam.InitializeClient();
+
 		ThreadSafe.MarkMainThread();
 
 		ThreadPool.SetMinThreads( Environment.ProcessorCount, Environment.ProcessorCount );

--- a/engine/Sandbox.Engine/Systems/Networking/System/GameNetworkSystem/GameNetworkSystem.Static.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/GameNetworkSystem/GameNetworkSystem.Static.cs
@@ -368,6 +368,8 @@ internal static class DedicatedServer
 	private static void OnConnected( SteamServersConnected_t cb )
 	{
 		Log.Warning( $"Connected to Steam" );
+
+		Utility.Steam.InitializeClient();
 	}
 
 	private static void OnDisconnected( SteamServersDisconnected_t cb )

--- a/engine/Sandbox.Engine/Utility/Steam.cs
+++ b/engine/Sandbox.Engine/Utility/Steam.cs
@@ -34,6 +34,12 @@ public static class Steam
 		if ( Application.IsUnitTest )
 			return;
 
+		if ( Application.IsDedicatedServer )
+		{
+			SteamId = NativeEngine.Steam.SteamGameServer_GetSteamID();
+			return;
+		}
+
 		var sf = NativeEngine.Steam.SteamFriends();
 		var su = NativeEngine.Steam.SteamUser();
 		var utils = NativeEngine.Steam.SteamUtils();


### PR DESCRIPTION
## Summary

In a dedicated server, Steam.SteamId returns 710013. This corresponds to the uninitialized SteamID
https://github.com/Facepunch/sbox-public/blob/bd85cb593d56ae897091bd721f37c044995691da/engine/Sandbox.Engine/Utility/Steam.cs#L18

#10846 

## Implementation Details

I add a path in `InitializeClient` only for the dedicated server, which initializes only the SteamID using `SteamGameServer_GetSteamID`. I call `InitializeClient` when the server is connected to Steam

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂