### PR TITLE
BaseFileSystem.FileExists returns false instead of exception on null/empty path

### DIFF
--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -139,9 +139,9 @@ public class BaseFileSystem
 	/// </summary>
 	public bool FileExists( string path )
 	{
-		ArgumentNullException.ThrowIfNullOrEmpty( path, "path" );
 		Assert.NotNull( system );
 
+		if ( string.IsNullOrEmpty( path ) ) return false;
 		if ( path.Contains( ":" ) ) return false;
 
 		return system.FileExists( FixPath( path ) );


### PR DESCRIPTION
## Summary
Modifies `BaseFileSystem.FileExists` to return false instead of throwing an exception when given a null or empty path.

## Motivation & Context
I feel a null path can pretty safely be considered to not exist, and it seemed pointless to need to specifically check for that. Throwing an exception seems harsh.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂