### PR TITLE
[Particles] Improve FaceVelocity and add Stretch Velocity

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
@@ -27,6 +27,10 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 	Rotation WorldRotation { get; }
 	bool FaceVelocity { get; }
 	float RotationOffset { get; }
+
+	// Stretches the sprite along its vertical axis based on velocity, overridden by renderers that expose it
+	bool Stretch => false;
+
 	bool MotionBlur { get; }
 	bool LeadingTrail { get; }
 	float BlurAmount { get; }
@@ -45,8 +49,8 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 	BillboardAlignment Alignment { get; }
 
 	// Stretch scaling, overridden by renderers that expose them
-	float SpeedScale => 0.0f;
-	float Length => 1.0f;
+	float StretchSpeedScale => 0.0f;
+	float StretchScale => 1.0f;
 
 	/// <summary>
 	/// Result of particle processing operation
@@ -79,6 +83,9 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 		// facing the camera
 		var isVelocityAligned = Alignment == BillboardAlignment.LookAtCamera && FaceVelocity;
 		var billboardModeUint = isVelocityAligned ? VelocityAlignedBillboardMode : (uint)(SpriteRenderer.BillboardMode)Alignment;
+		var stretchEnabled = Stretch;
+		var stretchSpeedScale = StretchSpeedScale;
+		var stretchScale = StretchScale;
 
 		var blurAmountRemapped = BlurAmount.Remap( 0, 1, 0, 6, false );
 		var blurSpacingRemapped = BlurSpacing.Remap( 0, 1, 0, 1, false );
@@ -148,6 +155,12 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 				if ( Type == ParticleType.Text || (sequenceData == Vector4.Zero && aspect != 1) )
 				{
 					scaleX *= aspect;
+				}
+
+				if ( stretchEnabled )
+				{
+					// Stretch along the velocity: proportional to size, plus proportional to speed
+					scaleY = scaleY * stretchScale + vel.Length * stretchSpeedScale;
 				}
 
 				float halfSize = MathF.Max( pivotMaxX * 2f * scaleX, pivotMaxY * 2f * scaleY );

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
@@ -16,6 +16,10 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 		Text
 	}
 
+	// GPU billboard mode for the velocity aligned billboard used by FaceVelocity, sits after
+	// the SpriteRenderer.BillboardMode values and is matched by the sprite shaders
+	const uint VelocityAlignedBillboardMode = 4;
+
 	ParticleType Type => ParticleType.Sprite;
 	ParticleEffect ParticleEffect { get; }
 	float Scale { get; }
@@ -39,6 +43,10 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 
 	// Additional properties needed for some renderers
 	BillboardAlignment Alignment { get; }
+
+	// Stretch scaling, overridden by renderers that expose them
+	float SpeedScale => 0.0f;
+	float Length => 1.0f;
 
 	/// <summary>
 	/// Result of particle processing operation
@@ -66,8 +74,11 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 		// Precompute constants
 		var scale = MathF.Abs( (Scale / 2f) * WorldScale.x );
 		var objectAngles = WorldRotation;
-		var billboardModeUint = (uint)(SpriteRenderer.BillboardMode)Alignment;
 		var isObjectAlignment = Alignment == BillboardAlignment.Object;
+		// LookAtCamera with FaceVelocity aligns the sprite's vertical axis to the 3D velocity while still
+		// facing the camera
+		var isVelocityAligned = Alignment == BillboardAlignment.LookAtCamera && FaceVelocity;
+		var billboardModeUint = isVelocityAligned ? VelocityAlignedBillboardMode : (uint)(SpriteRenderer.BillboardMode)Alignment;
 
 		var blurAmountRemapped = BlurAmount.Remap( 0, 1, 0, 6, false );
 		var blurSpacingRemapped = BlurSpacing.Remap( 0, 1, 0, 1, false );

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
@@ -110,6 +110,8 @@ public sealed partial class ParticleSpriteRenderer : ParticleRenderer, Component
 
 	/// <summary>
 	/// Aligns the sprite to face its velocity direction.
+	/// With LookAtCamera aligns the sprite's vertical axis to the particle's 3D velocity while still facing the camera,
+	/// other alignments rotate the sprite in screen space.
 	/// </summary>
 	[Property, ToggleGroup( "FaceVelocity" ), Order( 2 )]
 	public bool FaceVelocity { get; set; }

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
@@ -154,6 +154,26 @@ public sealed partial class ParticleSpriteRenderer : ParticleRenderer, Component
 	public float BlurOpacity { get; set; } = 0.5f;
 
 	/// <summary>
+	/// Stretches the sprite along its vertical axis based on the particle's velocity. Great for muzzle flashes
+	/// and other fast moving particles. Pair with <see cref="FaceVelocity"/> so the vertical axis follows the
+	/// direction of motion.
+	/// </summary>
+	[Property, ToggleGroup( "Stretch Velocity" ), Order( 4 )]
+	public bool Stretch { get; set; }
+
+	/// <summary>
+	/// Stretches particles proportionally to their speed. Set to 0 for constant stretching.
+	/// </summary>
+	[Property, ToggleGroup( "Stretch Velocity" ), Range( 0, 1 )]
+	public float StretchSpeedScale { get; set; } = 0.0f;
+
+	/// <summary>
+	/// Scale of the stretching of
+	/// </summary>
+	[Property, ToggleGroup( "Stretch Velocity" ), Range( 0, 2 )]
+	public float StretchScale { get; set; } = 1.0f;
+
+	/// <summary>
 	/// The animation that is currently being played. Returns null if no sprite is set or the sprite has no animations.
 	/// </summary>
 	public Sprite.Animation CurrentAnimation => _sprite?.GetAnimation( _currentAnimationIndex );

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/ParticleSpriteRenderer.cs
@@ -158,19 +158,19 @@ public sealed partial class ParticleSpriteRenderer : ParticleRenderer, Component
 	/// and other fast moving particles. Pair with <see cref="FaceVelocity"/> so the vertical axis follows the
 	/// direction of motion.
 	/// </summary>
-	[Property, ToggleGroup( "Stretch Velocity" ), Order( 4 )]
+	[Property, ToggleGroup( "Stretch" ), Order( 4 )]
 	public bool Stretch { get; set; }
 
 	/// <summary>
 	/// Stretches particles proportionally to their speed. Set to 0 for constant stretching.
 	/// </summary>
-	[Property, ToggleGroup( "Stretch Velocity" ), Range( 0, 1 )]
+	[Property, ToggleGroup( "Stretch" ), Range( 0, 1 )]
 	public float StretchSpeedScale { get; set; } = 0.0f;
 
 	/// <summary>
 	/// Scale of the stretching of
 	/// </summary>
-	[Property, ToggleGroup( "Stretch Velocity" ), Range( 0, 2 )]
+	[Property, ToggleGroup( "Stretch" ), Range( 0, 2 )]
 	public float StretchScale { get; set; } = 1.0f;
 
 	/// <summary>

--- a/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
@@ -164,8 +164,9 @@ CS
 		// Transfer sprite to out buffer
 		if(isValid)
 		{
-			if ( sprite.RotationOffset > -1 )
-			{	
+			// Velocity aligned billboards apply the rotation offset in the vertex shader instead
+			if ( sprite.RotationOffset > -1 && sprite.BillboardMode != 4 )
+			{
 				float4 ss = mul( g_matWorldToView, float4( sprite.Velocity, 0 ) );
 				ss.z = 0;
 				ss = normalize( ss );

--- a/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
@@ -174,6 +174,56 @@ VS
 		return transform;
 	}
 
+	// Velocity aligned billboard - the sprite's vertical axis is aligned to the particle
+	// velocity and the sprite rotates around it to face the camera
+	float4x4 BuildVelocityAlignedBillboardMatrix(float3 position, float3 velocity, float3 scale, float2 offset, float rollDegrees)
+	{
+		float3 stretchAxis = normalize(velocity);
+
+		// Face the camera position - orthographic cameras have no useful position, use the view direction
+		bool isOrthographic = g_matViewToProjection[3].w != 0.0f;
+		float3 viewDir = isOrthographic ? g_vCameraDirWs : (position - g_vCameraPositionWs);
+
+		// Project the view direction onto the plane perpendicular to the velocity
+		viewDir -= stretchAxis * dot(viewDir, stretchAxis);
+		float viewLength = length(viewDir);
+
+		if (viewLength < 0.001)
+		{
+			// Camera is on the velocity axis, pick any perpendicular direction
+			float3 reference = abs(stretchAxis.x) < 0.9 ? float3(1, 0, 0) : float3(0, 0, 1);
+			viewDir = normalize(cross(stretchAxis, reference));
+		}
+		else
+		{
+			viewDir = viewDir / viewLength;
+		}
+
+		float3 billboardRight = normalize(cross(stretchAxis, -viewDir));
+		float3 billboardUp = stretchAxis;
+		float3 billboardForward = -viewDir;
+
+		// Apply Z/Roll rotation around the view axis
+		if (rollDegrees != 0)
+		{
+			float3x3 zRotation = MatrixBuildRotationAboutAxis(viewDir, rollDegrees);
+			billboardRight = mul(zRotation, billboardRight);
+			billboardUp = mul(zRotation, billboardUp);
+		}
+
+		// Apply offset in billboard space
+		float3 offsetPos = position + GetSpriteOffset(offset, -billboardRight, -billboardUp, scale);
+
+		// Build transformation matrix
+		float4x4 transform;
+		transform[0] = float4(billboardRight * scale.x, 0);
+		transform[1] = float4(billboardUp * scale.y, 0);
+		transform[2] = float4(billboardForward * scale.z, 0);
+		transform[3] = float4(offsetPos, 1);
+
+		return transform;
+	}
+
 	PixelInput MainVs( uint vertexIndex : SV_VertexID, uint instanceID : SV_InstanceID )
 	{
 		SpriteVertex v = Vertices[vertexIndex];
@@ -194,6 +244,19 @@ VS
 		{
 			scale.y *= -1;
 			transform = BuildBillboardMatrix(position, sprite.Rotation, scale, sprite.Offset, true);
+		}
+		else if (billboardMode == 4) // Face velocity - align vertical axis to velocity, face camera
+		{
+			if (dot(sprite.Velocity, sprite.Velocity) > 0.001)
+			{
+				scale.y *= -1;
+				transform = BuildVelocityAlignedBillboardMatrix(position, sprite.Velocity, scale, sprite.Offset, max(sprite.RotationOffset, 0));
+			}
+			else
+			{
+				// Not moving - fall back to a regular billboard
+				transform = BuildBillboardMatrix(position, sprite.Rotation, scale, sprite.Offset, false);
+			}
 		}
 		else // No billboard - use full rotation
 		{


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
The issue we had is that FaceCamera alignement was just rotating the particle but it make FaceVelocity broke
And also while digging that i found out that for muzzle a Stretch thing could be good as a new option

## Motivation & Context

It let us do muzzleflash effect much better

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

When FaceVelocity is enabled with LookAtCamera, it now does a propper 3D velocity-aligned billboard instead of the screen-space roll through `BuildVelocityAlignedBillboardMatrix` (thx jean claude for the BuildStretchedBillboardMatrix ngl it helped me a lot). To acheive that i made a new billboard mode `VelocityAlignedBillboardMode = 4`
RotationOffset still works in this mode but i moved it's application to the vertex shader when we're billboard mode 4

Then i also added a StretchVelocity option that Simply modify scaleY to stretch our sprite

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/3fa31862-3166-4fb4-9150-02fe2027560a

https://github.com/user-attachments/assets/98ef8b1e-90d4-47f2-bd8b-bf7f78863f47




## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂