### PR TITLE
[Particles] Add distance bias to ParticleSphereEmitter

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Particles/Emitter/ParticleSphereEmitter.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Particles/Emitter/ParticleSphereEmitter.cs
@@ -12,6 +12,18 @@ public sealed class ParticleSphereEmitter : ParticleEmitter
 	[Property, Range( -1000, 1000 )] public float Velocity { get; set; } = 100.0f;
 	[Property] public bool OnEdge { get; set; } = false;
 
+	/// <summary>
+	/// Scales the random spawn direction per axis. (1,1,1) spawns in the full sphere,
+	/// (0,0,1) restricts spawning to a line along Z, (0,0,0) spawns at the center only.
+	/// </summary>
+	[Property] public Vector3 DistanceBias { get; set; } = new Vector3( 1, 1, 1 );
+
+	/// <summary>
+	/// Takes the absolute value of the random spawn direction per axis, where non-zero.
+	/// For example (0,0,1) with a distance bias of (0,0,1) spawns only from the center upwards.
+	/// </summary>
+	[Property] public Vector3 DistanceBiasAbsoluteValue { get; set; } = Vector3.Zero;
+
 
 	protected override void DrawGizmos()
 	{
@@ -28,11 +40,18 @@ public sealed class ParticleSphereEmitter : ParticleEmitter
 	public override bool Emit( ParticleEffect target )
 	{
 		var random = Vector3.Random;
+
+		if ( DistanceBiasAbsoluteValue.x != 0.0f ) random.x = MathF.Abs( random.x );
+		if ( DistanceBiasAbsoluteValue.y != 0.0f ) random.y = MathF.Abs( random.y );
+		if ( DistanceBiasAbsoluteValue.z != 0.0f ) random.z = MathF.Abs( random.z );
+
+		random *= DistanceBias;
+
 		var offset = random;
 		var radius = Radius * WorldScale;
 		var pos = WorldPosition;
 
-		if ( OnEdge )
+		if ( OnEdge && !random.IsNearlyZero() )
 		{
 			pos += random.Normal * radius;
 		}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

When i did transition with my particles maker from gmod, they instantly asked me about this option, it was really trivial to do so here is my pr

## Motivation & Context

Sometimes you just want a half of sphere or even particle spawn in circle, now it's possible instead of a sphere

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

So it's a 2 step but super easy, first if DistanceBiasAbs is not 0 we make abs the random values
and after we multiplied random by DistanceBias and then we got our system ready !

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/4b200df8-71b0-44f8-ae03-3960a7a4846f

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂