### PR TITLE
Preserve DontDestroyOnLoad survivors hierarchy during non-additive scene loads

### DIFF
--- a/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.LoadSave.cs
@@ -59,9 +59,22 @@ public partial class Scene : GameObject
 				// get all the gameobjects that should survive
 				var savedObjects = GetAllObjects( false ).Where( x => x.Flags.Contains( GameObjectFlags.DontDestroyOnLoad ) );
 
-				// move them to the scene root
+				// move only DontDestroyOnLoad roots that are not already under another DontDestroyOnLoad ancestor to the scene root
 				foreach ( var saved in savedObjects )
 				{
+					bool hasSurvivingAncestor = false;
+					for ( var parent = saved.Parent; parent != this; parent = parent.Parent )
+					{
+						if ( parent?.Flags.Contains( GameObjectFlags.DontDestroyOnLoad ) == true )
+						{
+							hasSurvivingAncestor = true;
+							break;
+						}
+					}
+
+					if ( hasSurvivingAncestor )
+						continue;
+
 					saved.SetParent( this );
 				}
 

--- a/engine/Tests/Sandbox.Test.Engine/Scene/Core/SceneLoadSave.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Scene/Core/SceneLoadSave.cs
@@ -149,6 +149,68 @@ public class SceneLoadSaveTest : SceneTest
 	}
 
 	/// <summary>
+	/// When both parent and child are flagged DontDestroyOnLoad, the hierarchy is
+	/// preserved across a non-additive scene load instead of flattening both objects
+	/// to the scene root.
+	/// </summary>
+	[TestMethod]
+	public void NonAdditiveLoadPreservesSurvivorHierarchy()
+	{
+		var scene = new Scene();
+		using var sceneScope = scene.Push();
+
+		var survivorParent = scene.CreateObject();
+		survivorParent.Name = "Survivor Parent";
+		survivorParent.Flags |= GameObjectFlags.DontDestroyOnLoad;
+
+		var survivorChild = new GameObject( survivorParent, name: "Survivor Child" );
+		survivorChild.Flags |= GameObjectFlags.DontDestroyOnLoad;
+
+		var sceneFile = MakeSceneFile( "loadsave_survivor_hierarchy.scene", "Loaded Object" );
+
+		Assert.IsTrue( scene.Load( MakeOptions( sceneFile ) ) );
+
+		Assert.IsTrue( survivorParent.IsValid );
+		Assert.IsTrue( survivorChild.IsValid );
+		Assert.AreEqual( scene, survivorParent.Parent );
+		Assert.AreEqual( survivorParent, survivorChild.Parent );
+		Assert.AreEqual( 1, scene.Directory.FindByName( "Loaded Object" ).Count() );
+
+		scene.Destroy();
+	}
+
+	/// <summary>
+	/// A DontDestroyOnLoad object that already has a DontDestroyOnLoad ancestor keeps its hierarchy intact.
+	/// </summary>
+	[TestMethod]
+	public void NonAdditiveLoadPreservesNestedSurvivorHierarchy()
+	{
+		var scene = new Scene();
+		using var sceneScope = scene.Push();
+
+		var survivorParent = scene.CreateObject();
+		survivorParent.Name = "Survivor Parent";
+		survivorParent.Flags |= GameObjectFlags.DontDestroyOnLoad;
+
+		var middle = new GameObject( survivorParent, name: "Middle" );
+		var survivorChild = new GameObject( middle, name: "Survivor Child" );
+		survivorChild.Flags |= GameObjectFlags.DontDestroyOnLoad;
+
+		var sceneFile = MakeSceneFile( "loadsave_nested_survivor_hierarchy.scene", "Loaded Object" );
+
+		Assert.IsTrue( scene.Load( MakeOptions( sceneFile ) ) );
+
+		Assert.IsTrue( survivorParent.IsValid );
+		Assert.IsTrue( survivorChild.IsValid );
+		Assert.AreEqual( scene, survivorParent.Parent );
+		Assert.AreEqual( survivorParent, middle.Parent );
+		Assert.AreEqual( middle, survivorChild.Parent );
+		Assert.AreEqual( 1, scene.Directory.FindByName( "Loaded Object" ).Count() );
+
+		scene.Destroy();
+	}
+
+	/// <summary>
 	/// DeleteEverything overrides DontDestroyOnLoad - nothing survives the load.
 	/// </summary>
 	[TestMethod]


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

When the scene looks for DontDestroyOnLoad objects to save when the map changes, it does not take into account that it could be under another DontDestroyOnLoad gameobject which means it would unintentionally put it under scene root even though it would have survived anyway all we do is lose the parent of that object.

This checks if the parent(s) of that object are already DontDestroyOnLoad and if so it doesn't reset them to scene root

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #2374

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

This only does the root DontDestroyOnLoad elements because the expectation that anything under a DontDestroyOnLoad gameobject will survive so we don't have to do anything special.

I had to make it do a look up the chain of parents due to a situation where we have a 
DontDestroyOnLoad GameObject  -> GameObject -> DontDestroyOnLoad GameObject 

The last GameObject would have been set at object root if I had just checked the parent 

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Before: https://youtu.be/E8HKvSVCVv4
After: https://youtu.be/XqSLROrtaHM

Project is in this issue #2374

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂