### PR TITLE
Add render resolution slider, advanced quality settings and menu background modes

### DIFF
--- a/engine/Sandbox.Engine/Core/Bootstrap.cs
+++ b/engine/Sandbox.Engine/Core/Bootstrap.cs
@@ -176,9 +176,11 @@ internal static class Bootstrap
 			InitEngineConVars();
 
 			// RenderSettings may be constructed before these convars exist, silently dropping
-			// its writes - re-apply the quality groups and advanced overrides now
+			// its writes - re-apply the quality groups and advanced overrides now. The upscaler
+			// settings also need pushing here so the cookies win over machine_convars.vcfg.
 			Settings.RenderSettings.Instance.Config.SetDefaults( Settings.RenderSettings.Instance );
 			Settings.RenderSettings.Instance.ApplyAdvancedOverrides();
+			Settings.RenderSettings.Instance.ApplyUpscalerSettings();
 
 			if ( IToolsDll.Current is not null )
 			{

--- a/engine/Sandbox.Engine/Core/Bootstrap.cs
+++ b/engine/Sandbox.Engine/Core/Bootstrap.cs
@@ -175,6 +175,11 @@ internal static class Bootstrap
 
 			InitEngineConVars();
 
+			// RenderSettings may be constructed before these convars exist, silently dropping
+			// its writes - re-apply the quality groups and advanced overrides now
+			Settings.RenderSettings.Instance.Config.SetDefaults( Settings.RenderSettings.Instance );
+			Settings.RenderSettings.Instance.ApplyAdvancedOverrides();
+
 			if ( IToolsDll.Current is not null )
 			{
 				using var x = StartupTiming?.ScopeTimer( $"IToolsDll Bootstrap Init" );

--- a/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.cs
@@ -112,18 +112,28 @@ public partial class RenderSettings
 		{
 			VideoSettings.Set<UpscalerMode>( "upscaler.mode", value );
 			ConVarSystem.SetInt( "r_upscaling", (int)value, true );
+
+			// Re-clamp the render scale for the new mode - FSR1 has a higher minimum
+			UpscalerRenderScale = UpscalerRenderScale;
 		}
 	}
 
 	/// <summary>
-	/// Render-resolution scale used by Stretch and FSR1 modes (25-100%).
+	/// FSR1 (EASU) is only specified for upscale factors up to 2x per axis. Below 50%
+	/// render scale it produces blocky smearing, and RCAS sharpening amplifies the
+	/// undersampling into speckle artifacts. Stretch has no such constraint.
+	/// </summary>
+	static float MinRenderScale( UpscalerMode mode ) => mode == UpscalerMode.FSR1 ? 0.5f : 0.25f;
+
+	/// <summary>
+	/// Render-resolution scale used by Stretch (25-100%) and FSR1 (50-100%) modes.
 	/// </summary>
 	public float UpscalerRenderScale
 	{
 		get => VideoSettings.Get<float>( "upscaler.render_scale", 0.75f );
 		set
 		{
-			float v = Math.Clamp( value, 0.25f, 1.0f );
+			float v = Math.Clamp( value, MinRenderScale( UpscalerMode ), 1.0f );
 			VideoSettings.Set<float>( "upscaler.render_scale", v );
 			ConVarSystem.SetFloat( "r_upscaler_render_scale", v, true );
 		}
@@ -281,11 +291,13 @@ public partial class RenderSettings
 	/// </summary>
 	internal void ApplyUpscalerSettings()
 	{
-		if ( VideoSettings.TryGet<UpscalerMode>( "upscaler.mode", out var mode ) )
+		if ( !VideoSettings.TryGet<UpscalerMode>( "upscaler.mode", out var mode ) )
+			mode = UpscalerMode;
+		else
 			ConVarSystem.SetInt( "r_upscaling", (int)mode, true );
 
 		if ( VideoSettings.TryGet<float>( "upscaler.render_scale", out var scale ) )
-			ConVarSystem.SetFloat( "r_upscaler_render_scale", Math.Clamp( scale, 0.25f, 1.0f ), true );
+			ConVarSystem.SetFloat( "r_upscaler_render_scale", Math.Clamp( scale, MinRenderScale( mode ), 1.0f ), true );
 
 		if ( VideoSettings.TryGet<float>( "upscaler.fsr1_sharpness", out var fsr1Sharpness ) )
 			ConVarSystem.SetFloat( "r_fsr_rcas_sharpness", fsr1Sharpness, true );

--- a/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.cs
@@ -22,6 +22,7 @@ public partial class RenderSettings
 
 		// Explicit advanced choices apply on top of the quality group fan-out
 		ApplyAdvancedOverrides();
+		ApplyUpscalerSettings();
 	}
 
 	public int MaxFrameRate
@@ -270,6 +271,30 @@ public partial class RenderSettings
 	{
 		get => ConVarSystem.GetInt( "maxdecals", 1000, true );
 		set => ConVarSystem.SetInt( "maxdecals", value, true );
+	}
+
+	/// <summary>
+	/// Push the cookie-backed upscaler choices to their convars. The native engine
+	/// restores machine_convars.vcfg at startup, which can disagree with what the
+	/// settings UI shows - the cookies are the source of truth, so they win.
+	/// Settings the user never touched have no cookie and keep the engine's value.
+	/// </summary>
+	internal void ApplyUpscalerSettings()
+	{
+		if ( VideoSettings.TryGet<UpscalerMode>( "upscaler.mode", out var mode ) )
+			ConVarSystem.SetInt( "r_upscaling", (int)mode, true );
+
+		if ( VideoSettings.TryGet<float>( "upscaler.render_scale", out var scale ) )
+			ConVarSystem.SetFloat( "r_upscaler_render_scale", Math.Clamp( scale, 0.25f, 1.0f ), true );
+
+		if ( VideoSettings.TryGet<float>( "upscaler.fsr1_sharpness", out var fsr1Sharpness ) )
+			ConVarSystem.SetFloat( "r_fsr_rcas_sharpness", fsr1Sharpness, true );
+
+		if ( VideoSettings.TryGet<Fsr3UpscalerQuality>( "upscaler.quality", out var fsr3Quality ) && fsr3Quality != Fsr3UpscalerQuality.Off )
+			ConVarSystem.SetInt( "r_fsr3_quality", (int)fsr3Quality, true );
+
+		if ( VideoSettings.TryGet<float>( "upscaler.fsr3_sharpness", out var fsr3Sharpness ) )
+			ConVarSystem.SetFloat( "r_fsr3_sharpness", fsr3Sharpness, true );
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.cs
@@ -19,6 +19,9 @@ public partial class RenderSettings
 	internal RenderSettings()
 	{
 		Config.SetDefaults( this );
+
+		// Explicit advanced choices apply on top of the quality group fan-out
+		ApplyAdvancedOverrides();
 	}
 
 	public int MaxFrameRate
@@ -72,6 +75,9 @@ public partial class RenderSettings
 		{
 			VideoSettings.Set<PostProcessQuality>( "postprocess.quality", value );
 			Config.SetGroupConVars( "PostProcessQuality", value.ToString() );
+
+			// Explicit advanced choices win over the group fan-out
+			ApplyAdvancedOverrides();
 		}
 	}
 
@@ -82,6 +88,9 @@ public partial class RenderSettings
 		{
 			VideoSettings.Set<ShadowQuality>( "shadow.quality", value );
 			Config.SetGroupConVars( "ShadowQuality", value.ToString() );
+
+			// Explicit advanced choices win over the group fan-out
+			ApplyAdvancedOverrides();
 		}
 	}
 
@@ -106,14 +115,14 @@ public partial class RenderSettings
 	}
 
 	/// <summary>
-	/// Render-resolution scale used by Stretch (40-100%) and FSR1 (50-100%) modes.
+	/// Render-resolution scale used by Stretch and FSR1 modes (25-100%).
 	/// </summary>
 	public float UpscalerRenderScale
 	{
 		get => VideoSettings.Get<float>( "upscaler.render_scale", 0.75f );
 		set
 		{
-			float v = Math.Clamp( value, 0.4f, 1.0f );
+			float v = Math.Clamp( value, 0.25f, 1.0f );
 			VideoSettings.Set<float>( "upscaler.render_scale", v );
 			ConVarSystem.SetFloat( "r_upscaler_render_scale", v, true );
 		}
@@ -157,6 +166,135 @@ public partial class RenderSettings
 			VideoSettings.Set<float>( "upscaler.fsr3_sharpness", v );
 			ConVarSystem.SetFloat( "r_fsr3_sharpness", v, true );
 		}
+	}
+
+	//
+	// Advanced settings. Getters read the live convar so the UI reflects reality,
+	// setters store a cookie so explicit choices survive restarts and group changes.
+	//
+
+	/// <summary>
+	/// Cascaded shadow maps for the directional (sun) light.
+	/// </summary>
+	public bool SunShadows
+	{
+		get => ConVarSystem.GetInt( "r.shadows.csm.enabled", 1, true ) != 0;
+		set
+		{
+			VideoSettings.Set<bool>( "shadow.csm.enabled", value );
+			ConVarSystem.SetValue( "r.shadows.csm.enabled", value.ToString(), true );
+		}
+	}
+
+	/// <summary>
+	/// Shadow maps for local (spot/point) lights.
+	/// </summary>
+	public bool DynamicShadows
+	{
+		get => ConVarSystem.GetInt( "r.shadows.local.enabled", 1, true ) != 0;
+		set
+		{
+			VideoSettings.Set<bool>( "shadow.local.enabled", value );
+			ConVarSystem.SetValue( "r.shadows.local.enabled", value.ToString(), true );
+		}
+	}
+
+	/// <summary>
+	/// Screen-space contact shadows for directional lights.
+	/// </summary>
+	public bool ContactShadows
+	{
+		get => ConVarSystem.GetInt( "r.shadows.contact.enabled", 1, true ) != 0;
+		set
+		{
+			VideoSettings.Set<bool>( "shadow.contact.enabled", value );
+			ConVarSystem.SetValue( "r.shadows.contact.enabled", value.ToString(), true );
+		}
+	}
+
+	/// <summary>
+	/// Maximum distance from the camera that sun shadows are rendered.
+	/// <see cref="ShadowQuality"/> also drives this, an explicit value set here wins.
+	/// </summary>
+	public float ShadowDistance
+	{
+		get => ConVarSystem.GetFloat( "r.shadows.csm.distance", 15000, true );
+		set
+		{
+			VideoSettings.Set<float>( "shadow.csm.distance", value );
+			ConVarSystem.SetFloat( "r.shadows.csm.distance", value, true );
+		}
+	}
+
+	/// <summary>
+	/// Ambient occlusion quality (0 off, 1 low, 2 medium, 3 high).
+	/// <see cref="PostProcessQuality"/> also drives this, an explicit value set here wins.
+	/// </summary>
+	public int AmbientOcclusionQuality
+	{
+		get => ConVarSystem.GetInt( "r_ao_quality", 3, true );
+		set
+		{
+			VideoSettings.Set<int>( "ao.quality", value );
+			ConVarSystem.SetInt( "r_ao_quality", value, true );
+		}
+	}
+
+	/// <summary>
+	/// Screen-space reflection resolution divisor (0 disabled, 4 quarter res, 2 half res, 1 full res).
+	/// <see cref="PostProcessQuality"/> also drives this, an explicit value set here wins.
+	/// </summary>
+	public int ReflectionQuality
+	{
+		get => ConVarSystem.GetInt( "r_ssr_downsample_ratio", 2, true );
+		set
+		{
+			VideoSettings.Set<int>( "ssr.downsample", value );
+			ConVarSystem.SetInt( "r_ssr_downsample_ratio", value, true );
+		}
+	}
+
+	/// <summary>
+	/// Bloom post-processing effect.
+	/// </summary>
+	public bool BloomEnabled
+	{
+		get => ConVarSystem.GetInt( "r_bloom", 1, true ) != 0;
+		set => ConVarSystem.SetValue( "r_bloom", value.ToString(), true );
+	}
+
+	/// <summary>
+	/// Maximum number of temporary decals (bullet holes etc) kept in the world.
+	/// </summary>
+	public int MaxDecals
+	{
+		get => ConVarSystem.GetInt( "maxdecals", 1000, true );
+		set => ConVarSystem.SetInt( "maxdecals", value, true );
+	}
+
+	/// <summary>
+	/// Re-apply explicitly chosen advanced settings on top of what the quality groups
+	/// wrote. Settings the user never touched have no cookie and follow their group.
+	/// </summary>
+	internal void ApplyAdvancedOverrides()
+	{
+		if ( VideoSettings.TryGet<bool>( "shadow.csm.enabled", out var csm ) )
+			ConVarSystem.SetValue( "r.shadows.csm.enabled", csm.ToString(), true );
+
+		if ( VideoSettings.TryGet<bool>( "shadow.local.enabled", out var local ) )
+			ConVarSystem.SetValue( "r.shadows.local.enabled", local.ToString(), true );
+
+		if ( VideoSettings.TryGet<bool>( "shadow.contact.enabled", out var contact ) )
+			ConVarSystem.SetValue( "r.shadows.contact.enabled", contact.ToString(), true );
+
+		if ( VideoSettings.TryGet<float>( "shadow.csm.distance", out var distance ) )
+			ConVarSystem.SetFloat( "r.shadows.csm.distance", distance, true );
+
+		if ( VideoSettings.TryGet<int>( "ao.quality", out var ao ) )
+			ConVarSystem.SetInt( "r_ao_quality", ao, true );
+
+		if ( VideoSettings.TryGet<int>( "ssr.downsample", out var ssr ) )
+			ConVarSystem.SetInt( "r_ssr_downsample_ratio", ssr, true );
 	}
 
 	public void ResetVideoConfig()

--- a/game/addons/menu/Code/DevUI/DevUI.cs
+++ b/game/addons/menu/Code/DevUI/DevUI.cs
@@ -8,6 +8,7 @@ public class DevLayer : RootPanel
 	{
 		AddChild<DeveloperMode>();
 		AddChild<ConsoleOverlay>();
+		AddChild<PerformanceOverlay>();
 
 		ExceptionNotification = AddChild<ExceptionNotification>();
 

--- a/game/addons/menu/Code/DevUI/PerfOverlay/PerfDump.cs
+++ b/game/addons/menu/Code/DevUI/PerfOverlay/PerfDump.cs
@@ -1,0 +1,178 @@
+using Sandbox.Diagnostics;
+
+namespace Sandbox.UI.Dev;
+
+/// <summary>
+/// Samples per-frame performance stats for a fixed duration and writes a JSON
+/// report to the game's logs folder. Ticked every frame by <see cref="PerformanceOverlay"/>.
+/// </summary>
+public static class PerfDump
+{
+	static List<double> _frameMs;
+	static List<double> _gpuMs;
+	static List<double> _drawCalls;
+	static List<double> _triangles;
+	static float _duration;
+	static float _remaining;
+	static bool _quitWhenDone;
+	static float _quitCountdown = -1;
+
+	public static bool Active => _frameMs is not null;
+
+	[MenuConCmd( "perf_dump", Help = "Sample performance every frame for N seconds (default 10), write a JSON report to logs/ and take a screenshot. Pass 'quit' as the second argument to exit the game afterwards." )]
+	public static void Run( float seconds = 10, string then = "" )
+	{
+		if ( Active )
+		{
+			Log.Warning( "perf_dump: already sampling, ignoring" );
+			return;
+		}
+
+		if ( seconds <= 0 ) seconds = 10;
+		seconds = Math.Clamp( seconds, 1, 300 );
+
+		_duration = seconds;
+		_remaining = seconds;
+		_quitWhenDone = string.Equals( then, "quit", StringComparison.OrdinalIgnoreCase );
+		_frameMs = new();
+		_gpuMs = new();
+		_drawCalls = new();
+		_triangles = new();
+
+		Log.Info( $"perf_dump: sampling for {seconds:0.#} seconds..." );
+	}
+
+	public static void Tick()
+	{
+		// Grace period after finishing so the screenshot capture completes before quitting.
+		if ( _quitCountdown > 0 )
+		{
+			_quitCountdown -= RealTime.Delta;
+			if ( _quitCountdown <= 0 )
+			{
+				Log.Info( "perf_dump: quitting" );
+				ConsoleSystem.Run( "quit" );
+			}
+		}
+
+		if ( !Active )
+			return;
+
+		_frameMs.Add( PerformanceStats.FrameTime * 1000.0 );
+		_gpuMs.Add( PerformanceStats.GpuFrametime );
+		_drawCalls.Add( FrameStats.Current.DrawCalls );
+		_triangles.Add( FrameStats.Current.TrianglesRendered );
+
+		_remaining -= RealTime.Delta;
+		if ( _remaining <= 0 )
+			Finish();
+	}
+
+	static void Finish()
+	{
+		var frameMs = _frameMs;
+		var gpuMs = _gpuMs;
+		var drawCalls = _drawCalls;
+		var triangles = _triangles;
+
+		_frameMs = null;
+		_gpuMs = null;
+		_drawCalls = null;
+		_triangles = null;
+
+		if ( frameMs.Count == 0 )
+		{
+			Log.Warning( "perf_dump: no samples collected" );
+			return;
+		}
+
+		var avgFrameMs = frameMs.Average();
+		var p99FrameMs = Percentile( frameMs, 99 );
+
+		var report = new Dictionary<string, object>
+		{
+			["timestamp"] = DateTime.Now.ToString( "yyyy-MM-dd HH:mm:ss" ),
+			["durationSeconds"] = Math.Round( _duration, 2 ),
+			["sampleCount"] = frameMs.Count,
+			["fps"] = new Dictionary<string, object>
+			{
+				["avg"] = Round( 1000.0 / avgFrameMs ),
+				["min"] = Round( 1000.0 / frameMs.Max() ),
+				["max"] = Round( 1000.0 / frameMs.Min() ),
+				["onePercentLow"] = Round( 1000.0 / p99FrameMs ),
+			},
+			["frameMs"] = Summarize( frameMs ),
+			["gpuMs"] = Summarize( gpuMs ),
+			["drawCalls"] = Summarize( drawCalls ),
+			["trianglesRendered"] = Summarize( triangles ),
+			["vram"] = new Dictionary<string, object>
+			{
+				["usedMB"] = Round( Graphics.VideoMemoryUsed / (1024.0 * 1024.0) ),
+				["budgetMB"] = Round( Graphics.VideoMemoryBudget / (1024.0 * 1024.0) ),
+			},
+			// Include the active graphics settings so reports are comparable
+			["settings"] = SampleSettings(),
+		};
+
+		try
+		{
+			// The engine runs with game/ as the working directory, next to logs/sbox.log.
+			var dir = System.IO.Path.GetFullPath( "logs" );
+			System.IO.Directory.CreateDirectory( dir );
+
+			var path = System.IO.Path.Combine( dir, $"perf_dump_{DateTime.Now:yyyyMMdd_HHmmss}.json" );
+			var json = System.Text.Json.JsonSerializer.Serialize( report, new System.Text.Json.JsonSerializerOptions { WriteIndented = true } );
+			System.IO.File.WriteAllText( path, json );
+
+			Log.Info( $"perf_dump: {frameMs.Count} samples over {_duration:0.#}s, avg {1000.0 / avgFrameMs:0.#} fps - written to {path}" );
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( $"perf_dump: failed to write report - {e.Message}" );
+		}
+
+		// Take a screenshot so the numbers come with a visual reference
+		ConsoleSystem.Run( "screenshot" );
+
+		if ( _quitWhenDone )
+			_quitCountdown = 3;
+	}
+
+	static Dictionary<string, object> SampleSettings()
+	{
+		string[] convars =
+		[
+			"r.shadows.csm.enabled", "r.shadows.local.enabled", "r.shadows.contact.enabled",
+			"r.shadows.csm.distance", "r_ao_quality", "r_ssr_downsample_ratio",
+			"r_bloom", "maxdecals", "r_upscaling", "r_upscaler_render_scale",
+			"volume_fog_width", "volume_fog_height", "r_texture_stream_max_resolution",
+		];
+
+		var result = new Dictionary<string, object>();
+		foreach ( var name in convars )
+			result[name] = ConsoleSystem.GetValue( name, "<unset>" );
+
+		return result;
+	}
+
+	static Dictionary<string, object> Summarize( List<double> samples )
+	{
+		return new Dictionary<string, object>
+		{
+			["min"] = Round( samples.Min() ),
+			["avg"] = Round( samples.Average() ),
+			["max"] = Round( samples.Max() ),
+			["p95"] = Round( Percentile( samples, 95 ) ),
+			["p99"] = Round( Percentile( samples, 99 ) ),
+		};
+	}
+
+	static double Percentile( List<double> samples, double percentile )
+	{
+		var sorted = samples.OrderBy( x => x ).ToList();
+		var index = (int)Math.Ceiling( percentile / 100.0 * sorted.Count ) - 1;
+		return sorted[Math.Clamp( index, 0, sorted.Count - 1 )];
+	}
+
+	static double Round( double value ) => Math.Round( value, 2 );
+}

--- a/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor
+++ b/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor
@@ -1,0 +1,47 @@
+@namespace Sandbox.UI.Dev
+@using Sandbox.UI.Dev.Stats
+@inherits Panel
+
+<root class="perf-overlay">
+
+    <StatValue Value="@Fps" Title="FPS"></StatValue>
+    <StatValue Value="@FrameAvg" Title="Frame Avg"></StatValue>
+    <StatValue Value="@FrameWorst" Title="Frame Worst"></StatValue>
+    <StatValue Value="@GpuMs" Title="GPU"></StatValue>
+    <StatValue Value="@DrawCalls" Title="Draw Calls"></StatValue>
+    <StatValue Value="@Vram" Title="VRAM"></StatValue>
+
+</root>
+
+
+@code
+{
+    [MenuConVar( "perf_overlay", Help = "Show a compact performance overlay in the corner of the screen", Saved = true )]
+    public static bool ShowPerfOverlay { get; set; }
+
+    static float AvgFrameMs => Sandbox.Diagnostics.PerformanceStats.LastSecond.FrameAvg;
+
+    string Fps => AvgFrameMs > 0 ? (1000f / AvgFrameMs).ToString( "0" ) : "-";
+    string FrameAvg => AvgFrameMs.ToString( "0.0 ms" );
+    string FrameWorst => Sandbox.Diagnostics.PerformanceStats.LastSecond.FrameMax.ToString( "0.0 ms" );
+    string GpuMs => Sandbox.Diagnostics.PerformanceStats.GpuFrametime.ToString( "0.0 ms" );
+    string DrawCalls => Sandbox.Diagnostics.FrameStats.Current.DrawCalls.ToMetric();
+    string Vram => $"{Graphics.VideoMemoryUsed / (1024.0 * 1024.0):0}/{Graphics.VideoMemoryBudget / (1024.0 * 1024.0):0} MB";
+
+    public override void Tick()
+    {
+        base.Tick();
+
+        SetClass( "visible", ShowPerfOverlay );
+
+        PerfDump.Tick();
+    }
+
+    protected override int BuildHash()
+    {
+        if ( !ShowPerfOverlay )
+            return 0;
+
+        return HashCode.Combine( Sandbox.Diagnostics.PerformanceStats.LastSecond );
+    }
+}

--- a/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor.scss
+++ b/game/addons/menu/Code/DevUI/PerfOverlay/PerformanceOverlay.razor.scss
@@ -1,0 +1,19 @@
+PerformanceOverlay
+{
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    flex-direction: column;
+    padding: 10px 14px;
+    background-color: #000000aa;
+    border-radius: 8px;
+    font-family: Poppins;
+    font-size: 12px;
+    pointer-events: none;
+    display: none;
+
+    &.visible
+    {
+        display: flex;
+    }
+}

--- a/game/addons/menu/Code/MainMenu.razor
+++ b/game/addons/menu/Code/MainMenu.razor
@@ -33,7 +33,16 @@
 
     public static MainMenu Instance { get; private set; }
 
+    [MenuConVar( "menu_background", Help = "Menu background detail: full, simple or off", Saved = true )]
+    public static string BackgroundMode { get; set; } = "full";
+
     static bool _welcomeShown;
+
+    string _appliedDetailMode;
+    bool _backgroundWasEnabled;
+    readonly Dictionary<SpotLight, bool> _savedShadows = new();
+    readonly Dictionary<Component, bool> _savedPostFx = new();
+    Dictionary<string, List<Sandbox.Clutter.ClutterGridSystem.ClutterStorage.Instance>> _savedClutter;
 
     override protected void OnEnabled()
     {
@@ -75,7 +84,97 @@
         SetClass( "is-vr", Application.IsVR );
         SetClass( "has-streamer-account", Sandbox.MenuEngine.Account.HasLinkedStreamerServices );
 
+        var mode = BackgroundMode?.ToLowerInvariant() switch
+        {
+            "simple" => "simple",
+            "off" => "off",
+            _ => "full"
+        };
+
         var isInGame = Application.IsEditor ? false : Game.InGame;
-        Background.Enabled = Navigator?.CurrentUrl == "/home" && !isInGame;
+        var showBackground = Navigator?.CurrentUrl == "/home" && !isInGame && mode != "off";
+        Background.Enabled = showBackground;
+
+        // Only touch the scene while the background is active - its components can't be
+        // found while the object is disabled. Reapply when it comes back on.
+        var justEnabled = showBackground && !_backgroundWasEnabled;
+        _backgroundWasEnabled = showBackground;
+
+        if ( showBackground && (_appliedDetailMode != mode || justEnabled) )
+        {
+            ApplyBackgroundDetail( mode == "simple" );
+            _appliedDetailMode = mode;
+        }
+    }
+
+    void ApplyBackgroundDetail( bool simple )
+    {
+        if ( simple )
+        {
+            foreach ( var light in Scene.GetAllComponents<SpotLight>() )
+            {
+                if ( !_savedShadows.ContainsKey( light ) )
+                    _savedShadows[light] = light.Shadows;
+
+                light.Shadows = false;
+            }
+
+            foreach ( var fx in Scene.GetAllComponents<Sandbox.Bloom>().Cast<Component>().Concat( Scene.GetAllComponents<Sandbox.AmbientOcclusion>() ) )
+            {
+                if ( !_savedPostFx.ContainsKey( fx ) )
+                    _savedPostFx[fx] = fx.Enabled;
+
+                fx.Enabled = false;
+            }
+        }
+        else
+        {
+            foreach ( var (light, shadows) in _savedShadows )
+            {
+                if ( light.IsValid() )
+                    light.Shadows = shadows;
+            }
+
+            _savedShadows.Clear();
+
+            foreach ( var (fx, enabled) in _savedPostFx )
+            {
+                if ( fx.IsValid() )
+                    fx.Enabled = enabled;
+            }
+
+            _savedPostFx.Clear();
+        }
+
+        ApplyClutterDetail( simple );
+    }
+
+    void ApplyClutterDetail( bool simple )
+    {
+        var clutter = Scene.GetSystem<Sandbox.Clutter.ClutterGridSystem>();
+        if ( clutter?.Storage is null )
+            return;
+
+        if ( simple )
+        {
+            if ( _savedClutter is not null || clutter.Storage.TotalCount == 0 )
+                return;
+
+            // Painted clutter has no visibility toggle, so snapshot the instances,
+            // clear them and restore the snapshot when switching back to Full.
+            _savedClutter = clutter.Storage.GetAllInstances().ToDictionary( x => x.Key, x => x.Value.ToList() );
+            clutter.Storage.ClearAll();
+            clutter.Flush();
+        }
+        else if ( _savedClutter is not null )
+        {
+            foreach ( var (modelPath, instances) in _savedClutter )
+            {
+                clutter.Storage.AddInstances( modelPath, instances );
+            }
+
+            _savedClutter = null;
+            clutter.Flush();
+        }
     }
 }

--- a/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
+++ b/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
@@ -539,13 +539,16 @@
 
         // The render resolution slider drives the upscaler - 100% renders native, below that
         // FSR1 upscales unless Stretch or FSR1 was picked explicitly. FSR3 sets its own
-        // scale through quality presets.
+        // scale through quality presets. FSR1 (EASU) is only specified up to 2x per axis,
+        // so scales below 50% fall back to Stretch instead of producing smear/speckle.
         if ( UpscalerMode != Sandbox.Engine.Settings.UpscalerMode.FSR3 )
         {
             if ( UpscalerRenderScalePercent >= 100 )
                 UpscalerMode = Sandbox.Engine.Settings.UpscalerMode.Off;
             else if ( UpscalerMode == Sandbox.Engine.Settings.UpscalerMode.Off )
-                UpscalerMode = Sandbox.Engine.Settings.UpscalerMode.FSR1;
+                UpscalerMode = UpscalerRenderScalePercent < 50 ? Sandbox.Engine.Settings.UpscalerMode.Stretch : Sandbox.Engine.Settings.UpscalerMode.FSR1;
+            else if ( UpscalerMode == Sandbox.Engine.Settings.UpscalerMode.FSR1 && UpscalerRenderScalePercent < 50 )
+                UpscalerMode = Sandbox.Engine.Settings.UpscalerMode.Stretch;
         }
 
         MenuUtility.RenderSettings.UpscalerMode = UpscalerMode;

--- a/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
+++ b/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
@@ -59,6 +59,16 @@
 
         <h2><i>brush</i>Quality</h2>
 
+        @if ( UpscalerMode != Sandbox.Engine.Settings.UpscalerMode.FSR3 )
+        {
+            <row class="with-gaps">
+                <cell class="glass with-padding is-label">
+                    Render Resolution
+                </cell>
+                <SliderControl class="glass with-grow" Value:bind=@UpscalerRenderScalePercent Min="@(25)" Max="@(100)" Step="@(1)" ShowTextEntry="@true"></SliderControl>
+            </row>
+        }
+
         <row class="with-gaps">
             <cell class="glass with-padding is-label">
                 Anti-Aliasing
@@ -101,6 +111,20 @@
             <SliderControl class="glass with-grow" Value:bind=@MotionBlurScale Min="@(0.0f)" Max="@(1.0f)" Step="@(0.01f)" ShowTextEntry="@true"></SliderControl>
         </row>
 
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Menu Background
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@MenuBackgroundOptions Value:bind=@MenuBackground></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Performance Overlay
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@ToggleOptions Value:bind=@PerformanceOverlayEnabled></ButtonGroup>
+        </row>
+
         <h2><i>auto_awesome</i>Upscaling</h2>
 
         <row class="with-gaps">
@@ -110,23 +134,8 @@
             <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@UpscalerModeOptions Value:bind=@UpscalerMode></ButtonGroup>
         </row>
 
-        @if ( UpscalerMode == Sandbox.Engine.Settings.UpscalerMode.Stretch )
+        @if ( UpscalerMode == Sandbox.Engine.Settings.UpscalerMode.FSR1 )
         {
-            <row class="with-gaps">
-                <cell class="glass with-padding is-label">
-                    Render Quality
-                </cell>
-                <SliderControl class="glass with-grow" Value:bind=@UpscalerRenderScalePercent Min="@(40)" Max="@(100)" Step="@(1)" ShowTextEntry="@true"></SliderControl>
-            </row>
-        }
-        else if ( UpscalerMode == Sandbox.Engine.Settings.UpscalerMode.FSR1 )
-        {
-            <row class="with-gaps">
-                <cell class="glass with-padding is-label">
-                    Render Quality
-                </cell>
-                <SliderControl class="glass with-grow" Value:bind=@UpscalerRenderScalePercent Min="@(50)" Max="@(100)" Step="@(1)" ShowTextEntry="@true"></SliderControl>
-            </row>
             <row class="with-gaps">
                 <cell class="glass with-padding is-label">
                     Sharpness
@@ -153,6 +162,64 @@
                 <SliderControl class="glass with-grow" Value:bind=@Fsr3SharpnessPercent Min="@(0)" Max="@(100)" Step="@(1)" ShowTextEntry="@true"></SliderControl>
             </row>
         }
+
+        <h2><i>tune</i>Advanced</h2>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Shadow Distance
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@ShadowDistanceOptions Value:bind=@ShadowDistance></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Sun Shadows
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@ToggleOptions Value:bind=@SunShadows></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Dynamic Light Shadows
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@ToggleOptions Value:bind=@DynamicShadows></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Contact Shadows
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@ToggleOptions Value:bind=@ContactShadows></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Ambient Occlusion
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@AmbientOcclusionOptions Value:bind=@AoQuality></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Reflections
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@ReflectionOptions Value:bind=@ReflectionQuality></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Bloom
+            </cell>
+            <ButtonGroup class="glass with-grow" ButtonClass="glass with-grow with-click" Options=@ToggleOptions Value:bind=@BloomEnabled></ButtonGroup>
+        </row>
+
+        <row class="with-gaps">
+            <cell class="glass with-padding is-label">
+                Decal Limit
+            </cell>
+            <SliderControl class="glass with-grow" Value:bind=@DecalLimit Min="@(0)" Max="@(1000)" Step="@(50)" ShowTextEntry="@true"></SliderControl>
+        </row>
     </div>
 
      <SettingsFooter OnCancel=@OnCancel OnRestore=@OnRestore OnApply=@OnApply></SettingsFooter>
@@ -168,9 +235,61 @@
     public bool VSync { get; set; }
     public TextureQuality TextureDetail { get; set; }
     public VolumetricFogQuality VolumetricFogQuality { get; set; }
-    public PostProcessQuality PostProcessQuality { get; set; }
-    public ShadowQuality ShadowQuality { get; set; }
+
+    PostProcessQuality _postProcessQuality;
+    public PostProcessQuality PostProcessQuality
+    {
+        get => _postProcessQuality;
+        set
+        {
+            // The bind system echoes the current value back after ReadSettings, don't let it stomp the advanced rows
+            if ( _postProcessQuality == value )
+                return;
+
+            _postProcessQuality = value;
+
+            // Sync the advanced rows to the group's fan-out values (mirrors quality_profiles.json)
+            (AoQuality, ReflectionQuality) = value switch
+            {
+                Sandbox.Engine.Settings.PostProcessQuality.Low => (0, 0),
+                Sandbox.Engine.Settings.PostProcessQuality.Medium => (2, 4),
+                _ => (3, 2),
+            };
+        }
+    }
+
+    ShadowQuality _shadowQuality;
+    public ShadowQuality ShadowQuality
+    {
+        get => _shadowQuality;
+        set
+        {
+            // The bind system echoes the current value back after ReadSettings, don't let it stomp the advanced rows
+            if ( _shadowQuality == value )
+                return;
+
+            _shadowQuality = value;
+
+            // Mirrors r.shadows.csm.distance in quality_profiles.json
+            ShadowDistance = value switch
+            {
+                Sandbox.Engine.Settings.ShadowQuality.Low => 4000,
+                Sandbox.Engine.Settings.ShadowQuality.Medium => 9000,
+                _ => 15000,
+            };
+        }
+    }
+
     public float MotionBlurScale { get; set; }
+
+    public int ShadowDistance { get; set; }
+    public bool SunShadows { get; set; }
+    public bool DynamicShadows { get; set; }
+    public bool ContactShadows { get; set; }
+    public int AoQuality { get; set; }
+    public int ReflectionQuality { get; set; }
+    public bool BloomEnabled { get; set; }
+    public int DecalLimit { get; set; }
     public int FrameRateLimit { get; set; }
     public int MenuFrameRateLimit { get; set; }
     public int InactiveFrameRateLimit { get; set; }
@@ -180,6 +299,8 @@
     public int UpscalerRenderScalePercent { get; set; }
     public int Fsr1SharpnessPercent { get; set; }
     public int Fsr3SharpnessPercent { get; set; }
+    public string MenuBackground { get; set; }
+    public bool PerformanceOverlayEnabled { get; set; }
 
     List<Option> UpscalerModeOptions = new List<Option>()
     {
@@ -214,11 +335,20 @@
     };
 
     List<Option> VSyncOptions = [new("Off", false), new("On", true)];
+    List<Option> ToggleOptions = [new("Off", false), new("On", true)];
+    List<Option> MenuBackgroundOptions = [new("Full", "full"), new("Simple", "simple"), new("Off", "off")];
+
+    // Near/Medium/Far match the ShadowQuality group's r.shadows.csm.distance values
+    List<Option> ShadowDistanceOptions = [new("Near", 4000), new("Medium", 9000), new("Far", 15000)];
+    List<Option> AmbientOcclusionOptions = [new("Off", 0), new("Low", 1), new("Medium", 2), new("High", 3)];
+
+    // Values are the r_ssr_downsample_ratio resolution divisor - 0 = off, 4 = quarter res, 2 = half res
+    List<Option> ReflectionOptions = [new("Off", 0), new("Low", 4), new("High", 2)];
 
     List<Option> TextureDetailOptions = [new("Low", Sandbox.Engine.Settings.TextureQuality.Low), new("Medium", Sandbox.Engine.Settings.TextureQuality.Medium), new("High", Sandbox.Engine.Settings.TextureQuality.High)];
-    List<Option> VolumetricFogQualityOptions = [new("Low", VolumetricFogQuality.Low), new("Medium", VolumetricFogQuality.Medium), new("High", VolumetricFogQuality.High)];
-    List<Option> PostProcessOptions = [new("Low", PostProcessQuality.Low), new("Medium", PostProcessQuality.Medium), new("High", PostProcessQuality.High)];
-    List<Option> ShadowQualityOptions = [new("Low", ShadowQuality.Low), new("Medium", ShadowQuality.Medium), new("High", ShadowQuality.High)];
+    List<Option> VolumetricFogQualityOptions = [new("Low", Sandbox.Engine.Settings.VolumetricFogQuality.Low), new("Medium", Sandbox.Engine.Settings.VolumetricFogQuality.Medium), new("High", Sandbox.Engine.Settings.VolumetricFogQuality.High)];
+    List<Option> PostProcessOptions = [new("Low", Sandbox.Engine.Settings.PostProcessQuality.Low), new("Medium", Sandbox.Engine.Settings.PostProcessQuality.Medium), new("High", Sandbox.Engine.Settings.PostProcessQuality.High)];
+    List<Option> ShadowQualityOptions = [new("Low", Sandbox.Engine.Settings.ShadowQuality.Low), new("Medium", Sandbox.Engine.Settings.ShadowQuality.Medium), new("High", Sandbox.Engine.Settings.ShadowQuality.High)];
 
     static List<Option> _resolutionOptions = [];
     public static List<Option> ResolutionOptions
@@ -289,6 +419,37 @@
         UpscalerRenderScalePercent = (int)MathF.Round( MenuUtility.RenderSettings.UpscalerRenderScale * 100f );
         Fsr1SharpnessPercent = (int)MathF.Round( MenuUtility.RenderSettings.Fsr1Sharpness * 100f );
         Fsr3SharpnessPercent = (int)MathF.Round( MenuUtility.RenderSettings.Fsr3Sharpness * 100f );
+
+        // Off renders at native resolution, show the slider at 100%
+        if ( UpscalerMode == Sandbox.Engine.Settings.UpscalerMode.Off )
+            UpscalerRenderScalePercent = 100;
+
+        MenuBackground = MainMenu.BackgroundMode;
+        PerformanceOverlayEnabled = Sandbox.UI.Dev.PerformanceOverlay.ShowPerfOverlay;
+
+        // Read after the quality groups so live values overwrite the group defaults seeded above
+        ShadowDistance = SnapShadowDistance( MenuUtility.RenderSettings.ShadowDistance );
+        SunShadows = MenuUtility.RenderSettings.SunShadows;
+        DynamicShadows = MenuUtility.RenderSettings.DynamicShadows;
+        ContactShadows = MenuUtility.RenderSettings.ContactShadows;
+        AoQuality = Math.Clamp( MenuUtility.RenderSettings.AmbientOcclusionQuality, 0, 3 );
+        ReflectionQuality = SnapReflectionQuality( MenuUtility.RenderSettings.ReflectionQuality );
+        BloomEnabled = MenuUtility.RenderSettings.BloomEnabled;
+        DecalLimit = Math.Clamp( MenuUtility.RenderSettings.MaxDecals, 0, 1000 );
+    }
+
+    // Console-set values can be anything, snap to the nearest button so the UI always shows a selection
+    static int SnapShadowDistance( float distance )
+    {
+        if ( distance < 6500 ) return 4000;
+        if ( distance < 12000 ) return 9000;
+        return 15000;
+    }
+
+    static int SnapReflectionQuality( int ratio )
+    {
+        if ( ratio <= 0 ) return 0;
+        return ratio >= 3 ? 4 : 2;
     }
 
     public void OnRestore()
@@ -346,15 +507,39 @@
         MenuUtility.RenderSettings.ShadowQuality = ShadowQuality;
         MenuUtility.RenderSettings.MotionBlurScale = MotionBlurScale;
 
+        // Applied after the quality groups so explicit choices win over the group fan-out
+        MenuUtility.RenderSettings.ShadowDistance = ShadowDistance;
+        MenuUtility.RenderSettings.SunShadows = SunShadows;
+        MenuUtility.RenderSettings.DynamicShadows = DynamicShadows;
+        MenuUtility.RenderSettings.ContactShadows = ContactShadows;
+        MenuUtility.RenderSettings.AmbientOcclusionQuality = AoQuality;
+        MenuUtility.RenderSettings.ReflectionQuality = ReflectionQuality;
+        MenuUtility.RenderSettings.BloomEnabled = BloomEnabled;
+        MenuUtility.RenderSettings.MaxDecals = DecalLimit;
+
         MenuUtility.RenderSettings.MaxFrameRate = FrameRateLimit;
         MenuUtility.RenderSettings.MaxFrameRateMenu = MenuFrameRateLimit;
         MenuUtility.RenderSettings.MaxFrameRateInactive = InactiveFrameRateLimit;
+
+        // The render resolution slider drives the upscaler - 100% renders native, below that
+        // FSR1 upscales unless Stretch or FSR1 was picked explicitly. FSR3 sets its own
+        // scale through quality presets.
+        if ( UpscalerMode != Sandbox.Engine.Settings.UpscalerMode.FSR3 )
+        {
+            if ( UpscalerRenderScalePercent >= 100 )
+                UpscalerMode = Sandbox.Engine.Settings.UpscalerMode.Off;
+            else if ( UpscalerMode == Sandbox.Engine.Settings.UpscalerMode.Off )
+                UpscalerMode = Sandbox.Engine.Settings.UpscalerMode.FSR1;
+        }
 
         MenuUtility.RenderSettings.UpscalerMode = UpscalerMode;
         MenuUtility.RenderSettings.Fsr3UpscalerQuality = Fsr3UpscalerQuality;
         MenuUtility.RenderSettings.UpscalerRenderScale = UpscalerRenderScalePercent / 100f;
         MenuUtility.RenderSettings.Fsr1Sharpness = Fsr1SharpnessPercent / 100f;
         MenuUtility.RenderSettings.Fsr3Sharpness = Fsr3SharpnessPercent / 100f;
+
+        MainMenu.BackgroundMode = MenuBackground;
+        Sandbox.UI.Dev.PerformanceOverlay.ShowPerfOverlay = PerformanceOverlayEnabled;
 
         MenuUtility.RenderSettings.Apply();
     }

--- a/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
+++ b/game/addons/menu/Code/Modals/Settings/VideoSettings.razor
@@ -294,7 +294,23 @@
     public int MenuFrameRateLimit { get; set; }
     public int InactiveFrameRateLimit { get; set; }
 
-    public Sandbox.Engine.Settings.UpscalerMode UpscalerMode { get; set; }
+    Sandbox.Engine.Settings.UpscalerMode _upscalerMode;
+    public Sandbox.Engine.Settings.UpscalerMode UpscalerMode
+    {
+        get => _upscalerMode;
+        set
+        {
+            if ( _upscalerMode == value )
+                return;
+
+            _upscalerMode = value;
+
+            // Off means native resolution - snap the slider to 100% so OnApply
+            // doesn't turn the choice back into an upscaler
+            if ( value == Sandbox.Engine.Settings.UpscalerMode.Off )
+                UpscalerRenderScalePercent = 100;
+        }
+    }
     public Sandbox.Engine.Settings.Fsr3UpscalerQuality Fsr3UpscalerQuality { get; set; }
     public int UpscalerRenderScalePercent { get; set; }
     public int Fsr1SharpnessPercent { get; set; }

--- a/game/core/cfg/quality_profiles.json
+++ b/game/core/cfg/quality_profiles.json
@@ -24,9 +24,9 @@
     {
         "Low":
         {
-            "r_dof_quality": "1",
+            "r_dof_quality": "0",
             "r_motionblur_quality": "0",
-            "r_ao_quality": "1",
+            "r_ao_quality": "0",
             "r_ao_resolution": "4",
             "r_ao_denoise_passes": "2",
             "r_ssr_downsample_ratio": "0"
@@ -78,6 +78,8 @@
             "r.shadows.maxresolution": "512",
             "r.shadows.csm.maxresolution": "1024",
             "r.shadows.csm.maxcascades": "2",
+            "r.shadows.csm.distance": "4000",
+            "r.shadows.max": "16",
             "r.shadows.quality": "1"
         },
         "Medium":
@@ -85,6 +87,8 @@
             "r.shadows.maxresolution": "1024",
             "r.shadows.csm.maxresolution": "2048",
             "r.shadows.csm.maxcascades": "3",
+            "r.shadows.csm.distance": "9000",
+            "r.shadows.max": "64",
             "r.shadows.quality": "2"
         },
         "High":
@@ -92,6 +96,8 @@
             "r.shadows.maxresolution": "2048",
             "r.shadows.csm.maxresolution": "4096",
             "r.shadows.csm.maxcascades": "4",
+            "r.shadows.csm.distance": "15000",
+            "r.shadows.max": "256",
             "r.shadows.quality": "3"
         }
     }


### PR DESCRIPTION
**Depends on #11428** — the "Performance Overlay" row in VideoSettings.razor binds to `Sandbox.UI.Dev.PerformanceOverlay.ShowPerfOverlay`, which is added there. That branch is now merged into this one so CI can build it standalone, but #11428 should still land first (the merge will deduplicate).

The video settings page currently exposes a handful of coarse quality groups. On low-end hardware (integrated GPUs in particular) that's not enough control — the difference between playable and not is usually one or two specific features, not a whole tier.

This adds:

- **Render Resolution slider (25–100%)** shown for all upscaler modes except FSR3 (which manages its own scale through quality presets). At 100% the upscaler switches off; below that FSR1 kicks in unless Stretch/FSR1 was picked explicitly. The engine-side clamp on `upscaler.render_scale` is relaxed from 0.4 to 0.25. Picking Off snaps the slider back to 100% so the two controls can't contradict each other.
- **Advanced section** with individual controls that were previously only reachable via console: shadow distance, sun shadows, dynamic light shadows, contact shadows, ambient occlusion quality, SSR quality, bloom, decal limit. Getters read the live convar so the UI always reflects reality; setters store a cookie so an explicit choice survives restarts and quality-group changes (`RenderSettings.ApplyAdvancedOverrides` re-applies cookies on top of the group fan-out). Settings the user never touched keep following their group.
- **Startup re-apply in Bootstrap**: `RenderSettings` can be constructed before the engine convars are registered, which silently drops its writes. After `InitEngineConVars()` we now re-run `SetDefaults` + `ApplyAdvancedOverrides` + `ApplyUpscalerSettings` so saved settings actually take effect on boot. The upscaler part matters: the native engine restores `machine_convars.vcfg` at startup, and without the re-apply the saved upscaler choice (including Off) never reached `r_upscaling` — the vcfg value silently won.
- **Menu Background setting (Full / Simple / Off)** — a new option controlling the home menu background. Simple turns off spotlight shadows, bloom, AO and painted clutter in the menu scene (snapshot/restore, nothing is lost when switching back to Full); Off disables the background scene entirely. Backed by the saved `menu_background` convar.
- **Low quality profile cuts** in `quality_profiles.json`: DoF and AO off on Low, and the shadow tiers now also set `r.shadows.csm.distance` and `r.shadows.max` (4000/16, 9000/64, 15000/256).

Measured on an Intel iGPU in the menu scene: the advanced knobs take GPU frame time from 33.5 ms to 23.8 ms without dropping the whole quality tier.
