### PR TITLE
[UI] Better alpha compositing with image and background color 

### DIFF
--- a/game/addons/base/Assets/shaders/ui_cssbox.shader
+++ b/game/addons/base/Assets/shaders/ui_cssbox.shader
@@ -337,8 +337,11 @@ PS
 				vImage *= bgTint;
 			#endif
 
-			vBox.rgb = lerp( vBox.rgb, vImage.rgb, saturate( vImage.a + ( 1 - vBox.a ) ) );
-			vBox.a = max( vBox.a, vImage.a );
+			// Alpha composite the background image over the background color (source-over, premultiplied).
+			float4 vComposited;
+			vComposited.a = vImage.a + ( 1 - vImage.a ) * vBox.a;
+			vComposited.rgb = vComposited.a > 0.0 ? ( vImage.a * vImage.rgb + ( 1 - vImage.a ) * vBox.a * vBox.rgb ) * rcp( max( vComposited.a, 1e-5 ) ) : vBox.rgb;
+			vBox = vComposited;
 		}
 		
 		o.vColor = vBox;

--- a/game/addons/base/Assets/shaders/ui_cssbox_batched.shader
+++ b/game/addons/base/Assets/shaders/ui_cssbox_batched.shader
@@ -496,8 +496,11 @@ PS
 				vImage *= bgTint;
 			#endif
 
-			col.rgb = lerp( col.rgb, vImage.rgb, saturate( vImage.a + ( 1 - col.a ) ) );
-			col.a = max( col.a, vImage.a );
+			// Alpha composite the background image over the background color (source-over, premultiplied).
+			float4 vComposited;
+			vComposited.a = vImage.a + ( 1 - vImage.a ) * col.a;
+			vComposited.rgb = vComposited.a > 0.0 ? ( vImage.a * vImage.rgb + ( 1 - vImage.a ) * col.a * col.rgb ) * rcp( max( vComposited.a, 1e-5 ) ) : col.rgb;
+			col = vComposited;
 		}
 
 		// Border image or solid border


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

While working with gradient put on top of a background color with opacity the render sbox have compared to figma was really different

## Motivation & Context

Look exactly like figma or web does

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

Before: lerp(bg.rgb, image.rgb, saturate(image.a + (1 - bg.a))) + max(bg.a, image.a) — approximate, not real compositing.

After: Standard source-over in 3 steps:

out.a = image.a + (1 - image.a) * bg.a
Premult blend: image.a * image.rgb + (1 - image.a) * bg.a * bg.rgb
Unpremult: divide RGB by out.a (with 1e-5 guard)
Image is composited over vBox (background color), then written back to vBox for border/corner processing.

## Screenshots / Videos (if applicable)

repro:
[bug_ui_alpha.zip](https://github.com/user-attachments/files/29615962/bug_ui_alpha.zip)


Before:
<img width="864" height="618" alt="image" src="https://github.com/user-attachments/assets/74427a03-507d-41b4-aa28-a2178d488d46" />

After:
<img width="819" height="560" alt="image" src="https://github.com/user-attachments/assets/bb554bfa-87e4-4a78-9714-ab80eb229a02" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂