### PR TITLE
fix gradient point options

### DIFF
--- a/game/addons/tools/Code/Widgets/GradientEditor/GradientEditorWidget.cs
+++ b/game/addons/tools/Code/Widgets/GradientEditor/GradientEditorWidget.cs
@@ -553,7 +553,7 @@ class GradientStopWidget : Widget
 
 		OnAddPoint?.Invoke( delta );
 
-		Pressed = Points.FirstOrDefault( x => x.Time == delta );
+		Pressed = Points.FirstOrDefault( x => MathF.Abs( x.Time - delta ) < 0.001f );
 		Pressed?.Pressed?.Invoke( Pressed );
 		Update();
 	}

--- a/game/addons/tools/Code/Widgets/GradientEditor/GradientEditorWidget.cs
+++ b/game/addons/tools/Code/Widgets/GradientEditor/GradientEditorWidget.cs
@@ -81,7 +81,6 @@ public partial class GradientEditorWidget : Widget
 		{
 			_value = value;
 			Update();
-			ValueChanged?.Invoke( _value );
 			UpdatePoints();
 		}
 	}
@@ -168,6 +167,9 @@ public partial class GradientEditorWidget : Widget
 
 	private void SelectNext( bool forward )
 	{
+		if ( selectedPoint is null )
+			return;
+
 		int currentIdx = selectedPoint.Index;
 
 		if ( IsColorSelection )
@@ -234,9 +236,26 @@ public partial class GradientEditorWidget : Widget
 		Update();
 	}
 
+	public override void OnDestroyed()
+	{
+		try
+		{
+			ValueChanged?.Invoke( _value );
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( e, "GradientEditorWidget.OnDestroyed" );
+		}
+
+		base.OnDestroyed();
+	}
+
 	[Shortcut( "editor.delete", "DEL" )]
 	void DeletePoint()
 	{
+		if ( selectedPoint is null )
+			return;
+
 		alphaBar.Points.Remove( selectedPoint );
 		colorBar.Points.Remove( selectedPoint );
 
@@ -359,6 +378,8 @@ public partial class GradientEditorWidget : Widget
 		editColor.Enabled = color && p is not null;
 		editAlpha.Enabled = !color && p is not null;
 		editPosition.Enabled = p is not null;
+
+		Update();
 	}
 
 	[WidgetGallery]
@@ -532,7 +553,7 @@ class GradientStopWidget : Widget
 
 		OnAddPoint?.Invoke( delta );
 
-		Pressed = Points.FirstOrDefault( x => x.Time == delta );
+		Pressed = Points.FirstOrDefault( x => MathF.Abs( x.Time - delta ) < 0.001f );
 		Pressed?.Pressed?.Invoke( Pressed );
 		Update();
 	}

--- a/game/addons/tools/Code/Widgets/GradientEditor/GradientEditorWidget.cs
+++ b/game/addons/tools/Code/Widgets/GradientEditor/GradientEditorWidget.cs
@@ -553,7 +553,7 @@ class GradientStopWidget : Widget
 
 		OnAddPoint?.Invoke( delta );
 
-		Pressed = Points.FirstOrDefault( x => MathF.Abs( x.Time - delta ) < 0.001f );
+		Pressed = Points.FirstOrDefault( x => x.Time == delta );
 		Pressed?.Pressed?.Invoke( Pressed );
 		Update();
 	}


### PR DESCRIPTION
fixes gradient point options from disappearing when clicking points, panel, or GradientPresets.

# Pull Request

## Summary
Fixes the GradientEditorWidget to prevent the options for gradient points from disappearing inside of a component property popup.

## Motivation & Context

Fixes: #11442 

## Implementation Details
No obvious trade-offs encountered during testing.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/612d53cd-d431-480a-9c36-ed5b725afbfd

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂