### PR TITLE
Add downloaded games list to the storage settings page

### DIFF
--- a/engine/Sandbox.Engine/Services/Packages/DownloadedPackages.cs
+++ b/engine/Sandbox.Engine/Services/Packages/DownloadedPackages.cs
@@ -1,0 +1,143 @@
+using System.IO;
+
+namespace Sandbox;
+
+/// <summary>
+/// Keeps a record of every package we've downloaded into the asset cache, so we
+/// can attribute cached files to packages later (storage usage, cleanup etc).
+/// Records live alongside the cache in download/.packages/.
+/// </summary>
+internal static class DownloadedPackages
+{
+	const string Folder = ".packages";
+
+	internal class Record
+	{
+		public string Ident { get; set; }
+		public string Title { get; set; }
+		public string Type { get; set; }
+		public string Thumb { get; set; }
+		public long Version { get; set; }
+		public DateTimeOffset Downloaded { get; set; }
+		public DateTimeOffset LastUsed { get; set; }
+		public List<Entry> Files { get; set; }
+
+		public struct Entry
+		{
+			public string Path { get; set; }
+			public string Crc { get; set; }
+			public long Size { get; set; }
+		}
+	}
+
+	static string RecordPath( string ident ) => $"{Folder}/{ident.ToLowerInvariant()}.json";
+
+	/// <summary>
+	/// Write or refresh the record for this package. Called whenever a package
+	/// is downloaded or mounted from cache.
+	/// </summary>
+	public static void Update( Package package, ManifestSchema.File[] files )
+	{
+		var fs = EngineFileSystem.DownloadedFiles;
+		if ( fs is null ) return;
+
+		var ident = Package.FormatIdent( package.Org.Ident, package.Ident );
+		var record = fs.ReadJsonOrDefault<Record>( RecordPath( ident ) ) ?? new Record { Downloaded = DateTimeOffset.UtcNow };
+
+		record.Ident = ident;
+		record.Title = package.Title;
+		record.Type = package.TypeName;
+		record.Thumb = package.Thumb;
+		record.Version = package.Revision?.VersionId ?? 0;
+		record.LastUsed = DateTimeOffset.UtcNow;
+		record.Files = files.Select( x => new Record.Entry { Path = x.Path, Crc = x.Crc, Size = x.Size } ).ToList();
+
+		try
+		{
+			fs.CreateDirectory( Folder );
+			fs.WriteJson( RecordPath( ident ), record );
+		}
+		catch ( System.Exception e )
+		{
+			Log.Warning( e, $"Couldn't write download record for {ident}" );
+		}
+	}
+
+	/// <summary>
+	/// All the packages we have download records for
+	/// </summary>
+	public static IEnumerable<Record> All()
+	{
+		var fs = EngineFileSystem.DownloadedFiles;
+		if ( fs is null ) yield break;
+
+		foreach ( var file in fs.FindFile( Folder, "*.json" ) )
+		{
+			var record = fs.ReadJsonOrDefault<Record>( $"{Folder}/{file}" );
+			if ( record?.Files is null ) continue;
+
+			yield return record;
+		}
+	}
+
+	public static Record Find( string ident )
+	{
+		if ( !Package.TryParseIdent( ident, out var parsed ) )
+			return null;
+
+		ident = Package.FormatIdent( parsed.org, parsed.package );
+		return EngineFileSystem.DownloadedFiles?.ReadJsonOrDefault<Record>( RecordPath( ident ) );
+	}
+
+	/// <summary>
+	/// The absolute path this file would be cached at, or null if it isn't on disk right now.
+	/// </summary>
+	public static string GetCachedFilePath( Record.Entry entry )
+	{
+		if ( !ulong.TryParse( entry.Crc, System.Globalization.NumberStyles.HexNumber, null, out var crc ) )
+			return null;
+
+		var path = AssetDownloadCache.GetAbsolutePath( entry.Path, crc );
+		return File.Exists( path ) ? path : null;
+	}
+
+	/// <summary>
+	/// Delete a package's cached files and its record. Files that another recorded
+	/// package also references are left alone - everything re-downloads on demand anyway.
+	/// </summary>
+	public static void Delete( Record record )
+	{
+		var shared = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+
+		foreach ( var other in All() )
+		{
+			if ( string.Equals( other.Ident, record.Ident, StringComparison.OrdinalIgnoreCase ) )
+				continue;
+
+			foreach ( var entry in other.Files )
+			{
+				shared.Add( $"{entry.Path}:{entry.Crc}" );
+			}
+		}
+
+		foreach ( var entry in record.Files )
+		{
+			if ( shared.Contains( $"{entry.Path}:{entry.Crc}" ) )
+				continue;
+
+			var path = GetCachedFilePath( entry );
+			if ( path is null ) continue;
+
+			try
+			{
+				File.Delete( path );
+			}
+			catch ( System.Exception e )
+			{
+				Log.Warning( e, $"Failed to delete cached file {path}" );
+			}
+		}
+
+		EngineFileSystem.DownloadedFiles?.DeleteFile( RecordPath( record.Ident ) );
+	}
+}

--- a/engine/Sandbox.Engine/Services/Packages/Package.Download.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Download.cs
@@ -53,6 +53,9 @@ public partial class Package
 		// filter out files we're never going to download
 		entries = entries.Where( FilterFileDownloads ).ToArray();
 
+		// remember what we downloaded, so storage tools can attribute cache files to packages
+		DownloadedPackages.Update( this, entries );
+
 		if ( options.SkipAssetDownload )
 		{
 			entries = entries.Where( x => x.Path.StartsWith( ".bin" ) ).ToArray();

--- a/engine/Sandbox.Menu/MenuUtility.Storage.cs
+++ b/engine/Sandbox.Menu/MenuUtility.Storage.cs
@@ -48,6 +48,100 @@ public static partial class MenuUtility
 		}
 
 		/// <summary>
+		/// A package we've downloaded into the cache at some point
+		/// </summary>
+		public struct PackageEntry
+		{
+			public string Ident { get; set; }
+			public string Title { get; set; }
+			public string Type { get; set; }
+			public string Thumb { get; set; }
+			public DateTimeOffset Downloaded { get; set; }
+			public DateTimeOffset LastPlayed { get; set; }
+
+			/// <summary>
+			/// Bytes this package's files are currently taking up in the cache
+			/// </summary>
+			public long Size { get; set; }
+
+			/// <summary>
+			/// How many of this package's files are currently in the cache
+			/// </summary>
+			public int FileCount { get; set; }
+		}
+
+		/// <summary>
+		/// Get all the packages we have download records for, with their current cache usage.
+		/// Runs in a thread because it stats a lot of files.
+		/// </summary>
+		public static async Task<List<PackageEntry>> GetPackagesAsync()
+		{
+			return await Task.Run( () =>
+			{
+				var list = new List<PackageEntry>();
+
+				foreach ( var record in DownloadedPackages.All() )
+				{
+					var entry = new PackageEntry
+					{
+						Ident = record.Ident,
+						Title = record.Title,
+						Type = record.Type,
+						Thumb = record.Thumb,
+						Downloaded = record.Downloaded,
+						LastPlayed = record.LastUsed
+					};
+
+					foreach ( var file in record.Files )
+					{
+						if ( DownloadedPackages.GetCachedFilePath( file ) is null )
+							continue;
+
+						entry.Size += file.Size;
+						entry.FileCount++;
+					}
+
+					list.Add( entry );
+				}
+
+				return list;
+			} );
+		}
+
+		/// <summary>
+		/// Get the files a package has in the cache right now. Filename is the
+		/// content path, so it can be categorized by extension.
+		/// </summary>
+		public static IEnumerable<FileEntry> GetPackageFiles( string ident )
+		{
+			var record = DownloadedPackages.Find( ident );
+			if ( record is null ) yield break;
+
+			foreach ( var file in record.Files )
+			{
+				var path = DownloadedPackages.GetCachedFilePath( file );
+				if ( path is null ) continue;
+
+				yield return new FileEntry
+				{
+					Filename = file.Path,
+					Size = file.Size
+				};
+			}
+		}
+
+		/// <summary>
+		/// Delete a package's cached files. It'll redownload next time it's played.
+		/// </summary>
+		public static async Task DeletePackageAsync( string ident )
+		{
+			var record = DownloadedPackages.Find( ident );
+			if ( record is null ) return;
+
+			await Task.Run( () => DownloadedPackages.Delete( record ) );
+		}
+
+		/// <summary>
 		/// Delete all files that haven't been used since x date.
 		/// </summary>
 		public static async Task FlushAsync( DateTime beforeDate )

--- a/engine/Sandbox.Menu/MenuUtility.Storage.cs
+++ b/engine/Sandbox.Menu/MenuUtility.Storage.cs
@@ -10,6 +10,65 @@ public static partial class MenuUtility
 	/// </summary>
 	public static class Storage
 	{
+		/// <summary>
+		/// How long a scan stays "fresh". The settings page will still show
+		/// older results instantly, but kick off a background refresh.
+		/// </summary>
+		public static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes( 2 );
+
+		static UsageSnapshot _cachedUsage;
+
+		/// <summary>
+		/// Last completed scan, if any. May be older than <see cref="CacheTtl"/>.
+		/// </summary>
+		public static UsageSnapshot LastUsage => _cachedUsage;
+
+		/// <summary>
+		/// Snapshot of storage usage from a completed scan. Kept so the
+		/// settings page can reopen without rescanning the download cache.
+		/// </summary>
+		public sealed class UsageSnapshot
+		{
+			public DateTimeOffset CapturedAt { get; set; }
+			public long Files { get; set; }
+			public long Size { get; set; }
+			public long OldSize { get; set; }
+			public Dictionary<string, long> SizeBreakdown { get; set; } = new();
+			public List<PackageEntry> Packages { get; set; } = new();
+			public Dictionary<string, string> PackageBreakdowns { get; set; } = new();
+
+			public bool IsFresh( TimeSpan? maxAge = null )
+			{
+				return DateTimeOffset.UtcNow - CapturedAt <= (maxAge ?? CacheTtl);
+			}
+		}
+
+		/// <summary>
+		/// True if we have a scan that is still within <paramref name="maxAge"/>.
+		/// </summary>
+		public static bool TryGetCachedUsage( out UsageSnapshot snapshot, TimeSpan? maxAge = null )
+		{
+			snapshot = _cachedUsage;
+			return snapshot is not null && snapshot.IsFresh( maxAge );
+		}
+
+		/// <summary>
+		/// Remember the results of a completed scan for the rest of the session.
+		/// </summary>
+		public static void SetCachedUsage( UsageSnapshot snapshot )
+		{
+			_cachedUsage = snapshot;
+		}
+
+		/// <summary>
+		/// Drop the cached scan. Called after deletes / flush, or when the
+		/// user hits Refresh.
+		/// </summary>
+		public static void InvalidateCache()
+		{
+			_cachedUsage = null;
+		}
+
 		public struct FileEntry
 		{
 			public string Filename { get; set; }
@@ -138,6 +197,7 @@ public static partial class MenuUtility
 			var record = DownloadedPackages.Find( ident );
 			if ( record is null ) return;
 
+			InvalidateCache();
 			await Task.Run( () => DownloadedPackages.Delete( record ) );
 		}
 
@@ -147,6 +207,8 @@ public static partial class MenuUtility
 		public static async Task FlushAsync( DateTime beforeDate )
 		{
 			var path = EngineFileSystem.DownloadedFiles.GetFullPath( "/" );
+
+			InvalidateCache();
 
 			//
 			// Run the guts of the logic in a thread to avoid hitching

--- a/game/addons/menu/Code/Modals/Settings/Storage.razor
+++ b/game/addons/menu/Code/Modals/Settings/Storage.razor
@@ -83,8 +83,14 @@
                 </column>
 
                 <column class="dates">
-                    <div>Downloaded @package.Downloaded.Humanize()</div>
-                    <div>Played @package.LastPlayed.Humanize()</div>
+                    <div class="date-row">
+                        <span class="label">Downloaded</span>
+                        <span class="value">@FormatAge( package.Downloaded )</span>
+                    </div>
+                    <div class="date-row">
+                        <span class="label">Last played</span>
+                        <span class="value">@FormatAge( package.LastPlayed )</span>
+                    </div>
                 </column>
 
                 <div class="size">@package.Size.FormatBytes()</div>
@@ -220,6 +226,17 @@
     string GetBreakdown( string ident )
     {
         return PackageBreakdowns.GetValueOrDefault( ident, "" );
+    }
+
+    /// <summary>
+    /// Relative age for the list ("3 days ago"). Falls back if the stamp is missing.
+    /// </summary>
+    static string FormatAge( DateTimeOffset when )
+    {
+        if ( when == default )
+            return "—";
+
+        return $"{(DateTimeOffset.Now - when).Humanize( 1 )} ago";
     }
 
     static string ClassifyFile( string filename )

--- a/game/addons/menu/Code/Modals/Settings/Storage.razor
+++ b/game/addons/menu/Code/Modals/Settings/Storage.razor
@@ -122,7 +122,7 @@
 
         @if (refreshTask == null || refreshTask.IsCompleted)
         {
-            <Button Icon="restore" @onclick=@TryRefresh>Refresh</Button>
+            <Button Icon="restore" @onclick=@ForceRefresh>Refresh</Button>
         }
 
         @if (clearTask?.IsCompleted ?? true)
@@ -139,6 +139,11 @@
     /// The default dead period. If a file hasn't been used in this many days assume it's dead
     /// </summary>
     const int DaysAgo = 7;
+
+    /// <summary>
+    /// Show cached results immediately, but rescan quietly once they're this old.
+    /// </summary>
+    static readonly TimeSpan SoftRefreshAge = TimeSpan.FromSeconds( 45 );
 
     Task refreshTask;
     Task clearTask;
@@ -169,6 +174,12 @@
     long SharedSize => Packages.Where( x => !IsGame(x) ).Sum( x => x.Size );
     int SharedCount => Packages.Count( x => !IsGame(x) );
 
+    /// <summary>
+    /// True when the page is already showing something useful (cached or partial).
+    /// Background refreshes shouldn't wipe this mid-scan.
+    /// </summary>
+    bool HasDisplay => Size > 0 || Packages.Count > 0;
+
     IEnumerable<MenuUtility.Storage.PackageEntry> SortedPackages => SortBy switch
     {
         "played" => GamePackages.OrderByDescending( x => x.LastPlayed ),
@@ -183,7 +194,55 @@
         if (!firstTime)
             return;
 
-        TryRefresh();
+        var hadCache = TryApplyCache();
+
+        // Fresh cache: nothing to do. Stale or missing: scan (keeping cached UI if we have it).
+        if (!hadCache || IsCacheStale())
+            TryRefresh();
+    }
+
+    /// <summary>
+    /// Paint the last scan onto the page without touching disk.
+    /// </summary>
+    bool TryApplyCache()
+    {
+        var snap = MenuUtility.Storage.LastUsage;
+        if ( snap is null )
+            return false;
+
+        ApplySnapshot( snap );
+        return true;
+    }
+
+    bool IsCacheStale()
+    {
+        var snap = MenuUtility.Storage.LastUsage;
+        return snap is null || !snap.IsFresh( SoftRefreshAge );
+    }
+
+    void ApplySnapshot( MenuUtility.Storage.UsageSnapshot snap )
+    {
+        SizeBreakdown = new Dictionary<string, long>( snap.SizeBreakdown );
+        Packages = snap.Packages.ToList();
+        PackageBreakdowns = new Dictionary<string, string>( snap.PackageBreakdowns );
+        Files = snap.Files;
+        Size = snap.Size;
+        OldSize = snap.OldSize;
+        StateHasChanged();
+    }
+
+    void StoreCache()
+    {
+        MenuUtility.Storage.SetCachedUsage( new MenuUtility.Storage.UsageSnapshot
+        {
+            CapturedAt = DateTimeOffset.UtcNow,
+            Files = Files,
+            Size = Size,
+            OldSize = OldSize,
+            SizeBreakdown = new Dictionary<string, long>( SizeBreakdown ),
+            Packages = Packages.ToList(),
+            PackageBreakdowns = new Dictionary<string, string>( PackageBreakdowns )
+        } );
     }
 
     /// <summary>
@@ -195,7 +254,7 @@
         await clearTask;
         clearTask = null;
 
-        TryRefresh();
+        ForceRefresh();
     }
 
     /// <summary>
@@ -210,7 +269,7 @@
     async Task DeletePackage( MenuUtility.Storage.PackageEntry package )
     {
         await MenuUtility.Storage.DeletePackageAsync( package.Ident );
-        TryRefresh();
+        ForceRefresh();
     }
 
     /// <summary>
@@ -221,6 +280,15 @@
         if (refreshTask != null && !refreshTask.IsCompleted ) return;
 
         refreshTask = Refresh();
+    }
+
+    /// <summary>
+    /// User hit Refresh — drop the cache and rescan.
+    /// </summary>
+    void ForceRefresh()
+    {
+        MenuUtility.Storage.InvalidateCache();
+        TryRefresh();
     }
 
     string GetBreakdown( string ident )
@@ -258,47 +326,64 @@
 
     async Task Refresh()
     {
-        SizeBreakdown.Clear();
-        Files = 0;
-        Size = 0;
-        OldSize = 0;
+        // Scan into locals first so a background refresh doesn't blank the cached UI.
+        var sizeBreakdown = new Dictionary<string, long>();
+        long files = 0;
+        long size = 0;
+        long oldSize = 0;
 
         DateTime cutoff = DateTime.Now.AddDays(-DaysAgo);
+        var showingProgress = !HasDisplay;
 
-        StateHasChanged();
+        if ( showingProgress )
+        {
+            SizeBreakdown.Clear();
+            Files = 0;
+            Size = 0;
+            OldSize = 0;
+            StateHasChanged();
+        }
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
         foreach (var entry in MenuUtility.Storage.GetStorageFiles())
         {
-            Files++;
-            Size += entry.Size;
+            files++;
+            size += entry.Size;
 
             if (entry.LastAccessed < cutoff)
-                OldSize += entry.Size;
+                oldSize += entry.Size;
 
             var type = ClassifyFile(entry.Filename);
 
-            if (!SizeBreakdown.ContainsKey(type))
-                SizeBreakdown[type] = 0;
+            if (!sizeBreakdown.ContainsKey(type))
+                sizeBreakdown[type] = 0;
 
-            SizeBreakdown[type] += entry.Size;
+            sizeBreakdown[type] += entry.Size;
 
-
-            if (sw.ElapsedMilliseconds > 16)
+            if (showingProgress && sw.ElapsedMilliseconds > 16)
             {
+                SizeBreakdown = new Dictionary<string, long>( sizeBreakdown );
+                Files = files;
+                Size = size;
+                OldSize = oldSize;
                 sw.Restart();
                 await Task.DelayRealtime( 1 );
                 StateHasChanged();
             }
         }
 
+        SizeBreakdown = sizeBreakdown;
+        Files = files;
+        Size = size;
+        OldSize = oldSize;
         StateHasChanged();
 
         Packages = await MenuUtility.Storage.GetPackagesAsync();
         StateHasChanged();
 
         await RefreshBreakdowns();
+        StoreCache();
     }
 
     /// <summary>
@@ -306,8 +391,7 @@
     /// </summary>
     async Task RefreshBreakdowns()
     {
-        PackageBreakdowns.Clear();
-
+        var breakdowns = new Dictionary<string, string>();
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
         foreach (var package in GamePackages)
@@ -327,10 +411,13 @@
                 }
             }
 
-            PackageBreakdowns[package.Ident] = string.Join(" • ", counts.OrderByDescending(x => x.Value)
+            breakdowns[package.Ident] = string.Join(" • ", counts.OrderByDescending(x => x.Value)
                 .Select(x => $"{x.Value:n0} {(x.Value == 1 ? x.Key : x.Key + "s")}"));
 
+            PackageBreakdowns = new Dictionary<string, string>( breakdowns );
             StateHasChanged();
         }
+
+        PackageBreakdowns = breakdowns;
     }
 }

--- a/game/addons/menu/Code/Modals/Settings/Storage.razor
+++ b/game/addons/menu/Code/Modals/Settings/Storage.razor
@@ -61,6 +61,55 @@
 
         </column>
 
+        <div class="list-header">
+            <h2>Downloaded Games</h2>
+            <ButtonGroup class="glass" ButtonClass="glass with-click" Options=@SortOptions Value:bind=@SortBy></ButtonGroup>
+        </div>
+
+        @if (!GamePackages.Any())
+        {
+            <div class="empty-list">Games you download will show up here once they've been played.</div>
+        }
+
+        @foreach (var package in SortedPackages)
+        {
+            <row class="package-row">
+
+                <div class="thumb" style="background-image: url( @(string.IsNullOrEmpty(package.Thumb) ? "/ui/sbox-logo-square.svg" : package.Thumb) )"></div>
+
+                <column class="info">
+                    <div class="title">@package.Title <span class="ident">@package.Ident</span></div>
+                    <div class="breakdown">@GetBreakdown(package.Ident)</div>
+                </column>
+
+                <column class="dates">
+                    <div>Downloaded @package.Downloaded.Humanize()</div>
+                    <div>Played @package.LastPlayed.Humanize()</div>
+                </column>
+
+                <div class="size">@package.Size.FormatBytes()</div>
+
+                <Button Icon="delete" Tooltip="Delete Cached Files" @onclick=@(() => ConfirmDelete(package))></Button>
+
+            </row>
+        }
+
+        @if (SharedCount > 0)
+        {
+            <row class="package-row shared">
+
+                <div class="thumb is-icon"><icon>checkroom</icon></div>
+
+                <column class="info">
+                    <div class="title">Avatar Items &amp; Shared Assets</div>
+                    <div class="breakdown">@SharedCount packages - clothing and other assets used across games</div>
+                </column>
+
+                <div class="size">@SharedSize.FormatBytes()</div>
+
+            </row>
+        }
+
 	</div>
 
     <div class="page-footer">
@@ -90,9 +139,36 @@
 
     Dictionary<string, long> SizeBreakdown = new Dictionary<string, long>();
 
+    List<MenuUtility.Storage.PackageEntry> Packages = new();
+    Dictionary<string, string> PackageBreakdowns = new();
+
     long Files;
     long Size;
     long OldSize;
+
+    string SortBy { get; set; } = "size";
+
+    List<Option> SortOptions = [new("Size", "size"), new("Last Played", "played"), new("Name", "name")];
+
+    /// <summary>
+    /// Package types that are games you join and play. Everything else (clothing,
+    /// models etc) is shared content and gets lumped into a single line.
+    /// </summary>
+    static readonly string[] GameTypes = ["game", "gamemode", "map"];
+
+    static bool IsGame( MenuUtility.Storage.PackageEntry package ) => GameTypes.Contains( package.Type, StringComparer.OrdinalIgnoreCase );
+
+    IEnumerable<MenuUtility.Storage.PackageEntry> GamePackages => Packages.Where( IsGame );
+
+    long SharedSize => Packages.Where( x => !IsGame(x) ).Sum( x => x.Size );
+    int SharedCount => Packages.Count( x => !IsGame(x) );
+
+    IEnumerable<MenuUtility.Storage.PackageEntry> SortedPackages => SortBy switch
+    {
+        "played" => GamePackages.OrderByDescending( x => x.LastPlayed ),
+        "name" => GamePackages.OrderBy( x => x.Title ),
+        _ => GamePackages.OrderByDescending( x => x.Size )
+    };
 
     protected override void OnAfterTreeRender(bool firstTime)
     {
@@ -117,6 +193,21 @@
     }
 
     /// <summary>
+    /// Ask before purging a package's cached files
+    /// </summary>
+    void ConfirmDelete( MenuUtility.Storage.PackageEntry package )
+    {
+        MenuOverlay.Question( $"Delete {package.Size.FormatBytes()} of cached files for {package.Title}? It'll redownload next time you play it.", "delete",
+            () => _ = DeletePackage( package ), null );
+    }
+
+    async Task DeletePackage( MenuUtility.Storage.PackageEntry package )
+    {
+        await MenuUtility.Storage.DeletePackageAsync( package.Ident );
+        TryRefresh();
+    }
+
+    /// <summary>
     /// Refresh the file usage (if there isn't already a refresh in progress)
     /// </summary>
     void TryRefresh()
@@ -124,6 +215,28 @@
         if (refreshTask != null && !refreshTask.IsCompleted ) return;
 
         refreshTask = Refresh();
+    }
+
+    string GetBreakdown( string ident )
+    {
+        return PackageBreakdowns.GetValueOrDefault( ident, "" );
+    }
+
+    static string ClassifyFile( string filename )
+    {
+        if (filename.Contains(".vpk", StringComparison.OrdinalIgnoreCase)) return "Map";
+        if (filename.Contains(".vtex", StringComparison.OrdinalIgnoreCase)) return "Texture";
+        if (filename.Contains(".shader", StringComparison.OrdinalIgnoreCase)) return "Shader";
+        if (filename.Contains(".png", StringComparison.OrdinalIgnoreCase)) return "Image";
+        if (filename.Contains(".jpg", StringComparison.OrdinalIgnoreCase)) return "Image";
+        if (filename.Contains(".gif", StringComparison.OrdinalIgnoreCase)) return "Image";
+        if (filename.Contains(".mp4", StringComparison.OrdinalIgnoreCase)) return "Video";
+        if (filename.Contains(".vmt", StringComparison.OrdinalIgnoreCase)) return "Material";
+        if (filename.Contains(".vmat", StringComparison.OrdinalIgnoreCase)) return "Material";
+        if (filename.Contains(".vmdl", StringComparison.OrdinalIgnoreCase)) return "Model";
+        if (filename.Contains(".vsnd", StringComparison.OrdinalIgnoreCase)) return "Sound";
+
+        return "Other";
     }
 
     async Task Refresh()
@@ -147,23 +260,7 @@
             if (entry.LastAccessed < cutoff)
                 OldSize += entry.Size;
 
-            var type = "Other";
-
-            if (entry.Filename.Contains(".vpk", StringComparison.OrdinalIgnoreCase)) type = "Map";
-            else if (entry.Filename.Contains(".vtex", StringComparison.OrdinalIgnoreCase)) type = "Texture";
-            else if (entry.Filename.Contains(".shader", StringComparison.OrdinalIgnoreCase)) type = "Shader";
-            else if (entry.Filename.Contains(".png", StringComparison.OrdinalIgnoreCase)) type = "Image";
-            else if (entry.Filename.Contains(".jpg", StringComparison.OrdinalIgnoreCase)) type = "Image";
-            else if (entry.Filename.Contains(".gif", StringComparison.OrdinalIgnoreCase)) type = "Image";
-            else if (entry.Filename.Contains(".mp4", StringComparison.OrdinalIgnoreCase)) type = "Video";
-            else if (entry.Filename.Contains(".vmt", StringComparison.OrdinalIgnoreCase)) type = "Material";
-            else if (entry.Filename.Contains(".vmdl", StringComparison.OrdinalIgnoreCase)) type = "Model";
-            else if (entry.Filename.Contains(".vsnd", StringComparison.OrdinalIgnoreCase)) type = "Sound";
-
-            if (type == "Other")
-            {
-             //   type = System.IO.Path.GetExtension( entry.Filename );
-            }
+            var type = ClassifyFile(entry.Filename);
 
             if (!SizeBreakdown.ContainsKey(type))
                 SizeBreakdown[type] = 0;
@@ -180,5 +277,43 @@
         }
 
         StateHasChanged();
+
+        Packages = await MenuUtility.Storage.GetPackagesAsync();
+        StateHasChanged();
+
+        await RefreshBreakdowns();
+    }
+
+    /// <summary>
+    /// Count each package's cached files by type, same categories as the totals above
+    /// </summary>
+    async Task RefreshBreakdowns()
+    {
+        PackageBreakdowns.Clear();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        foreach (var package in GamePackages)
+        {
+            var counts = new Dictionary<string, int>();
+
+            foreach (var file in MenuUtility.Storage.GetPackageFiles(package.Ident))
+            {
+                var type = ClassifyFile(file.Filename);
+
+                counts[type] = counts.GetValueOrDefault(type) + 1;
+
+                if (sw.ElapsedMilliseconds > 16)
+                {
+                    sw.Restart();
+                    await Task.DelayRealtime( 1 );
+                }
+            }
+
+            PackageBreakdowns[package.Ident] = string.Join(" • ", counts.OrderByDescending(x => x.Value)
+                .Select(x => $"{x.Value:n0} {(x.Value == 1 ? x.Key : x.Key + "s")}"));
+
+            StateHasChanged();
+        }
     }
 }

--- a/game/addons/menu/Code/Modals/Settings/Storage.razor.scss
+++ b/game/addons/menu/Code/Modals/Settings/Storage.razor.scss
@@ -2,28 +2,51 @@
 .page-content
 {
     font-family: Poppins;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: scroll;
+
+    > *
+    {
+        flex-shrink: 0;
+    }
 }
 
 .page-footer
 {
+    flex-grow: 0;
+    padding: 16px;
     gap: 16px;
 }
 
-button.button
+.page-footer button.button
 {
     font-family: Poppins;
-    font-size: 14px;
-    font-weight: bold;
-    padding: 2px 16px;
     background-color: #525967;
+    color: white;
+    font-size: 14px;
+    padding: 4px 16px;
+    font-weight: bold;
     border-radius: 8px;
-    color: #c6d4ee;
+    cursor: pointer;
+    border: 3px solid transparent;
+    gap: 8px;
+    flex-shrink: 0;
 
     &:hover
     {
-        filter: brightness(1.5);
-        color: white;
+        filter: brightness( 1.5 );
+    }
+
+    IconPanel
+    {
+        font-size: 28px;
+        opacity: 0.5;
+    }
+
+    label
+    {
+        flex-grow: 1;
+        text-align: center;
     }
 }
 
@@ -101,4 +124,134 @@ button.button
 {
     background-color: #5F592D;
     color: #C0C654;
+}
+
+.list-header
+{
+    flex-shrink: 0;
+    margin-top: 24px;
+    justify-content: space-between;
+    align-items: center;
+
+    ButtonGroup
+    {
+        width: auto;
+        padding-right: 0;
+    }
+}
+
+.empty-list
+{
+    flex-shrink: 0;
+    padding: 24px;
+    justify-content: center;
+    color: #8a92a6;
+    font-family: Poppins;
+}
+
+row.package-row
+{
+    gap: 16px;
+    padding: 8px 16px 8px 8px;
+
+    .thumb
+    {
+        width: 64px;
+        height: 64px;
+        flex-shrink: 0;
+        border-radius: 8px;
+        background-size: cover;
+        background-position: center;
+        background-color: rgba(white, 0.05);
+    }
+
+    .info
+    {
+        flex-grow: 1;
+        flex-shrink: 1;
+        flex-direction: column;
+        justify-content: center;
+        gap: 4px;
+        overflow: hidden;
+
+        .title
+        {
+            font-family: Poppins;
+            font-weight: 600;
+            font-size: 15px;
+            color: white;
+            align-items: center;
+            gap: 8px;
+
+            .ident
+            {
+                font-weight: 400;
+                font-size: 12px;
+                color: #8a92a6;
+            }
+        }
+
+        .breakdown
+        {
+            font-size: 11px;
+            color: #8a92a6;
+            white-space: nowrap;
+        }
+    }
+
+    .dates
+    {
+        flex-shrink: 0;
+        flex-direction: column;
+        justify-content: center;
+        gap: 4px;
+        font-size: 11px;
+        color: #8a92a6;
+        text-align: right;
+        align-items: flex-end;
+    }
+
+    .size
+    {
+        flex-shrink: 0;
+        width: 90px;
+        justify-content: flex-end;
+        align-items: center;
+        font-family: Poppins;
+        font-weight: 600;
+        font-size: 14px;
+        color: #c6d4ee;
+    }
+
+    .thumb.is-icon
+    {
+        justify-content: center;
+        align-items: center;
+
+        icon
+        {
+            font-size: 32px;
+            color: #8a92a6;
+        }
+    }
+
+    &.shared
+    {
+        padding-right: 56px;
+    }
+
+    button.button
+    {
+        flex-shrink: 0;
+        background-color: #525967;
+        border-radius: 8px;
+        padding: 4px 12px;
+        color: #c6d4ee;
+
+        &:hover
+        {
+            filter: brightness( 1.5 );
+            color: white;
+        }
+    }
 }

--- a/game/addons/menu/Code/Modals/Settings/Storage.razor.scss
+++ b/game/addons/menu/Code/Modals/Settings/Storage.razor.scss
@@ -14,39 +14,44 @@
 .page-footer
 {
     flex-grow: 0;
-    padding: 16px;
-    gap: 16px;
+    flex-shrink: 0;
+    padding: 12px 16px;
+    gap: 12px;
+    align-items: center;
 }
 
 .page-footer button.button
 {
     font-family: Poppins;
     background-color: #525967;
-    color: white;
-    font-size: 14px;
-    padding: 4px 16px;
-    font-weight: bold;
+    color: #c6d4ee;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 0 16px;
+    height: 36px;
     border-radius: 8px;
     cursor: pointer;
-    border: 3px solid transparent;
-    gap: 8px;
+    gap: 6px;
     flex-shrink: 0;
+    align-items: center;
+    white-space: nowrap;
 
     &:hover
     {
         filter: brightness( 1.5 );
+        color: white;
     }
 
     IconPanel
     {
-        font-size: 28px;
-        opacity: 0.5;
+        font-size: 16px;
+        opacity: 0.7;
     }
 
     label
     {
-        flex-grow: 1;
-        text-align: center;
+        flex-grow: 0;
+        white-space: nowrap;
     }
 }
 
@@ -205,10 +210,28 @@ row.package-row
         flex-direction: column;
         justify-content: center;
         gap: 4px;
+        min-width: 160px;
         font-size: 11px;
-        color: #8a92a6;
-        text-align: right;
-        align-items: flex-end;
+
+        .date-row
+        {
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 12px;
+
+            .label
+            {
+                color: #6b7388;
+                white-space: nowrap;
+            }
+
+            .value
+            {
+                color: #aab3c7;
+                white-space: nowrap;
+                text-align: right;
+            }
+        }
     }
 
     .size


### PR DESCRIPTION
The storage settings page shows total cache usage by file type, but there's no way to see which games are taking the space or to free up space per game — your only option is nuking the whole cache.

- **`DownloadedPackages` (engine)** keeps a small JSON record per package in `download/.packages/` — ident, title, type, thumb, version, download/last-used times and the file manifest (path, CRC, size). `Package.DownloadAsync` refreshes the record on every download or cache mount, so records converge for packages downloaded before this change after they're played once.
- **`MenuUtility.Storage`** exposes the records to the menu: per-package current cache usage (only counts files actually on disk right now), per-package file lists for the type breakdown, and deletion.
- **Storage page** gets a "Downloaded Games" list — thumbnail, title/ident, per-type file breakdown, download/last-played dates, size on disk — sortable by size, last played or name. Non-game packages (clothing, models etc) are rolled up into a single "Avatar Items & Shared Assets" row.
- **Deleting is always safe:** it only removes cached files, never anything authoritative — the package re-downloads on demand next time it's played (that's how the cache already works). Files that another recorded package also references are left alone. Delete asks for confirmation and states the size it will free.

Self-contained; no dependency on the other PRs.
