### PR TITLE
Fix editor dragndrop props and right click create object not work with DPI

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
@@ -570,7 +570,7 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 	}
 
 	/// <summary>
-	/// Convert from screen pixel coordinates (DPI aware) to a ray in world space.
+	/// Convert from screen pixel coordinates (not DPI scaled, see EditorUtility) to a ray in world space.
 	/// </summary>
 	public Ray ScreenPixelToRay( Vector2 pixelPosition )
 	{

--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
@@ -569,6 +569,9 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 		return new Vector2( v.x, v.y );
 	}
 
+	/// <summary>
+	/// Convert from screen pixel coordinates (DPI aware) to a ray in world space.
+	/// </summary>
 	public Ray ScreenPixelToRay( Vector2 pixelPosition )
 	{
 		EnsureSceneCameraCreated();

--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
@@ -569,9 +569,6 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 		return new Vector2( v.x, v.y );
 	}
 
-	/// <summary>
-	/// Convert from screen pixel coordinates (not DPI scaled, see EditorUtility) to a ray in world space.
-	/// </summary>
 	public Ray ScreenPixelToRay( Vector2 pixelPosition )
 	{
 		EnsureSceneCameraCreated();

--- a/engine/Sandbox.Tools/Utility/Utility.cs
+++ b/engine/Sandbox.Tools/Utility/Utility.cs
@@ -528,6 +528,20 @@ public static partial class EditorUtility
 	public static bool IsRecordingVideo => ScreenRecorder.IsRecording();
 
 	/// <summary>
+	/// Convert from local widget pixel coordinates to a ray in world space.
+	/// Converts logical Qt coordinates to the camera's physical pixel space before delegating to <see cref="CameraComponent.ScreenPixelToRay"/>.
+	/// </summary>
+	/// <param name="camera">The camera to cast from. Should have <see cref="CameraComponent.CustomSize"/> set to the widget render size.</param>
+	/// <param name="pixelPosition">Cursor position in local widget coordinates (logical pixels).</param>
+	public static Ray ScreenPixelToRay( CameraComponent camera, Vector2 pixelPosition )
+	{
+		if ( !camera.IsValid() )
+			return default;
+
+		return camera.ScreenPixelToRay( pixelPosition * Application.DpiScale );
+	}
+
+	/// <summary>
 	/// Display a modal dialog message. This is a blocking call.
 	/// </summary>
 	public static void DisplayDialog( string title, string message, string okay = "Okay", string icon = "⚠️", Widget parent = null )

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
@@ -88,12 +88,15 @@ public partial class SceneViewportWidget : Widget
 
 		if ( currentDrop is not null )
 		{
+			// Normalize pos (Qt logical pixels vs camera's physical pixels)
+			var normalizedPos = (ev.LocalPosition - Renderer.Position) / Renderer.Size;
+		
 			// TODO: Render meshes don't support tags, material drop doesn't need it though
 			var tr = SceneEditorSession.Active.Scene.Trace
 							.WithoutTags( "isdragdrop", "trigger" )
 							.UseRenderMeshes( currentDrop is MaterialDropObject )
 							.UsePhysicsWorld( currentDrop is not MaterialDropObject )
-							.Ray( _activeCamera.ScreenPixelToRay( ev.LocalPosition - Renderer.Position ), _activeCamera.ZFar + MathF.Abs( _activeCamera.ZNear ) )
+							.Ray( _activeCamera.ScreenNormalToRay( normalizedPos ), _activeCamera.ZFar + MathF.Abs( _activeCamera.ZNear ) )
 							.Run();
 
 			if ( !tr.Hit )

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
@@ -88,7 +88,6 @@ public partial class SceneViewportWidget : Widget
 
 		if ( currentDrop is not null )
 		{
-
 			// TODO: Render meshes don't support tags, material drop doesn't need it though
 			var tr = SceneEditorSession.Active.Scene.Trace
 							.WithoutTags( "isdragdrop", "trigger" )

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
@@ -90,7 +90,7 @@ public partial class SceneViewportWidget : Widget
 		{
 			// Normalize pos (Qt logical pixels vs camera's physical pixels)
 			var normalizedPos = (ev.LocalPosition - Renderer.Position) / Renderer.Size;
-		
+
 			// TODO: Render meshes don't support tags, material drop doesn't need it though
 			var tr = SceneEditorSession.Active.Scene.Trace
 							.WithoutTags( "isdragdrop", "trigger" )

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.DragDrop.cs
@@ -88,15 +88,13 @@ public partial class SceneViewportWidget : Widget
 
 		if ( currentDrop is not null )
 		{
-			// Normalize pos (Qt logical pixels vs camera's physical pixels)
-			var normalizedPos = (ev.LocalPosition - Renderer.Position) / Renderer.Size;
 
 			// TODO: Render meshes don't support tags, material drop doesn't need it though
 			var tr = SceneEditorSession.Active.Scene.Trace
 							.WithoutTags( "isdragdrop", "trigger" )
 							.UseRenderMeshes( currentDrop is MaterialDropObject )
 							.UsePhysicsWorld( currentDrop is not MaterialDropObject )
-							.Ray( _activeCamera.ScreenNormalToRay( normalizedPos ), _activeCamera.ZFar + MathF.Abs( _activeCamera.ZNear ) )
+							.Ray( EditorUtility.ScreenPixelToRay( _activeCamera, ev.LocalPosition - Renderer.Position ), _activeCamera.ZFar + MathF.Abs( _activeCamera.ZNear ) )
 							.Run();
 
 			if ( !tr.Hit )

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
@@ -370,7 +370,8 @@ public partial class SceneViewportWidget : Widget
 		return false;
 	}
 
-	Ray CursorTraceRay => _activeCamera.ScreenPixelToRay( initialMousePosition );
+	// Convert initialMousePosition (Qt pixels) to camera screen-normal (divide by Renderer.Size)
+	Ray CursorTraceRay => _activeCamera.ScreenNormalToRay( (initialMousePosition - Renderer.Position) / Renderer.Size );
 
 	[Shortcut( "editor.paste", "CTRL+V" )]
 	void Paste()

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
@@ -370,8 +370,7 @@ public partial class SceneViewportWidget : Widget
 		return false;
 	}
 
-	// Convert initialMousePosition (Qt pixels) to camera screen-normal (divide by Renderer.Size)
-	Ray CursorTraceRay => _activeCamera.ScreenNormalToRay( (initialMousePosition - Renderer.Position) / Renderer.Size );
+	Ray CursorTraceRay => EditorUtility.ScreenPixelToRay( _activeCamera, initialMousePosition - Renderer.Position );
 
 	[Shortcut( "editor.paste", "CTRL+V" )]
 	void Paste()

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
@@ -370,7 +370,7 @@ public partial class SceneViewportWidget : Widget
 		return false;
 	}
 
-	Ray CursorTraceRay => EditorUtility.ScreenPixelToRay( _activeCamera, initialMousePosition - Renderer.Position );
+	Ray CursorTraceRay => EditorUtility.ScreenPixelToRay( _activeCamera, initialMousePosition );
 
 	[Shortcut( "editor.paste", "CTRL+V" )]
 	void Paste()


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Okay so it's my 3rd PR for it, this one might be the good one, no unusefull change or what

So the issue was that with > 100% DPI right click to create a object nor dragndrop a model wouldnt be at cursor pos but moved near top left of the screen

## Motivation & Context

So it drives me crazy that none of these 2 work well with DPI scaled windows, so i change it to use normalized version and use the renderer dpi size



Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

Just used normalized version, no need to pass DPI scale everywhere nor change ScreenRect size or changes in camera

## Screenshots / Videos (if applicable)

See #10510 

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂