### PR TITLE
[Particles] Fix FaceVelocity reseting pos when damping

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Particles/Particle.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Particle.cs
@@ -14,6 +14,12 @@ public partial class Particle : IDynamicFloatContext
 
 	[ActionGraphInclude]
 	public Vector3 Velocity;
+
+	/// <summary>
+	/// The last non-zero velocity, used by velocity aligned billboards to keep their orientation when the particle stops moving.
+	/// </summary>
+	internal Vector3 LastVelocity;
+
 	public Color Color;
 	public Color OverlayColor;
 	public float Alpha;
@@ -109,6 +115,7 @@ public partial class Particle : IDynamicFloatContext
 		p.Angles = Angles.Zero;
 		p.Frame = 0;
 		p.Velocity = 0;
+		p.LastVelocity = 0;
 		p.Color = Color.White;
 		p.OverlayColor = Color.White.WithAlpha( 0 );
 		p.Alpha = 1;

--- a/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Renderers/IBatchedParticleSpriteRenderer.cs
@@ -70,6 +70,7 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 		var objectAngles = WorldRotation;
 		var billboardModeUint = (uint)(SpriteRenderer.BillboardMode)Alignment;
 		var isObjectAlignment = Alignment == BillboardAlignment.Object;
+		var needVelocityAlignmentFix = Alignment == BillboardAlignment.LookAtCamera || Alignment == BillboardAlignment.RotateToCamera;
 
 		var blurAmountRemapped = BlurAmount.Remap( 0, 1, 0, 6, false );
 		var blurSpacingRemapped = BlurSpacing.Remap( 0, 1, 0, 1, false );
@@ -159,12 +160,22 @@ internal interface IBatchedParticleSpriteRenderer : ISpriteRenderGroup
 				// we are packing the exponent in the second half of the lighting flag
 				uint packedExponent = (uint)((byte)lightingValue | rgbe.a << 16);
 
+				var velocity = vel;
+				if ( needVelocityAlignmentFix )
+				{
+					// Keep the last orientation when the particle stops moving, matches the shader's velocity threshold
+					if ( velocity.LengthSquared > 0.001f )
+						p.LastVelocity = velocity;
+					else
+						velocity = p.LastVelocity;
+				}
+
 				var spritePtr = destinationPtr + validCount;
 
 				spritePtr->Position = new Vector3( pos.x, pos.y, pos.z );
 				spritePtr->Rotation = new Vector3( angles.pitch, angles.yaw, angles.roll );
 				spritePtr->Scale = new Vector2( scaleX, scaleY );
-				spritePtr->Velocity = new Vector3( vel.x, vel.y, vel.z );
+				spritePtr->Velocity = velocity;
 				spritePtr->MotionBlur = new Vector4( leadingTrailMultiplier, blurAmountRemapped, blurSpacingRemapped, blurOpacity );
 				spritePtr->TextureHandle = textureHandle;
 				spritePtr->TintColor = tintColor.RawInt;


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

When using FaceVelocity and the particle stop having velocity cause damping per exemple, then it would get back to his particle rotation instead of keeping the last rotation

## Implementation Details

So instead of falling back to no velocity behavior we'll cache the last velocity and if the velocity is <  0.001f then we use last velocity so we keep getting a so little velocity to keep the face velocity behavior

## Screenshots / Videos (if applicable)

Before
https://github.com/user-attachments/assets/ecd1838c-938e-4772-9b75-41e43bb3aad0

After

https://github.com/user-attachments/assets/a5fd2f96-2e72-4aef-9434-41a390a8c1b2


## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂