### PR TITLE
All network messages are caught earlier in the chain to prevent malformed packets from dropping subsequent messages

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Message.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Message.cs
@@ -91,7 +91,19 @@ internal partial class NetworkSystem
 		Connection?.GetIncomingMessages( HandleIncomingMessage );
 	}
 
-	void HandleIncomingMessage( NetworkMessage msg )
+	internal void HandleIncomingMessage( NetworkMessage msg )
+	{
+		try
+		{
+			HandleIncomingMessageInternal( msg );
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( e, $"Error processing network message from {msg.Source}" );
+		}
+	}
+
+	void HandleIncomingMessageInternal( NetworkMessage msg )
 	{
 		// Conna: If this message is not from the host and we're still connecting, ignore it.
 		if ( !IsHost && !msg.Source.IsHost && Connection.Local.IsConnecting )
@@ -162,14 +174,7 @@ internal partial class NetworkSystem
 			// defined in an assemblly we didn't recieve yet (because we're connecting)
 			// so just ignore these exceptions, but output an error for now so we know it's happening.
 			//
-			try
-			{
-				obj = TypeLibrary.FromBytes<object>( ref msg.Data );
-			}
-			catch ( Exception e )
-			{
-				Log.Warning( e, $"Skipping message from {msg.Source}, deserialize error ({e.Message})!" );
-			}
+			obj = TypeLibrary.FromBytes<object>( ref msg.Data );
 
 			if ( obj is null )
 			{
@@ -185,15 +190,7 @@ internal partial class NetworkSystem
 
 			if ( typeMessageHandlers.TryGetValue( obj.GetType(), out var h ) )
 			{
-				try
-				{
-					h( obj, msg.Source, requestGuid );
-				}
-				catch ( Exception e )
-				{
-					Log.Warning( e );
-				}
-
+				h( obj, msg.Source, requestGuid );
 				return;
 			}
 
@@ -209,15 +206,7 @@ internal partial class NetworkSystem
 
 		if ( messageHandlers.TryGetValue( type, out var handler ) )
 		{
-			try
-			{
-				handler( type, msg );
-			}
-			catch ( Exception e )
-			{
-				Log.Warning( e );
-			}
-
+			handler( type, msg );
 			return;
 		}
 

--- a/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
@@ -186,6 +186,49 @@ public class NetworkTest
 	}
 
 	[TestMethod]
+	public void MalformedClientTickDoesNotThrowAndSubsequentTickStillApplies()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeHost();
+		clientAndHost.Client.VisibilityOrigins = [new Vector3( 1f, 1f, 1f )];
+
+		var malformedData = new byte[0];
+		using ( var malformed = new ByteStream( 64 ) )
+		{
+			// Count says 1 origin but only 2 floats are provided, so z is missing.
+			malformed.Write( InternalMessageType.ClientTick );
+			malformed.Write( (char)1 );
+			malformed.Write( 10f );
+			malformed.Write( 20f );
+			malformedData = malformed.ToArray();
+		}
+
+		var validData = new byte[0];
+		using ( var valid = new ByteStream( 64 ) )
+		{
+			valid.Write( InternalMessageType.ClientTick );
+			valid.Write( (char)1 );
+			valid.Write( 1f );
+			valid.Write( 2f );
+			valid.Write( 3f );
+			validData = valid.ToArray();
+		}
+
+		var stream = new[] { malformedData, validData };
+		foreach ( var data in stream )
+		{
+			using var reader = ByteStream.CreateReader( data );
+			Networking.System.HandleIncomingMessage( new NetworkSystem.NetworkMessage { Source = clientAndHost.Client, Data = reader } );
+		}
+
+		// The malformed packet should have been caught and ignored, and the valid one applied.
+		Assert.AreEqual( 1, clientAndHost.Client.VisibilityOrigins.Length );
+		Assert.AreEqual( new Vector3( 1f, 2f, 3f ), clientAndHost.Client.VisibilityOrigins[0] );
+	}
+
+	[TestMethod]
 	public void RegisterSyncProps()
 	{
 		Assert.IsNotNull( Game.TypeLibrary.GetType<ModelRenderer>(), "TypeLibrary hasn't been given the game assembly" );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Currently we try catch when we enter one of the message handler types; most of them have try catches around them however its just nicer to put it at the top of HandleIncomingMessageInternal and then we dont have to litter this code with try catches. 

This comes with the added benefit of if we ever forget to add try catches E.G OnReceiveClientTick then it won't matter.
https://github.com/Facepunch/sbox-public/blob/655bba77f2ebd2a9afca90ec2d9bddbee16875b6/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Message.cs#L237-L280

## Motivation & Context

The change below shows the damage that this can cause if something goes unnoticed and this isn't even the only one. 

Fixes: #11298

## Implementation Details

At the moment people can "spam" the logs with errors however it does say who and its no different from now. In the future it may be best to kick players creating a lot of errors on the server or even allow the devs to hook into what to do. However for now this works.

## Screenshots / Videos (if applicable)

Errors will now look like this: 
```
2026/06/26 20:44:32.7790	[Generic] Ignoring malformed incoming message from DEADMONSTOR	System.OverflowException: Arithmetic operation resulted in an overflow.
   at Sandbox.ByteStream.ReadByteStream(Int32 size) in Sandbox.System\Utility\ByteStream\ByteStream.cs:line 559
   at Sandbox.Network.NetworkSystem.HandleIncomingMessageInternal(NetworkMessage msg) in Sandbox.Engine\Systems\Networking\System\NetworkSystem.Message.cs:line 128
   at Sandbox.Network.NetworkSystem.HandleIncomingMessage(NetworkMessage msg) in Sandbox.Engine\Systems\Networking\System\NetworkSystem.Message.cs:line 98
```
## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂