### PR TITLE
Enable Library references and interoperability

### DIFF
--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoader.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoader.cs
@@ -181,6 +181,9 @@ internal sealed partial class PackageLoader : IDisposable
 					if ( baseHotloaded ) return true;
 					break;
 
+				case "library":
+					break;
+
 				default:
 					return false;
 			}

--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.Compiling.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.Compiling.cs
@@ -274,6 +274,17 @@ public partial class Project
 				yield return library.Package;
 			}
 		}
+		else if ( Config.PackageReferences is { Count: > 0 } )
+		{
+			foreach ( var ident in Config.PackageReferences )
+			{
+				var library = Project.Libraries.FirstOrDefault( x =>
+					x.HasCodePath() && x.Package.GetIdent( false, false ).Equals( ident, StringComparison.OrdinalIgnoreCase ) );
+
+				if ( library is not null )
+					yield return library.Package;
+			}
+		}
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.Solution.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.Solution.cs
@@ -112,6 +112,10 @@ public sealed partial class Project
 			{
 				AddLibrariesToProject( project );
 			}
+			else if ( Config.Type == "library" && !IsBuiltIn )
+			{
+				AddDeclaredLibrariesToProject( project );
+			}
 		}
 
 		if ( Config.Type == "game" || Config.Type == "library" || Config.Type == "addon" )
@@ -151,6 +155,19 @@ public sealed partial class Project
 		foreach ( var library in Project.Libraries.Where( x => x.HasCodePath() ) )
 		{
 			project.PackageReferences.Add( library.Package.GetIdent( false, false ) );
+		}
+	}
+
+	private void AddDeclaredLibrariesToProject( ProjectInfo project )
+	{
+		if ( Config.PackageReferences is null )
+			return;
+
+		foreach ( var library in Project.Libraries.Where( x => x.HasCodePath() ) )
+		{
+			var ident = library.Package.GetIdent( false, false );
+			if ( Config.PackageReferences.Contains( ident, StringComparer.OrdinalIgnoreCase ) )
+				project.PackageReferences.Add( ident );
 		}
 	}
 

--- a/engine/Sandbox.Tools/Utility/Utility.Projects.Compile.cs
+++ b/engine/Sandbox.Tools/Utility/Utility.Projects.Compile.cs
@@ -38,40 +38,41 @@ public static partial class EditorUtility
 			bool hasBase = false;
 
 			//
-			// Install any libraries (unless we are a library)
+			// Install the libraries this project references
 			//
-			if ( project.Config.Type != "library" )
+			foreach ( var (library, references) in SortLibrariesForCompilation( Project.Libraries, logOutput ) )
 			{
-				foreach ( var (library, references) in SortLibrariesForCompilation( Project.Libraries, logOutput ) )
+				if ( project.Config.Type == "library" &&
+					!project.Package.PackageReferences.Contains( library.Package.GetIdent( false, false ), StringComparer.OrdinalIgnoreCase ) )
+					continue;
+
+				await PackageManager.InstallAsync( new PackageLoadOptions( library.Package.FullIdent, "publish" ) );
+
+				// Compile library
 				{
-					await PackageManager.InstallAsync( new PackageLoadOptions( library.Package.FullIdent, "publish" ) );
+					var compileSettings = new Compiler.Configuration();
+					compileSettings.Clean();
+					compileSettings.ReleaseMode = Compiler.ReleaseMode.Release;
 
-					// Compile library
+					var libCompiler = compileGroup.CreateCompiler( library.Package.CompilerName, library.GetCodePath(), compileSettings );
+					libCompiler.UseAbsoluteSourcePaths = false;
+					libCompiler.GeneratedCode.AppendLine( "global using static Sandbox.Internal.GlobalGameNamespace;" );
+
+					// Required by razor
+					libCompiler.GeneratedCode.AppendLine( "global using Microsoft.AspNetCore.Components;" );
+					libCompiler.GeneratedCode.AppendLine( "global using Microsoft.AspNetCore.Components.Rendering;" );
+
+					libCompiler.AddBaseReference();
+
+					foreach ( var reference in references )
 					{
-						var compileSettings = new Compiler.Configuration();
-						compileSettings.Clean();
-						compileSettings.ReleaseMode = Compiler.ReleaseMode.Release;
-
-						var libCompiler = compileGroup.CreateCompiler( library.Package.CompilerName, library.GetCodePath(), compileSettings );
-						libCompiler.UseAbsoluteSourcePaths = false;
-						libCompiler.GeneratedCode.AppendLine( "global using static Sandbox.Internal.GlobalGameNamespace;" );
-
-						// Required by razor
-						libCompiler.GeneratedCode.AppendLine( "global using Microsoft.AspNetCore.Components;" );
-						libCompiler.GeneratedCode.AppendLine( "global using Microsoft.AspNetCore.Components.Rendering;" );
-
-						libCompiler.AddBaseReference();
-
-						foreach ( var reference in references )
-						{
-							libCompiler.AddReference( reference.Package );
-						}
+						libCompiler.AddReference( reference.Package );
 					}
+				}
 
-					// add a reference to it from the main compiler
-					{
-						compiler.AddReference( library.Package );
-					}
+				// add a reference to it from the main compiler
+				{
+					compiler.AddReference( library.Package );
 				}
 			}
 

--- a/game/addons/tools/Code/Editor/ProjectSettings/ProjectSettingsWindow.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/ProjectSettingsWindow.cs
@@ -194,6 +194,7 @@ internal sealed class ProjectSettingsWindow : Window
 		else if ( project.Config.Type == "library" )
 		{
 			AddCategoryToList( typeof( CompilerCategory ), "Compiler" );
+			AddCategoryToList( typeof( ReferencesCategory ), "Other" );
 		}
 		else if ( project.Config.Type == "tool" )
 		{


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR enables libraries to reference other libraries and resolve references topologically

## Motivation & Context

[ongoing discussion about library dependencies](https://github.com/Facepunch/sbox-public/issues/4322#issuecomment-4805954144)

## Implementation Details

This implementation is a rudimentary version of library <-> library interoperability, allowing a library author to declare references manually in their library's project settings. Enumeration of packages is type-agnostic so minimal changes were needed.

Libraries are topologically sorted and any cyclic dependencies are logged by `SortLibrariesForCompilation` so this was already production-ready but gated by the allow-list simply not including libraries.

Version resolution and "dependency hell" is not a concern in this PR. s&box already stops short of version resolution which is the exact same path taken here. As mentioned in the discussion in #4322 - it is not necessarily FacePunch's job to solve the dependency problem in the same way npm does, but a middle-ground that allows the community of library creators to create and maintain their own dependency models while the Library Manager simply hosts those libraries is a workable solution with minimal effort applied. 

This change enables users who want to utilize more generalized libraries, reduces code duplication, and allows for composition and a quicker / easier game development cycle.

## Screenshots / Videos (if applicable)

See visuals and further explanation in the #4322 issue post linked above.

## Checklist

- [ x ] Code follows existing style and conventions
- [ x ] No unnecessary formatting or unrelated changes
- [ x ] Public APIs are documented (if applicable)
- [ x ] Unit tests added where applicable and all passing
- [ x ] I’m okay with this PR being rejected or requested to change 🙂