### PR TITLE
fix clutter grid system being executed in headless mode

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
@@ -36,6 +36,9 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 
 	public ClutterGridSystem( Scene scene ) : base( scene )
 	{
+		if ( Application.IsHeadless )
+			return;
+
 		Listen( Stage.FinishUpdate, 0, OnUpdate, "ClutterGridSystem.Update" );
 		Listen( Stage.SceneLoaded, 0, RebuildPaintedLayer, "ClutterGridSystem.RestorePainted" );
 	}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Prevent `ClutterGridSystem` from registering its update and scene-load callbacks when s&box runs headless.

## Motivation & Context

Dedicated servers load scene systems even though they have no graphics output. `ClutterGridSystem` previously registered its callbacks in that environment, which could result in disposed `GpuBuffer<float>` errors during clutter updates.

Fixes: Can't find any issue related to that in gh.

## Implementation Details

Just add a guard `if (Application.IsHeadless) return;` in the constructor so the system never subscribes to `FinishUpdate` or `SceneLoaded`; this avoids unnecessary per-frame execution.

## Screenshots / Videos (if applicable)

Not applicable. headless/dedicated-server-only change.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂