### PR TITLE
Flags preserved at runtime on prefab instances

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
@@ -325,9 +325,6 @@ public partial class GameObject
 			JsonUpgrader.Upgrade( serializedVersion, node, GetType() );
 		}
 
-		DeserializeFlags( node, options );
-		Flags |= GameObjectFlags.Deserializing;
-
 		if ( node[JsonKeys.EditorSkipPrefabBreakOnRefresh] is null )
 		{
 			_prefabInstanceData = null;
@@ -419,12 +416,10 @@ public partial class GameObject
 			PrefabInstance.InitLookups( nodePrefabToInstanceId );
 			PrefabInstance.InitPatch( instancePatch );
 			PrefabInstance.RemapPrefabIdsToInstanceIds( ref node );
-
-			// Re-deserialize flags now that node points at the actual patched prefab data instead of
-			// the instance-source stub (which has no Flags key).
-			DeserializeFlags( node, options );
-			Flags |= GameObjectFlags.Deserializing;
 		}
+
+		DeserializeFlags( node, options );
+		Flags |= GameObjectFlags.Deserializing;
 
 		// Handle networked prefab instances, we just init the path
 		if ( node[JsonKeys.NetworkedPrefabInstance] is JsonValue _prefab && _prefab.TryGetValue( out prefabSource ) )

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
@@ -419,6 +419,11 @@ public partial class GameObject
 			PrefabInstance.InitLookups( nodePrefabToInstanceId );
 			PrefabInstance.InitPatch( instancePatch );
 			PrefabInstance.RemapPrefabIdsToInstanceIds( ref node );
+
+			// Re-deserialize flags now that node points at the actual patched prefab data instead of
+			// the instance-source stub (which has no Flags key).
+			DeserializeFlags( node, options );
+			Flags |= GameObjectFlags.Deserializing;
 		}
 
 		// Handle networked prefab instances, we just init the path

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Prefab/Prefab.Instances.PrefabInstanceData.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Prefab/Prefab.Instances.PrefabInstanceData.cs
@@ -683,6 +683,80 @@ public class InstanceDataTest
 			"a persisted flag should be recorded as a Flags override in the prefab patch" );
 	}
 
+	[TestMethod]
+	public void StaticFlagOnPrefabRoot_IsPreservedOnFullPrefabInstance()
+	{
+		var saveLocation = "___static_flag_instance.prefab";
+		using var prefab = SceneTests.Helpers.RegisterPrefabFromJson( saveLocation, _staticFlagPrefabSource );
+
+		// The prefab root itself carries the Static flag.
+		var prefabScene = SceneUtility.GetPrefabScene( ResourceLibrary.Get<PrefabFile>( saveLocation ) );
+		Assert.IsTrue( prefabScene.Flags.Contains( GameObjectFlags.Static ), "Prefab root should have the Static flag." );
+
+		var scene = new Scene();
+		using var sceneScope = scene.Push();
+
+		// Deserialize a full prefab instance stub, the stub has no Flags key, so the Static flag can only come from the patched prefab data.
+		var hierarchy = scene.CreateObject();
+		hierarchy.Deserialize( Json.ParseToJsonObject( _gameObjectWithStaticFlagPrefabInstance ) );
+
+		Assert.AreEqual( 1, hierarchy.Children.Count );
+		var instance = hierarchy.Children[0];
+		Assert.IsTrue( instance.IsPrefabInstanceRoot, "Deserialized child should be a full prefab instance root." );
+		Assert.IsTrue( instance.Flags.Contains( GameObjectFlags.Static ),
+			"Static flag from the prefab root must be preserved on the full prefab instance." );
+		Assert.IsTrue( instance.IsStatic );
+	}
+
+	static readonly string _staticFlagPrefabSource = """"
+	{
+		"__guid": "a1b2c3d4-1111-4111-8111-111111111111",
+		"Flags": 32768,
+		"Name": "StaticObject",
+		"Position": "0,0,0",
+		"Enabled": true,
+		"Components": [
+			{
+				"__type": "ModelRenderer",
+				"__guid": "a1b2c3d4-2222-4222-8222-222222222222",
+				"BodyGroups": 18446744073709551615,
+				"MaterialGroup": null,
+				"MaterialOverride": null,
+				"Model": null,
+				"RenderType": "On",
+				"Tint": "1,0,0,1"
+			}
+		],
+		"Children": []
+	}
+	"""";
+
+	static readonly string _gameObjectWithStaticFlagPrefabInstance = """"
+	{
+		"__guid": "a1b2c3d4-0000-4000-8000-000000000000",
+		"Name": "Root",
+		"Position": "0,0,0",
+		"Enabled": true,
+		"Children": [
+			{
+				"__guid": "a1b2c3d4-3333-4333-8333-333333333333",
+				"__version": 1,
+				"__Prefab": "___static_flag_instance.prefab",
+				"__PrefabInstancePatch": {
+					"AddedObjects": [],
+					"RemovedObjects": [],
+					"PropertyOverrides": [],
+					"MovedObjects": []
+				},
+				"__PrefabIdToInstanceId": {
+					"a1b2c3d4-1111-4111-8111-111111111111": "a1b2c3d4-3333-4333-8333-333333333333",
+					"a1b2c3d4-2222-4222-8222-222222222222": "a1b2c3d4-4444-4444-8444-444444444444"
+				}
+			}
+		]
+	}
+	"""";
+
 	static readonly string _basicPrefabSource = """"
 	{
 		"__guid": "fab370f8-2e2c-48cf-a523-e4be49723490",


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

Persisted flags like static, that were set on a prefab root were dropped on prefab instances loaded from disk. This re-reads them so instances keep them at runtime.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #11425

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

I double checked that flags are the only thing that get lost because its the only thing above, just opted to reapply them instead of shuffling around 30 callsites.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Before: https://youtu.be/qCTVTaP2sEs
After: https://youtu.be/CLl-3CntYqI

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂