### PR TITLE
Avoid render scene widget when save scene

### DIFF
--- a/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
+++ b/engine/Sandbox.Tools/Qt/SceneRenderingWidget.cs
@@ -10,6 +10,25 @@ public class SceneRenderingWidget : Frame
 {
 	private static readonly HashSet<SceneRenderingWidget> All = new();
 
+	private static int _suspendRenderingCount;
+
+	/// <summary>
+	/// While true, <see cref="RenderAll"/> skips rendering every scene widget.
+	/// </summary>
+	public static bool IsRenderingSuspended => _suspendRenderingCount > 0;
+
+	/// <summary>
+	/// Temporarily stop all scene widgets (viewports, asset previews, thumbnails) from rendering
+	/// until the returned scope is disposed. Useful around heavy blocking work such as saving a
+	/// scene, where pumped frames would otherwise waste several seconds re-rendering every viewport.
+	/// Reference counted, so nested suspensions are safe.
+	/// </summary>
+	public static IDisposable SuspendRendering()
+	{
+		_suspendRenderingCount++;
+		return new Sandbox.Utility.DisposeAction( static () => _suspendRenderingCount-- );
+	}
+
 	internal SwapChainHandle_t SwapChain;
 
 	/// <summary>
@@ -258,6 +277,9 @@ public class SceneRenderingWidget : Frame
 
 	internal static void RenderAll()
 	{
+		if ( IsRenderingSuspended )
+			return;
+
 		foreach ( var widget in All )
 		{
 			if ( !widget.Visible ) continue;

--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
@@ -354,6 +354,11 @@ public partial class SceneEditorSession : Scene.ISceneEditorSession
 			ProjectCookie.SetString( $"LastSaveLocation.{extension}", Path.GetDirectoryName( saveLocation ) );
 		}
 
+		// Serializing and compiling the scene blocks the main thread for a while. Any frames
+		// pumped during that time would otherwise re-render every scene viewport/preview (~tens
+		// of ms each), stacking up into a multi-second stall - so pause widget rendering for now.
+		using var suspendRendering = SceneRenderingWidget.SuspendRendering();
+
 		EditorEvent.Run( "scene.beforesave", Active.Scene );
 
 		var asset = AssetSystem.CreateResource( extension, saveLocation );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Save scene is too long for me so i'm trying to optimize that, already made a pr with blob instead of json that help, here is a 2nd

Take -50% time to save a scene cause render widget during stall would accumulate frame to render

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details


## Screenshots / Videos (if applicable)

Here is what it look like during stall when save before (it would double time of save)
<img width="3280" height="1458" alt="image" src="https://github.com/user-attachments/assets/43496817-5113-4024-b219-a8befab37b10" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂