### PR TITLE
Allow multiple active Voice components

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Audio/VoiceComponent.cs
@@ -301,7 +301,7 @@ public class Voice : Component
 	private void OnVoice( Memory<byte> compressed )
 	{
 		if ( IsProxy ) return;
-		if ( singleRecorder != this ) return;
+		if ( !recording ) return;
 
 		if ( Networking.System is not null )
 		{


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR allows multiple `Voice` components to record and send voice data at the same time.

Currently, the voice callback only allows the `singleRecorder` component to continue:

```csharp
if ( singleRecorder != this )
	return;
```

This prevents using multiple `Voice` components on the same player, even when they are meant to represent different voice channels.

This PR changes the check to:

```csharp
if ( !recording )
	return;
```

so every active recording `Voice` component can process the compressed voice callback and send its own RPC.

## Motivation & Context

I understand why exposing `VoiceManager` directly is not desired, especially because of the concerns around recording players without their knowledge.

However, without access to `VoiceManager`, it is currently not possible to build a custom voice component. At the same time, the default `Voice` component cannot be duplicated because of the `singleRecorder` check.

In my use case, I need two distinct voice channels that can be active at the same time:

* a 3D proximity voice channel
* a 2D call/radio voice channel

Ideally, voice channels would be supported directly so the same compressed voice packet would not need to be sent twice. But this change at least makes it possible to build separate voice behavior using the existing `Voice` component.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

The main change is replacing:

```csharp
if ( singleRecorder != this )
	return;
```

with:

```csharp
if ( !recording )
	return;
```

This keeps the check limited to components that are actively recording, while allowing more than one active `Voice` component to handle the same compressed voice callback.

The tradeoff is that if multiple `Voice` components are recording, the same voice data may be sent more than once, once per active component. This is not ideal, but it allows projects to implement separate 2D and 3D voice behavior without requiring direct access to `VoiceManager`.

## Screenshots / Videos (if applicable)

Not applicable.

## Checklist

* [x] Code follows existing style and conventions
* [x] No unnecessary formatting or unrelated changes
* [ ] Public APIs are documented (if applicable)
* [ ] Unit tests added where applicable and all passing
* [x] I’m okay with this PR being rejected or requested to change 🙂
