### PR TITLE
[Terrain] Add option to ShowGrid + show it not only on paint tool

### DIFF
--- a/game/addons/tools/Code/Scene/Terrain/BrushSettings.cs
+++ b/game/addons/tools/Code/Scene/Terrain/BrushSettings.cs
@@ -6,6 +6,7 @@ public class BrushSettings
 	[Property, Range( 0.0f, 1.0f ), Step( 0.01f ), WideMode] public float Opacity { get; set; } = 0.5f;
 	[Property, Range( 0, 360 ), Step( 1 ), WideMode] public float Rotation { get; set; } = 0;
 	[Property] public bool RandomRotation { get; set; } = false;
+	[Property, Title( "Show Grid" )] public bool ShowGridPreview { get; set; } = true;
 }
 
 public class BrushSettingsWidgetWindow : WidgetWindow

--- a/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
@@ -83,6 +83,7 @@ public partial class TerrainEditorTool : EditorTool
 			var rot = group.Add( ControlSheetRow.Create( so.GetProperty( nameof( BrushSettings.Rotation ) ) ) );
 			rot.Enabled = !BrushSettings.RandomRotation;
 			var rndRot = group.Add( ControlSheetRow.Create( so.GetProperty( nameof( BrushSettings.RandomRotation ) ) ) );
+			group.Add( ControlSheetRow.Create( so.GetProperty( nameof( BrushSettings.ShowGridPreview ) ) ) );
 
 			so.OnPropertyChanged += ( prop ) =>
 			{
@@ -194,7 +195,7 @@ public partial class TerrainEditorTool : EditorTool
 		_previewObject.Color = color;
 		_previewObject.BrushRotation = BrushSettings.Rotation;
 
-		if ( terrain?.Storage is not null )
+		if ( BrushSettings.ShowGridPreview && terrain?.Storage is not null )
 		{
 			var tx = terrain.WorldTransform;
 			_previewObject.CellSize = terrain.Storage.TerrainSize / terrain.Storage.Resolution;
@@ -225,11 +226,18 @@ public partial class TerrainEditorTool : EditorTool
 			_previewObject.Color = color.WithAlpha( 0 );
 			_previewObject.BrushRotation = BrushSettings.Rotation;
 
-			var ttx = terrain.WorldTransform;
-			_previewObject.CellSize = terrain.Storage.TerrainSize / terrain.Storage.Resolution;
-			_previewObject.TerrainOrigin = ttx.Position;
-			_previewObject.TerrainRight = ttx.Rotation.Right;
-			_previewObject.TerrainForward = ttx.Rotation.Forward;
+			if ( BrushSettings.ShowGridPreview )
+			{
+				var ttx = terrain.WorldTransform;
+				_previewObject.CellSize = terrain.Storage.TerrainSize / terrain.Storage.Resolution;
+				_previewObject.TerrainOrigin = ttx.Position;
+				_previewObject.TerrainRight = ttx.Rotation.Right;
+				_previewObject.TerrainForward = ttx.Rotation.Forward;
+			}
+			else
+			{
+				_previewObject.CellSize = 0f;
+			}
 		}
 		else if ( _previewObject != null )
 		{

--- a/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
@@ -109,7 +109,7 @@ public abstract class BaseBrushTool : EditorTool
 			SceneOverlay.Parent.Cursor = CursorShape.Blank;
 
 			DrawBrushAdjustText();
-			DrawBrushPreviewAt( _lastHitWorldPos, _lastHitTx );
+			DrawBrushPreviewAt( _lastHitWorldPos, _lastHitTx, terrain );
 			return;
 		}
 		else
@@ -162,7 +162,7 @@ public abstract class BaseBrushTool : EditorTool
 			OnPaintEnded( terrain );
 		}
 
-		DrawBrushPreviewAt( _lastHitWorldPos, _lastHitTx, PaintMode ? terrain : null );
+		DrawBrushPreviewAt( _lastHitWorldPos, _lastHitTx, terrain );
 	}
 
 	void DrawBrushPreviewAt( Vector3 worldPos, Transform tx, Terrain terrain = null )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
It was frustrating for my mappers to not seeing the grid when smooth / raise / lower


## Motivation & Context


Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

So i added a option to toggle and fix occurrences where terrain wasnt passed to `DrawBrushPreviewAt` everytime
so now it's always passed and we verify if we draw grid there instead of only when paint mode

## Screenshots / Videos (if applicable)
<img width="504" height="87" alt="image" src="https://github.com/user-attachments/assets/8e63f966-b18e-4c98-898b-615f56fc7b55" />

<img width="1914" height="1226" alt="image" src="https://github.com/user-attachments/assets/9c671373-14c2-446e-9822-54eabe3f4832" />

<img width="1901" height="1134" alt="image" src="https://github.com/user-attachments/assets/2a79a584-76b3-4f0e-8b72-d8d9c8285671" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂