### PR TITLE
Add constructor for extension to [FilePath]

### DIFF
--- a/engine/Sandbox.Engine/Editor/Hammer/PropertyAttributes.cs
+++ b/engine/Sandbox.Engine/Editor/Hammer/PropertyAttributes.cs
@@ -88,6 +88,12 @@ public class ImageAssetPathAttribute : AssetPathAttribute
 [AttributeUsage( AttributeTargets.Property )]
 public class FilePathAttribute : System.Attribute
 {
+	public FilePathAttribute() { }
+	public FilePathAttribute( string extension )
+	{
+		Extension = extension;
+	}
+
 	/// <summary>
 	/// The extension to filter by. If empty, all files are shown.
 	/// Can be a comma separated list of extensions, or a single extension.


### PR DESCRIPTION
## Summary
Adds a constructor to `[FilePath]` to avoid needing to type out `Extension =` for the single editable property in the attribute

## Motivation & Context
This looks kind of bad
<img width="265" height="76" alt="image" src="https://github.com/user-attachments/assets/33a6a3c5-9e23-4e06-885e-0598ef1a1791" />

This looks a lot nicer
<img width="140" height="61" alt="image" src="https://github.com/user-attachments/assets/827ff707-ec74-4d3a-9c56-4df8c02966fc" />

Also added an empty constructor to avoid breaking existing code

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂