### PR TITLE
Fix SyncFlags.FromHost properties being overwritten by client refresh message

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Component.Serialize.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Component.Serialize.cs
@@ -198,6 +198,29 @@ public abstract partial class Component : BytePack.ISerializer
 	}
 
 	/// <summary>
+	/// Rewrites members marked with <see cref="SyncFlags.FromHost"/> in a component JSON payload
+	/// to this component's current values, so incoming refresh data cannot overwrite host-authoritative state.
+	/// </summary>
+	internal void PreserveFromHostSyncMembers( JsonObject componentJson )
+	{
+		foreach ( var propertyAndAttribute in ReflectionQueryCache.SyncProperties( GetType() ) )
+		{
+			if ( !propertyAndAttribute.Attribute.Flags.HasFlag( SyncFlags.FromHost ) )
+				continue;
+
+			try
+			{
+				var currentValue = propertyAndAttribute.Property.GetValue( this );
+				componentJson[propertyAndAttribute.Property.Name] = Json.ToNode( currentValue, propertyAndAttribute.Property.PropertyType );
+			}
+			catch
+			{
+				componentJson.Remove( propertyAndAttribute.Property.Name );
+			}
+		}
+	}
+
+	/// <summary>
 	/// Deserialize this component as per <see cref="Deserialize"/> but update <see cref="GameObject"/> and <see cref="Component"/> property
 	/// references immediately instead of having them deferred.
 	/// </summary>

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
@@ -841,6 +841,76 @@ public partial class GameObject
 	}
 
 	/// <summary>
+	/// Rewrites members marked with <see cref="SyncFlags.FromHost"/> to current component values
+	/// for all component payloads inside a serialized game object tree.
+	/// </summary>
+	internal void PreserveFromHostSyncMembers( JsonObject node )
+	{
+		if ( node[JsonKeys.Components] is JsonArray componentArray )
+		{
+			foreach ( var componentNode in componentArray )
+			{
+				if ( componentNode is JsonObject componentJson )
+				{
+					Component existingComponent = null;
+
+					if ( Scene.IsValid() && componentJson.TryGetPropertyValue( Component.JsonKeys.Id, out var componentIdNode ) )
+					{
+						try
+						{
+							existingComponent = Scene.Directory.FindComponentByGuid( componentIdNode.Deserialize<Guid>() );
+						}
+						catch
+						{
+							existingComponent = null;
+						}
+					}
+
+					if ( existingComponent.IsValid() )
+					{
+						existingComponent.PreserveFromHostSyncMembers( componentJson );
+					}
+					else
+					{
+						RemoveFromHostSyncMembers( componentJson );
+					}
+				}
+			}
+		}
+
+		if ( node[JsonKeys.Children] is JsonArray childArray )
+		{
+			foreach ( var childNode in childArray )
+			{
+				if ( childNode is JsonObject childJson )
+				{
+					PreserveFromHostSyncMembers( childJson );
+				}
+			}
+		}
+	}
+
+
+	private void RemoveFromHostSyncMembers( JsonObject componentJson )
+	{
+		var componentTypeName = componentJson.GetPropertyValue( Component.JsonKeys.Type, "" );
+		if ( string.IsNullOrEmpty( componentTypeName ) )
+			return;
+
+		var componentType = Game.TypeLibrary.GetType<Component>( componentTypeName, true );
+		if ( componentType is null || componentType.TargetType.IsAbstract )
+			return;
+
+		foreach ( var propertyAndAttribute in ReflectionQueryCache.SyncProperties( componentType.TargetType ) )
+		{
+			if ( !propertyAndAttribute.Attribute.Flags.HasFlag( SyncFlags.FromHost ) )
+				continue;
+
+			componentJson.Remove( propertyAndAttribute.Property.Name );
+		}
+	}
+
+	/// <summary>
 	/// Push ActionGraph source location and cache if we're a prefab instance or map object.
 	/// </summary>
 	private ActionGraph.SerializationOptionsScope? PushDeserializeContext()
@@ -1061,5 +1131,4 @@ public partial class GameObject
 		internal const string EditorPrefabInstanceNestedSource = "__EditorPrefabNestedInstance";
 		internal const string EditorSkipPrefabBreakOnRefresh = "__EditorSkipPrefabBreakOnRefresh";
 	}
-
 }

--- a/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
@@ -730,7 +730,10 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 
 			// Only the host can modify network flags after the object has been spawned.
 			if ( !source.IsHost )
+			{
 				jsonObj.Remove( GameObject.JsonKeys.NetworkFlags );
+				GameObject.PreserveFromHostSyncMembers( jsonObj );
+			}
 
 			GameObject.SetParentFromNetwork( scene.Directory.FindByGuid( message.Parent ) );
 			GameObject.NetworkRefresh( jsonObj );

--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -935,6 +935,11 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 			gameObject.SetParentFromNetwork( parentObject );
 		}
 
+		if ( source is not null && !source.IsHost )
+		{
+			gameObject.PreserveFromHostSyncMembers( gameObjectJson );
+		}
+
 		using ( var _ = CallbackBatch.Batch() )
 		using ( BlobDataSerializer.LoadFromMemory( message.BlobData ) )
 		{
@@ -1007,6 +1012,11 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		else if ( component.GameObject != gameObject )
 		{
 			return;
+		}
+
+		if ( source is not null && !source.IsHost )
+		{
+			component.PreserveFromHostSyncMembers( componentJson );
 		}
 
 		using ( CallbackBatch.Batch() )

--- a/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Nodes;
 using Sandbox.Internal;
 using Sandbox.Network;
 using SceneTests;
@@ -627,8 +628,114 @@ public class NetworkTest
 		scene.Destroy();
 	}
 
+	[TestMethod]
+	public void FromHostPropertyNotOverwrittenByRefresh()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeHost();
+
+		var go = new GameObject();
+		go.Parent = scene;
+
+		var comp = go.Components.Create<FromHostPropertyComponent>();
+		go.NetworkSpawn( clientAndHost.Client );
+
+		Assert.AreEqual( 1, comp.FromHostInt );
+
+		comp.FromHostInt = 2;
+		Assert.AreEqual( 2, comp.FromHostInt );
+
+		var refreshMsg = go._net.GetRefreshMessage();
+		var rootJson = JsonNode.Parse( refreshMsg.JsonData ).AsObject();
+
+		if ( rootJson[GameObject.JsonKeys.Components] is JsonArray components )
+		{
+			foreach ( var node in components )
+			{
+				if ( node is not JsonObject componentJson )
+					continue;
+
+				if ( componentJson.TryGetPropertyValue( Component.JsonKeys.Id, out var idNode )
+					&& idNode.GetValue<Guid>() == comp.Id )
+				{
+					componentJson[nameof( FromHostPropertyComponent.FromHostInt )] = 3;
+					break;
+				}
+			}
+		}
+
+		refreshMsg.JsonData = rootJson.ToJsonString();
+
+		go._net.OnRefreshMessage( clientAndHost.Client, refreshMsg );
+
+		Assert.AreEqual( 2, comp.FromHostInt, "FromHost property should not be overwritten by network refresh on the host" );
+	}
+
+	[TestMethod]
+	public void RegularPropertyOverwrittenByRefresh()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeHost();
+
+		var go = new GameObject();
+		go.Parent = scene;
+
+		var comp = go.Components.Create<RegularPropertyComponent>();
+		go.NetworkSpawn( clientAndHost.Client );
+
+		Assert.AreEqual( 1, comp.RegularInt );
+
+		comp.RegularInt = 2;
+		Assert.AreEqual( 2, comp.RegularInt );
+
+		var refreshMsg = go._net.GetRefreshMessage();
+		var rootJson = JsonNode.Parse( refreshMsg.JsonData ).AsObject();
+
+		if ( rootJson[GameObject.JsonKeys.Components] is JsonArray components )
+		{
+			foreach ( var node in components )
+			{
+				if ( node is not JsonObject componentJson )
+					continue;
+
+				if ( componentJson.TryGetPropertyValue( Component.JsonKeys.Id, out var idNode )
+					&& idNode.GetValue<Guid>() == comp.Id )
+				{
+					componentJson[nameof( RegularPropertyComponent.RegularInt )] = 3;
+					break;
+				}
+			}
+		}
+
+		refreshMsg.JsonData = rootJson.ToJsonString();
+
+		go._net.OnRefreshMessage( clientAndHost.Client, refreshMsg );
+
+		Assert.AreEqual( 3, comp.RegularInt, "Regular property should be overwritten by network refresh on the host" );
+	}
+
 	private class NetworkTestComponent : Component
 	{
 		[Sync] public int SyncInt { get; set; }
+	}
+
+	private class FromHostPropertyComponent : Component
+	{
+		[Property, Sync( SyncFlags.FromHost )]
+		public int FromHostInt { get; set; } = 1;
+	}
+
+	private class RegularPropertyComponent : Component
+	{
+		[Property, Sync]
+		public int RegularInt { get; set; } = 1;
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Previously, if a client sent an ObjectRefreshMsg (network refresh) to the host, it could potentially overwrite properties on the host that were supposed to be Host Authoritative (SyncFlags.FromHost), we now go over the RefreshMsg before applying them and overwriting the values.

## Motivation & Context

Fixes #564 

## Implementation Details

I avoided adding another option to the Deserialize as mentioned in https://github.com/Facepunch/sbox-public/pull/77#discussion_r2867597794

## Screenshots / Videos (if applicable)

With change: 

Host: 
<img width="439" height="101" alt="image" src="https://github.com/user-attachments/assets/27e53a9f-c10b-433a-beba-9d31dc5165d3" />

Client: 
<img width="406" height="239" alt="image" src="https://github.com/user-attachments/assets/56b0f1ed-d9b7-42d3-99e3-6595661f9844" />

Without change: 

Host: 
<img width="481" height="142" alt="image" src="https://github.com/user-attachments/assets/7a60fe6c-44c0-435e-bea4-91f3fd892318" />

Client: 
<img width="358" height="146" alt="image" src="https://github.com/user-attachments/assets/c364ffe2-e57a-4ab1-b86b-ae4677e914bf" />

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂