### PR TITLE
[Terrain] Flatten tool: add a way to follow brush normal + better guizmo

### DIFF
--- a/game/addons/base/Assets/shaders/terrain/cs_terrain_sculpt.shader
+++ b/game/addons/base/Assets/shaders/terrain/cs_terrain_sculpt.shader
@@ -43,6 +43,7 @@ CS
         float Rotation;
         float FlattenHeight;
         int SplatChannel;
+        float2 PlaneGradient;
     };
     StructuredBuffer<BrushData> BrushSettings < Attribute( "BrushSettings" ); >;
 
@@ -85,9 +86,13 @@ CS
             float brush = Brush.SampleLevel( g_sBilinearBorder, brushUV, 0 ) * BrushSettings[0].Strength;
             float height = Heightmap.Load( texel ).x;
 
+            // Follow the stroke plane across the brush footprint, the gradient is zero for a world aligned flatten
+            float2 texelDelta = float2( texel ) - float2( w, h ) * BrushSettings[0].UV;
+            float targetHeight = saturate( BrushSettings[0].FlattenHeight + dot( texelDelta, BrushSettings[0].PlaneGradient ) );
+
             // TODO: I think we're gonna need the delta of the last hit UV, so we can flatten everything
             // between those two points, oherwise there'll be gaps
-            Heightmap[texel] = lerp( height, BrushSettings[0].FlattenHeight, brush );
+            Heightmap[texel] = lerp( height, targetHeight, brush );
         }
         if ( D_SCULPT_MODE == MODE_SMOOTH )
         {

--- a/game/addons/base/Assets/shaders/terrain/cs_terrain_splat.shader
+++ b/game/addons/base/Assets/shaders/terrain/cs_terrain_splat.shader
@@ -34,6 +34,7 @@ CS
         float Rotation;
         float FlattenHeight;
         int SplatChannel;
+        float2 PlaneGradient;
     };
     StructuredBuffer<BrushData> BrushSettings < Attribute( "BrushSettings" ); >;
 

--- a/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainEditor.cs
@@ -84,6 +84,13 @@ public partial class TerrainEditorTool : EditorTool
 			rot.Enabled = !BrushSettings.RandomRotation;
 			var rndRot = group.Add( ControlSheetRow.Create( so.GetProperty( nameof( BrushSettings.RandomRotation ) ) ) );
 
+			// Flatten only option, the sidebar is rebuilt whenever the subtool changes
+			if ( CurrentTool is FlattenTool flatten )
+			{
+				var flattenSo = flatten.GetSerialized();
+				group.Add( ControlSheetRow.Create( flattenSo.GetProperty( nameof( FlattenTool.AlignToSurface ) ) ) );
+			}
+
 			so.OnPropertyChanged += ( prop ) =>
 			{
 				if ( prop?.Name == nameof( BrushSettings.RandomRotation ) && rot.IsValid() )

--- a/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
@@ -10,6 +10,7 @@ public struct BrushData
 	public float Rotation;
 	public float FlattenHeight;
 	public int SplatChannel;
+	public Vector2 PlaneGradient;
 }
 
 /// <summary>
@@ -78,6 +79,19 @@ public abstract class BaseBrushTool : EditorTool
 		return terrain.RayIntersects( Gizmo.CurrentRay, Gizmo.RayDepth, out position );
 	}
 
+	/// <summary>
+	/// Create the world space plane a stroke is locked to when it starts.
+	/// </summary>
+	protected virtual Plane CreateStrokePlane( Terrain terrain, Vector3 hitWorldPos )
+	{
+		return new Plane( hitWorldPos, terrain.WorldTransform.Rotation.Up );
+	}
+
+	/// <summary>
+	/// Draw extra tool specific gizmos around the brush at the current hit position.
+	/// </summary>
+	protected virtual void DrawToolPreview( Terrain terrain, Vector3 worldHitPos ) { }
+
 	public override void OnUpdate()
 	{
 		var terrain = GetSelectedComponent<Terrain>() ?? Scene.Get<Terrain>();
@@ -131,7 +145,7 @@ public abstract class BaseBrushTool : EditorTool
 				if ( _parent.BrushSettings.RandomRotation )
 					_parent.BrushSettings.Rotation = Random.Shared.NextSingle() * 360f;
 
-				StrokePlane = new Plane( _lastHitWorldPos, tx.Rotation.Up );
+				StrokePlane = CreateStrokePlane( terrain, _lastHitWorldPos );
 
 				_dragging = true;
 
@@ -163,6 +177,7 @@ public abstract class BaseBrushTool : EditorTool
 		}
 
 		DrawBrushPreviewAt( _lastHitWorldPos, _lastHitTx, PaintMode ? terrain : null );
+		DrawToolPreview( terrain, _lastHitWorldPos );
 	}
 
 	void DrawBrushPreviewAt( Vector3 worldPos, Transform tx, Terrain terrain = null )
@@ -222,6 +237,16 @@ public abstract class BaseBrushTool : EditorTool
 		cs.Attributes.Set( "Heightmap", terrain.HeightMap );
 		cs.Attributes.Set( "ControlMap", terrain.ControlMap );
 
+		// Normalized height change per heightmap texel, so the shader can flatten towards
+		// a tilted stroke plane. Zero when the stroke plane is aligned with the terrain up axis.
+		var strokeNormal = terrain.WorldTransform.NormalToLocal( StrokePlane.Normal );
+		var planeGradient = Vector2.Zero;
+		if ( MathF.Abs( strokeNormal.z ) > 0.001f )
+		{
+			var texelSize = terrain.Storage.TerrainSize / terrain.Storage.Resolution;
+			planeGradient = new Vector2( strokeNormal.x, strokeNormal.y ) / -strokeNormal.z * texelSize / terrain.Storage.TerrainHeight;
+		}
+
 		_brushBuffer ??= new GpuBuffer<BrushData>( 1 );
 		_brushBuffer.SetData( new[] { new BrushData
 		{
@@ -230,6 +255,7 @@ public abstract class BaseBrushTool : EditorTool
 			Size = size,
 			Rotation = paint.BrushSettings.Rotation * MathF.PI / 180f,
 			FlattenHeight = paint.FlattenHeight,
+			PlaneGradient = planeGradient,
 		} } );
 		cs.Attributes.Set( "BrushSettings", _brushBuffer );
 		cs.Attributes.Set( "Brush", paint.Brush.Texture );

--- a/game/addons/tools/Code/Scene/Terrain/Tools/FlattenTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/FlattenTool.cs
@@ -10,9 +10,35 @@
 [Order( 0 )]
 public class FlattenTool : BaseBrushTool
 {
+	/// <summary>
+	/// Align the flatten plane to the terrain surface normal where the stroke starts,
+	/// instead of the world up axis - lets you flatten along slopes.
+	/// </summary>
+	[Title( "Align to Surface" )]
+	public bool AlignToSurface
+	{
+		get => _alignToSurface;
+		set
+		{
+			_alignToSurface = value;
+			EditorCookie.Set( "TerrainTool.FlattenAlignToSurface", value );
+		}
+	}
+	bool _alignToSurface = EditorCookie.Get( "TerrainTool.FlattenAlignToSurface", false );
+
+	Vector3 _surfaceNormal = Vector3.Up;
+
 	public FlattenTool( TerrainEditorTool terrainEditorTool ) : base( terrainEditorTool )
 	{
 		Mode = SculptMode.Flatten;
+	}
+
+	protected override Plane CreateStrokePlane( Terrain terrain, Vector3 hitWorldPos )
+	{
+		if ( AlignToSurface )
+			return new Plane( hitWorldPos, _surfaceNormal );
+
+		return base.CreateStrokePlane( terrain, hitWorldPos );
 	}
 
 	public override bool GetHitPosition( Terrain terrain, out Vector3 position )
@@ -25,6 +51,43 @@ public class FlattenTool : BaseBrushTool
 			return hit.HasValue;
 		}
 
+		if ( AlignToSurface && terrain.RayIntersects( Gizmo.CurrentRay, Gizmo.RayDepth, out position, out var localNormal ) )
+		{
+			_surfaceNormal = terrain.WorldTransform.NormalToWorld( localNormal );
+			return true;
+		}
+
 		return base.GetHitPosition( terrain, out position );
+	}
+
+	protected override void DrawToolPreview( Terrain terrain, Vector3 worldHitPos )
+	{
+		var normal = _dragging ? StrokePlane.Normal
+			: AlignToSurface ? _surfaceNormal
+			: terrain.WorldTransform.Rotation.Up;
+		var color = Color.FromBytes( 150, 150, 250 ).WithAlpha( _dragging ? 0.6f : 0.35f );
+		var size = _parent.BrushSettings.Size;
+
+		using ( Gizmo.Scope( "FlattenPlanePreview", worldHitPos, Rotation.LookAt( normal ) ) )
+		{
+			Gizmo.Draw.IgnoreDepth = true;
+			Gizmo.Draw.LineThickness = 2;
+
+			// Rings extending past the brush so the flatten plane reads against the terrain
+			for ( int i = 1; i <= 3; i++ )
+			{
+				Gizmo.Draw.Color = color.WithAlphaMultiplied( 1.0f / i );
+				Gizmo.Draw.LineCircle( Vector3.Zero, size * (1.0f + i * 0.25f), sections: 48 );
+			}
+
+			var extent = size * 1.75f;
+			Gizmo.Draw.Color = color;
+			Gizmo.Draw.Line( Vector3.Left * extent, Vector3.Right * extent );
+			Gizmo.Draw.Line( Vector3.Up * extent, Vector3.Down * extent );
+
+			// Plane normal
+			Gizmo.Draw.Color = color.WithAlpha( 1.0f );
+			Gizmo.Draw.Arrow( Vector3.Zero, Vector3.Forward * size * 0.5f );
+		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

So the flatten tool was great but for doing slopes or like starting doing reliefs, it's hard with the raise / flatten, so i was like why not make the flatten locked to my brush plane

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details
So i actually implemented sevral things:
- A new guizmo for BaseBrushTools (DrawToolPreview) so any other tool that need a guizmo can
- A CreateStrokePlane function to enforce or not the AlignToSurface
- Passed a BrushPlane gradient to BrushData
- And so adapted the shader code for it (thx jean claude ngl)

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/afceb583-a911-4ef4-8d80-d5c28c6647ef

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂