### PR TITLE
Move PolygonMesh to binary blob

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Mesh/PolygonMesh.Serialize.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Mesh/PolygonMesh.Serialize.cs
@@ -34,10 +34,27 @@ public partial class PolygonMesh
 				var propertyName = reader.GetString();
 				reader.Read();
 
+				// New format: all heavy mesh data lives in a binary blob. When saved with an
+				// active blob context it's stored in the companion _d file (or compiled DBLOB
+				// block) and referenced here by guid. Without a context (clone, copy/paste) it's
+				// embedded inline as a base64 string so no data is lost.
+				if ( propertyName == "Data" )
+				{
+					var blob = reader.TokenType == JsonTokenType.String
+						? MeshBlob.FromBytes( reader.GetBytesFromBase64() )
+						: Json.Deserialize<MeshBlob>( ref reader );
+
+					if ( blob is not null )
+					{
+						blob.ApplyTo( mesh );
+						hasTextureCoords = true;
+					}
+				}
+
 				// Legacy: Position/Rotation are no longer written. They were world-space values
 				// that got overwritten by MeshComponent on enable. Kept for backward compat with
 				// old data that may not have TextureCoord and needs these to reconstruct UVs.
-				if ( propertyName == "Position" )
+				else if ( propertyName == "Position" )
 					mesh._transform = mesh.Transform.WithPosition( JsonSerializer.Deserialize<Vector3>( ref reader ) );
 
 				else if ( propertyName == "Rotation" )
@@ -150,40 +167,22 @@ public partial class PolygonMesh
 
 		mesh.CleanupUnusedMaterials();
 
-		using var ms = new MemoryStream();
-		using ( var zs = new GZipStream( ms, CompressionMode.Compress ) )
-		{
-			var data = mesh.Topology.Serialize();
-			zs.Write( data, 0, data.Length );
-		}
-
 		writer.WriteStartObject();
 
-		writer.WritePropertyName( nameof( mesh.Topology ) );
-		writer.WriteBase64StringValue( ms.ToArray() );
-
+		// All heavy mesh data is serialized as a binary blob. With an active blob context the
+		// blob is written to the companion _d file (or compiled DBLOB block) and only referenced
+		// here by guid; without a context (clone, copy/paste) it's embedded inline as base64.
 		// Position, Rotation, TextureUAxis, TextureVAxis, TextureScale, TextureOffset are not
 		// serialized because they are world-space dependent and derived at runtime.
 		// MeshComponent sets Mesh.Transform = WorldTransform on enable/transform change, which
 		// triggers ComputeFaceTextureParametersFromCoordinates() to recompute them from TextureCoord.
+		var blob = MeshBlob.FromMesh( mesh );
+		writer.WritePropertyName( "Data" );
 
-		writer.WritePropertyName( nameof( mesh.Positions ) );
-		JsonSerializer.Serialize( writer, mesh.Positions );
-
-		writer.WritePropertyName( nameof( mesh.Blends ) );
-		JsonSerializer.Serialize( writer, mesh.Blends );
-
-		writer.WritePropertyName( nameof( mesh.Colors ) );
-		JsonSerializer.Serialize( writer, mesh.Colors );
-
-		writer.WritePropertyName( nameof( mesh.TextureCoord ) );
-		JsonSerializer.Serialize( writer, mesh.TextureCoord );
-
-		writer.WritePropertyName( nameof( mesh.MaterialIndex ) );
-		JsonSerializer.Serialize( writer, mesh.MaterialIndex );
-
-		writer.WritePropertyName( nameof( mesh.EdgeFlags ) );
-		JsonSerializer.Serialize( writer, mesh.EdgeFlags );
+		if ( BlobDataSerializer.IsActive )
+			Json.Serialize( writer, blob );
+		else
+			writer.WriteBase64StringValue( blob.ToBytes() );
 
 		if ( mesh._materialsById.Count > 0 )
 		{
@@ -194,5 +193,128 @@ public partial class PolygonMesh
 		}
 
 		writer.WriteEndObject();
+	}
+
+	/// <summary>
+	/// Heavy mesh data (topology + per-element streams) serialized as a binary blob
+	/// instead of JSON. Stored in the companion _d file by <see cref="BlobData"/>.
+	/// </summary>
+	private sealed class MeshBlob : BlobData
+	{
+		public override int Version => 1;
+
+		public byte[] Topology { get; set; } = Array.Empty<byte>();
+		public Vector3[] Positions { get; set; } = Array.Empty<Vector3>();
+		public Color32[] Blends { get; set; } = Array.Empty<Color32>();
+		public Color32[] Colors { get; set; } = Array.Empty<Color32>();
+		public Vector2[] TextureCoord { get; set; } = Array.Empty<Vector2>();
+		public int[] MaterialIndex { get; set; } = Array.Empty<int>();
+		public int[] EdgeFlags { get; set; } = Array.Empty<int>();
+
+		public static MeshBlob FromMesh( PolygonMesh mesh )
+		{
+			return new MeshBlob
+			{
+				Topology = mesh.Topology.Serialize(),
+				Positions = mesh.Positions.ToArray(),
+				Blends = mesh.Blends.ToArray(),
+				Colors = mesh.Colors.ToArray(),
+				TextureCoord = mesh.TextureCoord.ToArray(),
+				MaterialIndex = mesh.MaterialIndex.ToArray(),
+				EdgeFlags = mesh.EdgeFlags.ToArray(),
+			};
+		}
+
+		/// <summary>
+		/// Serialize to a self-contained byte array (version header + payload), matching the
+		/// per-blob layout used by <see cref="BlobDataSerializer"/>. Used for the inline fallback
+		/// when no blob context is active.
+		/// </summary>
+		public byte[] ToBytes()
+		{
+			var stream = ByteStream.Create( 4096 );
+			try
+			{
+				stream.Write( Version );
+				var writer = new Writer { Stream = stream };
+				Serialize( ref writer );
+				stream = writer.Stream;
+				return stream.ToArray();
+			}
+			finally
+			{
+				stream.Dispose();
+			}
+		}
+
+		/// <summary>
+		/// Deserialize from a self-contained byte array produced by <see cref="ToBytes"/>.
+		/// </summary>
+		public static MeshBlob FromBytes( byte[] data )
+		{
+			var blob = new MeshBlob();
+			var stream = ByteStream.CreateReader( data );
+			try
+			{
+				int dataVersion = stream.Read<int>();
+				var reader = new Reader { Stream = stream, DataVersion = dataVersion };
+
+				if ( dataVersion < blob.Version )
+					blob.Upgrade( ref reader, dataVersion );
+				else
+					blob.Deserialize( ref reader );
+			}
+			finally
+			{
+				stream.Dispose();
+			}
+
+			return blob;
+		}
+
+		public void ApplyTo( PolygonMesh mesh )
+		{
+			using ( var ms = new MemoryStream( Topology ) )
+			using ( var br = new BinaryReader( ms ) )
+			{
+				mesh.Topology.Deserialize( br );
+			}
+
+			mesh.Positions.CopyFrom( Positions );
+			mesh.Blends.CopyFrom( Blends );
+			mesh.Colors.CopyFrom( Colors );
+			mesh.TextureCoord.CopyFrom( TextureCoord );
+			mesh.MaterialIndex.CopyFrom( MaterialIndex );
+			mesh.EdgeFlags.CopyFrom( EdgeFlags );
+		}
+
+		public override void Serialize( ref Writer writer )
+		{
+			writer.Stream.Write( Topology.Length );
+			if ( Topology.Length > 0 )
+				writer.Stream.Write( Topology );
+
+			writer.Stream.WriteArray( Positions );
+			writer.Stream.WriteArray( Blends );
+			writer.Stream.WriteArray( Colors );
+			writer.Stream.WriteArray( TextureCoord );
+			writer.Stream.WriteArray( MaterialIndex );
+			writer.Stream.WriteArray( EdgeFlags );
+		}
+
+		public override void Deserialize( ref Reader reader )
+		{
+			int topologyLength = reader.Stream.Read<int>();
+			Topology = new byte[topologyLength];
+			if ( topologyLength > 0 )
+				reader.Stream.Read( Topology, 0, topologyLength );
+
+			Positions = reader.Stream.ReadArray<Vector3>();
+			Blends = reader.Stream.ReadArray<Color32>();
+			Colors = reader.Stream.ReadArray<Color32>();
+			TextureCoord = reader.Stream.ReadArray<Vector2>();
+			MaterialIndex = reader.Stream.ReadArray<int>();
+			EdgeFlags = reader.Stream.ReadArray<int>();
+		}
 	}
 }

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/PolygonMeshSerializationTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/PolygonMeshSerializationTests.cs
@@ -86,16 +86,41 @@ public class PolygonMeshSerializationTest
 	}
 
 	[TestMethod]
-	public void WriteContainsExpectedFields()
+	public void WriteStoresMeshDataAsBinaryBlob()
 	{
 		var mesh = Json.Deserialize<PolygonMesh>( LegacyMeshJson );
 		var json = Json.Serialize( mesh );
 
-		Assert.IsTrue( json.Contains( "\"Topology\"" ) );
-		Assert.IsTrue( json.Contains( "\"Positions\"" ) );
-		Assert.IsTrue( json.Contains( "\"TextureCoord\"" ) );
-		Assert.IsTrue( json.Contains( "\"MaterialIndex\"" ) );
-		Assert.IsTrue( json.Contains( "\"EdgeFlags\"" ) );
+		// Heavy mesh data now lives in a single binary "Data" blob rather than as
+		// individual JSON arrays.
+		Assert.IsTrue( json.Contains( "\"Data\"" ) );
+		Assert.IsFalse( json.Contains( "\"Topology\"" ) );
+		Assert.IsFalse( json.Contains( "\"Positions\"" ) );
+		Assert.IsFalse( json.Contains( "\"TextureCoord\"" ) );
+		Assert.IsFalse( json.Contains( "\"MaterialIndex\"" ) );
+		Assert.IsFalse( json.Contains( "\"EdgeFlags\"" ) );
+	}
+
+	[TestMethod]
+	public void RoundTripThroughBlobContextPreservesData()
+	{
+		var original = Json.Deserialize<PolygonMesh>( LegacyMeshJson );
+
+		string json;
+
+		// With an active blob context the mesh data is written to the blob store and
+		// referenced by guid instead of being embedded inline.
+		using ( BlobDataSerializer.Capture() )
+		{
+			json = Json.Serialize( original );
+
+			Assert.IsTrue( json.Contains( "$blob" ), "Active context should write a blob reference" );
+
+			var restored = Json.Deserialize<PolygonMesh>( json );
+
+			Assert.AreEqual( original.VertexHandles.Count(), restored.VertexHandles.Count() );
+			Assert.AreEqual( original.FaceHandles.Count(), restored.FaceHandles.Count() );
+		}
 	}
 
 	[TestMethod]


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

I had a 150mb scene with just a part of my map and i hitted the text interopt limit size #11260 and i found 150mb too large for the scene it was, so i changed to binary blob and i found interesting effects:
- Save took 2x less time when saving a big mapping scene
- Reduce file size (ex: 150mb scene is now 44mb + the compiled version of 48mb)

## Motivation & Context

It suck to store in json, let's use asset data!

Fixes: #11260

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂