### PR TITLE
Adding grid to orthographic editor views

### DIFF
--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.OrientationGizmo.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.OrientationGizmo.cs
@@ -1,4 +1,4 @@
-namespace Editor;
+﻿namespace Editor;
 
 public partial class SceneViewportWidget
 {
@@ -146,12 +146,7 @@ public partial class SceneViewportWidget
 
 	private void OrbitAroundPivot()
 	{
-		_gizmoOrthoActive = false;
-
-		if ( State.Is2D )
-			State.View = ViewMode.Perspective;
-
-		cameraTargetPosition = null;
+		EnterPerspectiveView();
 
 		var delta = Application.CursorDelta * 0.1f;
 		GizmoInstance.OrbitCameraAroundPivot( _activeCamera, delta, ref cameraOrbitDistance );
@@ -172,11 +167,7 @@ public partial class SceneViewportWidget
 		var currentlyOrtho = _gizmoOrthoActive || State.Is2D;
 		if ( alreadyAligned && currentlyOrtho )
 		{
-			_gizmoOrthoActive = false;
-			if ( State.Is2D )
-				State.View = ViewMode.Perspective;
-
-			cameraTargetPosition = null;
+			EnterPerspectiveView();
 			return;
 		}
 
@@ -190,16 +181,7 @@ public partial class SceneViewportWidget
 		else if ( axisDir.z < -0.5f ) up = Vector3.Right;
 		else up = Vector3.Up;
 
-		State.CameraRotation = Rotation.LookAt( -axisDir, up );
-		State.CameraPosition = gizmoPivot + axisDir * distance;
-		State.CameraOrthoHeight = SizeFromDistanceAndFieldOfView( distance, EditorPreferences.CameraFieldOfView );
-
-		_activeCamera.WorldRotation = State.CameraRotation;
-		_activeCamera.WorldPosition = State.CameraPosition;
-
-		_gizmoOrthoActive = true;
-		_gizmoOrthoSnap = true;
-		cameraTargetPosition = null;
+		EnterOrthoView( axisDir, up, gizmoPivot, distance );
 	}
 
 	internal void PaintOrientationGizmo()

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.State.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.State.cs
@@ -126,6 +126,17 @@ public partial class SceneViewportWidget
 					break;
 			}
 		}
+
+		public static Gizmo.GridAxis GridAxisForDirection( Vector3 axisDir )
+		{
+			float[] a = [MathF.Abs( axisDir.x ), MathF.Abs( axisDir.y ), MathF.Abs( axisDir.z )];
+			return Array.IndexOf( a, a.Max() ) switch
+			{
+				0 => Gizmo.GridAxis.YZ,
+				1 => Gizmo.GridAxis.ZX,
+				_ => Gizmo.GridAxis.XY
+			};
+		}
 	}
 	public ViewportState State { get; init; }
 

--- a/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
+++ b/game/addons/tools/Code/Scene/SceneView/SceneViewportWidget.cs
@@ -192,6 +192,32 @@ public partial class SceneViewportWidget : Widget
 	private static float SizeFromDistanceAndFieldOfView( float distance, float fov )
 		=> 2.0f * distance * MathF.Tan( 0.5f * MathX.DegreeToRadian( fov ) );
 
+	private void EnterPerspectiveView()
+	{
+		_gizmoOrthoActive = false;
+		State.GridAxis = Gizmo.GridAxis.XY;
+
+		if ( State.Is2D )
+			State.View = ViewMode.Perspective;
+
+		cameraTargetPosition = null;
+	}
+
+	private void EnterOrthoView( Vector3 axisDir, Vector3 up, Vector3 pivot, float distance )
+	{
+		State.CameraRotation = Rotation.LookAt( -axisDir, up );
+		State.CameraPosition = pivot + axisDir * distance;
+		State.CameraOrthoHeight = SizeFromDistanceAndFieldOfView( distance, EditorPreferences.CameraFieldOfView );
+		State.GridAxis = ViewportState.GridAxisForDirection( axisDir );
+
+		_activeCamera.WorldRotation = State.CameraRotation;
+		_activeCamera.WorldPosition = State.CameraPosition;
+
+		_gizmoOrthoActive = true;
+		_gizmoOrthoSnap = true;
+		cameraTargetPosition = null;
+	}
+
 	/// <summary>
 	/// Returns the distance the camera needs to be from the target to fit the ortho height in the view at the given FOV.
 	/// </summary>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Unlike other game engines and 3D modeling tools like Maya or Blender, right now in S&box's editor, switching to an orthographic view along one of the axes (X, Y, Z) doesn't make the grid appear in that view. Currently the grid only exists on the XY plane in the regular perspective view.

This change makes the S&box editor behave in line with other industry tooling. The grid being visible in the orthographic views can make work easier (placing objects appropriately, etc).

## Motivation & Context

Largely as above, but I was motivated to do this by this issue which was raised:
https://github.com/Facepunch/sbox-public/issues/11405

Fixes: #11405 

## Implementation Details

In `SceneViewportWidget.OrientationGizmo.cs` within `SnapToAxis` I added code that checks which is the axis that the user has selected and uses a switch statement to select the appropriate grid axis to use. I subsequently set `State.GridAxis` to this.

When the user drags on the orientation gizmo to leave the orthographic view, in `OrbitAroundPivot`, I set `State.GridAxis` back to `Gizmo.GridAxis.XY`.

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂