### PR TITLE
Adds ForceVisibilityUpdate which bypasses cull-delay grace period on hiding

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Network.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Network.cs
@@ -790,6 +790,23 @@ public partial class GameObject
 		}
 
 		/// <summary>
+		/// Force an immediate re-check of network visibility for this object, bypassing the normal cull-delay
+		/// grace period. Call this when your <see cref="Component.INetworkVisible"/> implementation's result
+		/// changes and you want the new visibility state (e.g. hiding a dead player) to take effect on the very
+		/// next network tick instead of after the usual grace period.
+		/// <br/>
+		/// <br/>
+		/// Note: Do not call this every tick, only call it when you need the visibility state to be re-evaluated immediately.
+		/// </summary>
+		public void ForceVisibilityUpdate()
+		{
+			if ( !Active || (IsProxy && !Networking.IsHost) )
+				return;
+
+			go._net?.ForceVisibilityUpdate();
+		}
+
+		/// <summary>
 		/// Become the network owner of this object.
 		/// <br/>
 		/// <br/>

--- a/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
@@ -403,6 +403,24 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 	private const float CullDelay = 2f;
 
 	/// <summary>
+	/// Force the cull-delay grace period to expire for all connections tracking this object, so the
+	/// next call to <see cref="IDeltaSnapshot.UpdateTransmitState"/> re-evaluates visibility immediately
+	/// instead of waiting out <see cref="CullDelay"/>.
+	/// </summary>
+	internal void ForceVisibilityUpdate()
+	{
+		foreach ( var id in _cullStates.Keys )
+		{
+			var state = _cullStates[id];
+			if ( state.Culled )
+				continue;
+
+			state.LastVisibleAt = Time.Now - CullDelay;
+			_cullStates[id] = state;
+		}
+	}
+
+	/// <summary>
 	/// Remove a connection id from any internal data structures.
 	/// </summary>
 	/// <param name="id"></param>

--- a/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
@@ -602,6 +602,89 @@ public class NetworkTest
 		Assert.AreEqual( 2, comp2.SyncInt );
 	}
 
+	[TestMethod]
+	public void NetworkVisibleComponent_DeterminesPerConnectionVisibility()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeHost();
+
+		var hiddenFrom = new MockConnection( Guid.NewGuid() );
+
+		var go = new GameObject();
+		var visibility = go.Components.Create<VisibilityTestComponent>();
+		visibility.HiddenFrom = hiddenFrom;
+		go.NetworkSpawn( new NetworkSpawnOptions { Owner = Connection.Local, AlwaysTransmit = false } );
+
+		IDeltaSnapshot networkObject = go._net;
+		Connection[] targets = { clientAndHost.Client, hiddenFrom };
+
+		Time.Now = 0f;
+		networkObject.UpdateTransmitState( targets );
+
+		Time.Now = 3f;
+		networkObject.UpdateTransmitState( targets );
+
+		Assert.IsTrue( networkObject.ShouldTransmit( clientAndHost.Client ), "Connection allowed by INetworkVisible should keep receiving updates" );
+		Assert.IsFalse( networkObject.ShouldTransmit( hiddenFrom ), "Connection excluded by INetworkVisible should be culled" );
+	}
+
+	[TestMethod]
+	public void Culled_OnlyAfterGracePeriodElapses()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeHost();
+
+		var go = new GameObject();
+		var visibility = go.Components.Create<VisibilityTestComponent>();
+		go.NetworkSpawn( new NetworkSpawnOptions { Owner = Connection.Local, AlwaysTransmit = false } );
+
+		IDeltaSnapshot networkObject = go._net;
+		Connection[] targets = { clientAndHost.Client };
+
+		Time.Now = 0f;
+		networkObject.UpdateTransmitState( targets );
+		Assert.IsTrue( networkObject.ShouldTransmit( clientAndHost.Client ) );
+
+		visibility.IsVisible = false;
+		Time.Now = 1f;
+		networkObject.UpdateTransmitState( targets );
+		Assert.IsTrue( networkObject.ShouldTransmit( clientAndHost.Client ), "Should still be transmitting during the grace period" );
+
+		Time.Now = 3f;
+		networkObject.UpdateTransmitState( targets );
+		Assert.IsFalse( networkObject.ShouldTransmit( clientAndHost.Client ), "Should be culled once the grace period has elapsed" );
+	}
+
+	[TestMethod]
+	public void ForceVisibilityUpdate_BypassesGracePeriod()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeHost();
+
+		var go = new GameObject();
+		var visibility = go.Components.Create<VisibilityTestComponent>();
+		go.NetworkSpawn( new NetworkSpawnOptions { Owner = Connection.Local, AlwaysTransmit = false } );
+
+		IDeltaSnapshot networkObject = go._net;
+		Connection[] targets = { clientAndHost.Client };
+
+		Time.Now = 0f;
+		networkObject.UpdateTransmitState( targets );
+		Assert.IsTrue( networkObject.ShouldTransmit( clientAndHost.Client ) );
+
+		visibility.IsVisible = false;
+		go.Network.ForceVisibilityUpdate();
+
+		networkObject.UpdateTransmitState( targets );
+		Assert.IsFalse( networkObject.ShouldTransmit( clientAndHost.Client ), "ForceVisibilityUpdate should cull immediately, without waiting for the grace period" );
+	}
+
 	/// <summary>
 	/// When destroying a scene with networked objects, those objects must not emit <see cref="ObjectDestroyMsg"/>
 	/// inside a <see cref="SceneNetworkSystem.SuppressDestroyMessages"/> scope.
@@ -827,5 +910,19 @@ public class NetworkTest
 	{
 		[Property, Sync]
 		public int RegularInt { get; set; } = 1;
+	}
+
+	private class VisibilityTestComponent : Component, Component.INetworkVisible
+	{
+		public bool IsVisible { get; set; } = true;
+		public Connection HiddenFrom { get; set; }
+
+		bool Component.INetworkVisible.IsVisibleToConnection( Connection connection, in BBox worldBounds )
+		{
+			if ( connection == HiddenFrom )
+				return false;
+
+			return IsVisible;
+		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

Adds a ForceVisibilityUpdate() method that lets you force an immediate re-evaluation of network visibility for an object, instead of waiting out the normal cull-delay grace period.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #10982 

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

Intentionally opt-in rather than automatic because I think in general people are going to want the culling delay on more than off. So this is a function to shortcut that.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Both Before and After: https://www.youtube.com/watch?v=mphzAjutAmY
Code: 
```csharp
using Sandbox;

public sealed class Cube : Component, Component.INetworkVisible
{
	[ConVar] public static bool cube_enable { get; set; } = true;
	[ConVar] public static bool cube_enable_with_new_function { get; set; } = false;

	private bool _isVisibleToConnection = true;
	public bool IsVisibleToConnection( Connection conn, in BBox worldBounds )
	{
		if ( _isVisibleToConnection != cube_enable && cube_enable_with_new_function )
		{
			GameObject.Network.ForceVisibilityUpdate();
		}

		_isVisibleToConnection = cube_enable;
		return cube_enable;
	}
}
```

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂