### PR TITLE
Add performance overlay and perf_dump command

### DIFF
--- a/game/addons/menu/Code/DevUI/DevUI.cs
+++ b/game/addons/menu/Code/DevUI/DevUI.cs
@@ -8,6 +8,7 @@ public class DevLayer : RootPanel
 	{
 		AddChild<DeveloperMode>();
 		AddChild<ConsoleOverlay>();
+		AddChild<PerformanceOverlay>();
 
 		ExceptionNotification = AddChild<ExceptionNotification>();
 

--- a/game/addons/menu/Code/DevUI/PerfOverlay/PerfDump.cs
+++ b/game/addons/menu/Code/DevUI/PerfOverlay/PerfDump.cs
@@ -1,0 +1,178 @@
+using Sandbox.Diagnostics;
+
+namespace Sandbox.UI.Dev;
+
+/// <summary>
+/// Samples per-frame performance stats for a fixed duration and writes a JSON
+/// report to the game's logs folder. Ticked every frame by <see cref="PerformanceOverlay"/>.
+/// </summary>
+public static class PerfDump
+{
+	static List<double> _frameMs;
+	static List<double> _gpuMs;
+	static List<double> _drawCalls;
+	static List<double> _triangles;
+	static float _duration;
+	static float _remaining;
+	static bool _quitWhenDone;
+	static float _quitCountdown = -1;
+
+	public static bool Active => _frameMs is not null;
+
+	[MenuConCmd( "perf_dump", Help = "Sample performance every frame for N seconds (default 10), write a JSON report to logs/ and take a screenshot. Pass 'quit' as the second argument to exit the game afterwards." )]
+	public static void Run( float seconds = 10, string then = "" )
+	{
+		if ( Active )
+		{
+			Log.Warning( "perf_dump: already sampling, ignoring" );
+			return;
+		}
+
+		if ( seconds <= 0 ) seconds = 10;
+		seconds = Math.Clamp( seconds, 1, 300 );
+
+		_duration = seconds;
+		_remaining = seconds;
+		_quitWhenDone = string.Equals( then, "quit", StringComparison.OrdinalIgnoreCase );
+		_frameMs = new();
+		_gpuMs = new();
+		_drawCalls = new();
+		_triangles = new();
+
+		Log.Info( $"perf_dump: sampling for {seconds:0.#} seconds..." );
+	}
+
+	public static void Tick()
+	{
+		// Grace period after finishing so the screenshot capture completes before quitting.
+		if ( _quitCountdown > 0 )
+		{
+			_quitCountdown -= RealTime.Delta;
+			if ( _quitCountdown <= 0 )
+			{
+				Log.Info( "perf_dump: quitting" );
+				ConsoleSystem.Run( "quit" );
+			}
+		}
+
+		if ( !Active )
+			return;
+
+		_frameMs.Add( PerformanceStats.FrameTime * 1000.0 );
+		_gpuMs.Add( PerformanceStats.GpuFrametime );
+		_drawCalls.Add( FrameStats.Current.DrawCalls );
+		_triangles.Add( FrameStats.Current.TrianglesRendered );
+
+		_remaining -= RealTime.Delta;
+		if ( _remaining <= 0 )
+			Finish();
+	}
+
+	static void Finish()
+	{
+		var frameMs = _frameMs;
+		var gpuMs = _gpuMs;
+		var drawCalls = _drawCalls;
+		var triangles = _triangles;
+
+		_frameMs = null;
+		_gpuMs = null;
+		_drawCalls = null;
+		_triangles = null;
+
+		if ( frameMs.Count == 0 )
+		{
+			Log.Warning( "perf_dump: no samples collected" );
+			return;
+		}
+
+		var avgFrameMs = frameMs.Average();
+		var p99FrameMs = Percentile( frameMs, 99 );
+
+		var report = new Dictionary<string, object>
+		{
+			["timestamp"] = DateTime.Now.ToString( "yyyy-MM-dd HH:mm:ss" ),
+			["durationSeconds"] = Math.Round( _duration, 2 ),
+			["sampleCount"] = frameMs.Count,
+			["fps"] = new Dictionary<string, object>
+			{
+				["avg"] = Round( 1000.0 / avgFrameMs ),
+				["min"] = Round( 1000.0 / frameMs.Max() ),
+				["max"] = Round( 1000.0 / frameMs.Min() ),
+				["onePercentLow"] = Round( 1000.0 / p99FrameMs ),
+			},
+			["frameMs"] = Summarize( frameMs ),
+			["gpuMs"] = Summarize( gpuMs ),
+			["drawCalls"] = Summarize( drawCalls ),
+			["trianglesRendered"] = Summarize( triangles ),
+			["vram"] = new Dictionary<string, object>
+			{
+				["usedMB"] = Round( Graphics.VideoMemoryUsed / (1024.0 * 1024.0) ),
+				["budgetMB"] = Round( Graphics.VideoMemoryBudget / (1024.0 * 1024.0) ),
+			},
+			// Include the active graphics settings so reports are comparable
+			["settings"] = SampleSettings(),
+		};
+
+		try
+		{
+			// The engine runs with game/ as the working directory, next to logs/sbox.log.
+			var dir = System.IO.Path.GetFullPath( "logs" );
+			System.IO.Directory.CreateDirectory( dir );
+
+			var path = System.IO.Path.Combine( dir, $"perf_dump_{DateTime.Now:yyyyMMdd_HHmmss}.json" );
+			var json = System.Text.Json.JsonSerializer.Serialize( report, new System.Text.Json.JsonSerializerOptions { WriteIndented = true } );
+			System.IO.File.WriteAllText( path, json );
+
+			Log.Info( $"perf_dump: {frameMs.Count} samples over {_duration:0.#}s, avg {1000.0 / avgFrameMs:0.#} fps - written to {path}" );
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( $"perf_dump: failed to write report - {e.Message}" );
+		}
+
+		// Take a screenshot so the numbers come with a visual reference
+		ConsoleSystem.Run( "screenshot" );
+
+		if ( _quitWhenDone )
+			_quitCountdown = 3;
+	}
+
+	static Dictionary<string, object> SampleSettings()
+	{
+		string[] convars =
+		[
+			"r.shadows.csm.enabled", "r.shadows.local.enabled", "r.shadows.contact.enabled",
+			"r.shadows.csm.distance", "r_ao_quality", "r_ssr_downsample_ratio",
+			"r_bloom", "maxdecals", "r_upscaling", "r_upscaler_render_scale",
+			"volume_fog_width", "volume_fog_height", "r_texture_stream_max_resolution",
+		];
+
+		var result = new Dictionary<string, object>();
+		foreach ( var name in convars )
+			result[name] = ConsoleSystem.GetValue( name, "<unset>" );
+
+		return result;
+	}
+
+	static Dictionary<string, object> Summarize( List<double> samples )
+	{
+		return new Dictionary<string, object>
+		{
+			["min"] = Round( samples.Min() ),
+			["avg"] = Round( samples.Average() ),
+			["max"] = Round( samples.Max() ),
+			["p95"] = Round( Percentile( samples, 95 ) ),
+			["p99"] = Round( Percentile( samples, 99 ) ),
+		};
+	}
+
+	static double Percentile( List<double> samples, double percentile )
+	{
+		var sorted = samples.OrderBy( x => x ).ToList();
+		var index = (int)Math.Ceiling( percentile / 100.0 * sorted.Count ) - 1;
+		return sorted[Math.Clamp( index, 0, sorted.Count - 1 )];
+	}
+
+	static double Round( double value ) => Math.Round( value, 2 );
+}

--- a/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor
+++ b/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor
@@ -1,0 +1,47 @@
+@namespace Sandbox.UI.Dev
+@using Sandbox.UI.Dev.Stats
+@inherits Panel
+
+<root class="perf-overlay">
+
+    <StatValue Value="@Fps" Title="FPS"></StatValue>
+    <StatValue Value="@FrameAvg" Title="Frame Avg"></StatValue>
+    <StatValue Value="@FrameWorst" Title="Frame Worst"></StatValue>
+    <StatValue Value="@GpuMs" Title="GPU"></StatValue>
+    <StatValue Value="@DrawCalls" Title="Draw Calls"></StatValue>
+    <StatValue Value="@Vram" Title="VRAM"></StatValue>
+
+</root>
+
+
+@code
+{
+    [MenuConVar( "perf_overlay", Help = "Show a compact performance overlay in the corner of the screen", Saved = true )]
+    public static bool ShowPerfOverlay { get; set; }
+
+    static float AvgFrameMs => Sandbox.Diagnostics.PerformanceStats.LastSecond.FrameAvg;
+
+    string Fps => AvgFrameMs > 0 ? (1000f / AvgFrameMs).ToString( "0" ) : "-";
+    string FrameAvg => AvgFrameMs.ToString( "0.0 ms" );
+    string FrameWorst => Sandbox.Diagnostics.PerformanceStats.LastSecond.FrameMax.ToString( "0.0 ms" );
+    string GpuMs => Sandbox.Diagnostics.PerformanceStats.GpuFrametime.ToString( "0.0 ms" );
+    string DrawCalls => Sandbox.Diagnostics.FrameStats.Current.DrawCalls.ToMetric();
+    string Vram => $"{Graphics.VideoMemoryUsed / (1024.0 * 1024.0):0}/{Graphics.VideoMemoryBudget / (1024.0 * 1024.0):0} MB";
+
+    public override void Tick()
+    {
+        base.Tick();
+
+        SetClass( "visible", ShowPerfOverlay );
+
+        PerfDump.Tick();
+    }
+
+    protected override int BuildHash()
+    {
+        if ( !ShowPerfOverlay )
+            return 0;
+
+        return HashCode.Combine( Sandbox.Diagnostics.PerformanceStats.LastSecond );
+    }
+}

--- a/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor.scss
+++ b/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor.scss
@@ -1,0 +1,19 @@
+PerformanceOverlay
+{
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    flex-direction: column;
+    padding: 10px 14px;
+    background-color: #000000aa;
+    border-radius: 8px;
+    font-family: Poppins;
+    font-size: 12px;
+    pointer-events: none;
+    display: none;
+
+    &.visible
+    {
+        display: flex;
+    }
+}


### PR DESCRIPTION
Two small tools for measuring performance without a profiler attached:

- **`perf_overlay` (saved menu convar)** — a compact always-on-top overlay in the corner showing FPS, average/worst frame time, GPU time, draw calls and VRAM used/budget. Rendered from the existing `PerformanceStats`/`FrameStats` counters, reuses the DevUI `StatValue` component, mounted in `DevLayer` next to the console overlay. Costs nothing when hidden (BuildHash returns 0).
- **`perf_dump [seconds] [quit]`** — samples frame time, GPU time, draw calls and triangles every frame for N seconds (default 10), then writes a JSON report to `logs/` with min/avg/max/p95/p99 summaries, FPS stats including 1% lows, VRAM usage, and a snapshot of the relevant graphics convars so reports are comparable. Takes a screenshot when it finishes, and optionally quits the game afterwards so it can be scripted from the command line for automated before/after runs.

Self-contained; no engine changes.
