### PR TITLE
Standalone Fixes

### DIFF
--- a/engine/Sandbox.Engine/Services/Api/Api.Activity.cs
+++ b/engine/Sandbox.Engine/Services/Api/Api.Activity.cs
@@ -23,6 +23,13 @@ internal static partial class Api
 
 		public static async Task UpdateActivity( string game, string gameVersion, string map, string[] addons )
 		{
+			// A standalone build talks to no s&box services - Api.Init() never initializes the Backend there
+			// (so Backend.Account is null) and reporting activity isn't wanted for a self-hosted game. Bail BEFORE
+			// the mutex / Performance.Flip so nothing here can throw into the catch (which was logging an NRE on
+			// standalone startup); returning before the try also keeps the finally from releasing an unheld mutex.
+			if ( Application.IsStandalone )
+				return;
+
 			var shc = HashCode.Combine( game );
 			bool newSessionHash = shc != sessionHashCode;
 			sessionHashCode = shc;

--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Connections.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Connections.cs
@@ -127,6 +127,9 @@ internal partial class NetworkSystem
 
 	internal void OnDisconnected( Connection source )
 	{
+		// Capture the state before we reset it below, so we can report where a failed join dropped.
+		var previousState = source.State;
+
 		if ( source.State >= Connection.ChannelState.Welcome )
 		{
 			// We only need to call this if we called OnConnected, which would only
@@ -142,7 +145,17 @@ internal partial class NetworkSystem
 		if ( !IsHost )
 			return;
 
-		Log.Info( $"{source.Name} [{source.SteamId}] disconnected" );
+		// If the connection never got as far as sending us its UserInfo then it has no name or
+		// SteamId yet, so don't log a misleading "Unknown Player" - log the address and the
+		// handshake state it dropped at instead, which is far more useful for diagnosing failed joins.
+		if ( source.PreInfo is null && ConnectionInfo.Get( source.Id ) is null )
+		{
+			Log.Info( $"Connection from {source.Address} disconnected during handshake (state: {previousState})" );
+		}
+		else
+		{
+			Log.Info( $"{source.Name} [{source.SteamId}] disconnected" );
+		}
 
 		ConnectionInfo.Remove( source.Id );
 		OnConnectionInfoUpdated();

--- a/engine/Sandbox.Engine/Systems/Networking/Transports/SteamNetworkSockets/SteamConnections.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Transports/SteamNetworkSockets/SteamConnections.cs
@@ -112,8 +112,14 @@ internal static partial class SteamNetwork
 
 		internal override async Task<bool> OnReceiveUserInfo( UserInfo info )
 		{
+			// This runs before the connection has any ConnectionInfo/PreInfo, so a rejection here
+			// only surfaces to the server console via these logs - otherwise all the host sees is
+			// the generic "Unknown Player disconnected" from OnDisconnected.
+			var who = $"{info.Name} [{info.SteamId}]";
+
 			if ( info.AuthTicket == null || info.AuthTicket.Length == 0 )
 			{
+				Log.Info( $"Rejecting {who}: Invalid Auth Ticket (client sent no ticket - is Steam running/logged in on the client?)" );
 				Close( (int)NetConnectionEnd.Misc_SteamConnectivity, "Invalid Auth Ticket" );
 				return false;
 			}
@@ -123,6 +129,7 @@ internal static partial class SteamNetwork
 
 			if ( currentPlayerCount >= maxPlayers )
 			{
+				Log.Info( $"Rejecting {who}: Server Full ({currentPlayerCount}/{maxPlayers})" );
 				Close( (int)NetConnectionEnd.App_Generic, "Server Full" );
 				return false;
 			}
@@ -139,18 +146,38 @@ internal static partial class SteamNetwork
 			var result = Services.Auth.BeginAuthSession( info.SteamId, info.AuthTicket );
 			if ( result != BeginAuthResult.OK )
 			{
+				PendingAuth.Remove( info.SteamId );
+				Log.Warning( $"Rejecting {who}: BeginAuthSession failed ({result}) - check the server is logged onto Steam and the app id matches the client." );
 				Close( 0, result.ToString() );
 				return false;
 			}
 
 			// Wait for Steam to validate and tell us the app owner
-			var authResponse = await tcs.Task.WaitAsync( TimeSpan.FromSeconds( 30 ) );
+			ValidateAuthTicketResponse_t authResponse;
+			try
+			{
+				authResponse = await tcs.Task.WaitAsync( TimeSpan.FromSeconds( 30 ) );
+			}
+			catch ( TimeoutException )
+			{
+				// The ValidateAuthTicketResponse callback never arrived. Usually means the server
+				// couldn't reach Steam to validate the ticket. Clean up so we don't leak the pending
+				// entry or the auth session we started above.
+				PendingAuth.Remove( info.SteamId );
+				Services.Auth.EndAuthSession( info.SteamId );
+				Log.Warning( $"Rejecting {who}: timed out after 30s waiting for Steam to validate the auth ticket (is the server connected to Steam?)." );
+				Close( (int)NetConnectionEnd.Misc_SteamConnectivity, "Auth Timeout" );
+				return false;
+			}
 
 			if ( authResponse.AuthSessionResponse != AuthResponse.OK )
 			{
+				Log.Warning( $"Rejecting {who}: Auth Failed ({authResponse.AuthSessionResponse}) - the client likely doesn't own this app on Steam, or the app id is mismatched." );
 				Close( 0, $"Auth Failed: {authResponse.AuthSessionResponse}" );
 				return false;
 			}
+
+			Log.Info( $"{who} passed Steam authentication (owner {authResponse.OwnerSteamID})" );
 
 			OwnerSteamId = authResponse.OwnerSteamID;
 

--- a/engine/Sandbox.Reflection/Utility.cs
+++ b/engine/Sandbox.Reflection/Utility.cs
@@ -100,6 +100,13 @@ internal static class ReflectionUtility
 
 		var valueType = value.GetType();
 
+		// A default(ImmutableArray<T>) is a struct wrapping a null array: it boxes to a non-null object, but any
+		// collection access (even .Count) throws "operation cannot be performed on a default instance". Treat it
+		// as empty rather than letting it throw - this was the SceneTrace._traceIgnore* noise on shutdown.
+		if ( valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof( System.Collections.Immutable.ImmutableArray<> )
+			 && valueType.GetProperty( "IsDefault" )?.GetValue( value ) is true )
+			return false;
+
 		// Check if this is a generic collection whose element type matches
 		if ( HasGenericElementOfType( valueType, targetType ) )
 		{

--- a/engine/Sandbox.Tools/Theme.cs
+++ b/engine/Sandbox.Tools/Theme.cs
@@ -151,65 +151,73 @@ public static partial class Theme
 	private static void LoadFromFile()
 	{
 		var themeJson = FileSystem.Root.ReadAllText( "/addons/tools/assets/styles/theme.json" );
-		var theme = Json.Deserialize<Dictionary<string, string>>( themeJson );
+		var theme = string.IsNullOrWhiteSpace( themeJson )
+			? null
+			: Json.Deserialize<Dictionary<string, string>>( themeJson );
 
-		TabBackground = Color.Parse( theme["TabBackground"] ) ?? Color.Parse( "#3b3b3b" ).Value;
-		TabBarBackground = Color.Parse( theme["TabBarBackground"] ) ?? Color.Parse( "#242424" ).Value;
-		TabInactiveBackground = Color.Parse( theme["TabInactiveBackground"] ) ?? Color.Parse( "#242424" ).Value;
-		SurfaceBackground = Color.Parse( theme["SurfaceBackground"] ) ?? Color.Parse( "#3b3b3b" ).Value;
-		SurfaceLightBackground = Color.Parse( theme["SurfaceLightBackground"] ) ?? Color.Parse( "#696969" ).Value;
-		SidebarBackground = Color.Parse( theme["SidebarBackground"] ) ?? Color.Parse( "#242424" ).Value;
-		WindowBackground = Color.Parse( theme["WindowBackground"] ) ?? Color.Parse( "#181818" ).Value;
-		WidgetBackground = Color.Parse( theme["WidgetBackground"] ) ?? Color.Parse( "#242424" ).Value;
-		ControlBackground = Color.Parse( theme["ControlBackground"] ) ?? Color.Parse( "#181818" ).Value;
-		ButtonBackground = Color.Parse( theme["ButtonBackground"] ) ?? Color.Parse( "#181818" ).Value;
-		SelectedBackground = Color.Parse( theme["SelectedBackground"] ) ?? Color.Parse( "#808080" ).Value;
-		StatusBarBackground = Color.Parse( theme["StatusBarBackground"] ) ?? Color.Parse( "#242424" ).Value;
-		Text = Color.Parse( theme["Text"] ) ?? Color.Parse( "#FFFFFF" ).Value;
-		TextControl = Color.Parse( theme["TextControl"] ) ?? Color.Parse( "#FFFFFF" ).Value;
-		TextLight = Color.Parse( theme["TextLight"] ) ?? Color.Parse( "#9E9E9E" ).Value;
-		TextWidget = Color.Parse( theme["TextWidget"] ) ?? Color.Parse( "#FFFFFF" ).Value;
-		TextButton = Color.Parse( theme["TextButton"] ) ?? Color.Parse( "#FFFFFF" ).Value;
-		TextSelected = Color.Parse( theme["TextSelected"] ) ?? Color.Parse( "#66a3ff" ).Value;
-		TextLink = Color.Parse( theme["TextLink"] ) ?? Color.Parse( "#FFFFFF" ).Value;
-		TextHighlight = Color.Parse( theme["TextHighlight"] ) ?? Color.Parse( "#66a3ff" ).Value;
-		TextDisabled = Color.Parse( theme["TextDisabled"] ) ?? Color.Parse( "#FFFFFF55" ).Value;
-		Border = Color.Parse( theme["Border"] ) ?? Color.Parse( "#525252" ).Value;
-		BorderLight = Color.Parse( theme["BorderLight"] ) ?? Color.Parse( "#696969" ).Value;
-		BorderButton = Color.Parse( theme["BorderButton"] ) ?? Color.Parse( "#696969" ).Value;
-		Shadow = Color.Parse( theme["Shadow"] ) ?? Color.Parse( "#242424" ).Value;
-		Primary = Color.Parse( theme["Primary"] ) ?? Color.Parse( "#5a8deb" ).Value;
-		Overlay = Color.Parse( theme["Overlay"] ) ?? Color.Parse( "#242424" ).Value;
-		MultipleValues = Color.Parse( theme["MultipleValues"] ) ?? Color.Parse( "#808080" ).Value;
-		Highlight = Color.Parse( theme["Highlight"] ) ?? Color.Parse( "#9E9E9E" ).Value;
-		TextDark = Color.Parse( theme["TextDark"] ) ?? Color.Parse( "#000000" ).Value;
-		Base = Color.Parse( theme["Base"] ) ?? Color.Parse( "#202020" ).Value;
-		BaseAlt = Color.Parse( theme["BaseAlt"] ) ?? Color.Parse( "#242424" ).Value;
+		// The editor theme file isn't shipped with a STANDALONE build (and a hand-edited file may be missing
+		// keys), so every lookup is defensive: a missing file or key returns null and falls through to the inline
+		// default below. Without this, the static ctor threw on every field the moment anything touched Editor.Theme
+		// in a non-editor process (e.g. the shutdown reflection sweep), spamming the log.
+		string Get( string key ) => theme is not null && theme.TryGetValue( key, out var value ) ? value : null;
 
-		ToggleEnabled = Color.Parse( theme["ToggleEnabled"] ) ?? Color.Parse( "#5aeb5c" ).Value;
-		ToggleDisabled = Color.Parse( theme["ToggleDisabled"] ) ?? Color.Parse( "#566e56" ).Value;
+		TabBackground = Color.Parse( Get( "TabBackground" ) ) ?? Color.Parse( "#3b3b3b" ).Value;
+		TabBarBackground = Color.Parse( Get( "TabBarBackground" ) ) ?? Color.Parse( "#242424" ).Value;
+		TabInactiveBackground = Color.Parse( Get( "TabInactiveBackground" ) ) ?? Color.Parse( "#242424" ).Value;
+		SurfaceBackground = Color.Parse( Get( "SurfaceBackground" ) ) ?? Color.Parse( "#3b3b3b" ).Value;
+		SurfaceLightBackground = Color.Parse( Get( "SurfaceLightBackground" ) ) ?? Color.Parse( "#696969" ).Value;
+		SidebarBackground = Color.Parse( Get( "SidebarBackground" ) ) ?? Color.Parse( "#242424" ).Value;
+		WindowBackground = Color.Parse( Get( "WindowBackground" ) ) ?? Color.Parse( "#181818" ).Value;
+		WidgetBackground = Color.Parse( Get( "WidgetBackground" ) ) ?? Color.Parse( "#242424" ).Value;
+		ControlBackground = Color.Parse( Get( "ControlBackground" ) ) ?? Color.Parse( "#181818" ).Value;
+		ButtonBackground = Color.Parse( Get( "ButtonBackground" ) ) ?? Color.Parse( "#181818" ).Value;
+		SelectedBackground = Color.Parse( Get( "SelectedBackground" ) ) ?? Color.Parse( "#808080" ).Value;
+		StatusBarBackground = Color.Parse( Get( "StatusBarBackground" ) ) ?? Color.Parse( "#242424" ).Value;
+		Text = Color.Parse( Get( "Text" ) ) ?? Color.Parse( "#FFFFFF" ).Value;
+		TextControl = Color.Parse( Get( "TextControl" ) ) ?? Color.Parse( "#FFFFFF" ).Value;
+		TextLight = Color.Parse( Get( "TextLight" ) ) ?? Color.Parse( "#9E9E9E" ).Value;
+		TextWidget = Color.Parse( Get( "TextWidget" ) ) ?? Color.Parse( "#FFFFFF" ).Value;
+		TextButton = Color.Parse( Get( "TextButton" ) ) ?? Color.Parse( "#FFFFFF" ).Value;
+		TextSelected = Color.Parse( Get( "TextSelected" ) ) ?? Color.Parse( "#66a3ff" ).Value;
+		TextLink = Color.Parse( Get( "TextLink" ) ) ?? Color.Parse( "#FFFFFF" ).Value;
+		TextHighlight = Color.Parse( Get( "TextHighlight" ) ) ?? Color.Parse( "#66a3ff" ).Value;
+		TextDisabled = Color.Parse( Get( "TextDisabled" ) ) ?? Color.Parse( "#FFFFFF55" ).Value;
+		Border = Color.Parse( Get( "Border" ) ) ?? Color.Parse( "#525252" ).Value;
+		BorderLight = Color.Parse( Get( "BorderLight" ) ) ?? Color.Parse( "#696969" ).Value;
+		BorderButton = Color.Parse( Get( "BorderButton" ) ) ?? Color.Parse( "#696969" ).Value;
+		Shadow = Color.Parse( Get( "Shadow" ) ) ?? Color.Parse( "#242424" ).Value;
+		Primary = Color.Parse( Get( "Primary" ) ) ?? Color.Parse( "#5a8deb" ).Value;
+		Overlay = Color.Parse( Get( "Overlay" ) ) ?? Color.Parse( "#242424" ).Value;
+		MultipleValues = Color.Parse( Get( "MultipleValues" ) ) ?? Color.Parse( "#808080" ).Value;
+		Highlight = Color.Parse( Get( "Highlight" ) ) ?? Color.Parse( "#9E9E9E" ).Value;
+		TextDark = Color.Parse( Get( "TextDark" ) ) ?? Color.Parse( "#000000" ).Value;
+		Base = Color.Parse( Get( "Base" ) ) ?? Color.Parse( "#202020" ).Value;
+		BaseAlt = Color.Parse( Get( "BaseAlt" ) ) ?? Color.Parse( "#242424" ).Value;
 
-		Blue = Color.Parse( theme["Blue"] ) ?? Color.Parse( "#3273EB" ).Value;
-		Green = Color.Parse( theme["Green"] ) ?? Color.Parse( "#B0E24D" ).Value;
-		Red = Color.Parse( theme["Red"] ) ?? Color.Parse( "#FB5A5A" ).Value;
-		Yellow = Color.Parse( theme["Yellow"] ) ?? Color.Parse( "#E6DB74" ).Value;
-		Pink = Color.Parse( theme["Pink"] ) ?? Color.Parse( "#DF9194" ).Value;
+		ToggleEnabled = Color.Parse( Get( "ToggleEnabled" ) ) ?? Color.Parse( "#5aeb5c" ).Value;
+		ToggleDisabled = Color.Parse( Get( "ToggleDisabled" ) ) ?? Color.Parse( "#566e56" ).Value;
 
-		Prefab = Color.Parse( theme["Prefab"] ) ?? Color.Parse( "#3273EB" ).Value;
-		Folder = Color.Parse( theme["Folder"] ) ?? Color.Parse( "#E6DB74" ).Value;
+		Blue = Color.Parse( Get( "Blue" ) ) ?? Color.Parse( "#3273EB" ).Value;
+		Green = Color.Parse( Get( "Green" ) ) ?? Color.Parse( "#B0E24D" ).Value;
+		Red = Color.Parse( Get( "Red" ) ) ?? Color.Parse( "#FB5A5A" ).Value;
+		Yellow = Color.Parse( Get( "Yellow" ) ) ?? Color.Parse( "#E6DB74" ).Value;
+		Pink = Color.Parse( Get( "Pink" ) ) ?? Color.Parse( "#DF9194" ).Value;
 
-		if ( !float.TryParse( theme["ControlRadius"], out ControlRadius ) )
+		Prefab = Color.Parse( Get( "Prefab" ) ) ?? Color.Parse( "#3273EB" ).Value;
+		Folder = Color.Parse( Get( "Folder" ) ) ?? Color.Parse( "#E6DB74" ).Value;
+
+		if ( !float.TryParse( Get( "ControlRadius" ), out ControlRadius ) )
 			ControlRadius = 3.0f;
 
-		if ( !float.TryParse( theme["ControlHeight"], out ControlHeight ) )
+		if ( !float.TryParse( Get( "ControlHeight" ), out ControlHeight ) )
 			ControlHeight = 18.0f;
 
-		if ( !float.TryParse( theme["RowHeight"], out RowHeight ) )
+		if ( !float.TryParse( Get( "RowHeight" ), out RowHeight ) )
 			RowHeight = 16.0f;
 
-		HeadingFont = theme["HeadingFont"];
-		DefaultFont = theme["DefaultFont"];
-		MonospaceFont = theme["MonospaceFont"];
+		HeadingFont = Get( "HeadingFont" );
+		DefaultFont = Get( "DefaultFont" );
+		MonospaceFont = Get( "MonospaceFont" );
 	}
 
 	public static Color GetTint( EditorTint tint )


### PR DESCRIPTION
## Summary

Fixes several standalone build startup/shutdown issues and improves Steam connection diagnostics.

Standalone builds should not try to report s&box activity, should tolerate missing editor-only theme assets, and should avoid noisy reflection exceptions from default `ImmutableArray<T>` values. This also makes failed Steam auth handshakes easier to diagnose and cleans up pending auth/session state when validation times out or fails early.

## Motivation & Context

When running a standalone build, a few engine paths can still assume editor/service state exists:

- `Api.UpdateActivity` can run without backend account state initialized.
- `Editor.Theme` can be touched even when the standalone build does not ship the editor theme file.
- Reflection checks can trip over default `ImmutableArray<T>` instances during shutdown.
- Steam auth failures before `ConnectionInfo` exists are hard to diagnose because they appear as generic disconnects.

This PR makes those paths defensive so standalone logs are cleaner and actual connection/auth problems are easier to understand.

Fixes: N/A

## Implementation Details

- Early-out from `Api.UpdateActivity` for standalone builds before touching activity/session reporting state.
- Make `Theme.LoadFromFile()` tolerate missing/empty theme JSON and missing keys, falling back to the existing inline defaults.
- Treat default `ImmutableArray<T>` values as empty in `ReflectionUtility.HasElementOfType()` instead of attempting collection access.
- Improve Steam auth logging for missing tickets, full servers, failed `BeginAuthSession`, validation timeouts, auth failures, and successful validation.
- Clean up `PendingAuth` and end the Steam auth session if ticket validation times out.
- Improve host disconnect logs for connections that drop during handshake before user info is available.

## Screenshots / Videos (if applicable)

Not applicable; this is engine/runtime behavior and logging only.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (not applicable; no public API changes)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂