### PR TITLE
Fixed rotation gizmo sensitivity

### DIFF
--- a/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Rotation.cs
+++ b/engine/Sandbox.Engine/Editor/Gizmos/Control/Control.Rotation.cs
@@ -187,9 +187,6 @@ public static partial class Gizmo
 
 			//Gizmo.Draw.Plane( pressPoint, dragNormal );
 
-			// don't let scale affect the drag amounts
-			angleDifference /= Gizmo.Transform.UniformScale;
-
 			if ( angleDifference == 0.0f ) return false;
 
 			angleDelta = -angleDifference;


### PR DESCRIPTION
## Summary
Fixes rotation gizmo sensitivity being tied to its distance from the camera

## Motivation & Context
Made posing really annoying

## Implementation Details
This line was causing the issue, removing it causes the gizmo to work as expected at any distance.
```cs
// don't let scale affect the drag amounts
angleDifference /= Gizmo.Transform.UniformScale;
```
I also verified that scaling a gameobject has no effect on the rotation gizmo with the line removed.

## Video

https://github.com/user-attachments/assets/76bee6f5-f700-4881-8692-6d35c9d5ba31



## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂