### PR TITLE
Fix Scene map packages not loading clutter / mesh components

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -454,13 +454,13 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 		}
 
 		var props = sceneFile.SceneProperties;
-		
+
 		// Apply game object system properties
 		if ( props.TryGetPropertyValue( "GameObjectSystems", out var systemOverridesNode ) )
 		{
 			Scene.ApplyGameObjectSystemOverrides( systemOverridesNode );
 		}
-		
+
 		// Load the incoming scene's NavMesh
 		Scene.NavMesh.Deserialize( props["NavMesh"] as JsonObject );
 

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -425,6 +425,7 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 		using var optionsScope = ActionGraph.PushSerializationOptions( sceneFile.SerializationOptions with { ForceUpdateCached = Scene.IsEditor } );
 		using var sceneScope = Scene.Push();
+		using var blobs = BlobDataSerializer.Load( sceneFile.BinaryData, sceneFile.ResourcePath );
 		using var batchGroup = CallbackBatch.Batch();
 
 		foreach ( var json in sceneFile.GameObjects )
@@ -451,6 +452,17 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 				go.NetworkSpawn();
 			}
 		}
+
+		var props = sceneFile.SceneProperties;
+		
+		// Apply game object system properties
+		if ( props.TryGetPropertyValue( "GameObjectSystems", out var systemOverridesNode ) )
+		{
+			Scene.ApplyGameObjectSystemOverrides( systemOverridesNode );
+		}
+		
+		// Load the incoming scene's NavMesh
+		Scene.NavMesh.Deserialize( props["NavMesh"] as JsonObject );
 
 		return true;
 	}

--- a/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
+++ b/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
@@ -260,7 +260,7 @@ internal static class BlobDataSerializer
 					if ( blockData != null )
 						binaryData = ParseFile( blockData );
 				}
-				else if ( Game.Resources.Get<GameResource>( filePath ) is { } resource )
+				else if ( Game.Resources.Get<GameResource>( filePath ) is { Package: not null } resource )
 				{
 					var activePackage = PackageManager.Find( resource.Package.FullIdent );
 					if ( activePackage?.FileSystem?.FileExists( compiledPath ) ?? false )

--- a/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
+++ b/engine/Sandbox.Engine/Utility/BlobDataSerializer.cs
@@ -260,6 +260,20 @@ internal static class BlobDataSerializer
 					if ( blockData != null )
 						binaryData = ParseFile( blockData );
 				}
+				else if ( Game.Resources.Get<GameResource>( filePath ) is { } resource )
+				{
+					var activePackage = PackageManager.Find( resource.Package.FullIdent );
+					if ( activePackage?.FileSystem?.FileExists( compiledPath ) ?? false )
+					{
+						var blockData = Game.Resources.ReadCompiledResourceBlock( CompiledBlobName, activePackage.FileSystem.ReadAllBytes( compiledPath ) );
+						if ( blockData != null )
+							binaryData = ParseFile( blockData );
+					}
+				}
+				else
+				{
+					Log.Warning( $"Failed to locate binary blob: {filePath}" );
+				}
 			}
 		}
 


### PR DESCRIPTION
# Pull Request

## Summary

Allows BlobDataSerializer to locate binary blobs saved in package filesystems, and syncs the MapInstance scene loading path with Scene.Load. Without these changes your map won't load important data like clutter, baked nav meshes, and mesh component models.

## Motivation & Context

I wanted to publish a map using a Scene. When I tested it outside of the editor I found that none of my grass or mesh components were visible. I attempted a fix on the game side, but all of the data I would need to handle it nicely was marked as internal.

Fixes: N/A

## Implementation Details

Three notes:
1. I'm not 100% sure if I found the best method for getting the package's filesystem, it seems a little convoluted to me. I didn't immediately see a better way, but let me know if there is one.
2. I opted to leave out applying the scene properties when loading the MapInstance. When I looked at the list of properties that would be replaced it didn't seem desirable to update them. It's a quick change if you prefer I add it, though.
3. I added a warning when the data isn't found. This was a silent failure that took me a while to figure out. With the warning I would have found this in 5 minutes instead of 5 hours 😃 
 
## Screenshots / Videos (if applicable)

After Changes:
<img width="2530" height="1437" alt="image" src="https://github.com/user-attachments/assets/e86c941e-6a05-48ea-9033-a05a3a69711a" />
<img width="2538" height="1447" alt="image" src="https://github.com/user-attachments/assets/2c7eefa3-3e17-4757-9533-305a9d9dfd87" />

Before Changes:
<img width="2377" height="1188" alt="image" src="https://github.com/user-attachments/assets/34ff4e0b-4d55-4c62-bbdd-cee5149d2261" />
<img width="2370" height="1183" alt="image" src="https://github.com/user-attachments/assets/121ee2b5-c0d2-4b2b-8734-8e0e2f94a9b2" />

## Checklist

- [ x ] Code follows existing style and conventions
- [ x ] No unnecessary formatting or unrelated changes
- [ x ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ x ] I’m okay with this PR being rejected or requested to change 🙂