### PR TITLE
Reorder dedicated server NetworkSystem initialization to ensure Networking.IsActive is set by OnStart

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/Networking.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Networking.cs
@@ -505,9 +505,6 @@ public static partial class Networking
 
 	static async Task<bool> CreateDedicatedServer( LobbyConfig config, CancellationToken token = default )
 	{
-		var success = await DedicatedServer.Start( config );
-		if ( !success ) return false;
-
 		lock ( NetworkThreadLock )
 		{
 			var net = new NetworkSystem( "server", Engine.IGameInstanceDll.Current.TypeLibrary )
@@ -516,10 +513,24 @@ public static partial class Networking
 			};
 
 			System = net;
+			System.InitializeHost();
+		}
 
-			net.InitializeHost();
-			net.AddSocket( DedicatedServer.IpSocket );
-			net.AddSocket( DedicatedServer.IdSocket );
+		var success = await DedicatedServer.Start( config );
+		if ( !success )
+		{
+			// Currently we shutdown the server if we fail to start the lobby, however lets clean up just incase.
+			lock ( NetworkThreadLock )
+			{
+				System = null;
+			}
+			return false;
+		}
+
+		lock ( NetworkThreadLock )
+		{
+			System.AddSocket( DedicatedServer.IpSocket );
+			System.AddSocket( DedicatedServer.IdSocket );
 
 			return !token.IsCancellationRequested;
 		}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Changing the ordering of how dedicated servers create NetworkSystem so that Networking.IsActive is true in OnStart

Fixes #11170 

## Implementation Details
Currently on lobbies we create the network system and then init everything which allows Networking.IsActive to be set when OnStart is called, however dedicated servers do it the other way around meaning we need to assign the network system beforehand and cleanup if it fails. 

https://github.com/Facepunch/sbox-public/blob/8c9e8cbf53b1e68050636a972959a6ebced7e35c/engine/Sandbox.Engine/Systems/Networking/Networking.cs#L543-L575

## Screenshots / Videos (if applicable)

With change:
<img width="1113" height="626" alt="image" src="https://github.com/user-attachments/assets/330beee1-1b00-4185-ba70-a74ca9eb6eda" />

Without change:
<img width="1113" height="626" alt="image" src="https://github.com/user-attachments/assets/207c521d-578e-42e9-a912-28b373b5915c" />

Code just incase you guys want to check
```csharp
using Sandbox;

public sealed class NetworkingIsActiveDedicatedServer : Component
{
	protected override void OnStart()
	{
		base.OnStart();

		Log.Info($"NetworkingIsActiveDedicatedServer: {Networking.IsActive}");

		Log.Info("Waiting for 5 seconds to check if we're running as a dedicated server...");
		Task.Delay(5000).ContinueWith(_ =>
		{
			if (Networking.IsActive)
			{
				Log.Info("Networking is active, we are running as a dedicated server.");
			}
			else
			{
				Log.Info("Networking is not active, we are NOT running as a dedicated server.");
			}
		});
	}
}
```

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂