### PR TITLE
Change VoiceManager internal to public

### DIFF
--- a/engine/Sandbox.Engine/Utility/VoiceManager.cs
+++ b/engine/Sandbox.Engine/Utility/VoiceManager.cs
@@ -3,7 +3,7 @@ using System.Buffers;
 
 namespace Sandbox;
 
-internal static class VoiceManager
+public static class VoiceManager
 {
 	static ISteamUser steamUser;
 	static byte[] compressedBuffer = new byte[1024 * 32];


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR makes `VoiceManager` public so game code can create custom voice components and routing systems.

Right now, `VoiceManager` is `internal`, so projects cannot access the compressed microphone data directly. This makes it hard to build custom voice channels, such as having both a 3D proximity voice and a 2D call/radio voice.

## Motivation & Context

The default Voice component cannot simply be duplicated for multiple channels.

Even if multiple voice components are added, they all receive the compressed voice callback, but only one of them is allowed to continue because of the check inside the Voice callback that sends the RPC from the component:

if ( singleRecorder != this )
	return;

Because of that, only the active recorder component sends the voice RPC. This prevents having one Voice component for 3D proximity audio and another one for 2D call/radio audio at the same time.

Exposing `VoiceManager` allows projects to use the existing voice capture/compression pipeline and implement their own routing.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

This PR changes `VoiceManager` from `internal` to `public`.

This allows game code to access APIs such as:

```csharp
VoiceManager.OnCompressedVoiceData += OnCompressedVoiceData;
VoiceManager.StartRecording();
VoiceManager.StopRecording();
VoiceManager.Uncompress( buffer, OnDecodedVoice );
```

A project can then use one microphone recording source and dispatch the compressed voice data to multiple channels manually, for example:

```text
Microphone input
    -> proximity channel, played in 3D
    -> call/radio channel, played in 2D
```

## Screenshots / Videos (if applicable)

Not applicable.

## Checklist

* [x] Code follows existing style and conventions
* [x] No unnecessary formatting or unrelated changes
* [ ] Public APIs are documented (if applicable)
* [ ] Unit tests added where applicable and all passing
* [x] I’m okay with this PR being rejected or requested to change 🙂
