### PR TITLE
Improved TcpChannel to stop stuttering from non async reading

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System.Collections.Concurrent;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Channels;
 
@@ -18,44 +19,38 @@ internal class TcpChannel : Connection
 
 	public bool IsConnected => client?.Connected ?? false;
 
-	async void SocketLoop( CancellationToken token )
+	async Task SocketLoop( CancellationToken token )
 	{
 		try
 		{
-			while ( !client.Connected )
+			while ( client?.Connected != true )
 			{
-				await Task.Delay( 10 );
+				await Task.Delay( 10, token );
 				token.ThrowIfCancellationRequested();
 			}
 
-			_address = client.Client.RemoteEndPoint?.ToString() ?? client.Client.LocalEndPoint.ToString();
+			_address = client?.Client?.RemoteEndPoint?.ToString() ?? client?.Client?.LocalEndPoint?.ToString() ?? "Tcp";
 
 			var stream = client.GetStream();
 
-			_ = Task.Run( async () => await SendThread( token ) );
-			_ = FakeLagProcess();
+			_ = Task.Run( async () => await SendThread( token ), token );
+			_ = Task.Run( async () => await FakeLagProcess( token ), token );
 
 			while ( !token.IsCancellationRequested )
 			{
-				while ( client.Available > 0 )
+				var header = new byte[sizeof( int )];
+				await stream.ReadExactlyAsync( header.AsMemory( 0, header.Length ), token );
+
+				var messageLength = BitConverter.ToInt32( header );
+				if ( messageLength <= 0 )
 				{
-					var header = new byte[sizeof( int )];
-					stream.ReadExactly( header );
-
-					var messageLength = BitConverter.ToInt32( header );
-					if ( messageLength <= 0 )
-					{
-						Log.Warning( "Weird stuff here" );
-						return;
-					}
-
-					var packet = new byte[messageLength];
-					stream.ReadExactly( packet );
-
-					incoming.Writer.TryWrite( packet );
+					Log.Warning( $"TcpChannel: Invalid message length {messageLength} from {Address}" );
+					break;
 				}
 
-				await Task.Delay( 1 );
+				var packet = new byte[messageLength];
+				await stream.ReadExactlyAsync( packet.AsMemory( 0, packet.Length ), token );
+				await incoming.Writer.WriteAsync( packet, token );
 			}
 		}
 		catch ( OperationCanceledException )
@@ -66,10 +61,12 @@ internal class TcpChannel : Connection
 		{
 			Log.Warning( e, $"TcpChannel: {e.Message}" );
 		}
-
-		client?.Close();
-		client?.Dispose();
-		client = null;
+		finally
+		{
+			client?.Close();
+			client?.Dispose();
+			client = null;
+		}
 	}
 
 	readonly CancellationTokenSource tokenSource;
@@ -91,13 +88,12 @@ internal class TcpChannel : Connection
 		tokenSource = new();
 		isHost = false;
 
-		SocketLoop( tokenSource.Token );
+		_ = Task.Run( () => SocketLoop( tokenSource.Token ), tokenSource.Token );
 	}
 
 	public TcpChannel( string host, int port )
 	{
 		client = new();
-		client.ConnectAsync( host, port );
 		client.ReceiveBufferSize = 1024 * 1024;
 		client.SendBufferSize = 1024 * 1024;
 		client.LingerState = new( true, 15 ); // 15 seconds is a long time, but we want reliability
@@ -105,24 +101,40 @@ internal class TcpChannel : Connection
 		tokenSource = new();
 		isHost = true;
 
-		SocketLoop( tokenSource.Token );
+		_ = Task.Run( () => ConnectAndRunAsync( host, port, tokenSource.Token ) );
 	}
 
 	~TcpChannel()
 	{
-		tokenSource.Cancel();
+		tokenSource?.Cancel();
 	}
 
 	Channel<byte[]> sendChannel = Channel.CreateUnbounded<byte[]>();
 
-	private Queue<(byte[], RealTimeUntil, NetworkSystem.MessageHandler)> fakeLagIncoming = new();
-	private Queue<(byte[], RealTimeUntil)> fakeLagOutgoing = new();
+	private ConcurrentQueue<(byte[], RealTimeUntil, NetworkSystem.MessageHandler)> fakeLagIncoming = new();
+	private ConcurrentQueue<(byte[], RealTimeUntil)> fakeLagOutgoing = new();
 
-	private async Task FakeLagProcess()
+	private async Task ConnectAndRunAsync( string host, int port, CancellationToken token )
 	{
 		try
 		{
-			while ( !tokenSource.IsCancellationRequested )
+			await client.ConnectAsync( host, port );
+			await SocketLoop( token );
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( e, $"TcpChannel connect failed: {e.Message}" );
+			client?.Close();
+			client?.Dispose();
+			client = null;
+		}
+	}
+
+	private async Task FakeLagProcess( CancellationToken token )
+	{
+		try
+		{
+			while ( !token.IsCancellationRequested )
 			{
 				var processedPacket = false;
 
@@ -130,9 +142,11 @@ internal class TcpChannel : Connection
 				{
 					if ( i.Item2 )
 					{
-						processedPacket = true;
-						InvokeMessageHandler( i.Item3, i.Item1 );
-						fakeLagIncoming.Dequeue();
+						if ( fakeLagIncoming.TryDequeue( out _ ) )
+						{
+							processedPacket = true;
+							InvokeMessageHandler( i.Item3, i.Item1 );
+						}
 					}
 				}
 
@@ -140,16 +154,22 @@ internal class TcpChannel : Connection
 				{
 					if ( o.Item2 )
 					{
-						processedPacket = true;
-						sendChannel.Writer.TryWrite( BitConverter.GetBytes( o.Item1.Length ) );
-						sendChannel.Writer.TryWrite( o.Item1 );
-						fakeLagOutgoing.Dequeue();
+						if ( fakeLagOutgoing.TryDequeue( out _ ) )
+						{
+							processedPacket = true;
+							await sendChannel.Writer.WriteAsync( BitConverter.GetBytes( o.Item1.Length ), token );
+							await sendChannel.Writer.WriteAsync( o.Item1, token );
+						}
 					}
 				}
 
 				if ( !processedPacket ) // Maybe something will be ready later?
-					await Task.Delay( 1 );
+					await Task.Delay( 1, token );
 			}
+		}
+		catch ( OperationCanceledException )
+		{
+			// normal
 		}
 		catch ( Exception e )
 		{
@@ -159,7 +179,7 @@ internal class TcpChannel : Connection
 
 	internal override void InternalSend( byte[] output, NetFlags flags )
 	{
-		if ( !client.Connected )
+		if ( client?.Connected != true )
 			return;
 
 		if ( Networking.FakePacketLoss > 0 && !flags.HasFlag( NetFlags.Reliable ) )
@@ -197,13 +217,21 @@ internal class TcpChannel : Connection
 		{
 			while ( !token.IsCancellationRequested )
 			{
-				await sendChannel.Reader.WaitToReadAsync();
+				await sendChannel.Reader.WaitToReadAsync( token );
 
-				if ( !sendChannel.Reader.TryRead( out byte[] data ) )
+				if ( client?.Connected != true || !sendChannel.Reader.TryRead( out byte[] data ) )
 					continue;
 
-				client.GetStream().Write( data );
-				MessagesSent++;
+				var writeStream = client.GetStream();
+				try
+				{
+					await writeStream.WriteAsync( data, token );
+					MessagesSent++;
+				}
+				catch ( System.IO.IOException )
+				{
+					continue;
+				}
 			}
 		}
 		catch ( OperationCanceledException )
@@ -219,6 +247,7 @@ internal class TcpChannel : Connection
 	internal override void InternalClose( int closeCode, string closeReason )
 	{
 		tokenSource.Cancel();
+		tokenSource.Dispose();
 		GC.SuppressFinalize( this );
 	}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

While I was testing #11359 I found that sending too much data at once froze the clients even though it should have been in a thread, turns out the steam side is however the Tcp side isn't. This fixes that.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

With #11193 being merged I have been running my network testing code on it and I have found that running over the tcp socket is sometimes causing the main thread to lag while reading. 

## Implementation Details

I have tried to stay as close to how SteamConnections does it so you can expect the same experience between the two.

## Screenshots / Videos (if applicable)

Before: https://youtu.be/4XGdUtPUu88
After: https://youtu.be/_ZJ-pPIB8Zw

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂