### PR TITLE
Joining snapshot now hides non always transmit objects if applicable

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
@@ -392,6 +392,7 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 	internal readonly LocalSnapshotState LocalSnapshotState = new();
 
 	private readonly HashSet<Guid> _culledConnections = [];
+	private readonly HashSet<Guid> _createMessageConnections = [];
 	private readonly Dictionary<Guid, CullState> _cullStates = new();
 	private readonly SnapshotValueCache _snapshotCache = new();
 	private TimeUntil _nextUpdateCachedBounds;
@@ -410,6 +411,7 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 	{
 		LocalSnapshotState.RemoveConnection( id );
 		_culledConnections.Remove( id );
+		_createMessageConnections.Remove( id );
 		_cullStates.Remove( id );
 	}
 
@@ -428,6 +430,7 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 	private void ClearConnections()
 	{
 		LocalSnapshotState.ClearConnections();
+		_createMessageConnections.Clear();
 	}
 
 	bool IDeltaSnapshot.ShouldTransmit( Connection target )
@@ -446,6 +449,7 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 				if ( !_culledConnections.Remove( target.Id ) )
 					continue;
 
+				EnsureCreateMessageSent( target );
 				GameObject.Network.SetCullState( target, false );
 			}
 
@@ -496,6 +500,7 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 
 				LocalSnapshotState.RemoveConnection( target.Id );
 				GameObject.Network.SetCullState( target, false );
+				EnsureCreateMessageSent( target );
 
 				shouldTransmitToAny = true;
 				state.Culled = false;
@@ -519,11 +524,32 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 	}
 
 	/// <summary>
+	/// Ensure that a create message has been sent to the specified <see cref="Connection"/>. If it has not, then send it.
+	/// </summary>
+	/// <param name="target"></param>
+	internal void EnsureCreateMessageSent( Connection target )
+	{
+		if ( !_createMessageConnections.Add( target.Id ) )
+			return;
+
+		target.SendMessage( GetCreateMessage() );
+	}
+
+	/// <summary>
+	/// Mark that a create message has been sent to the specified <see cref="Connection"/>.
+	/// </summary>
+	/// <param name="target"></param>
+	internal void MarkCreateMessageSent( Connection target )
+	{
+		_createMessageConnections.Add( target.Id );
+	}
+
+	/// <summary>
 	/// Is this network object visible to the provided <see cref="Connection"/>. We'll check if we
 	/// have a culler component and use that, but we'll also use our bounds to determine if we're
 	/// visible.
 	/// </summary>
-	private bool IsVisible( Connection target, BBox worldBounds )
+	internal bool IsVisible( Connection target, BBox worldBounds )
 	{
 		// Do we have a INetworkVisible? We're going to let that take priority.
 		var go = GameObject;

--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -159,7 +159,14 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 			var networkObject = BatchSpawnList.FirstOrDefault();
 
 			if ( !(networkObject.GameObject?.IsDestroyed ?? true) )
+			{
 				Broadcast( networkObject.GetCreateMessage() );
+
+				foreach ( var recipient in GetFilteredConnections() )
+				{
+					networkObject.MarkCreateMessageSent( recipient );
+				}
+			}
 
 			BatchSpawnList.Clear();
 			return;
@@ -177,9 +184,21 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		}
 
 		msg.CreateMsgs = list.ToArray();
-		BatchSpawnList.Clear();
 
 		Broadcast( msg );
+
+		foreach ( var networkObject in BatchSpawnList )
+		{
+			if ( networkObject.GameObject?.IsDestroyed ?? true )
+				continue;
+
+			foreach ( var recipient in GetFilteredConnections() )
+			{
+				networkObject.MarkCreateMessageSent( recipient );
+			}
+		}
+
+		BatchSpawnList.Clear();
 	}
 
 	/// <summary>
@@ -201,6 +220,11 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		}
 
 		Broadcast( networkObject.GetCreateMessage() );
+
+		foreach ( var recipient in GetFilteredConnections() )
+		{
+			networkObject.MarkCreateMessageSent( recipient );
+		}
 	}
 
 	/// <summary>
@@ -290,15 +314,23 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 			NetworkObjects = new List<object>( 64 )
 		};
 
-		GetSnapshot( default, ref snapshot );
+		GetSnapshot( connection, ref snapshot );
 		output.Snapshot = snapshot;
+
+		foreach ( var networkObjectData in snapshot.NetworkObjects )
+		{
+			if ( networkObjectData is not ObjectCreateMsg createMessage )
+				continue;
+
+			var networkGameObject = activeScene.Directory.FindByGuid( createMessage.Guid );
+			networkGameObject?._net?.MarkCreateMessageSent( connection );
+		}
 
 		var bs = ByteStream.Create( 256 );
 		bs.Write( InternalMessageType.Packed );
 
 		Networking.System.Serialize( output, ref bs );
 		connection.SendStream( bs );
-
 		bs.Dispose();
 	}
 
@@ -395,7 +427,7 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 
 		using ( analytic.ScopeTimer( "NetworkObjectTime" ) )
 		{
-			Game.ActiveScene.SerializeNetworkObjects( msg.NetworkObjects );
+			Game.ActiveScene.SerializeNetworkObjects( source, msg.NetworkObjects );
 		}
 
 		var systems = Game.ActiveScene.GetSystems();

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
@@ -78,11 +78,36 @@ public partial class Scene : GameObject
 		system.DeltaSnapshots.Tick();
 	}
 
-	internal void SerializeNetworkObjects( List<object> collection )
+	internal void SerializeNetworkObjects( Connection source, List<object> collection )
 	{
 		foreach ( var target in networkedObjects )
 		{
-			collection.Add( target.GetCreateMessage() );
+			if ( target.GameObject?.IsDestroyed ?? true )
+			{
+				continue;
+			}
+
+			if ( source is null )
+			{
+				collection.Add( target.GetCreateMessage() );
+				continue;
+			}
+
+			if ( target.GameObject.Network.AlwaysTransmit || target.GameObject.NetworkMode == NetworkMode.Snapshot )
+			{
+				collection.Add( target.GetCreateMessage() );
+				continue;
+			}
+
+			var go = target.GameObject;
+			var worldBounds = go.GetLocalBounds() + go.WorldPosition;
+			var rootNetworkObject = target.RootNetworkObject;
+			IDeltaSnapshot root = rootNetworkObject != target ? rootNetworkObject : null;
+
+			if ( (root?.ShouldTransmit( source ) ?? false) || target.IsVisible( source, worldBounds ) )
+			{
+				collection.Add( target.GetCreateMessage() );
+			}
 		}
 	}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This is fundamentally trying to fix a workflow problem: when you "hide" an object from a client, the expectation is that the client doesn't have the object at all, not that it still exists in their world but happens to be invisible. INetworkVisible should prevent the object from ever reaching clients for whom it's false, rather than leaking it to them via the initial snapshot packet.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes #10938 / Implements #10938

## Implementation Details

Overall this is how it should have been to begin with however if someone is relying on behavior of the object existing on the client regardless of if this is true or false might have a problem however I had a look at a few of the gamemode's and they aren't even using this feature so I think we are okay.

The other solution to this was just to drop all of the sync var's but I thought in general it just makes sense to not have objects on the client that aren't meant to be there, dependent on how its setup per gamemode it could actually reduce the amount of objects.

This does require tracking who knows about what object however that shouldn't be a problem as its all guid's anyways

## Screenshots / Videos (if applicable)

Before: https://www.youtube.com/watch?v=2wtvSZDVpuc
After: https://www.youtube.com/watch?v=XQDwPhpbg70

```csharp
using Sandbox;
using static Sandbox.Component;

public sealed class TestNetworkVisible : Component, INetworkVisible
{
	public TestNetworkVisible()
	{
		Log.Info( "TestNetworkVisible created" );
	}

	protected override void OnAwake()
	{
		base.OnAwake();

		Log.Info( "TestNetworkVisible awake" );
	}

	[ConVar( "test_network_visible_debug" )]
	public static bool TestNetworkVisibleDebug { get; set; }

	public bool IsVisibleToConnection( Connection connection, in BBox worldBounds )
	{
		return TestNetworkVisibleDebug;
	}
}
```

The object that you put this on has to be network object + have AlwaysTransmit turned off. 

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂