### PR TITLE
Fix NullReferenceException in WaterVolume.OnFixedUpdate

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Game/WaterVolume.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Game/WaterVolume.cs
@@ -87,8 +87,9 @@ public sealed class WaterVolume : Component
 
 		var plane = GetWaterSurface();
 
-		foreach ( var body in collider.Touching.Select( x => x.GetComponentInParent<Rigidbody>() ).Where( x => x.IsValid() ).Distinct() )
+		foreach ( var body in collider.Touching.Where( x => x.IsValid() ).Select( x => x.GetComponentInParent<Rigidbody>() ).Distinct() )
 		{
+			if ( !body.IsValid() ) continue;
 			if ( body.IsProxy ) continue;
 			if ( !body.PhysicsBody.IsValid() ) continue;
 			if ( body.PhysicsBody.BodyType != PhysicsBodyType.Dynamic ) continue;


### PR DESCRIPTION
 Guards against a null collider in LINQ chain

# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

This PR fixes a NRE in the WaterVolume that happens when a collider is destroyed before it leaves the trigger.

## Motivation & Context

This change is needed because I discovered this NRE while developing a game and was getting it on other clients.

System.NullReferenceException: Object reference not set to an instance of an object.
   at Sandbox.WaterVolume.<>c.<OnFixedUpdate>b__38_0(Collider x)
   at System.Linq.Enumerable.IEnumerableSelectIterator2.MoveNext()
   at System.Linq.Enumerable.IEnumerableWhereIterator1.MoveNext()
   at System.Linq.Enumerable.DistinctIterator`1.MoveNext()
   at Sandbox.WaterVolume.OnFixedUpdate()
   at Sandbox.Component.InternalFixedUpdate()

## Implementation Details

I made sure to guard for null colliders within the LINQ statement, which was not done before. If a collider was null for some reason, it would cause an NRE.

## Screenshots / Videos (if applicable)

N/A

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂