### PR TITLE
Send heartbeat as a reliable packet so that we dont get kicked from doing nothing

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Message.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Message.cs
@@ -292,7 +292,7 @@ internal partial class NetworkSystem
 			ByteStream bs = ByteStream.Create( 512 );
 			bs.Write( InternalMessageType.HeartbeatPong );
 			bs.Write( serverRealTime ); // the time they sent
-			source.SendStream( bs, NetFlags.Unreliable | NetFlags.SendImmediate );
+			source.SendStream( bs, NetFlags.Reliable | NetFlags.SendImmediate );
 			bs.Dispose();
 		}
 

--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.cs
@@ -361,7 +361,7 @@ internal partial class NetworkSystem
 			bs.Write( InternalMessageType.HeartbeatPing );
 			bs.Write( RealTime.Now ); // Real time
 			bs.Write( Time.NowDouble ); // Game time
-			c.SendStream( bs, NetFlags.Unreliable | NetFlags.SendImmediate );
+			c.SendStream( bs, NetFlags.Reliable | NetFlags.SendImmediate );
 			bs.Dispose();
 		}
 	}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Currently if you end up going afk you don't send anything to the server that is reliable; however SteamSockets does not like this because it's expecting its m_nLastRecvReliableMsgNum to be incremented every 1 million calls to reliable. If we dont do this and the person comes back they will be kicked

```c++
// Sanity check against a HUGE jump in the message number.
// This is almost certainly bogus.  (OKOK, yes it is theoretically
// possible.  But for now while this thing is still under development,
// most likely it's a bug.  Eventually we can lessen these to handle
// the case where the app decides to send literally a million unreliable
// messages in between reliable messages.  The second condition is probably
// legit, though.)
if ( nOffset > 1000000 || nMsgNum > lane.m_nHighestSeenMsgNum+10000 )
{
  ConnectionState_ProblemDetectedLocally( k_ESteamNetConnectionEnd_Misc_InternalError,
	  "Reliable message number lurch.  Last reliable %lld, offset %llu, highest seen %lld",
	  (long long)lane.m_nLastRecvReliableMsgNum, (unsigned long long)nOffset,
	  (long long)lane.m_nHighestSeenMsgNum );
  return false;
}
```
https://github.com/ValveSoftware/GameNetworkingSockets/blob/f4525e39ee10f6b45181fd92d01fee75f7d71756/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp#L3770-L3784

## Motivation & Context

Fixes: #10529

## Implementation Details

I opted to do the heartbeat message instead of making a whole new message however if you would like a whole new message that second less frequently then I can do that as well

## Screenshots / Videos (if applicable)

Here is the code to repo it, basically just load this code up on the sandbox gamemode on a dedicated server and run the command on the server then don't move. Wait for it to finish and then go and move about and pull out weapons etc.

```csharp
using System;
using System.Threading.Tasks;
using Sandbox.Engine;

namespace Sandbox.Network;

internal partial class NetworkSystem
{
    [ConCmd( "net_test_lurch" )]
    public static async void RunLurchTest()
    {
        var system = Networking.System;
        if ( system == null ) return;

        Log.Info( "Starting Lurch Test: Sending 1,500,000 unreliable messages over 5 minutes..." );

        var totalMessages = 1500000;
        var durationSeconds = 300;
        var messagesPerSecond = totalMessages / durationSeconds;
        var batchSize = 100;
        var delayMs = (int)(1000.0 / (messagesPerSecond / (double)batchSize));

        var sentCount = 0;
        var startTime = DateTime.Now;

        try
        {
            while ( sentCount < totalMessages )
            {
                for ( int i = 0; i < batchSize && sentCount < totalMessages; i++ )
                {
                    var bs = ByteStream.Create( 16 );
                    bs.Write( InternalMessageType.HeartbeatPing );
                    bs.Write( RealTime.Now );
                    bs.Write( Time.NowDouble );

                    system.Broadcast( bs, Connection.ChannelState.Welcome, flags: NetFlags.Unreliable );

                    bs.Dispose();
                    sentCount++;
                }

                if ( sentCount % 10000 == 0 )
                {
                    Log.Info( $"Lurch Test Progress: {sentCount:N0} / {totalMessages:N0} ({(sentCount / (float)totalMessages) * 100:F1}%)" );
                }

                await Task.Delay( delayMs );
            }

            var totalTime = DateTime.Now - startTime;
            Log.Info( $"Lurch Test Complete! Sent {sentCount:N0} messages in {totalTime.TotalSeconds:F1}s" );
        }
        catch ( Exception e )
        {
            Log.Error( e, "Lurch Test failed" );
        }
    }
}
```

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂