### PR TITLE
Make ScreenPixelToRay DPI aware

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
@@ -574,14 +574,14 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 		EnsureSceneCameraCreated();
 		UpdateSceneCameraTransform( sceneCamera );
 
-		return sceneCamera.GetRay( pixelPosition, ScreenRect.Size );
+		return sceneCamera.GetRay( pixelPosition, ScreenRect.Size / Screen.DpiScale );
 	}
 
 	public Ray ScreenNormalToRay( Vector3 normalPosition )
 	{
 		var pixelPosition = new Vector3(
-			normalPosition.x * ScreenRect.Size.x,
-			normalPosition.y * ScreenRect.Size.y,
+			normalPosition.x * ScreenRect.Size.x / Screen.DpiScale,
+			normalPosition.y * ScreenRect.Size.y / Screen.DpiScale,
 			normalPosition.z );
 
 		return ScreenPixelToRay( pixelPosition );

--- a/engine/Sandbox.Engine/Utility/Screen.cs
+++ b/engine/Sandbox.Engine/Utility/Screen.cs
@@ -32,6 +32,12 @@ public static class Screen
 	/// </summary>
 	public static float DesktopScale { get; private set; } = 1.0f;
 
+	/// <summary>
+	/// The current dpi scale of the application window.
+	/// Reflects physical-to-logical pixel ratio used by the windowing system (eg. 2.25 at 225% DPI).
+	/// </summary>
+	public static float DpiScale { get; internal set; } = 1.0f;
+
 	internal static void UpdateFromEngine()
 	{
 		ThreadSafe.AssertIsMainThread();

--- a/engine/Sandbox.Tools/Qt/Application.cs
+++ b/engine/Sandbox.Tools/Qt/Application.cs
@@ -89,6 +89,9 @@ public static class Application
 
 	internal static void StartFrame()
 	{
+		// Push the Qt device pixel ratio into the engine-accessible Screen.DpiScale
+		Screen.DpiScale = DpiScale;
+
 		// we scale the delta by dpi scale. This should give something close to 
 		// the values they will be expecting, but will also provide fractions
 		// which CursorPos does not.


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

So all mouse position are not DPI aware due to how QT handle that, so divide ScreenRect.Size.x by dpi size so everything is correctly calculated

## Motivation & Context

#10510 got closed cause it was too much changes, here we dont change ScreenRect.Size just fix how it's called

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂