### PR TITLE
Fix package card titles getting clipped at fractional UI scales

### DIFF
--- a/game/addons/base/code/UI/Components/PackageCard.razor.scss
+++ b/game/addons/base/code/UI/Components/PackageCard.razor.scss
@@ -139,7 +139,8 @@ PackageCard
 	.package-title
 	{
 		text-overflow: ellipsis;
-		max-height: 24px;
+		// keep above the line height, or the title gets truncated away at fractional ui scales
+		max-height: 30px;
 		flex-shrink: 1;
 		font-size: 14px;
 	}


### PR DESCRIPTION
`.package-title` had `max-height: 24px` with `font-size: 14px`. At fractional UI scales (e.g. 125%/150% on Windows) the computed line height rounds to just over 24px, so the one-line title falls outside the max-height and `text-overflow: ellipsis` truncates it to nothing — game titles don't show in the games browser at small window sizes. Bumping the cap to 30px keeps it above the line height at every scale while still clamping the title to a single line.
