### PR TITLE
Change how MapInstance apply GameObjectSystem data 

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -472,7 +472,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 		if ( hasSystems )
 		{
-			_systemOverridesScope = Scene.ApplyGameObjectSystemOverrides( systemsNode, transient: true );
+			_systemOverridesScope = Scene.ApplyTransientGameObjectSystemOverrides( systemsNode );
 		}
 
 		return true;

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -58,6 +58,11 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 	Package loadedMapPkg;
 	string sceneMapScenePath;
 
+	// Reverts any GameObjectSystem property overrides this map applied to the host scene (e.g.
+	// painted clutter, which lives at scene level rather than under our GameObject). Disposed when
+	// the map unloads so those changes don't outlive the map.
+	IDisposable _systemOverridesScope;
+
 	public MapInstance() : base()
 	{
 		OnMapLoaded += UpdateDirtyReflections;
@@ -146,6 +151,12 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 		RemoveCollision();
 
 		Physics = null;
+
+		// GameObjectSystem data applied from this scene map (e.g. painted clutter) lives on the
+		// host scene's systems, not under this MapInstance, so it isn't covered by the child-object
+		// cleanup below. Reverting the override restores the systems to their pre-map state.
+		_systemOverridesScope?.Dispose();
+		_systemOverridesScope = null;
 
 		if ( GameObject.IsValid() && GameObject.Children is not null )
 		{
@@ -450,6 +461,17 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 			{
 				go.NetworkSpawn();
 			}
+		}
+
+		// A scene map's GameObjectSystems data (e.g. painted clutter stored on ClutterGridSystem)
+		// lives at scene level, not on a GameObject, so it isn't covered by the loop above. Apply
+		// it onto the host scene's systems so that data survives being loaded through a MapInstance.
+		// Note: this data is in absolute scene coordinates and is not offset by the MapInstance origin.
+		if ( sceneFile.SceneProperties is not null
+			&& sceneFile.SceneProperties.TryGetPropertyValue( "GameObjectSystems", out var systemsNode )
+			&& systemsNode is not null )
+		{
+			_systemOverridesScope = Scene.ApplyGameObjectSystemOverrides( systemsNode );
 		}
 
 		return true;

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -58,9 +58,10 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 	Package loadedMapPkg;
 	string sceneMapScenePath;
 
-	// Reverts any GameObjectSystem property overrides this map applied to the host scene (e.g.
-	// painted clutter, which lives at scene level rather than under our GameObject). Disposed when
-	// the map unloads so those changes don't outlive the map.
+	/// <summary>
+	/// Scope for reverting GameObjectSystem property overrides applied by this map (e.g. painted
+	/// clutter). Disposed when the map unloads so those changes don't outlive the map.
+	/// </summary>
 	IDisposable _systemOverridesScope;
 
 	public MapInstance() : base()
@@ -152,9 +153,8 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 		Physics = null;
 
-		// GameObjectSystem data applied from this scene map (e.g. painted clutter) lives on the
-		// host scene's systems, not under this MapInstance, so it isn't covered by the child-object
-		// cleanup below. Reverting the override restores the systems to their pre-map state.
+		// Revert any GameObjectSystem property overrides (e.g. painted clutter) this map applied
+		// to the host scene, restoring the scene's own pre-map values.
 		_systemOverridesScope?.Dispose();
 		_systemOverridesScope = null;
 
@@ -463,15 +463,16 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 			}
 		}
 
-		// A scene map's GameObjectSystems data (e.g. painted clutter stored on ClutterGridSystem)
-		// lives at scene level, not on a GameObject, so it isn't covered by the loop above. Apply
-		// it onto the host scene's systems so that data survives being loaded through a MapInstance.
-		// Note: this data is in absolute scene coordinates and is not offset by the MapInstance origin.
-		if ( sceneFile.SceneProperties is not null
-			&& sceneFile.SceneProperties.TryGetPropertyValue( "GameObjectSystems", out var systemsNode )
-			&& systemsNode is not null )
+		// Apply map-level GameObjectSystems (e.g. clutter) as transient overrides to the host scene.
+		// These are reverted when the map unloads and use absolute scene coordinates.
+		JsonNode systemsNode = null;
+		var hasSystems = sceneFile.SceneProperties is not null
+			&& sceneFile.SceneProperties.TryGetPropertyValue( "GameObjectSystems", out systemsNode )
+			&& systemsNode is not null;
+
+		if ( hasSystems )
 		{
-			_systemOverridesScope = Scene.ApplyGameObjectSystemOverrides( systemsNode );
+			_systemOverridesScope = Scene.ApplyGameObjectSystemOverrides( systemsNode, transient: true );
 		}
 
 		return true;

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
@@ -41,20 +41,21 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 	}
 
 	/// <summary>
-	/// Check for new terrains, queue generation/cleanup jobs, and process pending jobs.
+	/// Check for new terrains, cleaning up old ones, queue generation/cleanup jobs, and process pending jobs.
 	/// </summary>
 	private void OnUpdate()
 	{
 		var camera = GetActiveCamera();
-		if ( camera == null )
-			return;
+		if ( camera != null )
+		{
+			_lastCameraPosition = camera.WorldPosition;
 
-		_lastCameraPosition = camera.WorldPosition;
+			SubscribeToTerrains();
+			UpdateInfiniteLayers( _lastCameraPosition );
+			ProcessJobs();
+		}
 
-		SubscribeToTerrains();
-		UpdateInfiniteLayers( _lastCameraPosition );
-		ProcessJobs();
-
+		// Rebuild even if no camera is present (to delete painted clutter)
 		if ( _dirty )
 		{
 			RebuildPaintedLayer();

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -283,7 +283,10 @@ public partial class Scene : GameObject
 			{
 				if ( !property.CanWrite ) continue;
 
-				var currentValue = property.GetValue( system );
+				// Serialize pre-override value if masked by a transient override.
+				var currentValue = TryGetPreTransientValue( system, property, out var preValue )
+					? preValue
+					: property.GetValue( system );
 				var hasGlobalValue = ProjectSettings.Systems.TryGetPropertyValue( systemType, property, out var globalValue );
 				var compareValue = hasGlobalValue ? globalValue : SystemsConfig.GetDefaultValue( property );
 
@@ -347,14 +350,12 @@ public partial class Scene : GameObject
 			}
 		}
 
-		//
-		// We don't want system scene loads to overwrite the main scene's system properties.
-		// System scenes can add GameObjects, but they should not reconfigure systems that
-		// already belong to the main scene (same reason NavMesh is guarded below).
-		//
+		// Prevent system scene loads from overwriting main scene system properties.
 		if ( !isSystemScene && data.TryGetPropertyValue( "GameObjectSystems", out var systemOverridesNode ) )
 		{
+#pragma warning disable CA2000 // Dispose objects before losing scope
 			ApplyGameObjectSystemOverrides( systemOverridesNode );
+#pragma warning restore CA2000
 		}
 
 		//

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -353,9 +353,7 @@ public partial class Scene : GameObject
 		// Prevent system scene loads from overwriting main scene system properties.
 		if ( !isSystemScene && data.TryGetPropertyValue( "GameObjectSystems", out var systemOverridesNode ) )
 		{
-#pragma warning disable CA2000 // Dispose objects before losing scope
 			ApplyGameObjectSystemOverrides( systemOverridesNode );
-#pragma warning restore CA2000
 		}
 
 		//

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Nodes;
+using System.Text.Json.Nodes;
 
 namespace Sandbox;
 
@@ -91,18 +91,16 @@ public partial class Scene
 	}
 
 	/// <summary>
-	/// Apply scene-specific GameObjectSystem property overrides.
-	/// Called during scene deserialization, and when a scene map is loaded through a
-	/// <see cref="MapInstance"/>.
+	/// Tracks temporary GameObjectSystem overrides (e.g. from MapInstance) so original values can be restored.
 	/// </summary>
-	/// <returns>
-	/// A disposable that, when disposed, restores the overridden properties to the values they
-	/// held before this call. This lets transient sources (e.g. a <see cref="MapInstance"/>) apply
-	/// their system data non-destructively and cleanly revert it when they unload. Returns null
-	/// when nothing was applied. Callers that own the data permanently (the main scene load) can
-	/// simply ignore the return value.
-	/// </returns>
-	internal IDisposable ApplyGameObjectSystemOverrides( JsonNode overridesNode )
+	readonly List<SystemOverrideScope> _transientSystemOverrides = new();
+
+	/// <summary>
+	/// Applies GameObjectSystem overrides from the given node. Returns a disposable to revert changes.
+	/// </summary>
+	/// <param name="overridesNode">Serialized GameObjectSystems overrides.</param>
+	/// <param name="transient">If true, overrides are temporary and reverted on dispose; otherwise, they are saved with the scene.</param>
+	internal IDisposable ApplyGameObjectSystemOverrides( JsonNode overridesNode, bool transient = false )
 	{
 		if ( overridesNode is null )
 			return null;
@@ -122,7 +120,7 @@ public partial class Scene
 		if ( overrides is null || overrides.Count == 0 )
 			return null;
 
-		var revert = new SystemOverrideScope();
+		var revert = new SystemOverrideScope( this, transient );
 
 		foreach ( var system in systems.Values )
 		{
@@ -156,17 +154,44 @@ public partial class Scene
 			}
 		}
 
-		return revert.HasCaptures ? revert : null;
+		if ( !revert.HasCaptures )
+			return null;
+
+		if ( transient )
+			_transientSystemOverrides.Add( revert );
+
+		return revert;
 	}
 
 	/// <summary>
-	/// Remembers GameObjectSystem property values that an override replaced, and restores them when
-	/// disposed. This keeps system overrides (e.g. painted clutter loaded by a <see cref="MapInstance"/>)
-	/// non-destructive: the host scene's prior state is brought back as soon as the source goes away.
+	/// Gets the pre-override value for a system property if masked by a transient override.
+	/// </summary>
+	bool TryGetPreTransientValue( GameObjectSystem system, PropertyDescription property, out object value )
+	{
+		foreach ( var scope in _transientSystemOverrides )
+		{
+			if ( scope.TryGetCaptured( system, property, out value ) )
+				return true;
+		}
+
+		value = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Saves and restores previous GameObjectSystem property values.
 	/// </summary>
 	sealed class SystemOverrideScope : IDisposable
 	{
+		private readonly Scene _scene;
+		private readonly bool _transient;
 		private readonly List<(GameObjectSystem System, PropertyDescription Property, object PreviousValue)> _captured = new();
+
+		public SystemOverrideScope( Scene scene, bool transient )
+		{
+			_scene = scene;
+			_transient = transient;
+		}
 
 		public bool HasCaptures => _captured.Count > 0;
 
@@ -175,8 +200,29 @@ public partial class Scene
 			_captured.Add( (system, property, previousValue) );
 		}
 
+		/// <summary>
+		/// Returns the pre-override value captured for the given system property, if any.
+		/// </summary>
+		public bool TryGetCaptured( GameObjectSystem system, PropertyDescription property, out object value )
+		{
+			foreach ( var (s, p, previousValue) in _captured )
+			{
+				if ( s == system && p == property )
+				{
+					value = previousValue;
+					return true;
+				}
+			}
+
+			value = null;
+			return false;
+		}
+
 		public void Dispose()
 		{
+			if ( _transient )
+				_scene?._transientSystemOverrides.Remove( this );
+
 			// Restore in reverse, so stacked overrides unwind in the opposite order they applied.
 			for ( int i = _captured.Count - 1; i >= 0; i-- )
 			{

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -112,14 +112,20 @@ public partial class Scene
 	{
 		var revert = new SystemOverrideScope( this, transient: true );
 
-		ApplyGameObjectSystemOverrides( overridesNode, revert );
+		try {
+			ApplyGameObjectSystemOverrides( overridesNode, revert );
 
-		// Nothing matched, so there's nothing to revert - don't hand back a live scope.
-		if ( !revert.HasCaptures )
-			return null;
+			// Nothing matched, so there's nothing to revert - don't hand back a live scope.
+			if ( !revert.HasCaptures )
+				return null;
 
-		_transientSystemOverrides.Add( revert );
-		return revert;
+			_transientSystemOverrides.Add( revert );
+			return revert;
+		} 
+		finally
+		{
+			revert?.Dispose();
+		}
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 
 namespace Sandbox;
 
@@ -61,7 +61,7 @@ public partial class Scene
 	/// Apply configuration values to a GameObjectSystem with priority:
 	/// 1. Project-wide value (from <see cref="ProjectSettings.Systems"/>)
 	/// 2. Default value (already set by property initializer)
-	/// Scene-specific overrides are applied during deserialization via <see cref="ApplyGameObjectSystemOverrides"/>
+	/// Scene-specific overrides are applied during deserialization via <see cref="ApplyGameObjectSystemOverrides(JsonNode)"/>
 	/// </summary>
 	void ApplyGameObjectSystemConfig( GameObjectSystem system )
 	{
@@ -96,14 +96,41 @@ public partial class Scene
 	readonly List<SystemOverrideScope> _transientSystemOverrides = new();
 
 	/// <summary>
-	/// Applies GameObjectSystem overrides from the given node. Returns a disposable to revert changes.
+	/// Applies and saves GameObjectSystem overrides from the given node. For transient (revertible) overrides, use <see cref="ApplyTransientGameObjectSystemOverrides"/>.
 	/// </summary>
-	/// <param name="overridesNode">Serialized GameObjectSystems overrides.</param>
-	/// <param name="transient">If true, overrides are temporary and reverted on dispose; otherwise, they are saved with the scene.</param>
-	internal IDisposable ApplyGameObjectSystemOverrides( JsonNode overridesNode, bool transient = false )
+	/// <param name="overridesNode">Serialized system overrides.</param>
+	internal void ApplyGameObjectSystemOverrides( JsonNode overridesNode )
+	{
+		ApplyGameObjectSystemOverrides( overridesNode, capture: null );
+	}
+
+	/// <summary>
+	/// Applies GameObjectSystem overrides from the node and returns a disposable to revert them.
+	/// </summary>
+	/// <param name="overridesNode">Serialized system overrides.</param>
+	internal IDisposable ApplyTransientGameObjectSystemOverrides( JsonNode overridesNode )
+	{
+		var revert = new SystemOverrideScope( this, transient: true );
+
+		ApplyGameObjectSystemOverrides( overridesNode, revert );
+
+		// Nothing matched, so there's nothing to revert - don't hand back a live scope.
+		if ( !revert.HasCaptures )
+			return null;
+
+		_transientSystemOverrides.Add( revert );
+		return revert;
+	}
+
+	/// <summary>
+	/// Applies the overrides to the scene's systems
+	/// </summary>
+	/// <param name="overridesNode">Serialized system overrides.</param>
+	/// <param name="capture">if non-null, the previous value of each overridden property is recorded into it so the change can be reverted.</param>
+	void ApplyGameObjectSystemOverrides( JsonNode overridesNode, SystemOverrideScope capture )
 	{
 		if ( overridesNode is null )
-			return null;
+			return;
 
 		Dictionary<string, JsonObject> overrides;
 
@@ -114,13 +141,11 @@ public partial class Scene
 		catch ( System.Exception e )
 		{
 			Log.Warning( e, $"Error when deserializing GameObjectSystem overrides ({e.Message})" );
-			return null;
+			return;
 		}
 
 		if ( overrides is null || overrides.Count == 0 )
-			return null;
-
-		var revert = new SystemOverrideScope( this, transient );
+			return;
 
 		foreach ( var system in systems.Values )
 		{
@@ -139,8 +164,8 @@ public partial class Scene
 					try
 					{
 						// Remember the current value first, so the override can be unwound later.
-						if ( property.CanRead )
-							revert.Capture( system, property, property.GetValue( system ) );
+						if ( capture is not null && property.CanRead )
+							capture.Capture( system, property, property.GetValue( system ) );
 
 						// Deserialize the JSON node directly to the property's type
 						var value = Json.FromNode( valueNode, property.PropertyType );
@@ -153,14 +178,6 @@ public partial class Scene
 				}
 			}
 		}
-
-		if ( !revert.HasCaptures )
-			return null;
-
-		if ( transient )
-			_transientSystemOverrides.Add( revert );
-
-		return revert;
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -92,12 +92,20 @@ public partial class Scene
 
 	/// <summary>
 	/// Apply scene-specific GameObjectSystem property overrides.
-	/// Called during scene deserialization.
+	/// Called during scene deserialization, and when a scene map is loaded through a
+	/// <see cref="MapInstance"/>.
 	/// </summary>
-	internal void ApplyGameObjectSystemOverrides( JsonNode overridesNode )
+	/// <returns>
+	/// A disposable that, when disposed, restores the overridden properties to the values they
+	/// held before this call. This lets transient sources (e.g. a <see cref="MapInstance"/>) apply
+	/// their system data non-destructively and cleanly revert it when they unload. Returns null
+	/// when nothing was applied. Callers that own the data permanently (the main scene load) can
+	/// simply ignore the return value.
+	/// </returns>
+	internal IDisposable ApplyGameObjectSystemOverrides( JsonNode overridesNode )
 	{
 		if ( overridesNode is null )
-			return;
+			return null;
 
 		Dictionary<string, JsonObject> overrides;
 
@@ -108,11 +116,13 @@ public partial class Scene
 		catch ( System.Exception e )
 		{
 			Log.Warning( e, $"Error when deserializing GameObjectSystem overrides ({e.Message})" );
-			return;
+			return null;
 		}
 
 		if ( overrides is null || overrides.Count == 0 )
-			return;
+			return null;
+
+		var revert = new SystemOverrideScope();
 
 		foreach ( var system in systems.Values )
 		{
@@ -130,6 +140,10 @@ public partial class Scene
 				{
 					try
 					{
+						// Remember the current value first, so the override can be unwound later.
+						if ( property.CanRead )
+							revert.Capture( system, property, property.GetValue( system ) );
+
 						// Deserialize the JSON node directly to the property's type
 						var value = Json.FromNode( valueNode, property.PropertyType );
 						property.SetValue( system, value );
@@ -140,6 +154,45 @@ public partial class Scene
 					}
 				}
 			}
+		}
+
+		return revert.HasCaptures ? revert : null;
+	}
+
+	/// <summary>
+	/// Remembers GameObjectSystem property values that an override replaced, and restores them when
+	/// disposed. This keeps system overrides (e.g. painted clutter loaded by a <see cref="MapInstance"/>)
+	/// non-destructive: the host scene's prior state is brought back as soon as the source goes away.
+	/// </summary>
+	sealed class SystemOverrideScope : IDisposable
+	{
+		private readonly List<(GameObjectSystem System, PropertyDescription Property, object PreviousValue)> _captured = new();
+
+		public bool HasCaptures => _captured.Count > 0;
+
+		public void Capture( GameObjectSystem system, PropertyDescription property, object previousValue )
+		{
+			_captured.Add( (system, property, previousValue) );
+		}
+
+		public void Dispose()
+		{
+			// Restore in reverse, so stacked overrides unwind in the opposite order they applied.
+			for ( int i = _captured.Count - 1; i >= 0; i-- )
+			{
+				var (system, property, previousValue) = _captured[i];
+
+				try
+				{
+					property.SetValue( system, previousValue );
+				}
+				catch ( Exception ex )
+				{
+					Log.Warning( $"Failed to revert system override on {system.GetType().FullName}.{property.Name}: {ex.Message}" );
+				}
+			}
+
+			_captured.Clear();
 		}
 	}
 

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.System.cs
@@ -112,7 +112,8 @@ public partial class Scene
 	{
 		var revert = new SystemOverrideScope( this, transient: true );
 
-		try {
+		try
+		{
 			ApplyGameObjectSystemOverrides( overridesNode, revert );
 
 			// Nothing matched, so there's nothing to revert - don't hand back a live scope.
@@ -120,8 +121,12 @@ public partial class Scene
 				return null;
 
 			_transientSystemOverrides.Add( revert );
-			return revert;
-		} 
+
+			// Ownership transferred to the caller (and tracking list); don't dispose in finally.
+			var result = revert;
+			revert = null;
+			return result;
+		}
 		finally
 		{
 			revert?.Dispose();

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Core/SceneSystems.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Core/SceneSystems.cs
@@ -117,7 +117,7 @@ public class SceneSystemOverridesTest
 				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 42 } }
 				""" );
 
-			using ( scene.ApplyGameObjectSystemOverrides( node, transient: true ) )
+			using ( scene.ApplyTransientGameObjectSystemOverrides( node ) )
 			{
 				Assert.AreEqual( 42, system.Speed, "the transient override should apply while in scope" );
 			}
@@ -139,7 +139,7 @@ public class SceneSystemOverridesTest
 				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 42 } }
 				""" );
 
-			using var scope = scene.ApplyGameObjectSystemOverrides( node, transient: true );
+			using var scope = scene.ApplyTransientGameObjectSystemOverrides( node );
 
 			Assert.AreEqual( 42, scene.GetSystem<OverridableSystem>().Speed, "the override is live in the scene" );
 			Assert.IsNull( SerializedSystemSpeed( scene ), "but a transient override must not be written into GameObjectSystems" );
@@ -183,7 +183,7 @@ public class SceneSystemOverridesTest
 				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 42 } }
 				""" );
 
-			using ( scene.ApplyGameObjectSystemOverrides( mapNode, transient: true ) )
+			using ( scene.ApplyTransientGameObjectSystemOverrides( mapNode ) )
 			{
 				Assert.AreEqual( 42, scene.GetSystem<OverridableSystem>().Speed, "the transient overlay is live while in scope" );
 				Assert.AreEqual( 7, (int)SerializedSystemSpeed( scene ), "serialization keeps the scene's own value, not the overlay" );

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Core/SceneSystems.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Core/SceneSystems.cs
@@ -6,7 +6,9 @@ namespace SceneTests.Core;
 /// <summary>
 /// Pins how per-scene GameObjectSystem property overrides apply: matching systems get
 /// their properties set, unknown systems and malformed json warn instead of crashing,
-/// and one bad property doesn't stop the others.
+/// and one bad property doesn't stop the others. Also covers transient overrides (e.g.
+/// applied by a MapInstance): they revert on dispose and are excluded from the host
+/// scene's serialization so another source's data isn't baked in.
 /// </summary>
 [TestClass]
 public class SceneSystemOverridesTest
@@ -97,6 +99,114 @@ public class SceneSystemOverridesTest
 			scene.ApplyGameObjectSystemOverrides( JsonValue.Create( "this is not an object" ) );
 			scene.ApplyGameObjectSystemOverrides( null );
 		} );
+	}
+
+	/// <summary>
+	/// A transient override (e.g. applied by a MapInstance) reverts to the scene's own value
+	/// when its scope is disposed.
+	/// </summary>
+	[TestMethod]
+	public void TransientOverrideRevertsOnDispose()
+	{
+		WithTestSystems( scene =>
+		{
+			var system = scene.GetSystem<OverridableSystem>();
+			Assert.AreEqual( 0, system.Speed );
+
+			var node = Json.ParseToJsonObject( $$"""
+				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 42 } }
+				""" );
+
+			using ( scene.ApplyGameObjectSystemOverrides( node, transient: true ) )
+			{
+				Assert.AreEqual( 42, system.Speed, "the transient override should apply while in scope" );
+			}
+
+			Assert.AreEqual( 0, system.Speed, "the transient override should revert once disposed" );
+		} );
+	}
+
+	/// <summary>
+	/// A transient override is excluded from the scene's own serialization, so loading a map's
+	/// systems through a MapInstance doesn't bake that data into the host scene.
+	/// </summary>
+	[TestMethod]
+	public void TransientOverrideIsNotSerialized()
+	{
+		WithTestSystems( scene =>
+		{
+			var node = Json.ParseToJsonObject( $$"""
+				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 42 } }
+				""" );
+
+			using var scope = scene.ApplyGameObjectSystemOverrides( node, transient: true );
+
+			Assert.AreEqual( 42, scene.GetSystem<OverridableSystem>().Speed, "the override is live in the scene" );
+			Assert.IsNull( SerializedSystemSpeed( scene ), "but a transient override must not be written into GameObjectSystems" );
+		} );
+	}
+
+	/// <summary>
+	/// A non-transient override (the scene's own systems) is serialized normally.
+	/// </summary>
+	[TestMethod]
+	public void NonTransientOverrideIsSerialized()
+	{
+		WithTestSystems( scene =>
+		{
+			var node = Json.ParseToJsonObject( $$"""
+				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 42 } }
+				""" );
+
+			scene.ApplyGameObjectSystemOverrides( node );
+
+			Assert.AreEqual( 42, (int)SerializedSystemSpeed( scene ), "a non-transient override should be serialized" );
+		} );
+	}
+
+	/// <summary>
+	/// When a transient override masks a value the scene already owns, serialization keeps the
+	/// scene's own (pre-transient) value rather than the transient overlay - and disposing the
+	/// overlay leaves the scene's own value intact.
+	/// </summary>
+	[TestMethod]
+	public void TransientOverridePreservesSceneOwnValue()
+	{
+		WithTestSystems( scene =>
+		{
+			var ownNode = Json.ParseToJsonObject( $$"""
+				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 7 } }
+				""" );
+			scene.ApplyGameObjectSystemOverrides( ownNode );
+
+			var mapNode = Json.ParseToJsonObject( $$"""
+				{ "{{typeof( OverridableSystem ).FullName}}": { "Speed": 42 } }
+				""" );
+
+			using ( scene.ApplyGameObjectSystemOverrides( mapNode, transient: true ) )
+			{
+				Assert.AreEqual( 42, scene.GetSystem<OverridableSystem>().Speed, "the transient overlay is live while in scope" );
+				Assert.AreEqual( 7, (int)SerializedSystemSpeed( scene ), "serialization keeps the scene's own value, not the overlay" );
+			}
+
+			Assert.AreEqual( 7, scene.GetSystem<OverridableSystem>().Speed, "after dispose the scene's own value remains" );
+			Assert.AreEqual( 7, (int)SerializedSystemSpeed( scene ) );
+		} );
+	}
+
+	/// <summary>
+	/// Reads the serialized value of <see cref="OverridableSystem.Speed"/> out of the scene's
+	/// GameObjectSystems block, or null if it wasn't serialized.
+	/// </summary>
+	static JsonNode SerializedSystemSpeed( Scene scene )
+	{
+		if ( scene.SerializeProperties()["GameObjectSystems"] is not JsonObject systems )
+			return null;
+
+		if ( systems[typeof( OverridableSystem ).FullName] is not JsonObject props )
+			return null;
+
+		return props["Speed"];
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

So when doing #11338 i encounter a issue where disable / enable the MapInstance wouldnt clear the clutter, and i discover that how MapInstance is applied to GOS is really weird and not made to let a swapable MapInstance work

## Motivation & Context

Anto helped me find out the issue, thx btw for help

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

So i did in a way that a MapInstance data is disposable and we can layer on map disable dispose and so unset the MapInstance data and so no more residual clutter

Ngl i'm still not sure if we should keep scene data as well as MapInstance one ? Like a overlay system, i prepared a POC but then it induce other issue (maybe intended not sure about what you want) like if i paint on my scene on a MapInstance terrain it will work and both will show, but then when disable MapInstance (so terrain too), the data stay ?

https://github.com/user-attachments/assets/b3ea8fdc-358d-422b-b729-424ee19ca8a9


If it's what you want lmk cause i didnt want to overcommit so i stayed like that simple solution like before


## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/759a045d-6ac8-4537-a055-e5c0f0a0c1da


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂