### PR TITLE
Defer UI text texture disposal until frame end

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Engine/TextBlock.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Engine/TextBlock.cs
@@ -459,7 +459,7 @@ internal sealed class TextBlock : IDisposable
 		if ( Texture == null )
 			return;
 
-		LastTexture?.Dispose();
+		RetireTexture( LastTexture );
 		LastTexture = Texture;
 
 		Texture = null;
@@ -600,7 +600,7 @@ internal sealed class TextBlock : IDisposable
 					return;
 				}
 
-				LastTexture?.Dispose();
+				RetireTexture( LastTexture );
 				LastTexture = null;
 			}
 
@@ -704,11 +704,18 @@ internal sealed class TextBlock : IDisposable
 	{
 		ReleaseTexture();
 
-		LastTexture?.Dispose();
+		RetireTexture( LastTexture );
 		LastTexture = null;
 
 		Block = null;
 		Style = null;
 		SizeCache = null;
+	}
+
+	/// <summary>Keep a retired text texture alive until queued UI rendering has finished with its bindless index.</summary>
+	private static void RetireTexture( Texture texture )
+	{
+		if ( texture is not null )
+			EngineLoop.DisposeAtFrameEnd( texture );
 	}
 }


### PR DESCRIPTION
Queued UI render commands can retain bindless indices after a text block releases its texture. Retire replaced and disposed text textures at frame end so those commands cannot sample a recycled texture slot.

---

## Summary

Defers disposal of retired UI text textures until the end of the frame.

This prevents queued UI render commands from sampling a recycled bindless texture slot, which could appear as flickering pink-and-black missing textures.

## Motivation & Context

UI text could intermittently render with a missing texture when multiple cameras and ScenePanels were active. The issue was most visible on transient or frequently changing UI, including tooltips, text entries, chat tabs, and changing player lists.

`TextBlock` could dispose a replaced texture while UI render commands referencing its bindless index were still queued. If that index was recycled before the commands executed, they could sample an unrelated or invalid texture.

Fixes: N/A

## Implementation Details

Replaced immediate disposal in the three `TextBlock` retirement paths with a shared `RetireTexture` helper.

The helper uses the existing `EngineLoop.DisposeAtFrameEnd` mechanism, keeping retired textures alive until queued frame rendering has completed. Textures are retained only for the remainder of the current frame.

No public APIs were changed.

## Validation

- Reproduced consistently with the main game camera, a second ScenePanel, and a third ScenePanel
- Confirmed the fix prevents flickering in tooltips, text entries, chat tabs, and changing player lists
- Temporarily exposed deferred retirement through a ConVar for live comparison
- Observed no meaningful performance difference with deferred retirement enabled
- Engine compile check passed

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/dd983a12-2e90-4f3c-872c-74c81bdd5ede

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂