### PR TITLE
Notify addon editors when parent packages are updated

### DIFF
--- a/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
@@ -1,4 +1,5 @@
 ﻿using Refit;
+using Sandbox.Engine;
 using Sandbox.Internal;
 using Sandbox.Protobuf;
 using System.Collections.Concurrent;
@@ -475,6 +476,7 @@ public partial class Package
 		if ( msg.Data is PackageMsg.Update packageUpdated )
 		{
 			ClearCache( packageUpdated.PackageIdent );
+			IToolsDll.Current?.RunEvent( "package.updated", packageUpdated.PackageIdent, packageUpdated.RevisionId );
 		}
 
 		if ( msg.Data is PackageMsg.Changed packageChanged )

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoadOptions.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoadOptions.cs
@@ -45,6 +45,12 @@ internal struct PackageLoadOptions
 	public bool AllowLocalPackages { get; set; } = true;
 
 	/// <summary>
+	/// Replace an already-mounted remote package when <see cref="PackageIdent"/> requests a different exact revision.
+	/// This is intentionally opt-in so ordinary dependency installs keep using their mounted revision.
+	/// </summary>
+	public bool ReplaceExistingRevision { get; set; }
+
+	/// <summary>
 	/// If true we will only download the code files (.bin) and not the assets.
 	/// </summary>
 	public bool SkipAssetDownload { get; set; }

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
@@ -67,7 +67,7 @@ internal static partial class PackageManager
 		var existingPackage = Find( options.PackageIdent, options.AllowLocalPackages );
 		if ( existingPackage != null )
 		{
-			if ( !options.ReplaceExistingRevision || MatchesRequestedRevision( existingPackage, options.PackageIdent ) )
+			if ( !ShouldReplaceExistingRevision( options, existingPackage.Package.Revision?.VersionId ) )
 			{
 				existingPackage.AddContextTag( options.ContextTag );
 				log.Info( $"Install Package (Already Mounted) {options.PackageIdent} [{options.ContextTag}]" );
@@ -131,12 +131,18 @@ internal static partial class PackageManager
 		return ap;
 	}
 
-	private static bool MatchesRequestedRevision( ActivePackage activePackage, string packageIdent )
+	/// <summary>
+	/// Returns whether an explicitly requested exact revision should replace the mounted revision.
+	/// </summary>
+	internal static bool ShouldReplaceExistingRevision( PackageLoadOptions options, long? activeRevisionId )
 	{
-		if ( !Package.TryParseIdent( packageIdent, out var parsed ) || parsed.version is null )
-			return true;
+		if ( !options.ReplaceExistingRevision )
+			return false;
 
-		return activePackage.Package.Revision?.VersionId == parsed.version.Value;
+		if ( !Package.TryParseIdent( options.PackageIdent, out var parsed ) || parsed.version is null )
+			return false;
+
+		return activeRevisionId != parsed.version.Value;
 	}
 
 	public static void UnmountTagged( string tag )

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
@@ -59,21 +59,30 @@ internal static partial class PackageManager
 		if ( options.PackageIdent == "local.base" )
 			options.PackageIdent = "local.base#local";
 
+		ActivePackage replacingPackage = null;
+
 		//
 		// If this package exists then mark it with our tag and move on
 		//
 		var existingPackage = Find( options.PackageIdent, options.AllowLocalPackages );
 		if ( existingPackage != null )
 		{
-			existingPackage.AddContextTag( options.ContextTag );
-			log.Info( $"Install Package (Already Mounted) {options.PackageIdent} [{options.ContextTag}]" );
-			options.Loading?.LoadingProgress( LoadingProgress.Create( $"Loading {existingPackage.Package.Title}" ) );
-			return existingPackage;
+			if ( !options.ReplaceExistingRevision || MatchesRequestedRevision( existingPackage, options.PackageIdent ) )
+			{
+				existingPackage.AddContextTag( options.ContextTag );
+				log.Info( $"Install Package (Already Mounted) {options.PackageIdent} [{options.ContextTag}]" );
+				options.Loading?.LoadingProgress( LoadingProgress.Create( $"Loading {existingPackage.Package.Title}" ) );
+				return existingPackage;
+			}
+
+			replacingPackage = existingPackage;
 		}
 
 		log.Trace( $"Install Package {options.PackageIdent} [{options.ContextTag}]" );
 		options.Loading?.LoadingProgress( LoadingProgress.Create( $"Fetching {options.PackageIdent}" ) );
-		var package = await FetchPackageAsync( options.PackageIdent, options.AllowLocalPackages );
+		var package = options.ReplaceExistingRevision
+			? await Package.FetchAsync( options.PackageIdent, false, false )
+			: await FetchPackageAsync( options.PackageIdent, options.AllowLocalPackages );
 
 		options.CancellationToken.ThrowIfCancellationRequested();
 
@@ -110,8 +119,24 @@ internal static partial class PackageManager
 			}
 		}
 
+		if ( replacingPackage is not null )
+		{
+			ap.Tags.UnionWith( replacingPackage.Tags );
+			ServerPackages.Forget( replacingPackage );
+			replacingPackage.Delete();
+			ActivePackages.Remove( replacingPackage );
+		}
+
 		ap.AddContextTag( options.ContextTag );
 		return ap;
+	}
+
+	private static bool MatchesRequestedRevision( ActivePackage activePackage, string packageIdent )
+	{
+		if ( !Package.TryParseIdent( packageIdent, out var parsed ) || parsed.version is null )
+			return true;
+
+		return activePackage.Package.Revision?.VersionId == parsed.version.Value;
 	}
 
 	public static void UnmountTagged( string tag )
@@ -183,7 +208,7 @@ internal static partial class PackageManager
 		//
 		foreach ( var packageName in dependancies )
 		{
-			await InstallAsync( options with { PackageIdent = packageName } );
+			await InstallAsync( options with { PackageIdent = packageName, ReplaceExistingRevision = false } );
 			options.CancellationToken.ThrowIfCancellationRequested();
 		}
 

--- a/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
@@ -248,6 +248,23 @@ internal class ServerPackages
 
 		return dl;
 	}
+
+	/// <summary>
+	/// Forget cached downloads that point at a package revision which has just been replaced.
+	/// </summary>
+	internal static void Forget( PackageManager.ActivePackage activePackage )
+	{
+		if ( Downloads is null )
+			return;
+
+		foreach ( var key in Downloads
+			.Where( x => ReferenceEquals( x.Value.activePackage, activePackage ) )
+			.Select( x => x.Key )
+			.ToArray() )
+		{
+			Downloads.Remove( key );
+		}
+	}
 }
 
 internal class UpdateLoadingScreen : ILoadingInterface

--- a/engine/Sandbox.Tools/Utility/Utility.Projects.cs
+++ b/engine/Sandbox.Tools/Utility/Utility.Projects.cs
@@ -81,5 +81,72 @@ public static partial class EditorUtility
 		{
 			await Project.GenerateSolution();
 		}
+
+		/// <summary>
+		/// Replaces the mounted parent of the current addon with an exact remote revision,
+		/// recompiles the addon against it, then recreates the editor game instance.
+		/// </summary>
+		public static async Task UpdateParentPackage( string packageIdent, long revisionId )
+		{
+			ThreadSafe.AssertIsMainThread();
+
+			var project = Project.Current ?? throw new System.InvalidOperationException( "No project is currently open." );
+			var parentPackage = project.Config.GetMetaOrDefault<string>( "ParentPackage", null );
+
+			if ( project.Config.Type != "addon" || !IsSamePackage( parentPackage, packageIdent ) )
+				throw new System.InvalidOperationException( $"'{packageIdent}' is not the current addon's parent package." );
+
+			if ( revisionId is <= 0 or > int.MaxValue )
+				throw new System.ArgumentOutOfRangeException( nameof( revisionId ), "The package revision is invalid." );
+
+			var mountedParent = PackageManager.Find( parentPackage, false );
+			if ( mountedParent?.Package.Revision?.VersionId > revisionId )
+				return;
+
+			Package.TryParseIdent( parentPackage, out var parentParts );
+			var exactIdent = Package.FormatIdent( parentParts.org, parentParts.package, (int)revisionId );
+			var updatedPackage = await Package.FetchAsync( exactIdent, false, false );
+
+			if ( updatedPackage?.Revision?.VersionId != revisionId )
+				throw new System.InvalidOperationException( $"Unable to fetch revision {revisionId} of '{packageIdent}'." );
+
+			var gameInstance = Sandbox.Engine.IGameInstanceDll.Current
+				?? throw new System.InvalidOperationException( "The editor game instance is not available." );
+
+			gameInstance.CloseGame();
+
+			await PackageManager.InstallAsync( new PackageLoadOptions( exactIdent, "tools" )
+			{
+				AllowLocalPackages = false,
+				ReplaceExistingRevision = true
+			} );
+
+			await AssetSystem.InstallAsync( updatedPackage, false );
+
+			project.Compiler?.MarkForRecompile();
+			project.EditorCompiler?.MarkForRecompile();
+			await Project.GenerateSolution();
+
+			if ( !await Updated( project ) )
+				throw new System.InvalidOperationException( "The addon failed to compile against the updated parent package." );
+
+			if ( !await gameInstance.LoadGamePackageAsync( exactIdent, Sandbox.Engine.GameLoadingFlags.Host | Sandbox.Engine.GameLoadingFlags.Reload, default ) )
+				throw new System.InvalidOperationException( "The updated parent package could not be loaded." );
+
+			await project.Package.MountAsync( true );
+			await ResourceLoader.LoadAllGameResourceAsync( FileSystem.Mounted, default, true );
+		}
+
+		private static bool IsSamePackage( string left, string right )
+		{
+			if ( !Package.TryParseIdent( left, out var leftParts ) || leftParts.local )
+				return false;
+
+			if ( !Package.TryParseIdent( right, out var rightParts ) || rightParts.local )
+				return false;
+
+			return string.Equals( leftParts.org, rightParts.org, System.StringComparison.OrdinalIgnoreCase )
+				&& string.Equals( leftParts.package, rightParts.package, System.StringComparison.OrdinalIgnoreCase );
+		}
 	}
 }

--- a/engine/Tests/Sandbox.Test.Unit/Packages/PackageManagerRevisionTests.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Packages/PackageManagerRevisionTests.cs
@@ -1,0 +1,40 @@
+namespace PackageTests;
+
+[TestClass]
+public class PackageManagerRevisionTests
+{
+	[TestMethod]
+	public void MountedRevisionIsStableByDefault()
+	{
+		var options = new PackageLoadOptions( "facepunch.sandbox#42", "test" );
+
+		Assert.IsFalse( PackageManager.ShouldReplaceExistingRevision( options, 41 ) );
+	}
+
+	[TestMethod]
+	[DataRow( "facepunch.sandbox#42", 41L, true )]
+	[DataRow( "facepunch.sandbox#42", 42L, false )]
+	[DataRow( "facepunch.sandbox", 41L, false )]
+	[DataRow( "facepunch.sandbox#local", 41L, false )]
+	[DataRow( "not-a-package", 41L, false )]
+	public void ExplicitReplacementRequiresDifferentExactRevision( string packageIdent, long activeRevisionId, bool expected )
+	{
+		var options = new PackageLoadOptions( packageIdent, "test" )
+		{
+			ReplaceExistingRevision = true
+		};
+
+		Assert.AreEqual( expected, PackageManager.ShouldReplaceExistingRevision( options, activeRevisionId ) );
+	}
+
+	[TestMethod]
+	public void ExactRevisionReplacesPackageWithMissingRevisionMetadata()
+	{
+		var options = new PackageLoadOptions( "facepunch.sandbox#42", "test" )
+		{
+			ReplaceExistingRevision = true
+		};
+
+		Assert.IsTrue( PackageManager.ShouldReplaceExistingRevision( options, null ) );
+	}
+}

--- a/game/addons/tools/Code/Notification/ParentPackageUpdateToast.cs
+++ b/game/addons/tools/Code/Notification/ParentPackageUpdateToast.cs
@@ -80,7 +80,7 @@ internal sealed class ParentPackageUpdateToast : ToastWidget
 		{
 			await EditorUtility.Projects.UpdateParentPackage( PackageIdent, RevisionId );
 
-			if ( !IsValid() )
+			if ( !IsValid )
 				return;
 
 			isUpdating = false;
@@ -95,7 +95,7 @@ internal sealed class ParentPackageUpdateToast : ToastWidget
 		{
 			Log.Warning( exception, $"Unable to update parent package {PackageIdent}: {exception.Message}" );
 
-			if ( !IsValid() )
+			if ( !IsValid )
 				return;
 
 			isUpdating = false;
@@ -124,7 +124,7 @@ internal sealed class ParentPackageUpdateToast : ToastWidget
 			.OfType<ParentPackageUpdateToast>()
 			.FirstOrDefault( x => IsSamePackage( x.PackageIdent, packageIdent ) );
 
-		if ( existing.IsValid() )
+		if ( existing is { IsValid: true } )
 		{
 			existing.SetAvailableRevision( revisionId );
 			return;

--- a/game/addons/tools/Code/Notification/ParentPackageUpdateToast.cs
+++ b/game/addons/tools/Code/Notification/ParentPackageUpdateToast.cs
@@ -1,0 +1,147 @@
+namespace Editor;
+
+internal sealed class ParentPackageUpdateToast : ToastWidget
+{
+	readonly Button.Primary updateButton;
+	readonly Button dismissButton;
+	bool isUpdating;
+
+	public string PackageIdent { get; }
+	public long RevisionId { get; private set; }
+
+	ParentPackageUpdateToast( string packageIdent, long revisionId )
+	{
+		PackageIdent = packageIdent;
+		Icon = "system_update_alt";
+		DrawTimer = false;
+
+		updateButton = new Button.Primary( "Update", "download", this )
+		{
+			FixedWidth = 112,
+			FixedHeight = 28,
+			Clicked = UpdatePackage
+		};
+
+		dismissButton = new Button( "Not Now", this )
+		{
+			FixedWidth = 92,
+			FixedHeight = 28,
+			Clicked = () => ToastManager.Dismiss( this )
+		};
+
+		SetAvailableRevision( revisionId );
+	}
+
+	void SetAvailableRevision( long revisionId )
+	{
+		if ( isUpdating )
+			return;
+
+		base.Reset();
+		RevisionId = revisionId;
+		Title = "Parent package update available";
+		Subtitle = $"A new revision of {PackageIdent} is available. Update it without restarting the editor?";
+		BorderColor = Theme.Primary;
+		IsRunning = false;
+		updateButton.Visible = true;
+		updateButton.Enabled = true;
+		updateButton.Text = "Update";
+		updateButton.Icon = "download";
+		dismissButton.Visible = true;
+	}
+
+	protected override Vector2 SizeHint() => new( 390, 118 );
+
+	protected override void DoLayout()
+	{
+		base.DoLayout();
+
+		const float margin = 16;
+		var y = Height - updateButton.Height - margin;
+		dismissButton.Position = new Vector2( Width - dismissButton.Width - margin, y );
+		updateButton.Position = new Vector2( dismissButton.Position.x - updateButton.Width - 8, y );
+	}
+
+	async void UpdatePackage()
+	{
+		if ( isUpdating )
+			return;
+
+		isUpdating = true;
+		IsRunning = true;
+		Title = "Updating parent package";
+		Subtitle = $"Downloading revision {RevisionId} of {PackageIdent}...";
+		updateButton.Enabled = false;
+		updateButton.Text = "Updating";
+		updateButton.Icon = "sync";
+		dismissButton.Visible = false;
+
+		try
+		{
+			await EditorUtility.Projects.UpdateParentPackage( PackageIdent, RevisionId );
+
+			if ( !IsValid() )
+				return;
+
+			isUpdating = false;
+			IsRunning = false;
+			Title = "Parent package updated";
+			Subtitle = $"{PackageIdent} is now using revision {RevisionId}.";
+			BorderColor = Theme.Green;
+			updateButton.Visible = false;
+			ToastManager.Remove( this, 4 );
+		}
+		catch ( System.Exception exception )
+		{
+			Log.Warning( exception, $"Unable to update parent package {PackageIdent}: {exception.Message}" );
+
+			if ( !IsValid() )
+				return;
+
+			isUpdating = false;
+			IsRunning = false;
+			Title = "Parent package update failed";
+			Subtitle = exception.Message;
+			BorderColor = Theme.Red;
+			updateButton.Visible = true;
+			updateButton.Enabled = true;
+			updateButton.Text = "Retry";
+			updateButton.Icon = "refresh";
+			dismissButton.Visible = true;
+		}
+	}
+
+	[Event( "package.updated" )]
+	public static void OnPackageUpdated( string packageIdent, long revisionId )
+	{
+		var project = Project.Current;
+		var parentPackage = project?.Config.GetMetaOrDefault<string>( "ParentPackage", null );
+
+		if ( project?.Config.Type != "addon" || !IsSamePackage( parentPackage, packageIdent ) )
+			return;
+
+		var existing = ToastManager.All
+			.OfType<ParentPackageUpdateToast>()
+			.FirstOrDefault( x => IsSamePackage( x.PackageIdent, packageIdent ) );
+
+		if ( existing.IsValid() )
+		{
+			existing.SetAvailableRevision( revisionId );
+			return;
+		}
+
+		_ = new ParentPackageUpdateToast( packageIdent, revisionId );
+	}
+
+	static bool IsSamePackage( string left, string right )
+	{
+		if ( !Package.TryParseIdent( left, out var leftParts ) || leftParts.local )
+			return false;
+
+		if ( !Package.TryParseIdent( right, out var rightParts ) || rightParts.local )
+			return false;
+
+		return string.Equals( leftParts.org, rightParts.org, System.StringComparison.OrdinalIgnoreCase )
+			&& string.Equals( leftParts.package, rightParts.package, System.StringComparison.OrdinalIgnoreCase );
+	}
+}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Adds an editor notification when the parent package of the currently opened addon receives a new revision.

The notification lets the developer either update the parent package immediately or dismiss the update. Updating refreshes the parent package, recompiles the addon, and reloads the editor game instance without requiring a full editor restart.

## Motivation & Context

Addon projects currently keep using the mounted revision of their parent package until the editor is restarted. This makes development across a parent game and its addons slower, since every parent package publication requires restarting each addon editor.

This change provides an explicit, optional refresh flow while keeping normal package installation and dependency resolution unchanged.

Fixes: N/A

## Implementation Details

- Forwards package revision update messages to the editor after invalidating the package cache.
- Adds a toast shown only when the updated package matches the current addon's configured `ParentPackage`.
- Provides **Update** and **Not Now** actions.
- Coalesces repeated notifications for the same parent package.
- Downloads the exact updated revision without using cached package metadata.
- Replaces the mounted parent package while preserving its existing context tags.
- Clears stale `ServerPackages` download references after replacement.
- Regenerates the solution and recompiles the addon against the new parent revision.
- Reloads the parent game, addon assemblies, assets, and game resources without restarting the editor.
- Keeps revision replacement strictly opt-in through `ReplaceExistingRevision`.
- Explicitly prevents dependency installations from inheriting the replacement behavior.
- Displays success, failure, and retry states in the notification.

## Screenshots / Videos (if applicable)

A screenshot or short recording of the parent package update notification can be added after the live package publication flow is re-tested.

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/d09015b4-bf41-446a-8e15-f00491d7bd51" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂