### PR TITLE
Fix box & hull collider center offset ignoring collider rotation rela…

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Collider/BoxCollider.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/BoxCollider.cs
@@ -81,13 +81,9 @@ public sealed class BoxCollider : Collider
 		var body = Rigidbody;
 		var world = Transform.TargetWorld;
 		var local = body.IsValid() ? body.Transform.TargetWorld.WithScale( 1.0f ).ToLocal( world ) : global::Transform.Zero;
-		var box = BBox.FromPositionAndSize( Center, Scale );
-		box.Mins *= world.Scale;
-		box.Maxs *= world.Scale;
-		box.Mins += local.Position;
-		box.Maxs += local.Position;
+		var center = local.PointToWorld( Center );
 
-		Shape.UpdateBoxShape( box.Center, local.Rotation, box.Size * 0.5f );
+		Shape.UpdateBoxShape( center, local.Rotation, Scale * world.Scale * 0.5f );
 
 		CalculateLocalBounds();
 	}
@@ -106,17 +102,8 @@ public sealed class BoxCollider : Collider
 
 	protected override IEnumerable<PhysicsShape> CreatePhysicsShapes( PhysicsBody targetBody, Transform local )
 	{
-		var box = BBox.FromPositionAndSize( Center, Scale );
-
-		var scale = WorldScale;
-
-		// scale by our scale!
-		box.Mins *= scale;
-		box.Maxs *= scale;
-
-		// move!
-		box.Mins += local.Position;
-		box.Maxs += local.Position;
+		var center = local.PointToWorld( Center );
+		var box = BBox.FromPositionAndSize( center, Scale * WorldScale );
 
 		var shape = targetBody.AddBoxShape( box, local.Rotation );
 

--- a/engine/Sandbox.Engine/Scene/Components/Collider/HullCollider.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Collider/HullCollider.cs
@@ -138,12 +138,8 @@ public sealed class HullCollider : Collider
 
 		if ( Type == PrimitiveType.Box )
 		{
-			var box = BBox.FromPositionAndSize( Center, BoxSize );
-			box.Mins *= world.Scale;
-			box.Maxs *= world.Scale;
-			box.Mins += local.Position;
-			box.Maxs += local.Position;
-			Shape.UpdateBoxShape( box.Center, local.Rotation, box.Size * 0.5f );
+			var center = local.PointToWorld( Center );
+			Shape.UpdateBoxShape( center, local.Rotation, BoxSize * world.Scale * 0.5f );
 		}
 		else if ( Type == PrimitiveType.Cone )
 		{
@@ -171,11 +167,8 @@ public sealed class HullCollider : Collider
 
 		if ( Type == PrimitiveType.Box )
 		{
-			var box = BBox.FromPositionAndSize( Center, BoxSize );
-			box.Mins *= scale;
-			box.Maxs *= scale;
-			box.Mins += local.Position;
-			box.Maxs += local.Position;
+			var center = local.PointToWorld( Center );
+			var box = BBox.FromPositionAndSize( center, BoxSize * scale );
 			Shape = body.AddBoxShape( box, local.Rotation );
 		}
 		else if ( Type == PrimitiveType.Cone )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

Fixes `BoxCollider` and `HullCollider` producing a physics shape offset from their gizmo when the collider is rotated relative to its parent `Rigidbody`.

The `Center` offset was translated into the body's space but never rotated, causing the actual `PhysicsShape` to sit in the wrong spot while the green editor gizmo (drawn in the collider's own space) stayed correct: visible as **two boxes** when `Center != (0,0,0)` and the a rigidbody is involved.

## Motivation & Context

Any rotated child GameObject with a `BoxCollider` or `Hull` box under a `Rigidbody` parent has its collision volume silently misplaced relative to what's shown in the editor, since collision math never applied `local.Rotation` to `Center`.

Disabling the parent `Rigidbody` (which makes the local transform identity) hide the bug.

## Implementation Details

`SphereCollider` and `CapsuleCollider` already transform their center via `local.PointToWorld(...)`, which correctly rotates the local offset into the `Rigidbody`'s space before translating it. While `BoxCollider` and `HullCollider` only doing:

```csharp
box.Mins += local.Position;
box.Maxs += local.Position;
```

a plain translation with no rotation applied to the offset which is correct only when the collider's rotation matches the Rigidbody's. Changed both `UpdateShape` and `CreatePhysicsShapes` in `BoxCollider.cs` and `HullCollider.cs` to use `local.PointToWorld( Center )` instead, matching the existing idiom (in `SphereCollider`).

## Screenshots / Videos (if applicable)


BEFORE (see the box collider move as it rotates while the sphere collider remains completely still)
https://github.com/user-attachments/assets/0dc5832e-ee62-4f9d-bf61-89f2a82232d9

AFTER (every colliders are completly still while rotating)
https://github.com/user-attachments/assets/0640b6fd-4167-4b89-ad12-038251a920bb


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable) — n/a, no public API changed
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂