### PR TITLE
Expose runtime addon components in inspector

### DIFF
--- a/engine/Sandbox.Engine/Core/Context/IToolsDll.cs
+++ b/engine/Sandbox.Engine/Core/Context/IToolsDll.cs
@@ -36,6 +36,11 @@ internal unsafe interface IToolsDll
 	/// </summary>
 	public Task LoadProject();
 
+	/// <summary>
+	/// Enroll a runtime package's assemblies into the tools type library.
+	/// </summary>
+	public void LoadPackageAssemblies( Package package );
+
 	public object InspectedObject { get; set; }
 
 	/// <summary>

--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -963,6 +963,7 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 	public Task LoadPackageAssembliesAsync( Package package )
 	{
 		AssemblyEnroller.LoadPackage( package.FullIdent, true );
+		Engine.IToolsDll.Current?.LoadPackageAssemblies( package );
 		return Task.CompletedTask;
 	}
 }

--- a/engine/Sandbox.Tools/ToolsDll.cs
+++ b/engine/Sandbox.Tools/ToolsDll.cs
@@ -207,6 +207,12 @@ internal class ToolsDll : IToolsDll
 		await StartupLoadProject.Run();
 	}
 
+	public void LoadPackageAssemblies( Package package )
+	{
+		if ( package is null || AssemblyEnroller is null ) return;
+		AssemblyEnroller.LoadPackage( package.FullIdent );
+	}
+
 	/// <summary>
 	/// Called from the code generator, the job of this function is:
 	/// 1. Make sure the package is downloaded and installed
@@ -237,8 +243,9 @@ internal class ToolsDll : IToolsDll
 	{
 		log.Trace( $"OnPackageInstalled: {package.Package.FullIdent} {context}" );
 
-		// only load if a tools context
-		if ( context != "tools" && context != "hammer" && package.Package is not LocalPackage ) return;
+		// Runtime-mounted packages can create objects that the editor inspects directly. Enroll their
+		// assemblies too, otherwise EditorTypeLibrary can't describe components from remote addons.
+		if ( !ShouldEnrollPackage( package.Package, context ) ) return;
 
 		// The menu addon should never leak into other projects, its loading is handled in MenuDll.
 		if ( package.Package is LocalPackage { Project.Config.Ident: "menu" } && Project.Current?.Config?.Ident != "menu" ) return;
@@ -247,6 +254,11 @@ internal class ToolsDll : IToolsDll
 
 		// make sure it's loaded into our context
 		AssemblyEnroller.LoadPackage( package.Package.FullIdent );
+	}
+
+	internal static bool ShouldEnrollPackage( Package package, string context )
+	{
+		return package is LocalPackage || context is "tools" or "hammer" or "game";
 	}
 
 	public void OnFunctionKey( ButtonCode key, KeyboardModifiers modifiers )

--- a/engine/Tests/Sandbox.Test.Unit/Tools/PackageEnrollment.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Tools/PackageEnrollment.cs
@@ -1,0 +1,16 @@
+namespace ToolsTests;
+
+[TestClass]
+public class PackageEnrollmentTests
+{
+	[TestMethod]
+	public void RuntimePackagesAreEnrolledForEditorInspection()
+	{
+		var remotePackage = new Package();
+
+		Assert.IsTrue( ToolsDll.ShouldEnrollPackage( remotePackage, "game" ) );
+		Assert.IsTrue( ToolsDll.ShouldEnrollPackage( remotePackage, "tools" ) );
+		Assert.IsTrue( ToolsDll.ShouldEnrollPackage( remotePackage, "hammer" ) );
+		Assert.IsFalse( ToolsDll.ShouldEnrollPackage( remotePackage, "menu" ) );
+	}
+}

--- a/game/addons/tools/Code/Scene/GameObjectInspector/ComponentListWidget.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/ComponentListWidget.cs
@@ -39,7 +39,6 @@ public class ComponentListWidget : Widget
 
 		// A list of components we've already seen
 		HashSet<Component> used = new HashSet<Component>();
-		HashSet<Component> toRemove = new HashSet<Component>();
 
 		//
 		// Here we build a list of all components that are on all the selected game objects
@@ -59,12 +58,6 @@ public class ComponentListWidget : Widget
 		{
 			if ( !component.IsValid() ) continue;
 			if ( component.Flags.HasFlag( ComponentFlags.Hidden ) ) continue;
-			var baseType = EditorTypeLibrary.GetType( component.GetType() )?.BaseType?.TargetType;
-			if ( !(baseType == typeof( Component ) || (baseType?.IsSubclassOf( typeof( Component ) ) ?? false)) )
-			{
-				toRemove.Add( component );
-				continue;
-			}
 
 			// Get all the components of this type on all the selected game objects
 			var allGobs = gobs.Select( x => x.Components.GetAll()
@@ -109,11 +102,6 @@ public class ComponentListWidget : Widget
 			newLayout.Add( sheet );
 
 			current[component] = sheet;
-		}
-
-		foreach ( var t in toRemove )
-		{
-			t?.Destroy();
 		}
 
 		Layout.Clear( true );
@@ -295,7 +283,7 @@ public class ComponentListWidget : Widget
 		menu.AddSeparator();
 
 		var t = EditorTypeLibrary.GetType( component.GetType() );
-		if ( t.SourceFile is not null )
+		if ( t?.SourceFile is not null )
 		{
 			bool isPackage = component.GetType().Assembly.IsPackage();
 			var filename = System.IO.Path.GetFileName( t.SourceFile );
@@ -404,7 +392,7 @@ public class ComponentListWidget : Widget
 		menu.AddSeparator();
 
 		var t = EditorTypeLibrary.GetType( component.GetType() );
-		if ( t.SourceFile is not null )
+		if ( t?.SourceFile is not null )
 		{
 			bool isPackage = component.GetType().Assembly.IsPackage();
 			var filename = System.IO.Path.GetFileName( t.SourceFile );


### PR DESCRIPTION
# Pull Request

## Summary

Fixes components from runtime-mounted addons not appearing in the editor inspector.

Runtime addon assemblies are now enrolled in the editor type library, allowing their component types to be resolved and inspected correctly.

## Motivation & Context

Runtime addon components were successfully created and started, but their types were unavailable in `EditorTypeLibrary`.

The inspector treated these unresolved types as invalid and destroyed their component instances. This left the associated GameObject visible in the hierarchy with an empty component list.

## Implementation Details

- Enroll assemblies from runtime-mounted addon packages in the tools type library.
- Synchronize runtime package assembly loading with the editor.
- Keep components visible when editor type metadata is temporarily unavailable.
- Make component source-file actions null-safe for unresolved editor types.
- Add a unit test covering package enrollment from the `game` context.

## Screenshots / Videos

Before the fix, the runtime-created GameObject appeared in the hierarchy without its addon component, even though the component had been created and started. (Before / After)

<img width="398" height="961" alt="before" src="https://github.com/user-attachments/assets/5ca6079e-c65c-4e25-a07a-51cf0392ea0f" />

<img width="398" height="961" alt="after" src="https://github.com/user-attachments/assets/887753f7-b8d8-4977-a01d-3155057bdd74" />

After the fix, the addon component remains attached and is displayed in the inspector.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂jected or requested to change 🙂