### PR TITLE
[Terrain] Fix brush size being treated as radius instead of diameter

### DIFF
--- a/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
@@ -210,7 +210,7 @@ public abstract class BaseBrushTool : EditorTool
 
 	protected virtual void OnPaint( Terrain terrain, TerrainPaintParameters paint )
 	{
-		int size = (int)Math.Floor( paint.BrushSettings.Size / terrain.Storage.TerrainSize * terrain.Storage.Resolution );
+		int size = (int)Math.Floor( paint.BrushSettings.Size * 2.0f / terrain.Storage.TerrainSize * terrain.Storage.Resolution );
 		size = Math.Max( size, 1 );
 
 		var opacity = paint.BrushSettings.Opacity * (AllowBrushInvert && Gizmo.IsCtrlPressed ? -1.0f : 1.0f);


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

So when you painted something, it wasnt looking like the brush preview

## Motivation & Context

My mappers yelled at me lol

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

I discover that the brush preview was good but what's passed to shaders wasnt
It was passing the radius instead of the diameter to shader

## Screenshots / Videos (if applicable)

before
<img width="1278" height="857" alt="image" src="https://github.com/user-attachments/assets/f89991c1-0824-4bcc-b702-7d07e12ffbd9" />

after
<img width="969" height="603" alt="image" src="https://github.com/user-attachments/assets/a576dc20-8f26-446b-b102-abed94c3ac8d" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂