### PR TITLE
Clutter fix publish

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -435,11 +435,13 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 		using var optionsScope = ActionGraph.PushSerializationOptions( sceneFile.SerializationOptions with { ForceUpdateCached = Scene.IsEditor } );
 		using var sceneScope = Scene.Push();
 		// Establish a blob context so any binary blob data ($blob) in the map scene - both on
-		// GameObjects and on GameObjectSystems (e.g. painted clutter) - can be resolved.
-		// A cached SceneFile has its BinaryData consumed after first load and the compiled file
-		// isn't always reachable via the default path, so resolve the blob bytes explicitly.
-		using var blobs = BlobDataSerializer.LoadFromMemory( ResolveMapBlobData( sceneFile, path ) ?? System.Array.Empty<byte>() );
+		// GameObjects and on GameObjectSystems (e.g. painted clutter) - can be resolved. Uses the
+		// in-memory BinaryData if still present, otherwise falls back to the compiled file on disk.
+		using var blobs = BlobDataSerializer.Load( sceneFile.BinaryData, path );
 		using var batchGroup = CallbackBatch.Batch();
+
+		// Clear cached binary data now that we've loaded it.
+		sceneFile.BinaryData = null;
 
 		foreach ( var json in sceneFile.GameObjects )
 		{
@@ -478,52 +480,6 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 		}
 
 		return true;
-	}
-
-	/// <summary>
-	/// Resolve the raw blob bytes (in the blob-file format understood by <see cref="BlobDataSerializer"/>)
-	/// for a map scene. A cached <see cref="SceneFile"/> has its in-memory BinaryData consumed after its
-	/// first load, and the compiled file isn't always reachable via the default mounted filesystem in
-	/// every context (e.g. editing/playing a local scene through a MapInstance), so we probe several
-	/// filesystems and fall back to extracting the DBLOB block from the compiled scene.
-	/// </summary>
-	private static byte[] ResolveMapBlobData( SceneFile sceneFile, string compiledPath )
-	{
-		if ( sceneFile?.BinaryData is { Length: > 0 } inMemory )
-			return inMemory;
-
-		if ( string.IsNullOrWhiteSpace( compiledPath ) )
-			return null;
-
-		var basePath = compiledPath.EndsWith( "_c" ) ? compiledPath[..^2] : compiledPath;
-		var sidecarPath = basePath + "_d";
-		var resourcePath = basePath + "_c";
-
-		BaseFileSystem[] filesystems =
-		{
-			FileSystem.Mounted,
-			PackageManager.MountedFileSystem,
-		};
-
-		foreach ( var fs in filesystems )
-		{
-			if ( fs is null )
-				continue;
-
-			// The "_d" sidecar is already stored in the blob-file format.
-			if ( fs.FileExists( sidecarPath ) )
-				return fs.ReadAllBytes( sidecarPath ).ToArray();
-
-			// Otherwise pull the DBLOB block out of the compiled scene.
-			if ( fs.FileExists( resourcePath ) )
-			{
-				var block = Game.Resources.ReadCompiledResourceBlock( BlobDataSerializer.CompiledBlobName, fs.ReadAllBytes( resourcePath ) );
-				if ( block is { Length: > 0 } )
-					return block;
-			}
-		}
-
-		return null;
 	}
 
 	private bool ShouldIgnoreGameObject( JsonObject json )

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -434,14 +434,9 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 		using var optionsScope = ActionGraph.PushSerializationOptions( sceneFile.SerializationOptions with { ForceUpdateCached = Scene.IsEditor } );
 		using var sceneScope = Scene.Push();
-		// Establish a blob context so any binary blob data ($blob) in the map scene - both on
-		// GameObjects and on GameObjectSystems (e.g. painted clutter) - can be resolved. Uses the
-		// in-memory BinaryData if still present, otherwise falls back to the compiled file on disk.
+		// Set up a blob context to resolve binary data in the map scene.
 		using var blobs = BlobDataSerializer.Load( sceneFile.BinaryData, path );
 		using var batchGroup = CallbackBatch.Batch();
-
-		// Clear cached binary data now that we've loaded it.
-		sceneFile.BinaryData = null;
 
 		foreach ( var json in sceneFile.GameObjects )
 		{
@@ -468,10 +463,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 			}
 		}
 
-		// A scene map's GameObjectSystems data (e.g. painted clutter stored on ClutterGridSystem)
-		// lives at scene level, not on a GameObject, so it isn't covered by the loop above. Apply
-		// it onto the host scene's systems so that data survives being loaded through a MapInstance.
-		// Note: this data is in absolute scene coordinates and is not offset by the MapInstance origin.
+		// Apply scene-level GameObjectSystems data (e.g. painted clutter) to the host scene
 		if ( sceneFile.SceneProperties is not null
 			&& sceneFile.SceneProperties.TryGetPropertyValue( "GameObjectSystems", out var systemsNode )
 			&& systemsNode is not null )

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -425,6 +425,11 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 		using var optionsScope = ActionGraph.PushSerializationOptions( sceneFile.SerializationOptions with { ForceUpdateCached = Scene.IsEditor } );
 		using var sceneScope = Scene.Push();
+		// Establish a blob context so any binary blob data ($blob) in the map scene - both on
+		// GameObjects and on GameObjectSystems (e.g. painted clutter) - can be resolved.
+		// A cached SceneFile has its BinaryData consumed after first load and the compiled file
+		// isn't always reachable via the default path, so resolve the blob bytes explicitly.
+		using var blobs = BlobDataSerializer.LoadFromMemory( ResolveMapBlobData( sceneFile, path ) ?? System.Array.Empty<byte>() );
 		using var batchGroup = CallbackBatch.Batch();
 
 		foreach ( var json in sceneFile.GameObjects )
@@ -452,7 +457,64 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 			}
 		}
 
+		// A scene map's GameObjectSystems data (e.g. painted clutter stored on ClutterGridSystem)
+		// lives at scene level, not on a GameObject, so it isn't covered by the loop above. Apply
+		// it onto the host scene's systems so that data survives being loaded through a MapInstance.
+		// Note: this data is in absolute scene coordinates and is not offset by the MapInstance origin.
+		if ( sceneFile.SceneProperties is not null
+			&& sceneFile.SceneProperties.TryGetPropertyValue( "GameObjectSystems", out var systemsNode )
+			&& systemsNode is not null )
+		{
+			Scene.ApplyGameObjectSystemOverrides( systemsNode );
+		}
+
 		return true;
+	}
+
+	/// <summary>
+	/// Resolve the raw blob bytes (in the blob-file format understood by <see cref="BlobDataSerializer"/>)
+	/// for a map scene. A cached <see cref="SceneFile"/> has its in-memory BinaryData consumed after its
+	/// first load, and the compiled file isn't always reachable via the default mounted filesystem in
+	/// every context (e.g. editing/playing a local scene through a MapInstance), so we probe several
+	/// filesystems and fall back to extracting the DBLOB block from the compiled scene.
+	/// </summary>
+	private static byte[] ResolveMapBlobData( SceneFile sceneFile, string compiledPath )
+	{
+		if ( sceneFile?.BinaryData is { Length: > 0 } inMemory )
+			return inMemory;
+
+		if ( string.IsNullOrWhiteSpace( compiledPath ) )
+			return null;
+
+		var basePath = compiledPath.EndsWith( "_c" ) ? compiledPath[..^2] : compiledPath;
+		var sidecarPath = basePath + "_d";
+		var resourcePath = basePath + "_c";
+
+		BaseFileSystem[] filesystems =
+		{
+			FileSystem.Mounted,
+			PackageManager.MountedFileSystem,
+		};
+
+		foreach ( var fs in filesystems )
+		{
+			if ( fs is null )
+				continue;
+
+			// The "_d" sidecar is already stored in the blob-file format.
+			if ( fs.FileExists( sidecarPath ) )
+				return fs.ReadAllBytes( sidecarPath ).ToArray();
+
+			// Otherwise pull the DBLOB block out of the compiled scene.
+			if ( fs.FileExists( resourcePath ) )
+			{
+				var block = Game.Resources.ReadCompiledResourceBlock( BlobDataSerializer.CompiledBlobName, fs.ReadAllBytes( resourcePath ) );
+				if ( block is { Length: > 0 } )
+					return block;
+			}
+		}
+
+		return null;
 	}
 
 	private bool ShouldIgnoreGameObject( JsonObject json )

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -58,11 +58,6 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 	Package loadedMapPkg;
 	string sceneMapScenePath;
 
-	/// <summary>
-	/// Scope for reverting GameObjectSystem property overrides applied by this map.
-	/// </summary>
-	IDisposable _systemOverridesScope;
-
 	public MapInstance() : base()
 	{
 		OnMapLoaded += UpdateDirtyReflections;
@@ -151,10 +146,6 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 		RemoveCollision();
 
 		Physics = null;
-
-		// Revert system overrides (e.g. painted clutter) from this map.
-		_systemOverridesScope?.Dispose();
-		_systemOverridesScope = null;
 
 		if ( GameObject.IsValid() && GameObject.Children is not null )
 		{
@@ -468,7 +459,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 			&& sceneFile.SceneProperties.TryGetPropertyValue( "GameObjectSystems", out var systemsNode )
 			&& systemsNode is not null )
 		{
-			_systemOverridesScope = Scene.ApplyGameObjectSystemOverrides( systemsNode );
+			Scene.ApplyGameObjectSystemOverrides( systemsNode );
 		}
 
 		return true;

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -58,9 +58,9 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 	Package loadedMapPkg;
 	string sceneMapScenePath;
 
-	// Reverts any GameObjectSystem property overrides this map applied to the host scene (e.g.
-	// painted clutter, which lives at scene level rather than under our GameObject). Disposed when
-	// the map unloads so those changes don't outlive the map.
+	/// <summary>
+	/// Scope for reverting GameObjectSystem property overrides applied by this map.
+	/// </summary>
 	IDisposable _systemOverridesScope;
 
 	public MapInstance() : base()
@@ -152,9 +152,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 		Physics = null;
 
-		// GameObjectSystem data applied from this scene map (e.g. painted clutter) lives on the
-		// host scene's systems, not under this MapInstance, so it isn't covered by the child-object
-		// cleanup below. Reverting the override restores the systems to their pre-map state.
+		// Revert system overrides (e.g. painted clutter) from this map.
 		_systemOverridesScope?.Dispose();
 		_systemOverridesScope = null;
 

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -58,6 +58,11 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 	Package loadedMapPkg;
 	string sceneMapScenePath;
 
+	// Reverts any GameObjectSystem property overrides this map applied to the host scene (e.g.
+	// painted clutter, which lives at scene level rather than under our GameObject). Disposed when
+	// the map unloads so those changes don't outlive the map.
+	IDisposable _systemOverridesScope;
+
 	public MapInstance() : base()
 	{
 		OnMapLoaded += UpdateDirtyReflections;
@@ -146,6 +151,12 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 		RemoveCollision();
 
 		Physics = null;
+
+		// GameObjectSystem data applied from this scene map (e.g. painted clutter) lives on the
+		// host scene's systems, not under this MapInstance, so it isn't covered by the child-object
+		// cleanup below. Reverting the override restores the systems to their pre-map state.
+		_systemOverridesScope?.Dispose();
+		_systemOverridesScope = null;
 
 		if ( GameObject.IsValid() && GameObject.Children is not null )
 		{
@@ -465,7 +476,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 			&& sceneFile.SceneProperties.TryGetPropertyValue( "GameObjectSystems", out var systemsNode )
 			&& systemsNode is not null )
 		{
-			Scene.ApplyGameObjectSystemOverrides( systemsNode );
+			_systemOverridesScope = Scene.ApplyGameObjectSystemOverrides( systemsNode );
 		}
 
 		return true;

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.Storage.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.Storage.cs
@@ -9,7 +9,7 @@ public sealed partial class ClutterGridSystem
 	/// Manages storage and serialization of painted clutter instances.
 	/// Uses binary serialization via BlobData for efficient storage.
 	/// </summary>
-	public sealed class ClutterStorage : BlobData
+	public sealed class ClutterStorage : BlobData, IBlobReferences
 	{
 		public override int Version => 1;
 
@@ -37,6 +37,12 @@ public sealed partial class ClutterGridSystem
 		/// Gets all model paths that have instances.
 		/// </summary>
 		public IEnumerable<string> ModelPaths => _instances.Keys;
+
+		/// <summary>
+		/// Model paths referenced by painted instances. Emitted into the resource JSON on save so
+		/// painted clutter models are included when the owning scene/prefab is published.
+		/// </summary>
+		public IEnumerable<string> GetReferencedResources() => ModelPaths;
 
 		/// <summary>
 		/// Gets instances for a specific model path.

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
@@ -34,10 +34,10 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 	[Property, Hide]
 	public ClutterStorage Storage
 	{
-		get => _storage;
+		get => field;
 		set
 		{
-			_storage = value;
+			field = value;
 			// The data may have been replaced wholesale (e.g. by a map load applying this
 			// scene's GameObjectSystem overrides). Mark dirty so the painted layer rebuilds
 			// on the next update.

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
@@ -25,12 +25,25 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 	private readonly List<Terrain> _sceneTerrains = [];
 	private readonly HashSet<ClutterLayer> _layersToRebuild = [];
 
+	private ClutterStorage _storage = new();
+
 	/// <summary>
 	/// Storage for painted clutter model instances.
 	/// Serialized with the scene - this is the source of truth for painted clutter.
 	/// </summary>
 	[Property, Hide]
-	public ClutterStorage Storage { get; set; } = new();
+	public ClutterStorage Storage
+	{
+		get => _storage;
+		set
+		{
+			_storage = value;
+			// The data may have been replaced wholesale (e.g. by a map load applying this
+			// scene's GameObjectSystem overrides). Mark dirty so the painted layer rebuilds
+			// on the next update.
+			_dirty = true;
+		}
+	}
 
 	/// <summary>
 	/// Layer for rendering painted model instances from Storage.

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
@@ -25,8 +25,6 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 	private readonly List<Terrain> _sceneTerrains = [];
 	private readonly HashSet<ClutterLayer> _layersToRebuild = [];
 
-	private ClutterStorage _storage = new();
-
 	/// <summary>
 	/// Storage for painted clutter model instances.
 	/// Serialized with the scene - this is the source of truth for painted clutter.
@@ -34,13 +32,11 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 	[Property, Hide]
 	public ClutterStorage Storage
 	{
-		get => field;
+		get;
 		set
 		{
 			field = value;
-			// The data may have been replaced wholesale (e.g. by a map load applying this
-			// scene's GameObjectSystem overrides). Mark dirty so the painted layer rebuilds
-			// on the next update.
+			// Mark as dirty to trigger layer rebuild.
 			_dirty = true;
 		}
 	}

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -91,17 +91,9 @@ public partial class Scene
 	}
 
 	/// <summary>
-	/// Apply scene-specific GameObjectSystem property overrides.
-	/// Called during scene deserialization, and when a scene map is loaded through a
-	/// <see cref="MapInstance"/>.
+	/// Applies scene-specific GameObjectSystem overrides during deserialization or map load.
+	/// Returns a disposable to revert these overrides, or null if none applied.
 	/// </summary>
-	/// <returns>
-	/// A disposable that, when disposed, restores the overridden properties to the values they
-	/// held before this call. This lets transient sources (e.g. a <see cref="MapInstance"/>) apply
-	/// their system data non-destructively and cleanly revert it when they unload. Returns null
-	/// when nothing was applied. Callers that own the data permanently (the main scene load) can
-	/// simply ignore the return value.
-	/// </returns>
 	internal IDisposable ApplyGameObjectSystemOverrides( JsonNode overridesNode )
 	{
 		if ( overridesNode is null )
@@ -160,9 +152,7 @@ public partial class Scene
 	}
 
 	/// <summary>
-	/// Remembers GameObjectSystem property values that an override replaced, and restores them when
-	/// disposed. This keeps system overrides (e.g. painted clutter loaded by a <see cref="MapInstance"/>)
-	/// non-destructive: the host scene's prior state is brought back as soon as the source goes away.
+	/// Saves and restores previous GameObjectSystem property values.
 	/// </summary>
 	sealed class SystemOverrideScope : IDisposable
 	{

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Nodes;
+using System.Text.Json.Nodes;
 
 namespace Sandbox;
 
@@ -91,13 +91,13 @@ public partial class Scene
 	}
 
 	/// <summary>
-	/// Applies scene-specific GameObjectSystem overrides during deserialization or map load.
-	/// Returns a disposable to revert these overrides, or null if none applied.
+	/// Apply scene-specific GameObjectSystem property overrides.
+	/// Called during scene deserialization.
 	/// </summary>
-	internal IDisposable ApplyGameObjectSystemOverrides( JsonNode overridesNode )
+	internal void ApplyGameObjectSystemOverrides( JsonNode overridesNode )
 	{
 		if ( overridesNode is null )
-			return null;
+			return;
 
 		Dictionary<string, JsonObject> overrides;
 
@@ -108,13 +108,11 @@ public partial class Scene
 		catch ( System.Exception e )
 		{
 			Log.Warning( e, $"Error when deserializing GameObjectSystem overrides ({e.Message})" );
-			return null;
+			return;
 		}
 
 		if ( overrides is null || overrides.Count == 0 )
-			return null;
-
-		var revert = new SystemOverrideScope();
+			return;
 
 		foreach ( var system in systems.Values )
 		{
@@ -132,10 +130,6 @@ public partial class Scene
 				{
 					try
 					{
-						// Remember the current value first, so the override can be unwound later.
-						if ( property.CanRead )
-							revert.Capture( system, property, property.GetValue( system ) );
-
 						// Deserialize the JSON node directly to the property's type
 						var value = Json.FromNode( valueNode, property.PropertyType );
 						property.SetValue( system, value );
@@ -146,43 +140,6 @@ public partial class Scene
 					}
 				}
 			}
-		}
-
-		return revert.HasCaptures ? revert : null;
-	}
-
-	/// <summary>
-	/// Saves and restores previous GameObjectSystem property values.
-	/// </summary>
-	sealed class SystemOverrideScope : IDisposable
-	{
-		private readonly List<(GameObjectSystem System, PropertyDescription Property, object PreviousValue)> _captured = new();
-
-		public bool HasCaptures => _captured.Count > 0;
-
-		public void Capture( GameObjectSystem system, PropertyDescription property, object previousValue )
-		{
-			_captured.Add( (system, property, previousValue) );
-		}
-
-		public void Dispose()
-		{
-			// Restore in reverse, so stacked overrides unwind in the opposite order they applied.
-			for ( int i = _captured.Count - 1; i >= 0; i-- )
-			{
-				var (system, property, previousValue) = _captured[i];
-
-				try
-				{
-					property.SetValue( system, previousValue );
-				}
-				catch ( Exception ex )
-				{
-					Log.Warning( $"Failed to revert system override on {system.GetType().FullName}.{property.Name}: {ex.Message}" );
-				}
-			}
-
-			_captured.Clear();
 		}
 	}
 

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -92,12 +92,20 @@ public partial class Scene
 
 	/// <summary>
 	/// Apply scene-specific GameObjectSystem property overrides.
-	/// Called during scene deserialization.
+	/// Called during scene deserialization, and when a scene map is loaded through a
+	/// <see cref="MapInstance"/>.
 	/// </summary>
-	internal void ApplyGameObjectSystemOverrides( JsonNode overridesNode )
+	/// <returns>
+	/// A disposable that, when disposed, restores the overridden properties to the values they
+	/// held before this call. This lets transient sources (e.g. a <see cref="MapInstance"/>) apply
+	/// their system data non-destructively and cleanly revert it when they unload. Returns null
+	/// when nothing was applied. Callers that own the data permanently (the main scene load) can
+	/// simply ignore the return value.
+	/// </returns>
+	internal IDisposable ApplyGameObjectSystemOverrides( JsonNode overridesNode )
 	{
 		if ( overridesNode is null )
-			return;
+			return null;
 
 		Dictionary<string, JsonObject> overrides;
 
@@ -108,11 +116,13 @@ public partial class Scene
 		catch ( System.Exception e )
 		{
 			Log.Warning( e, $"Error when deserializing GameObjectSystem overrides ({e.Message})" );
-			return;
+			return null;
 		}
 
 		if ( overrides is null || overrides.Count == 0 )
-			return;
+			return null;
+
+		var revert = new SystemOverrideScope();
 
 		foreach ( var system in systems.Values )
 		{
@@ -130,6 +140,10 @@ public partial class Scene
 				{
 					try
 					{
+						// Remember the current value first, so the override can be unwound later.
+						if ( property.CanRead )
+							revert.Capture( system, property, property.GetValue( system ) );
+
 						// Deserialize the JSON node directly to the property's type
 						var value = Json.FromNode( valueNode, property.PropertyType );
 						property.SetValue( system, value );
@@ -140,6 +154,45 @@ public partial class Scene
 					}
 				}
 			}
+		}
+
+		return revert.HasCaptures ? revert : null;
+	}
+
+	/// <summary>
+	/// Remembers GameObjectSystem property values that an override replaced, and restores them when
+	/// disposed. This keeps system overrides (e.g. painted clutter loaded by a <see cref="MapInstance"/>)
+	/// non-destructive: the host scene's prior state is brought back as soon as the source goes away.
+	/// </summary>
+	sealed class SystemOverrideScope : IDisposable
+	{
+		private readonly List<(GameObjectSystem System, PropertyDescription Property, object PreviousValue)> _captured = new();
+
+		public bool HasCaptures => _captured.Count > 0;
+
+		public void Capture( GameObjectSystem system, PropertyDescription property, object previousValue )
+		{
+			_captured.Add( (system, property, previousValue) );
+		}
+
+		public void Dispose()
+		{
+			// Restore in reverse, so stacked overrides unwind in the opposite order they applied.
+			for ( int i = _captured.Count - 1; i >= 0; i-- )
+			{
+				var (system, property, previousValue) = _captured[i];
+
+				try
+				{
+					property.SetValue( system, previousValue );
+				}
+				catch ( Exception ex )
+				{
+					Log.Warning( $"Failed to revert system override on {system.GetType().FullName}.{property.Name}: {ex.Message}" );
+				}
+			}
+
+			_captured.Clear();
 		}
 	}
 

--- a/engine/Sandbox.Engine/Utility/BlobData.cs
+++ b/engine/Sandbox.Engine/Utility/BlobData.cs
@@ -1,10 +1,8 @@
 namespace Sandbox;
 
 /// <summary>
-/// Implemented by <see cref="BlobData"/> types that reference other assets (by resource path)
-/// inside their binary payload. The resource compiler uses this to register those paths as
-/// runtime references so they get included when the owning resource is published. Without this,
-/// asset paths stored in binary blobs are invisible to the JSON reference scanner.
+/// For <see cref="BlobData"/> types whose binary data reference other assets by resource path.
+/// Ensures asset references in blobs are recognized by the resource compiler.
 /// </summary>
 public interface IBlobReferences
 {

--- a/engine/Sandbox.Engine/Utility/BlobData.cs
+++ b/engine/Sandbox.Engine/Utility/BlobData.cs
@@ -1,6 +1,20 @@
 namespace Sandbox;
 
 /// <summary>
+/// Implemented by <see cref="BlobData"/> types that reference other assets (by resource path)
+/// inside their binary payload. The resource compiler uses this to register those paths as
+/// runtime references so they get included when the owning resource is published. Without this,
+/// asset paths stored in binary blobs are invisible to the JSON reference scanner.
+/// </summary>
+public interface IBlobReferences
+{
+	/// <summary>
+	/// Enumerate the resource paths (e.g. model paths) referenced by this blob.
+	/// </summary>
+	IEnumerable<string> GetReferencedResources();
+}
+
+/// <summary>
 /// Base class for properties that should be serialized to binary format instead of JSON.
 /// Used for large data structures that would be inefficient as JSON.
 /// </summary>

--- a/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
+++ b/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
@@ -277,34 +277,58 @@ internal static class BlobDataSerializer
 	/// </summary>
 	public static BlobContext LoadFrom( string filePath )
 	{
-		Dictionary<Guid, byte[]> binaryData = null;
-
-		if ( !string.IsNullOrEmpty( filePath ) )
-		{
-			if ( filePath.EndsWith( "_c" ) )
-				filePath = filePath[..^2];
-
-			var path = filePath + "_d";
-
-			if ( FileSystem.Mounted?.FileExists( path ) == true )
-				binaryData = ParseFile( FileSystem.Mounted.ReadAllBytes( path ) );
-			else if ( File.Exists( path ) )
-				binaryData = ParseFile( File.ReadAllBytes( path ) );
-			else // Read from compiled scene instead
-			{
-				var compiledPath = filePath + "_c";
-				if ( FileSystem.Mounted?.FileExists( compiledPath ) == true )
-				{
-					var blockData = Game.Resources.ReadCompiledResourceBlock( CompiledBlobName, FileSystem.Mounted.ReadAllBytes( compiledPath ) );
-					if ( blockData != null )
-						binaryData = ParseFile( blockData );
-				}
-			}
-		}
+		var binaryData = ResolveBlobData( filePath );
 
 		var context = new BlobContext( _current, binaryData );
 		_current = context;
 		return context;
+	}
+
+	/// <summary>
+	/// Finds and parses the blob table for a resource, searching all relevant filesystems and file variations.
+	/// Checks both "_d" sidecar and compiled "_c" files, with disk fallback if needed (for published resources).
+	/// </summary>
+	private static Dictionary<Guid, byte[]> ResolveBlobData( string filePath )
+	{
+		if ( string.IsNullOrEmpty( filePath ) )
+			return null;
+
+		if ( filePath.EndsWith( "_c" ) )
+			filePath = filePath[..^2];
+
+		var sidecarPath = filePath + "_d";
+		var compiledPath = filePath + "_c";
+
+		ReadOnlySpan<BaseFileSystem> filesystems =
+		[
+			FileSystem.Mounted,
+			PackageManager.MountedFileSystem,
+		];
+
+		foreach ( var fs in filesystems )
+		{
+			if ( fs is null )
+				continue;
+
+			// The "_d" sidecar is already stored in the blob-file format.
+			if ( fs.FileExists( sidecarPath ) )
+				return ParseFile( fs.ReadAllBytes( sidecarPath ) );
+
+			// Otherwise pull the compiled blob block out of the compiled resource.
+			if ( fs.FileExists( compiledPath ) )
+			{
+				var blockData = Game.Resources.ReadCompiledResourceBlock( CompiledBlobName, fs.ReadAllBytes( compiledPath ) );
+				if ( blockData != null )
+					return ParseFile( blockData );
+			}
+		}
+
+		// Final fallback: a loose sidecar on raw disk (e.g. freshly saved in the editor and not
+		// yet visible through a mounted filesystem).
+		if ( File.Exists( sidecarPath ) )
+			return ParseFile( File.ReadAllBytes( sidecarPath ) );
+
+		return null;
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Utility/Json/BinaryConvert.cs
+++ b/engine/Sandbox.Engine/Utility/Json/BinaryConvert.cs
@@ -70,9 +70,7 @@ internal class BinaryConvert : JsonConverterFactory
 			writer.WriteStartObject();
 			writer.WriteString( "$blob", guid.ToString() );
 
-			// Emit any asset paths stored inside the (otherwise opaque) binary payload so the
-			// resource compiler's JSON scanner registers them as references and includes them
-			// when the owning resource is published.
+			// Emit asset references for resource compiler detection.
 			if ( value is IBlobReferences references )
 			{
 				writer.WriteStartArray( "$refs" );

--- a/engine/Sandbox.Engine/Utility/Json/BinaryConvert.cs
+++ b/engine/Sandbox.Engine/Utility/Json/BinaryConvert.cs
@@ -46,6 +46,11 @@ internal class BinaryConvert : JsonConverterFactory
 							blobGuid = guid;
 						}
 					}
+					else
+					{
+						// Skip any other properties (e.g. the "$refs" array used by the compiler).
+						reader.Skip();
+					}
 				}
 			}
 
@@ -64,6 +69,21 @@ internal class BinaryConvert : JsonConverterFactory
 
 			writer.WriteStartObject();
 			writer.WriteString( "$blob", guid.ToString() );
+
+			// Emit any asset paths stored inside the (otherwise opaque) binary payload so the
+			// resource compiler's JSON scanner registers them as references and includes them
+			// when the owning resource is published.
+			if ( value is IBlobReferences references )
+			{
+				writer.WriteStartArray( "$refs" );
+				foreach ( var path in references.GetReferencedResources() )
+				{
+					if ( !string.IsNullOrWhiteSpace( path ) )
+						writer.WriteStringValue( path );
+				}
+				writer.WriteEndArray();
+			}
+
 			writer.WriteEndObject();
 		}
 	}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

The clutter paint was working perfectly on normal map, but once published and use my MapInstance, you'd love every painting you made

## Motivation & Context

My mapper was doing great job on his addon that target my project and after publish i wanted to try load the map on my project via workshop, but it looked empty

Fixes: 

## Implementation Details

So i dig a little and at first thought well maybe the models don't get referenced on published, so i see that since it used BinaryBlob, the scanner of reference would not see it and so none models would be published if used exclusivly on clutter painting
So i did IBlobReference that let us specify what we reference

But it wasnt enough, it did fix publish of models but still not spawning a single model, so i dig a bit and found out the _d data of the clutter embeded into the scene_c wasnt read or was empty, a tired dig with claude and found a workaround to pull out these data and apply it on MapInstance

So then a single tree got placed, it was one that also was placed manually into the scene, so already referenced
The conclusion was that ClutterGridSystem, loaded wrong the model, i found out that switch to Model.Load instead of ResourceLibrary.Get<Model> fixed it

So now clutter paint work perfectly !

## Screenshots / Videos (if applicable)

<img width="1723" height="792" alt="image" src="https://github.com/user-attachments/assets/aca32642-9e2c-48c7-ae9f-f8a31ceac31a" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂