### PR TITLE
Improve terrain smooth when opacity > 1

### DIFF
--- a/game/addons/base/Assets/shaders/terrain/cs_terrain_sculpt.shader
+++ b/game/addons/base/Assets/shaders/terrain/cs_terrain_sculpt.shader
@@ -91,16 +91,24 @@ CS
         }
         if ( D_SCULPT_MODE == MODE_SMOOTH )
         {
-            float brush = Brush.SampleLevel( g_sBilinearBorder, brushUV, 0 ) * BrushSettings[0].Strength;
+            float brushSample = Brush.SampleLevel( g_sBilinearBorder, brushUV, 0 );
+            float strength = BrushSettings[0].Strength;
+            float brush = brushSample * strength;
             if ( brush <= 0.0f ) return;
-            
-            // Sample surroundings (3x3)
+
+            // Strength above 1 widens the averaging kernel so smoothing gets
+            // progressively "harder" over a larger area. The blend factor itself
+            // is clamped to [0,1] below so we never extrapolate past the average
+            // (which caused spikes/ringing at opacity > 1).
+            int radius = clamp( (int)ceil( abs( strength ) ), 1, 8 );
+
+            // Sample surroundings ((2*radius+1)^2 neighbourhood)
             float sum = 0.0f;
             int sampleCount = 0;
             
-            for ( int y = -1; y <= 1; y++ )
+            for ( int y = -radius; y <= radius; y++ )
             {
-                for ( int x = -1; x <= 1; x++ )
+                for ( int x = -radius; x <= radius; x++ )
                 {
                     int2 samplePos = texel + int2( x, y );
                     
@@ -114,8 +122,11 @@ CS
             
             float average = sum / sampleCount;
             float height = Heightmap.Load( texel ).x;
-            
-            Heightmap[texel] = lerp( height, average, brush );
+
+            // Clamp blend to [0,1] so the smooth only ever moves toward the
+            // neighbourhood average, never overshoots it.
+            float t = saturate( brush );
+            Heightmap[texel] = lerp( height, average, t );
         }
         if ( D_SCULPT_MODE == MODE_HOLE )
         {

--- a/game/addons/base/Assets/shaders/terrain/cs_terrain_sculpt.shader
+++ b/game/addons/base/Assets/shaders/terrain/cs_terrain_sculpt.shader
@@ -91,27 +91,24 @@ CS
         }
         if ( D_SCULPT_MODE == MODE_SMOOTH )
         {
-            float brushSample = Brush.SampleLevel( g_sBilinearBorder, brushUV, 0 );
+            float brush = Brush.SampleLevel( g_sBilinearBorder, brushUV, 0 );
             float strength = BrushSettings[0].Strength;
-            float brush = brushSample * strength;
-            if ( brush <= 0.0f ) return;
+            if ( brush <= 0.0f || strength <= 0.0f ) return;
 
-            // Strength above 1 widens the averaging kernel so smoothing gets
-            // progressively "harder" over a larger area. The blend factor itself
-            // is clamped to [0,1] below so we never extrapolate past the average
-            // (which caused spikes/ringing at opacity > 1).
-            int radius = clamp( (int)ceil( abs( strength ) ), 1, 8 );
+            // Kernel size and blend both follow the brush falloff - anything that
+            // cuts off abruptly leaves a crease along the stroke edge
+            int radius = clamp( (int)ceil( brush * strength ), 1, 8 );
 
-            // Sample surroundings ((2*radius+1)^2 neighbourhood)
+            // Average the (2*radius+1)^2 neighbourhood
             float sum = 0.0f;
             int sampleCount = 0;
-            
+
             for ( int y = -radius; y <= radius; y++ )
             {
                 for ( int x = -radius; x <= radius; x++ )
                 {
                     int2 samplePos = texel + int2( x, y );
-                    
+
                     if ( samplePos.x >= 0 && samplePos.y >= 0 && samplePos.x < w && samplePos.y < h )
                     {
                         sum += Heightmap.Load( samplePos ).x;
@@ -119,13 +116,16 @@ CS
                     }
                 }
             }
-            
+
             float average = sum / sampleCount;
             float height = Heightmap.Load( texel ).x;
 
-            // Clamp blend to [0,1] so the smooth only ever moves toward the
-            // neighbourhood average, never overshoots it.
-            float t = saturate( brush );
+            // Strength above 1 steepens the response curve instead of scaling, which
+            // would clip the falloff into a hard-edged stamp. Capped below full
+            // replacement: our neighbour reads race other threads' writes, and an
+            // uncapped blend lets already-averaged values cascade into a plateau.
+            float t = strength <= 1.0f ? brush * strength : min( 1.0f - pow( 1.0f - brush, strength ), 0.5f );
+
             Heightmap[texel] = lerp( height, average, t );
         }
         if ( D_SCULPT_MODE == MODE_HOLE )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

When we smooth we need a better smooth, so why not just improve strenght by modifying opacity > 1

## Motivation & Context

It create a so odd shape when smooth with opacity > 1

Fixes: partial fix of #11204 

## Implementation Details

Just change the smoothing algorythm to take wider zone to smooth when opacity > 1

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/1721fea2-4982-4f5e-9f48-708e4564047e

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂