### PR TITLE
Optimize world panel lookup for TickWorldInput

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/UISystem.cs
+++ b/engine/Sandbox.Engine/Systems/UI/UISystem.cs
@@ -230,7 +230,8 @@ internal class UISystem
 		//
 		// Tick various input systems
 		//
-		Input.Tick( RootPanels.Where( p => !p.IsWorldPanel ).OrderByDescending( x => x.ComputedStyle?.ZIndex ?? 0 ), allowMouseInput && DoAnyPanelsWantMouseVisible() );
+		Input.Tick( RootPanels.Where( p => !p.IsWorldPanel ).OrderByDescending( x => x.ComputedStyle?.ZIndex ?? 0 ),
+			allowMouseInput && DoAnyPanelsWantMouseVisible() );
 
 		TickWorldInput();
 
@@ -271,7 +272,9 @@ internal class UISystem
 				buttonState = Sandbox.Engine.InputContext.InputState.Game;
 
 				if ( CurrentFocus is not null )
-					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game ? InputContext.InputState.Game : InputContext.InputState.UI;
+					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game
+						? InputContext.InputState.Game
+						: InputContext.InputState.UI;
 			}
 
 			//
@@ -283,7 +286,9 @@ internal class UISystem
 				buttonState = Sandbox.Engine.InputContext.InputState.Game;
 
 				if ( CurrentFocus is not null )
-					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game ? InputContext.InputState.Game : InputContext.InputState.UI;
+					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game
+						? InputContext.InputState.Game
+						: InputContext.InputState.UI;
 			}
 
 			//
@@ -317,7 +322,9 @@ internal class UISystem
 				mouseState = InputContext.InputState.UI;
 
 			if ( CurrentFocus is not null )
-				buttonState = CurrentFocus.ButtonInput == PanelInputType.Game ? InputContext.InputState.Game : InputContext.InputState.UI;
+				buttonState = CurrentFocus.ButtonInput == PanelInputType.Game
+					? InputContext.InputState.Game
+					: InputContext.InputState.UI;
 
 			// No input if we're not playing
 			if ( !inGame )
@@ -333,12 +340,13 @@ internal class UISystem
 			}
 		}
 
-		Game.InputContext.UpdateInputFromUI( mouseState, Input.Hovered, Panel.MouseCapture is not null, buttonState, CurrentFocus );
+		Game.InputContext.UpdateInputFromUI( mouseState, Input.Hovered, Panel.MouseCapture is not null, buttonState,
+			CurrentFocus );
 	}
-	
+
 	IEnumerable<RootPanel> EnumerateWorldRootPanels()
 	{
-		foreach (var root in RootPanels)
+		foreach ( var root in RootPanels )
 		{
 			if ( !root.IsValid() )
 				continue;

--- a/engine/Sandbox.Engine/Systems/UI/UISystem.cs
+++ b/engine/Sandbox.Engine/Systems/UI/UISystem.cs
@@ -335,18 +335,31 @@ internal class UISystem
 
 		Game.InputContext.UpdateInputFromUI( mouseState, Input.Hovered, Panel.MouseCapture is not null, buttonState, CurrentFocus );
 	}
+	
+	IEnumerable<RootPanel> EnumerateWorldRootPanels()
+	{
+		foreach (var root in RootPanels)
+		{
+			if ( !root.IsValid() )
+				continue;
+
+			if ( !root.IsWorldPanel )
+				continue;
+
+			yield return root;
+		}
+	}
 
 	void TickWorldInput()
 	{
 		var scene = Game.ActiveScene;
 		if ( !scene.IsValid() ) return;
 
-		var rootPanels = scene.GetAllComponents<WorldPanel>();
 		var worldInputs = scene.GetAllComponents<WorldInput>();
 
 		foreach ( var worldInput in worldInputs )
 		{
-			worldInput.WorldPanelInput.Tick( rootPanels.Select( x => x.GetPanel() as RootPanel ), true );
+			worldInput.WorldPanelInput.Tick( EnumerateWorldRootPanels(), true );
 		}
 	}
 

--- a/engine/Sandbox.Engine/Systems/UI/UISystem.cs
+++ b/engine/Sandbox.Engine/Systems/UI/UISystem.cs
@@ -230,8 +230,7 @@ internal class UISystem
 		//
 		// Tick various input systems
 		//
-		Input.Tick( RootPanels.Where( p => !p.IsWorldPanel ).OrderByDescending( x => x.ComputedStyle?.ZIndex ?? 0 ),
-			allowMouseInput && DoAnyPanelsWantMouseVisible() );
+		Input.Tick( RootPanels.Where( p => !p.IsWorldPanel ).OrderByDescending( x => x.ComputedStyle?.ZIndex ?? 0 ), allowMouseInput && DoAnyPanelsWantMouseVisible() );
 
 		TickWorldInput();
 
@@ -272,9 +271,7 @@ internal class UISystem
 				buttonState = Sandbox.Engine.InputContext.InputState.Game;
 
 				if ( CurrentFocus is not null )
-					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game
-						? InputContext.InputState.Game
-						: InputContext.InputState.UI;
+					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game ? InputContext.InputState.Game : InputContext.InputState.UI;
 			}
 
 			//
@@ -286,9 +283,7 @@ internal class UISystem
 				buttonState = Sandbox.Engine.InputContext.InputState.Game;
 
 				if ( CurrentFocus is not null )
-					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game
-						? InputContext.InputState.Game
-						: InputContext.InputState.UI;
+					buttonState = CurrentFocus.ButtonInput == PanelInputType.Game ? InputContext.InputState.Game : InputContext.InputState.UI;
 			}
 
 			//
@@ -322,9 +317,7 @@ internal class UISystem
 				mouseState = InputContext.InputState.UI;
 
 			if ( CurrentFocus is not null )
-				buttonState = CurrentFocus.ButtonInput == PanelInputType.Game
-					? InputContext.InputState.Game
-					: InputContext.InputState.UI;
+				buttonState = CurrentFocus.ButtonInput == PanelInputType.Game ? InputContext.InputState.Game : InputContext.InputState.UI;
 
 			// No input if we're not playing
 			if ( !inGame )
@@ -340,8 +333,7 @@ internal class UISystem
 			}
 		}
 
-		Game.InputContext.UpdateInputFromUI( mouseState, Input.Hovered, Panel.MouseCapture is not null, buttonState,
-			CurrentFocus );
+		Game.InputContext.UpdateInputFromUI( mouseState, Input.Hovered, Panel.MouseCapture is not null, buttonState, CurrentFocus );
 	}
 
 	IEnumerable<RootPanel> EnumerateWorldRootPanels()


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Replace the per-frame `Scene.GetAllComponents<WorldPanel>()` lookup in `TickWorldInput` by iterating over the existing `UISystem.RootPanels` collection and selecting only world panels.

This avoids an unnecessary scene traversal every frame while preserving the existing behavior.

---

## Motivation & Context

`UISystem` already maintains a list of all root panels, making it unnecessary to query the scene for every `WorldPanel` during input processing.

Since `TickWorldInput` is executed every frame, reusing the existing collection reduces overhead and avoids unnecessary work.

Fixes: N/A

---

## Implementation Details

- Replaced the `GetAllComponents<WorldPanel>()` call with iteration over `UISystem.RootPanels`.
- Filtered the collection to valid world panels before passing them to the world input system.
- Removed the LINQ projection previously used to build the collection passed to `WorldPanelInput.Tick`.

---

## Screenshots / Videos (if applicable)

N/A

---

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂