### PR TITLE
Allow gib spawning by non hosts if they own the prop

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/Prop.cs
@@ -528,7 +528,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 		if ( Model is null )
 			return gibs;
 
-		var spawnServerGibs = !Network.IsProxy;
+		var spawnServerGibs = Networking.IsHost;
 		var spawnClientGibs = !Application.IsDedicatedServer;
 
 		var breaklist = Model.GetData<ModelBreakPiece[]>();
@@ -582,7 +582,7 @@ public class Prop : Component, Component.ExecuteInEditor, Component.IDamageable
 				{
 					gib.Tags.Add( "debris", "clientside" ); // no physics interactions
 				}
-				else if ( !IsProxy )
+				else if ( Networking.IsHost )
 				{
 					// Spawn on the network
 					gib.NetworkSpawn( true, null );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

This allows for clients that own props to spawn gibs on the server, just didn't think that it was the server so was an easy fix.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #11351 
Project is in the above issue.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Before: https://youtu.be/sj5TeMbmhJk
After: https://youtu.be/FvbHudgDP2I

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂