### PR TITLE
Recompute face texture parameters once streamed material textures load

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Mesh/MeshComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Mesh/MeshComponent.cs
@@ -151,6 +151,23 @@ public sealed class MeshComponent : Collider, ExecuteInEditor, ITintable, IMater
 		RebuildRenderMesh();
 
 		base.OnEnabledInternal();
+
+		_ = RecomputeTextureParametersWhenTexturesLoad();
+	}
+
+	// Face texture parameters are derived from the coordinates using each material's texture size.
+	// A streamed texture isn't resident yet when we enable, so its faces derive against a fallback
+	// size and the scale comes out wrong. Wait for the textures then derive from the coordinates again.
+	async Task RecomputeTextureParametersWhenTexturesLoad()
+	{
+		if ( !Scene.IsEditor || Mesh is null || !Mesh.HasLoadingMaterialTextures() )
+			return;
+
+		while ( this.IsValid() && Mesh is not null && Mesh.HasLoadingMaterialTextures() )
+			await Task.Delay( 10 );
+
+		if ( this.IsValid() && Mesh is not null )
+			Mesh.ComputeFaceTextureParametersFromCoordinates();
 	}
 
 	protected override void OnDisabled()

--- a/engine/Sandbox.Engine/Scene/Components/Mesh/PolygonMesh.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Mesh/PolygonMesh.cs
@@ -4339,6 +4339,18 @@ public sealed partial class PolygonMesh : IJsonConvert
 		return textureSize;
 	}
 
+	internal bool HasLoadingMaterialTextures()
+	{
+		foreach ( var material in Materials )
+		{
+			// A texture that is still streaming in has no valid size to derive a scale from
+			if ( material?.FirstTexture is { IsLoaded: false, IsError: false } )
+				return true;
+		}
+
+		return false;
+	}
+
 	public bool IsEdgeSmooth( HalfEdgeHandle hEdge )
 	{
 		if ( IsEdgeOpen( hEdge ) )


### PR DESCRIPTION
Face texture scale/offset aren't stored - they're derived from the UVs on enable (#4323) using the material's texture size. A streamed texture isn't resident yet at that point, so those faces derive against a fallback size and the scale reads back wrong (e.g. 0.125 → 0.25), and it's never corrected once the texture loads.

Wait for the material textures, then derive from the coordinates again.

Fixes #11360

## Previous commits that were considered
- #4323 (Layla) : "bake scale recomputes params from coordinates, we want uvs to stay the same when baking" -> this is the derive-from-coordinates design the fix preserves.
- #4501 (Lorenz) : "Remove all world-space properties from PolygonMesh serialization" -> where scale/offset stopped being serialized (the origin of the derive-on-load path).

## Screenshots / Videos (if applicable)
When I set the texture size to 0.2 on the right, and 0.1 on the left respectively and restart my editor, and I select those faces again it remembers the sizes correctly.

Right Side:
<img width="1142" height="525" alt="image" src="https://github.com/user-attachments/assets/57bcb6cc-0874-4e90-96e6-8b7b00c1da13" />

Left Side:
<img width="1131" height="553" alt="image" src="https://github.com/user-attachments/assets/46897a74-d8de-4c42-90e8-9fa7b8535f65" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂