### PR TITLE
Physics: sync only bodies the solver reports as moved

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ScenePhysicsSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ScenePhysicsSystem.cs
@@ -13,6 +13,11 @@ sealed class ScenePhysicsSystem : GameObjectSystem<ScenePhysicsSystem>
 	private HashSet<Rigidbody> RigidBodies { get; set; } = new();
 	private List<ISceneCollisionEvents> CollisionEvents { get; } = new();
 
+	// Rigidbodies whose physics body moved this step (populated from PhysicsWorld.OnBodyActive).
+	// We drain this each step instead of scanning every Rigidbody, so settled/asleep bodies cost nothing.
+	private readonly HashSet<Rigidbody> MovedRigidbodies = new();
+	private readonly List<Rigidbody> MovedBuffer = new();
+
 	internal bool Enabled { get; set; }
 
 	public ScenePhysicsSystem( Scene scene ) : base( scene )
@@ -35,6 +40,7 @@ sealed class ScenePhysicsSystem : GameObjectSystem<ScenePhysicsSystem>
 		PhysicsWorld.OnIntersectionEnd += OnIntersectionEnd;
 		PhysicsWorld.OnBodyOutOfBounds += OnBodyOutOfBounds;
 		PhysicsWorld.OnBodyFellAsleep += OnBodyFellAsleep;
+		PhysicsWorld.OnBodyActive += OnBodyActive;
 	}
 
 	public override void Dispose()
@@ -50,6 +56,7 @@ sealed class ScenePhysicsSystem : GameObjectSystem<ScenePhysicsSystem>
 		PhysicsWorld.OnIntersectionEnd -= OnIntersectionEnd;
 		PhysicsWorld.OnBodyOutOfBounds -= OnBodyOutOfBounds;
 		PhysicsWorld.OnBodyFellAsleep -= OnBodyFellAsleep;
+		PhysicsWorld.OnBodyActive -= OnBodyActive;
 	}
 
 	void UpdatePhysics()
@@ -91,14 +98,21 @@ sealed class ScenePhysicsSystem : GameObjectSystem<ScenePhysicsSystem>
 		PhysicsWorld?.Step( Time.NowDouble, Time.Delta, steps );
 
 		//
-		// Update the positions of the rigidbodies based on the new physics positions
-		// todo: we should only update ones that have changed, skip asleep?
+		// Update the positions of the rigidbodies that the solver reported as moved this step.
+		// Asleep/settled bodies don't fire OnBodyActive, so they're skipped entirely.
+		// We buffer then clear so UpdateTransformFromBody's transform-changed callbacks can't mutate the set mid-iteration.
 		//
-		// I don't feel comfortable doing this in a thread, because of all the LocalTransformChanged callbacks
-		// System.Threading.Tasks.Parallel.ForEach( Scene.GetAll<Rigidbody>(), c => c.UpdateTransformFromBody() );
-		foreach ( var obj in Scene.GetAll<Rigidbody>() )
+		MovedBuffer.Clear();
+		foreach ( var rb in MovedRigidbodies )
 		{
-			obj.UpdateTransformFromBody();
+			if ( rb.IsValid() )
+				MovedBuffer.Add( rb );
+		}
+		MovedRigidbodies.Clear();
+
+		foreach ( var rb in MovedBuffer )
+		{
+			rb.UpdateTransformFromBody();
 		}
 
 		//
@@ -164,6 +178,12 @@ sealed class ScenePhysicsSystem : GameObjectSystem<ScenePhysicsSystem>
 		var rb = body.Component as Rigidbody;
 		if ( rb.IsValid() == false ) return;
 		IScenePhysicsEvents.Post( x => x.OnFellAsleep( rb ) );
+	}
+
+	void OnBodyActive( PhysicsBody body )
+	{
+		if ( body.Component is Rigidbody rb )
+			MovedRigidbodies.Add( rb );
 	}
 
 	void DebugDrawPhysics()

--- a/engine/Sandbox.Engine/Systems/Physics/PhysicsBody.cs
+++ b/engine/Sandbox.Engine/Systems/Physics/PhysicsBody.cs
@@ -1237,6 +1237,8 @@ public sealed partial class PhysicsBody : IHandle
 
 		Dirty();
 
+		World?.OnBodyActive?.Invoke( this );
+
 		if ( wentOutOfBounds )
 		{
 			World?.OnBodyOutOfBounds?.Invoke( this );

--- a/engine/Sandbox.Engine/Systems/Physics/PhysicsWorld.cs
+++ b/engine/Sandbox.Engine/Systems/Physics/PhysicsWorld.cs
@@ -210,6 +210,12 @@ public sealed partial class PhysicsWorld : IHandle
 	internal Action<PhysicsBody> OnBodyOutOfBounds { get; set; }
 	internal Action<PhysicsBody> OnBodyFellAsleep { get; set; }
 
+	/// <summary>
+	/// Fired for each body that the solver reports as active (moved) this step. Used to drive
+	/// per-step transform sync without scanning every body. See <see cref="PhysicsBody.OnActive"/>.
+	/// </summary>
+	internal Action<PhysicsBody> OnBodyActive { get; set; }
+
 	unsafe void OnIntersection( VPhysIntersectionNotification_t* ptr )
 	{
 		try


### PR DESCRIPTION
## Summary

`ScenePhysicsSystem.UpdatePhysics` scanned every `Rigidbody` each physics step and called `UpdateTransformFromBody()` on all of them, doing a native transform read per body even for the many that are asleep/settled. That's O(all bodies) on the main thread every step, regardless of how many actually moved (there was a standing "todo: skip asleep?" here).

This change syncs only the bodies the solver reports as moved. Cost now scales with *moved* bodies instead of *total* bodies; asleep bodies cost nothing.

| Bodies (all asleep) | before | after | reduction |
|---------------------|--------|-------|-----------|
| 6000 | ~3.5 ms/step | ~0.8–1.3 ms/step | **~65–77%** |

*(Measured via `PerformanceStats.Timings.Physics`, median of per-step samples, all bodies settled. Master was consistent at ~3.5 ms; the branch varied 0.8–1.3 ms across runs.)*

## Motivation & Context

Scenes with many sleeping bodies such as settled debris, prop piles, destruction gibs paid a per-step transform-sync cost proportional to the *total* body count even when nothing was moving. The loop was pure waste for asleep bodies, and it runs on the main thread every step.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

The Native solver already fires a per-body callback only for bodies that moved this step (`PhysicsEngine.OnActive` → `PhysicsBody.OnActive`). This PR surfaces that as a new internal `PhysicsWorld.OnBodyActive` event and drives the sync from it:

- **`PhysicsWorld`** — new internal `Action<PhysicsBody> OnBodyActive`.
- **`PhysicsBody.OnActive`** — after `Dirty()`, invoke `World?.OnBodyActive?.Invoke( this )`.
- **`ScenePhysicsSystem`** — collect moved bodies into a `HashSet`, then drain only that set after the step instead of scanning `Scene.GetAll<Rigidbody>()`.


## Screenshots / Videos (if applicable)

**Before (master):**

https://github.com/user-attachments/assets/4999a590-77c8-4821-87ae-a091250ba254

**After (this branch):**

https://github.com/user-attachments/assets/7af5c3f2-9d38-4f86-92d0-49fad28e9301

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable) <!-- new event is internal -->
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂
