### PR TITLE
Clear resource loader watchers to ensure no late watcher messages come in

### DIFF
--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -145,6 +145,8 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 			PackageLoader.OnAfterHotload = OnAfterHotload;
 		}
 
+		ResourceLoader.Clear();
+
 		if ( DidMountNetworkedFiles )
 		{
 			EngineFileSystem.Mounted.UnMount( NetworkedLargeFiles.Files );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

Previously it was a race condition if the watchers inside of ResourceLoader would fire before or after we joined the game. Now we clear the watchers before we join so we don't end up getting the messages at all.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #11237

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

Previously this clear function was just not called, I am assuming it was meant to be put here 😆 

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Before: https://youtu.be/ZYEjKxSCzIY
After: https://youtu.be/8UFZVR0bYHo

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂