### PR TITLE
Nicer gizmos for GameObject bones

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
@@ -323,6 +323,8 @@ public partial class GameObject
 			Gizmo.Hitbox.Sphere( new Sphere( 0, bsize ) );
 			foreach ( var child in Children )
 			{
+				if ( !child.Flags.Contains( GameObjectFlags.Bone ) )
+					return;
 				if ( DrawBoneAsBip( child.Name, Name ) )
 					continue;
 				bip = false;

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
@@ -216,6 +216,69 @@ public partial class GameObject
 		}
 	}
 
+	// Used to deterimine if a bone gizmo should be drawn as a bip or a bone
+	static string[] _nonBipWhitelist = [
+		"pelvis", "hips", "spine", "ribcage", "head", "neck",
+		"shoulder", "collar", "clavicle", "arm", "elbow",
+		"hand", "wrist", "palm", "finger", "digit",
+		"meta", "index", "middle", "pinky", "ring", "thumb",
+		"leg", "thigh", "knee", "calf", "ankle",
+		"heel", "foot", "ball", "toe",
+	];
+	static string[] _nonBipBlacklist = [
+		"twist", "mscl", "lookat", "ik", "targ", "trg",
+		"tip", "end", "root", "reflex", "rfx", "dyn",
+		"cloth", "attach", "attch", "phys", "upnode",
+	];
+
+	/// <summary>
+	/// Try to guess based on names if a bone should be drawn as a bone (connected) or a bip (disconnected)
+	/// </summary>
+	static bool DrawBoneAsBip( string child, string parent = null )
+	{
+		var bip = true;
+		// if the name has one of these substrings its probably a bone
+		foreach ( var str in _nonBipWhitelist )
+		{
+			if ( !child.Contains( str, StringComparison.InvariantCultureIgnoreCase ) )
+				continue;
+			bip = false;
+			break;
+		}
+		if ( !bip )
+		{
+			// unless it has one of these, then its probably some procedural shit
+			foreach ( var str in _nonBipBlacklist )
+			{
+				if ( !child.Contains( str, StringComparison.InvariantCultureIgnoreCase ) )
+					continue;
+				bip = true;
+				break;
+			}
+		}
+		if ( parent is null )
+			return bip;
+		bip = bip || DrawBoneAsBip( parent ); //also check parent is valid
+		if ( bip && parent.Length == child.Length )
+		{
+			// even if it isn't a standard skeleton bone we still want to pick up chains
+			// so stuff like rope_01 -> rope_02 still draws as a bone
+			bip = false;
+			for ( var i = 0; i < parent.Length; i++ )
+			{
+				var a = parent[i];
+				var b = child[i];
+				if ( a == b )
+					continue;
+				if ( char.IsNumber( a ) && char.IsNumber( b ) )
+					continue;
+				bip = true;
+				break;
+			}
+		}
+		return bip;
+	}
+
 	void DrawBoneGizmo()
 	{
 		if ( !Gizmo.Settings.GizmosEnabled )
@@ -227,35 +290,67 @@ public partial class GameObject
 		if ( !Parent.IsValid() )
 			return;
 
-		if ( !Parent.Flags.Contains( GameObjectFlags.Bone ) )
-			return;
-
 		var distance = Root.WorldPosition.Distance( Gizmo.Camera.Position );
 		if ( distance > 500.0f )
 			return;
 
-		var position = WorldTransform.PointToLocal( Parent.WorldPosition );
-		var length = position.Length * 0.5f;
-		var width = length * 0.1f;
-
-		if ( width.AlmostEqual( 0.0f ) )
+		var bounds = BBox.FromPositionAndSize( WorldPosition );
+		foreach ( var child in Children )
+			bounds = bounds.AddPoint( child.WorldPosition );
+		if ( !Gizmo.Camera.GetFrustum( new( 0, 1 ), 1 ).IsInside( bounds.Grow( 8 ), true ) )
 			return;
 
 		using ( Gizmo.Scope( "Bone" ) )
 		{
-			Gizmo.Hitbox.DepthBias *= 0.2f;
-			Gizmo.Draw.IgnoreDepth = true;
-			Gizmo.Draw.Color = Color.White.WithAlpha( 0.2f );
+			Gizmo.Hitbox.DepthBias *= 0.1f;
 			Gizmo.Draw.LineThickness = 1;
+			Gizmo.Draw.IgnoreDepth = true;
+			Gizmo.Draw.Color = Gizmo.IsSelected ? Gizmo.Colors.Active : Gizmo.IsHovered ? Color.White : Color.White.Darken( 0.5f );
 
-			Gizmo.Draw.Line( 0, position );
+			var dist = Gizmo.CameraTransform.Position.Distance( WorldPosition );
+			var size = dist.Remap( 0, 256, 1.5f, 0.4f );
+			if ( Gizmo.Camera.Ortho )
+				size *= Gizmo.Camera.OrthoHeight * 0.006f;
+			else
+			{
+				size *= 1024.0f / Gizmo.Camera.Size.Length;
+				size *= dist * Gizmo.Camera.FieldOfView.DegreeToRadian() * 0.006f;
+			}
+			var rot = Gizmo.LocalCameraTransform.Rotation;
+			var bip = true;
+			// bones
+			var bsize = size * 0.6f;
+			Gizmo.Hitbox.Sphere( new Sphere( 0, bsize ) );
+			foreach ( var child in Children )
+			{
+				if ( DrawBoneAsBip( child.Name, Name ) )
+					continue;
+				bip = false;
 
-			Gizmo.Draw.Color = Gizmo.IsSelected ? Gizmo.Colors.Active : Gizmo.IsHovered ? Color.White : Color.White.WithAlpha( 0.2f );
-			Gizmo.Draw.LineThickness = Gizmo.IsSelected ? 2 : Gizmo.IsHovered ? 2 : 1;
+				var delta = Gizmo.CameraTransform.PointToLocal( child.WorldPosition ).WithX( 0 );
+				delta -= Gizmo.CameraTransform.PointToLocal( WorldPosition ).WithX( 0 );
+				var aim = rot * Rotation.FromRoll( MathF.Atan2( delta.z, delta.y ).RadianToDegree() - 90 );
+				var tip = Gizmo.Transform.PointToLocal( child.WorldPosition );
+				Gizmo.Draw.SolidTriangle( aim.Left * bsize, tip, aim.Right * bsize );
+				Gizmo.Draw.SolidTriangle( aim.Left * bsize, aim.Down * bsize, aim.Right * bsize );
 
-			Gizmo.Draw.Sprite( 0, 0.4f, Texture.White );
-
-			Gizmo.Hitbox.Sphere( new Sphere( 0, 0.4f ) );
+				Gizmo.Transform = Gizmo.Transform.WithRotation( Rotation.LookAt( Vector3.Direction( WorldPosition, child.WorldPosition ), rot.Up ) );
+				var girth = bsize * 0.6f;
+				Gizmo.Hitbox.BBox( new( new Vector3( 0, -girth, -girth ), new Vector3( tip.Length, girth, girth ) ) );
+				Gizmo.Transform = Gizmo.Transform.WithRotation( WorldRotation );
+			}
+			if ( bip )
+			{
+				// bip
+				Gizmo.Hitbox.Sphere( new Sphere( 0, size ) );
+				Gizmo.Draw.SolidTriangle( rot.Left * size, rot.Up * size, rot.Right * size );
+				Gizmo.Draw.SolidTriangle( rot.Left * size, rot.Down * size, rot.Right * size );
+			}
+			if ( Gizmo.IsHovered && !Gizmo.IsSelected )
+			{
+				var offset = Gizmo.LocalCameraTransform.Position.Length.Remap( 0, 256, 12, 6 );
+				Gizmo.Draw.ScreenText( Name, WorldPosition, Vector2.Right * offset, size: 14, flags: TextFlag.LeftCenter );
+			}
 
 			if ( Gizmo.WasClicked )
 				GizmoSelect();

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
@@ -220,15 +220,15 @@ public partial class GameObject
 	static string[] _nonBipWhitelist = [
 		"pelvis", "hips", "spine", "ribcage", "head", "neck",
 		"shoulder", "collar", "clavicle", "arm", "elbow",
-		"hand", "wrist", "palm", "finger", "digit",
-		"meta", "index", "middle", "pinky", "ring", "thumb",
-		"leg", "thigh", "knee", "calf", "ankle",
-		"heel", "foot", "ball", "toe",
+		"hand", "wrist", "palm", "finger", "digit", "meta",
+		"index", "middle", "pinky", "ring", "thumb", "leg",
+		"thigh", "knee", "calf", "ankle", "heel", "foot",
+		"ball", "toe"
 	];
 	static string[] _nonBipBlacklist = [
 		"twist", "mscl", "lookat", "ik", "targ", "trg",
 		"tip", "end", "root", "reflex", "rfx", "dyn",
-		"cloth", "attach", "attch", "phys", "upnode",
+		"cloth", "attach", "attch", "phys", "upnode"
 	];
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Gizmo.cs
@@ -223,7 +223,7 @@ public partial class GameObject
 		"hand", "wrist", "palm", "finger", "digit", "meta",
 		"index", "middle", "pinky", "ring", "thumb", "leg",
 		"thigh", "knee", "calf", "ankle", "heel", "foot",
-		"ball", "toe"
+		"ball", "toe", "shin"
 	];
 	static string[] _nonBipBlacklist = [
 		"twist", "mscl", "lookat", "ik", "targ", "trg",

--- a/game/sbox.runtimeconfig.json
+++ b/game/sbox.runtimeconfig.json
@@ -6,6 +6,7 @@
       "version": "10.0.0"
     },
     "configProperties": {
+      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
       "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
       "System.Runtime.TieredPGO": true,
       "System.Threading.ThreadPool.UseWindowsThreadPool": true

--- a/game/sbox.runtimeconfig.json
+++ b/game/sbox.runtimeconfig.json
@@ -6,7 +6,6 @@
       "version": "10.0.0"
     },
     "configProperties": {
-      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
       "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
       "System.Runtime.TieredPGO": true,
       "System.Threading.ThreadPool.UseWindowsThreadPool": true


### PR DESCRIPTION
## Summary
Replaces the gizmos for GameObject bones with fancier ones in the style of sfm bones / 'bips'. These gizmos can be selected by clicking on any part of the bone rather than just the root. Also fixes an issue where the pelvis bone (or any other root bones) wouldn't render gizmos and thus would not be selectable in the viewport.

## Motivation & Context
The existing gizmos are sometimes pretty hard to select and aren't easily readable.

## Implementation Details
Whether a bone should be connected to its parent or kept as a standalone 'bip' is guessed based on the names of the bones. The logic for determining if a bone can be connected is as follows:

If both the parent and child contain one of these strings
```
pelvis, hips, spine, ribcage, head, neck, shoulder,  collar,
clavicle, arm, elbow, hand, wrist, palm, finger, digit, meta,
index, middle, pinky, ring, thumb, leg, thigh, knee, calf,
ankle, heel, foot, ball, toe, shin
```
but not any of these strings (typically found on procedural helpers and the like)
```
twist, mscl, lookat, ik, targ, trg, tip, end, root, reflex, rfx,
dyn, cloth, attach, attch, phys, upnode
```
OR if the bone names appear to form a chain (e.g. rope_0 -> rope_1)

This logic works pretty well on the built in models as well as all the ones from other games that I had lying around, outside of that there's no real guarantee that it won't render bones incorrectly if they are named in a particularly unusual way (which even worst case isn't all that big an issue tbh). Might be a good idea to eventually expose this to the editor somewhere.

I also added basic frustum culling, without it these gizmos run roughly the same as the existing ones but performance was never that good for these. More of an issue with the gizmos system in general (I'm assuming there's a draw call per bone since they're all separate gameobjects). The culling helps keep performance under control with multiple characters in a scene. The 500 unit cutoff by distance is also still in place.

Colors are also the same as before, but the transparency for non hovered/selected bones was removed in favor of opaque grey because the transparency didn't play well with connected bones (each connection would overlay in a pretty ugly way). When a bone is hovered the name is displayed. I feel bones could maybe stand to be a bit more colorful, but outside of left vs right that strains the limits on what can be guessed from bone names alone.

## Screenshots
Facepunch models with standard bones, displaying selection and hovering. The hands and legs have twist and ik bones that by default are in the same location as the main hand/upper leg bones. It would previously be much more difficult to select the actual bone rather than the twist bone, now the main bones are connected and the twist bones are not.
<img width="1819" height="1282" alt="image" src="https://github.com/user-attachments/assets/84619a24-19b0-4bfd-9890-5c0c11ec4ac8" />

Cyberpunk model with a bunch of nonsense bones. No real way to make this not look like a complete mess, but with most of the helper/deformation/target/upnode/facial bones not connected it's a lot easier to find and select the bones you're most likely to actually want to edit. Physics bones on the hair are also detected as chains and connected.
<img width="659" height="1267" alt="image" src="https://github.com/user-attachments/assets/1a1bdb2c-e9a7-4bc0-aacc-3464d665009d" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂