### PR TITLE
Fix sync vars getting stuck on the client due to dropped/delayed ACKs

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/DeltaSnapshots/DeltaSnapshotSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/DeltaSnapshots/DeltaSnapshotSystem.cs
@@ -237,7 +237,7 @@ internal class DeltaSnapshotSystem
 					dataToSend ??= SnapshotData.Pool.Rent();
 					dataToSend[slot] = value;
 
-					state.AddPredicted( entry, Time );
+					state.AddPredicted( entry, snapshot.SnapshotId, Time );
 
 					entry.Connections?.Add( connectionId );
 				}
@@ -255,7 +255,7 @@ internal class DeltaSnapshotSystem
 					var slot = entry.Slot;
 					var value = entry.Value;
 
-					state.AddPredicted( entry, Time );
+					state.AddPredicted( entry, snapshot.SnapshotId, Time );
 					dataToSend[slot] = value;
 
 					entry.Connections?.Add( connectionId );
@@ -342,7 +342,7 @@ internal class DeltaSnapshotSystem
 				snapshotData ??= SnapshotData.Pool.Rent();
 				snapshotData[slot] = value;
 
-				state.AddPredicted( entry, Time );
+				state.AddPredicted( entry, snapshot.SnapshotId, Time );
 
 				entry.Connections?.Add( connectionId );
 			}
@@ -357,7 +357,7 @@ internal class DeltaSnapshotSystem
 				var slot = entry.Slot;
 				var value = entry.Value;
 
-				state.AddPredicted( entry, Time );
+				state.AddPredicted( entry, snapshot.SnapshotId, Time );
 				snapshotData[slot] = value;
 
 				entry.Connections?.Add( connectionId );

--- a/engine/Sandbox.Engine/Scene/Networking/DeltaSnapshots/RemoteSnapshotState.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/DeltaSnapshots/RemoteSnapshotState.cs
@@ -14,7 +14,7 @@ internal class RemoteSnapshotState
 	/// </summary>
 	private const float MaximumAckResponseTime = 0.25f;
 
-	private record struct PredictedEntry( byte[] Value, float ExpireTime, ulong Hash );
+	private record struct PredictedEntry( ushort SnapshotId, byte[] Value, float ExpireTime, ulong Hash );
 	public record struct Entry( ushort SnapshotId, byte[] Data, ulong Hash );
 
 	// One of these exists per (connection, object) and holds one entry per synced slot -> don't pre-size them
@@ -49,10 +49,11 @@ internal class RemoteSnapshotState
 	/// Add a predicted entry to the snapshot from a <see cref="DeltaSnapshot.SnapshotDataEntry"/>.
 	/// </summary>
 	/// <param name="input"></param>
+	/// <param name="snapshotId"></param>
 	/// <param name="timeNow"></param>
-	public void AddPredicted( in DeltaSnapshot.SnapshotDataEntry input, float timeNow )
+	public void AddPredicted( in DeltaSnapshot.SnapshotDataEntry input, ushort snapshotId, float timeNow )
 	{
-		_predictedData[input.Slot] = new PredictedEntry( input.Value, timeNow + MaximumAckResponseTime, input.Hash );
+		_predictedData[input.Slot] = new PredictedEntry( snapshotId, input.Value, timeNow + MaximumAckResponseTime, input.Hash );
 	}
 
 	/// <summary>
@@ -63,7 +64,11 @@ internal class RemoteSnapshotState
 		if ( Data.TryGetValue( input.Slot, out var entry ) && !IsNewer( snapshotId, entry.SnapshotId ) )
 			return;
 
-		_predictedData.Remove( input.Slot );
+		if ( _predictedData.TryGetValue( input.Slot, out var predicted ) && !IsNewer( predicted.SnapshotId, snapshotId ) )
+		{
+			_predictedData.Remove( input.Slot );
+		}
+
 		Data[input.Slot] = new Entry( snapshotId, input.Value, input.Hash );
 	}
 
@@ -88,10 +93,16 @@ internal class RemoteSnapshotState
 	/// </summary>
 	public bool TryGetHash( int slot, out ulong hash, float timeNow )
 	{
-		if ( _predictedData.TryGetValue( slot, out var predicted ) && timeNow <= predicted.ExpireTime )
+		if ( _predictedData.TryGetValue( slot, out var predicted ) )
 		{
-			hash = predicted.Hash;
-			return true;
+			if ( timeNow <= predicted.ExpireTime )
+			{
+				hash = predicted.Hash;
+				return true;
+			}
+
+			hash = 0;
+			return false;
 		}
 
 		if ( Data.TryGetValue( slot, out var e ) )
@@ -118,10 +129,16 @@ internal class RemoteSnapshotState
 	/// </summary>
 	public bool TryGetValue( int slot, out byte[] value, float timeNow )
 	{
-		if ( _predictedData.TryGetValue( slot, out var predicted ) && timeNow <= predicted.ExpireTime )
+		if ( _predictedData.TryGetValue( slot, out var predicted ) )
 		{
-			value = predicted.Value;
-			return true;
+			if ( timeNow <= predicted.ExpireTime )
+			{
+				value = predicted.Value;
+				return true;
+			}
+
+			value = null;
+			return false;
 		}
 
 		if ( Data.TryGetValue( slot, out var e ) )

--- a/engine/Tests/Sandbox.Test.Unit/Network/RemoteSnapshotState.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Network/RemoteSnapshotState.cs
@@ -1,0 +1,100 @@
+using System;
+using Sandbox.Network;
+
+namespace NetworkTests;
+
+[TestClass]
+public class RemoteSnapshotStateTest
+{
+	private static DeltaSnapshot.SnapshotDataEntry CreateEntry( int slot, byte value, ulong hash )
+	{
+		return new DeltaSnapshot.SnapshotDataEntry
+		{
+			Slot = slot,
+			Value = [value],
+			Hash = hash
+		};
+	}
+
+	[TestMethod]
+	public void OlderAckDoesNotClearNewerPredictedValue()
+	{
+		var state = new RemoteSnapshotState { ObjectId = Guid.NewGuid() };
+		const int slot = 42;
+
+		var ackAt1 = CreateEntry( slot, 1, 1001 );
+		var ackAt2 = CreateEntry( slot, 2, 1002 );
+		var predictedAt3 = CreateEntry( slot, 3, 1003 );
+
+		state.Update( ackAt1, snapshotId: 1 );
+		state.AddPredicted( predictedAt3, snapshotId: 3, timeNow: 0f );
+		state.Update( ackAt2, snapshotId: 2 );
+
+		Assert.IsTrue( state.TryGetHash( slot, out var hash, timeNow: 0.1f ) );
+		Assert.AreEqual( 1003ul, hash );
+	}
+
+	[TestMethod]
+	public void MatchingAckClearsPredictedValue()
+	{
+		var state = new RemoteSnapshotState { ObjectId = Guid.NewGuid() };
+		const int slot = 7;
+
+		var ackAt1 = CreateEntry( slot, 1, 2001 );
+		var ackAt2 = CreateEntry( slot, 2, 2002 );
+
+		state.Update( ackAt1, snapshotId: 1 );
+		state.AddPredicted( ackAt2, snapshotId: 2, timeNow: 0f );
+		state.Update( ackAt2, snapshotId: 2 );
+
+		Assert.IsTrue( state.TryGetHash( slot, out var hash, timeNow: 0.1f ) );
+		Assert.AreEqual( 2002ul, hash );
+	}
+
+	[TestMethod]
+	public void ExpiredPredictionForcesResend()
+	{
+		var state = new RemoteSnapshotState { ObjectId = Guid.NewGuid() };
+		const int slot = 99;
+
+		var initialValues = CreateEntry( slot, 0, 1000 );
+		state.Update( initialValues, snapshotId: 0 );
+
+		var predicted = CreateEntry( slot, 1, 1001 );
+		state.AddPredicted( predicted, snapshotId: 1, timeNow: 0f );
+
+		Assert.IsFalse( state.TryGetHash( slot, out _, timeNow: 0.3f ) );
+	}
+
+	[TestMethod]
+	public void NewerAckClearsOlderPredictedValue()
+	{
+		var state = new RemoteSnapshotState { ObjectId = Guid.NewGuid() };
+		const int slot = 10;
+
+		var predictedAt2 = CreateEntry( slot, 2, 3002 );
+		var ackAt5 = CreateEntry( slot, 5, 3005 );
+
+		state.AddPredicted( predictedAt2, snapshotId: 2, timeNow: 0f );
+		state.Update( ackAt5, snapshotId: 5 );
+
+		Assert.IsTrue( state.TryGetHash( slot, out var hash, timeNow: 0.1f ) );
+		Assert.AreEqual( 3005ul, hash );
+	}
+
+	[TestMethod]
+	public void OutOfOrderAckDoesNotClearNewerPrediction()
+	{
+		var state = new RemoteSnapshotState { ObjectId = Guid.NewGuid() };
+		const int slot = 55;
+
+		var predictedS2 = CreateEntry( slot, 2, 2002 );
+		var ackS1 = CreateEntry( slot, 1, 2001 );
+
+		state.AddPredicted( predictedS2, snapshotId: 2, timeNow: 0f );
+		state.Update( ackS1, snapshotId: 1 );
+
+		Assert.IsTrue( state.TryGetHash( slot, out var hash, timeNow: 0.1f ) );
+		Assert.AreEqual( 2002ul, hash );
+	}
+}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Currently sync vars do not check if the data in _predictedData is actually the right one they are acking, so its possible that we remove the wrong predictive data from an older snapshot id. This prevents a delayed or out-of-order ACK from removing a more recent predicted sync value, which could cause a synced variable to become "stuck" (incorrectly revert or stop being resent if they never receive it).

Examples:

• predicted=2, incoming=3 -> IsNewer(2,3) = false -> remove (OK)
• predicted=5, incoming=3 -> IsNewer(5,3) = true -> don't remove (keep prediction)

Fixes: #795 

## Implementation Details

TryGetHash now treats an expired prediction as a miss instead of falling back to older stored data. This forces a resend when the receiver likely didn’t get the predicted value, avoiding a synced variable becoming stuck on an older value in the case that we have "flickering" variables between two values. 

Server:
Value A, Value B, Value A (Server still thinks Value A is the value so no send), Value B

Client:
Value A, Value B (Ack fails to get in within time), Value B

## Screenshots / Videos (if applicable)

Before: 

https://youtu.be/i1XP1RmZJGQ

After:

https://youtu.be/MXKmexLvS80

The project for this bug is in #795 

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂