### PR TITLE
Fix Panel.MoveAfterSibling ordering

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Panel/Panel.Order.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Panel/Panel.Order.cs
@@ -56,7 +56,13 @@ public partial class Panel
 		if ( previousSibling.SiblingIndex == SiblingIndex - 1 )
 			return;
 
-		Parent.SetChildIndex( this, previousSibling.SiblingIndex );
+		var targetIndex = previousSibling.SiblingIndex;
+		if ( SiblingIndex > previousSibling.SiblingIndex )
+		{
+			targetIndex++;
+		}
+
+		Parent.SetChildIndex( this, targetIndex );
 	}
 
 	/// <summary>
@@ -83,6 +89,7 @@ public partial class Panel
 		_children.Remove( child );
 		_children.Insert( newIndex, child );
 		UpdateChildrenIndexes();
+		_renderChildrenDirty = true;
 
 		Assert.Equals( child.SiblingIndex, newIndex );
 	}

--- a/engine/Tests/Sandbox.Test.Engine/UI/Panel/Hierarchy.cs
+++ b/engine/Tests/Sandbox.Test.Engine/UI/Panel/Hierarchy.cs
@@ -136,10 +136,10 @@ public class PanelHierarchyTest
 
 	/// <summary>
 	/// MoveAfterSibling places a panel directly after the given sibling when
-	/// moving forwards, and throws when the panel has no parent at all.
+	/// moving forwards or backwards, and throws when the panel has no parent at all.
 	/// </summary>
 	[TestMethod]
-	public void MoveAfterSiblingForward()
+	public void MoveAfterSiblingReorders()
 	{
 		var parent = new Panel();
 		var a = parent.AddChild<Panel>();
@@ -149,6 +149,17 @@ public class PanelHierarchyTest
 		b.MoveAfterSibling( c );
 
 		CollectionAssert.AreEqual( new[] { a, c, b }, parent.Children.ToArray() );
+
+		var reverseParent = new Panel();
+		var reverseA = reverseParent.AddChild<Panel>();
+		var reverseB = reverseParent.AddChild<Panel>();
+		var reverseC = reverseParent.AddChild<Panel>();
+
+		reverseParent._renderChildrenDirty = false;
+		reverseC.MoveAfterSibling( reverseA );
+
+		CollectionAssert.AreEqual( new[] { reverseA, reverseC, reverseB }, reverseParent.Children.ToArray() );
+		Assert.IsTrue( reverseParent._renderChildrenDirty );
 
 		var orphan = new Panel();
 		Assert.ThrowsException<ArgumentException>( () => orphan.MoveAfterSibling( a ) );


### PR DESCRIPTION
## Summary

- Fix `Panel.MoveAfterSibling` so moving a child backwards places it directly after the target sibling.
- Mark render children dirty after `SetChildIndex` changes child order.
- Extend the panel hierarchy regression test to cover forward and backward moves.

## Root cause

`SetChildIndex` removes the child before inserting it at the requested index. When the moving child starts after the target sibling, the target index needs to be shifted by one to preserve the "after sibling" contract.

## Testing

- `dotnet run --project engine/Tools/SboxBuild/SboxBuild.csproj -- build --config Developer`
- `dotnet run --project engine/Tools/SboxBuild/SboxBuild.csproj -- format --verify`
- `dotnet test engine/Tests/Sandbox.Test.Engine/Sandbox.Test.Engine.csproj -c Release --filter "FullyQualifiedName~UITests.Panels.PanelHierarchyTest"`
- `dotnet run --project engine/Tools/SboxBuild/SboxBuild.csproj -- test --no-build --filter "TestCategory!=LiveBackend"`