### PR TITLE
Fix singlar snapshots receiving a stale snapshot

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/DeltaSnapshots/DeltaSnapshotSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/DeltaSnapshots/DeltaSnapshotSystem.cs
@@ -598,7 +598,7 @@ internal class DeltaSnapshotSystem
 			}
 			else
 			{
-				connectionData.ReceivedSnapshotStates[objectId] = RemoteSnapshotState.From( connectionId, snapshot );
+				state = connectionData.ReceivedSnapshotStates[objectId] = RemoteSnapshotState.From( connectionId, snapshot );
 			}
 
 			snapshotter.OnSnapshotAck( source, snapshot, state );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Just a small change to make sure the snapshotter gets the right state instead of potentially a null state

## Implementation Details

Looks like it was missed from the single pathway but it is fine in the Cluster one
https://github.com/Facepunch/sbox-public/blob/655bba77f2ebd2a9afca90ec2d9bddbee16875b6/engine/Sandbox.Engine/Scene/Networking/DeltaSnapshots/DeltaSnapshotSystem.cs#L463-L466

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂