### PR TITLE
Implement play mode activation for dedicated servers in editor

### DIFF
--- a/engine/Sandbox.Engine/Core/Context/IToolsDll.cs
+++ b/engine/Sandbox.Engine/Core/Context/IToolsDll.cs
@@ -17,6 +17,7 @@ internal unsafe interface IToolsDll
 	public void RunEvent<T>( Action<T> action );
 	public void Exiting();
 	public bool ConsoleFocus();
+	public void SetPlaying();
 	public void ExitPlaymode();
 
 	public void Spin();

--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -1,4 +1,5 @@
-﻿using Sandbox.Network;
+﻿using Sandbox.Engine;
+using Sandbox.Network;
 using Sandbox.Utility;
 using System.IO;
 using System.Text.Json.Nodes;
@@ -244,6 +245,11 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		// Let them know we have now loaded this scene.
 		var loadedMsg = new SceneLoadedMsg { SceneId = msg.SceneId, Id = msg.Id };
 		connection.SendMessage( loadedMsg, NetFlags.Reliable );
+
+		if ( Application.IsEditor )
+		{
+			IToolsDll.Current?.SetPlaying();
+		}
 
 		LoadingScreen.IsVisible = false;
 	}

--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
@@ -497,6 +497,11 @@ internal partial class NetworkSystem
 		if ( msg.HandshakeId != Connection.Local.HandshakeId )
 			return Task.CompletedTask;
 
+		if ( Application.IsEditor )
+		{
+			IToolsDll.Current?.SetPlaying();
+		}
+
 		Log.Trace( $"[{this}] I am spawning into the game!" );
 		LoadingScreen.IsVisible = false;
 

--- a/engine/Sandbox.Tools/Scene/EditorScene.cs
+++ b/engine/Sandbox.Tools/Scene/EditorScene.cs
@@ -252,9 +252,12 @@ public static class EditorScene
 
 		if ( playMode )
 		{
-			LoadingScreen.IsVisible = true;
-			LoadingScreen.Title = "Loading Game..";
-			IGameInstanceDll.Current.EditorPlay();
+			if ( IGameInstance.Current is null )
+			{
+				LoadingScreen.IsVisible = true;
+				LoadingScreen.Title = "Loading Game..";
+				IGameInstanceDll.Current.EditorPlay();
+			}
 		}
 		else
 		{
@@ -292,7 +295,6 @@ public static class EditorScene
 		}
 
 		SceneEditorSession.Active.SetPlaying( Game.ActiveScene );
-
 		EditorEvent.Run( "scene.play" );
 	}
 

--- a/engine/Sandbox.Tools/ToolsDll.cs
+++ b/engine/Sandbox.Tools/ToolsDll.cs
@@ -80,6 +80,21 @@ internal class ToolsDll : IToolsDll
 		EditorScene.Stop();
 	}
 
+	public void SetPlaying()
+	{
+		if ( Game.ActiveScene is null || !Game.ActiveScene.IsValid() )
+		{
+			return;
+		}
+
+		// Just incase we are ingame currently using the "connect" command we just stop the current session and start a new one, 
+		// so we dont end up with dupe GameSession
+		var sceneEditorSession = SceneEditorSession.All.FirstOrDefault( x => x.IsPlaying );
+		sceneEditorSession?.StopPlaying();
+
+		EditorScene.Play( true );
+	}
+
 	/// <summary>
 	/// Bootstrapping has finished. Close the splash screen and show the editor.
 	/// </summary>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

Everything was basically working however the editor didnt know it was actually "playing" this sets it up when we handshake with the server and when the server changes level just incase we get a map change because I saw that also broke it.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

From what I can see this also fixes #11358 

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

Currently we shutdown any "playing" sessions if we get another request via networking or map changes just so we dont have dupe GameSession

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Before: https://youtu.be/8WoF3FlTdpA
After: https://youtu.be/NshL0PY4rlM

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂