### PR TITLE
Fix Asset RegisterFile on DDGI

### DIFF
--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.cs
@@ -576,6 +576,11 @@ file class AssetFolderInstance : SceneFolder
 
 		if ( filename.StartsWith( '/' ) ) filename = filename[1..];
 
+		// Register the newly written file with the asset system so it is 
+		// immediately without waiting for the file watcher.
+		var absolutePath = System.IO.Path.Combine( _folder, filename );
+		AssetSystem.RegisterFile( absolutePath );
+
 		return System.IO.Path.Combine( _relativeFolder, filename ).NormalizeFilename( false );
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

So after baking a DDGI, the texture would failed to load and get me that
<img width="1860" height="486" alt="image" src="https://github.com/user-attachments/assets/8f8a42eb-90fa-441f-b0c5-45980ebc1024" />


## Motivation & Context

Afteer my mappers baked the map and publish it, it wont show on my scene using a MapInstance, so i dig a bit and find out it was wiping the bake after finish, and also it wasnt publishing the texture, so i was sure something wasnt normal

Fixes:

## Implementation Details

Just need to RegisterFile after a save on SceneEditorSession.WriteFile

## Screenshots / Videos (if applicable)
<img width="1854" height="465" alt="image" src="https://github.com/user-attachments/assets/56e58127-0883-4984-adb4-48d27f7c3738" />

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂