### PR TITLE
Fix networked MeshComponent invisible on late-joining clients

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -608,6 +608,10 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 				if ( nwo is not ObjectCreateMsg oc )
 					continue;
 
+				// Fold blobs into the shared scope - Deserialize is deferred to the batch flush,
+				// so a per-object scope would be gone before its blob data (eg. mesh) is read.
+				blobs.Load( oc.BlobData );
+
 				var go = new GameObject();
 				go.Deserialize( JsonNode.Parse( oc.JsonData ).AsObject(), networkDeserializeOptionsCreate );
 				createdNetworkObjects.Add( new( go, oc ) );

--- a/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
+++ b/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
@@ -287,6 +287,18 @@ internal static class BlobDataSerializer
 		public byte[] ToByteArray() => GetBlobData( Blobs );
 
 		/// <summary>
+		/// Merge extra serialized blob data into this open context, so separately-captured blobs
+		/// stay readable through one deferred deserialize pass.
+		/// </summary>
+		internal void Load( ReadOnlySpan<byte> data )
+		{
+			if ( data.Length == 0 ) return;
+
+			foreach ( var kvp in ParseFile( data ) )
+				BinaryData[kvp.Key] = kvp.Value;
+		}
+
+		/// <summary>
 		/// Store the captured blob data on a json object, so it travels with it.
 		/// </summary>
 		internal bool SaveTo( JsonNode json )

--- a/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
@@ -815,6 +815,49 @@ public class NetworkTest
 	}
 
 	[TestMethod]
+	public async Task NetworkedMeshSurvivesLateJoinSnapshot()
+	{
+		Assert.IsNotNull( TypeLibrary.GetType<MeshComponent>(), "TypeLibrary hasn't been given the game assembly" );
+
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeHost();
+
+		var block = new GameObject();
+		var meshComponent = block.Components.Create<MeshComponent>();
+
+		var mesh = new PolygonMesh();
+		var a = mesh.AddVertex( new Vector3( 0, 0, 0 ) );
+		var b = mesh.AddVertex( new Vector3( 64, 0, 0 ) );
+		var c = mesh.AddVertex( new Vector3( 64, 64, 0 ) );
+		var d = mesh.AddVertex( new Vector3( 0, 64, 0 ) );
+		mesh.AddFace( a, b, c, d );
+		meshComponent.Mesh = mesh;
+
+		var expectedFaces = mesh.FaceHandles.Count();
+		Assert.AreNotEqual( 0, expectedFaces, "Test mesh should have geometry to begin with" );
+
+		block.NetworkSpawn();
+
+		// Build the snapshot a late-joining client would receive.
+		var snapshot = new SnapshotMsg { GameObjectSystems = [], NetworkObjects = new List<object>() };
+		SceneNetworkSystem.Instance.GetSnapshot( default, ref snapshot );
+
+		// The mesh geometry rides in the object's own blob buffer - the exact data the client dropped.
+		var createMsg = snapshot.NetworkObjects.OfType<ObjectCreateMsg>().Single( x => x.Guid == block.Id );
+		Assert.IsNotNull( createMsg.BlobData, "Mesh blob data should be in the create message" );
+
+		// Client applies the snapshot into a fresh scene, like a late-joiner.
+		clientAndHost.BecomeClient();
+		await SceneNetworkSystem.Instance.SetSnapshotAsync( snapshot );
+
+		var clientMesh = Game.ActiveScene.GetAllComponents<MeshComponent>().FirstOrDefault();
+		Assert.IsNotNull( clientMesh, "MeshComponent missing on client" );
+		Assert.IsNotNull( clientMesh.Mesh, "Mesh data missing on client" );
+		Assert.AreEqual( expectedFaces, clientMesh.Mesh.FaceHandles.Count(), "Mesh geometry did not survive the snapshot" );
+	}
+
 	[DataRow( false, false, false, DisplayName = "Cullable + hidden -> excluded" )]
 	[DataRow( false, true, true, DisplayName = "Cullable + visible -> included" )]
 	[DataRow( true, false, true, DisplayName = "AlwaysTransmit -> included when hidden" )]


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

PolygonMesh geometry is stored as blob data, and reading it back needs the matching BlobDataSerializer scope open. In SetSnapshotAsync, objects deserialize inside a CallbackBatch, which defers property application until the batch flushes but each object's blob scope had already closed, so the mesh came back empty. ModelRenderer was unaffected (references a resource by path, no blob data).

## Motivation & Context

Fixes: #11453

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Before: https://youtu.be/rQXmdBViqLc
After: https://youtu.be/kYVfbwVzu3o

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂