### PR TITLE
[Terrain] QOL on editor tool

### DIFF
--- a/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
@@ -92,7 +92,8 @@ public partial class TerrainEditorTool : EditorTool
 		}
 
 		// Paint-only sections — hidden unless PaintTextureTool is active
-		var paintOnlySection = new PaintOnlySectionWidget( this, opacityRow );
+		var sidebarStretch = new Widget( sidebar ) { VerticalSizeMode = SizeMode.Flexible };
+		var paintOnlySection = new PaintOnlySectionWidget( this, opacityRow, sidebarStretch );
 		{
 			// Material selection
 			var terrain = GetSelectedComponent<Terrain>() ?? Scene.Get<Terrain>();
@@ -100,12 +101,12 @@ public partial class TerrainEditorTool : EditorTool
 			if ( terrain.IsValid() )
 			{
 				var group = ToolSidebarWidget.CreateGroupWidget( "Materials", SizeMode.Flexible );
-				paintOnlySection.Layout.Add( group );
+				paintOnlySection.Layout.Add( group, 1 );
 
 				var materialList = new TerrainMaterialList( paintOnlySection, terrain );
 				materialList.ItemSize += 24;
 				materialList.BuildItems();
-				group.ContentLayout.Add( materialList );
+				group.ContentLayout.Add( materialList, 1 );
 
 				var hlayout = group.ContentLayout.AddRow();
 				hlayout.Spacing = 8;
@@ -132,16 +133,17 @@ public partial class TerrainEditorTool : EditorTool
 				hlayout.Add( newTerrainMat, 1 );
 			}
 
-			sidebar.Layout.Add( paintOnlySection );
+			sidebar.Layout.Add( paintOnlySection, 1 );
+			sidebar.Layout.Add( sidebarStretch, 1 );
 		}
 
-		sidebar.Layout.AddStretchCell();
 		SetOpacityToolTip( opacityRow );
 
 		sidebar.AddShortcuts(
 			("Adjust Size", "Shift+MMB ↔"),
 			("Adjust Opacity", "Shift+MMB ↕"),
-			("Rotate", "CTRL+MMB ↔")
+			("Rotate", "CTRL+MMB ↔"),
+			("Switch brush preview", "Capslock")
 			);
 
 		return sidebar;
@@ -280,13 +282,16 @@ internal class PaintOnlySectionWidget : Widget
 {
 	readonly TerrainEditorTool _tool;
 	readonly ControlSheetRow _opacityRow;
+	readonly Widget _sidebarStretch;
 
-	public PaintOnlySectionWidget( TerrainEditorTool tool, ControlSheetRow opacityRow ) : base( null )
+	public PaintOnlySectionWidget( TerrainEditorTool tool, ControlSheetRow opacityRow, Widget sidebarStretch ) : base( null )
 	{
 		_tool = tool;
 		_opacityRow = opacityRow;
+		_sidebarStretch = sidebarStretch;
 		Layout = Layout.Column();
 		Layout.Spacing = 2;
+		VerticalSizeMode = SizeMode.Flexible;
 	}
 
 	[EditorEvent.Frame]
@@ -294,6 +299,9 @@ internal class PaintOnlySectionWidget : Widget
 	{
 		bool isPaint = _tool.CurrentTool is PaintTextureTool;
 		Hidden = !isPaint;
+
+		if ( _sidebarStretch.IsValid() )
+			_sidebarStretch.Hidden = isPaint;
 
 		if ( !_opacityRow.IsValid() ) return;
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Fix material part that didnt stretch vertically
Add shortcut for caps lock

## Motivation & Context

I have really many materials on my terrain but sometimes with DPI scaling, it's hard to see all of them, and getting it streach
and also cause i discover lately the capslock shortcut so better show it too

## Implementation Details
- Give the Materials group and list flex weight (1) so they grow inside the paint-only section.
- Replace the global AddStretchCell() with a toggleable sidebarStretch spacer that swaps with the paint section:
   - Paint Texture active → paintOnlySection grows, stretch hidden → Materials fills the panel.
   - Any other subtool → paint section hidden, stretch visible → compact layout, Shortcuts pinned to the bottom (same as before).

## Screenshots / Videos (if applicable)
Before:
<img width="465" height="1197" alt="image" src="https://github.com/user-attachments/assets/44b35758-6288-4dd3-a81d-e3ee3a7493cf" />
After:
<img width="627" height="2254" alt="image" src="https://github.com/user-attachments/assets/f1d6d2ec-550e-4f36-b786-3ce9f23d694e" />
(it's normal if it's errored lol)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂