### PR TITLE
Nest asset creation categories

### DIFF
--- a/game/addons/tools/Code/CreateAsset.cs
+++ b/game/addons/tools/Code/CreateAsset.cs
@@ -96,10 +96,16 @@ public static class CreateAsset
 
 		parent.AddSeparator();
 
-		var grouped = entries.OrderBy( x => x.Name ).GroupBy( x => x.Category ).OrderBy( x => x.Key );
+		var grouped = entries.OrderBy( x => x.Name )
+			.GroupBy( x => string.IsNullOrWhiteSpace( x.Category ) ? null : string.Join( "/", x.Category.Split( '/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries ) ) )
+			.OrderBy( x => x.Key == null ? null : x.Key + "~" );
 		foreach ( var group in grouped.Where( x => x.Key is not null ) )
 		{
-			var menu = parent.FindOrCreateMenu( group.Key );
+			var menu = parent;
+			foreach ( var category in group.Key.Split( '/' ) )
+			{
+				menu = menu.FindOrCreateMenu( category );
+			}
 
 			foreach ( var entry in group )
 			{


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Makes the Asset Browser `New` menu support slash-delimited asset categories as nested folders.

For example, `Category = "Survival/Crafting"` now appears as:

`New -> Survival -> Crafting -> Crafting Recipe`

instead of a flat `Survival/Crafting` submenu.

## Motivation & Context

Custom asset types can use category strings to organize creation options, but slash-delimited categories were previously shown as one flat menu label. This makes larger projects harder to scan when they group resource types into nested domains.

## Implementation Details
- Normalizes category strings by splitting on `/`, trimming empty segments, and joining them back before sorting/grouping.
- Walks each normalized category segment through `FindOrCreateMenu` to create nested folders.
- Sorts category groups so nested folders are created before loose items at the same level, keeping folders above direct options.
- Ignores null, empty, and whitespace-only categories in the categorized section.

## Screenshots / Videos (if applicable)
After:
<img width="740" height="515" alt="image" src="https://github.com/user-attachments/assets/62c8019d-548c-4f1b-9d1f-980d9caaa30b" />
(Bow weapon is placed in survival folder for ilustration that paths without `/` still work )
Before:
<img width="647" height="615" alt="image" src="https://github.com/user-attachments/assets/d40919fb-339b-4d39-a7b1-fae70df119a7" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂