### PR TITLE
Switch inspector to in-game version of gameobject when entering play mode

### DIFF
--- a/game/addons/tools/Code/Scene/GameObjectInspector/GameObjectInspector.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/GameObjectInspector.cs
@@ -145,6 +145,14 @@ public class GameObjectInspector : InspectorWidget
 		base.OnContextMenu( e );
 	}
 
+	[Event( "scene.play" )]
+	public void OnScenePlay()
+	{
+		// Try to switch to the game version of the object
+		var id = SerializedObject.GetProperty( nameof( GameObject.Id ) ).GetValue<Guid>();
+		EditorUtility.InspectorObject = Game.ActiveScene.Directory.FindByGuid( id );
+	}
+
 	[EditorEvent.Frame]
 	public void Frame()
 	{


### PR DESCRIPTION
## Summary
Previously if a GameObject was displayed in the inspector but not selected in the hierarchy the inspector would continue displaying the editor version of the object when entering play mode (so that any changes made would be reflected in the hidden editor scene and not the game scene). `GameObjectInspector` now actively attempts to switch to the correct object in the new scene rather than relying on the hierarchy selection changing so it works even if the object isn't selected.

## Motivation & Context
Always a bit annoying to accidentally edit the editor version of an object while in play mode

## Implementation Details
After the scene is loaded `GameObjectInspector` attempts to find its current gameobject in the new scene by guid. If it is successful it switches seamlessly to the in-game version, if it can't find the object the inspector is cleared.

## Video

https://github.com/user-attachments/assets/b4e19472-6ce7-4bca-809b-a340bd172dc5


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂