### PR TITLE
Fix proxy transform jitter with sync flags

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObject/GameTransform/GameTransform.Interpolation.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameTransform/GameTransform.Interpolation.cs
@@ -50,11 +50,17 @@ public partial class GameTransform
 	{
 		get
 		{
-			// If we're a proxy let's try to find the latest networked tranform to interpolate to, or our local transform.
-			if ( GameObject.IsProxy )
-				return _networkTransformBuffer?.IsEmpty == false ? _networkTransformBuffer.Last.State.Transform : _interpolatedLocal;
+			if ( !GameObject.IsProxy )
+				return _targetLocal;
 
-			return _targetLocal;
+			var flags = GameObject.Network?.Flags ?? NetworkFlags.None;
+			var networkTarget = _networkTransformBuffer?.IsEmpty == false ? _networkTransformBuffer.Last.State.Transform : _interpolatedLocal;
+
+			var result = _interpolatedLocal;
+			result.Position = (flags & NetworkFlags.NoPositionSync) != 0 ? _targetLocal.Position : networkTarget.Position;
+			result.Rotation = (flags & NetworkFlags.NoRotationSync) != 0 ? _targetLocal.Rotation : networkTarget.Rotation;
+			result.Scale = (flags & NetworkFlags.NoScaleSync) != 0 ? _targetLocal.Scale : networkTarget.Scale;
+			return result;
 		}
 	}
 
@@ -218,7 +224,7 @@ public partial class GameTransform
 	{
 		if ( GameObject.IsProxy )
 		{
-			InterpolateNetwork( now );
+			InterpolateProxy( now, cullBefore );
 			return;
 		}
 
@@ -250,24 +256,85 @@ public partial class GameTransform
 		}
 	}
 
-	void InterpolateNetwork( double now )
+	void InterpolateProxy( double now, double cullBefore )
 	{
+		var flags = GameObject.Network?.Flags ?? NetworkFlags.None;
+
 		if ( GameObject?.Flags.Contains( GameObjectFlags.NoInterpolation ) ?? false )
 		{
 			_networkTransformBuffer?.Clear();
+			_positionBuffer?.Clear();
+			_rotationBuffer?.Clear();
+			_scaleBuffer?.Clear();
 		}
 
-		if ( _networkTransformBuffer?.IsEmpty == false )
+		var hasNetwork = _networkTransformBuffer?.IsEmpty == false;
+		var networkState = _interpolatedLocal;
+		if ( hasNetwork )
 		{
 			var interpolationTime = Networking.InterpolationTime;
-			var state = _networkTransformBuffer.QueryAndCull( now - interpolationTime, now - (interpolationTime * 3f) );
-
-			_interpolatedLocal = state.Transform;
-			_targetLocal = _interpolatedLocal;
-			TransformChanged();
+			networkState = _networkTransformBuffer.QueryAndCull( now - interpolationTime, now - (interpolationTime * 3f) ).Transform;
 		}
 
-		if ( _networkTransformBuffer?.IsEmpty ?? true )
+		var tx = _interpolatedLocal;
+		var target = _targetLocal;
+
+		if ( (flags & NetworkFlags.NoPositionSync) == 0 )
+		{
+			_positionBuffer?.Clear();
+
+			if ( hasNetwork )
+			{
+				tx.Position = networkState.Position;
+				target.Position = networkState.Position;
+			}
+		}
+		else
+		{
+			tx.Position = _positionBuffer?.IsEmpty == false ? _positionBuffer.QueryAndCull( now, cullBefore ).Value : _targetLocal.Position;
+		}
+
+		if ( (flags & NetworkFlags.NoRotationSync) == 0 )
+		{
+			_rotationBuffer?.Clear();
+
+			if ( hasNetwork )
+			{
+				tx.Rotation = networkState.Rotation;
+				target.Rotation = networkState.Rotation;
+			}
+		}
+		else
+		{
+			tx.Rotation = _rotationBuffer?.IsEmpty == false ? _rotationBuffer.QueryAndCull( now, cullBefore ).Rotation : _targetLocal.Rotation;
+		}
+
+		if ( (flags & NetworkFlags.NoScaleSync) == 0 )
+		{
+			_scaleBuffer?.Clear();
+
+			if ( hasNetwork )
+			{
+				tx.Scale = networkState.Scale;
+				target.Scale = networkState.Scale;
+			}
+		}
+		else
+		{
+			tx.Scale = _scaleBuffer?.IsEmpty == false ? _scaleBuffer.QueryAndCull( now, cullBefore ).Value : _targetLocal.Scale;
+		}
+
+		var changed = tx != _interpolatedLocal || target != _targetLocal;
+		_interpolatedLocal = tx;
+		_targetLocal = target;
+
+		if ( changed )
+			TransformChanged();
+
+		var networkDone = _networkTransformBuffer?.IsEmpty ?? true;
+		var localDone = (_positionBuffer?.IsEmpty ?? true) && (_rotationBuffer?.IsEmpty ?? true) && (_scaleBuffer?.IsEmpty ?? true);
+
+		if ( networkDone && localDone )
 		{
 			Interpolate = false;
 		}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
@@ -93,6 +93,49 @@ public class NetworkTest
 	}
 
 	[TestMethod]
+	[DataRow( NetworkFlags.None )]
+	[DataRow( NetworkFlags.NoPositionSync )]
+	[DataRow( NetworkFlags.NoRotationSync )]
+	[DataRow( NetworkFlags.NoScaleSync )]
+	public void ProxyKeepsUnsyncedComponentLocal( NetworkFlags flags )
+	{
+		Assert.IsNotNull( TypeLibrary.GetType<ModelRenderer>(), "TypeLibrary hasn't been given the game assembly" );
+
+		using var scope = new Scene().Push();
+
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+
+		clientAndHost.BecomeClient();
+
+		var go = new GameObject();
+		go.Network.Flags |= flags;
+
+		go.NetworkSpawn( clientAndHost.Host );
+		Assert.IsTrue( go.IsProxy );
+
+		var localTransform = new Transform( new Vector3( 100f, 0f, 0f ), Rotation.From( 0f, 45f, 0f ), Vector3.One * 2f );
+		var networkTransform = new Transform( new Vector3( -100f, 0f, 0f ), Rotation.From( 0f, 90f, 0f ), Vector3.One * 4f );
+
+		go.Transform.Local = localTransform;
+
+		var time = Time.NowDouble;
+		go.Transform.FromNetwork( networkTransform, false );
+
+		go.Transform.Update( time + Networking.InterpolationTime * 2f, time );
+
+		var expected = new Transform(
+			(flags & NetworkFlags.NoPositionSync) != 0 ? localTransform.Position : networkTransform.Position,
+			(flags & NetworkFlags.NoRotationSync) != 0 ? localTransform.Rotation : networkTransform.Rotation,
+			(flags & NetworkFlags.NoScaleSync) != 0 ? localTransform.Scale : networkTransform.Scale );
+
+		var local = go.Transform.InterpolatedLocal;
+
+		Assert.IsTrue( local.Position.AlmostEqual( expected.Position ), $"Position was {local.Position}" );
+		Assert.IsTrue( local.Rotation.Distance( expected.Rotation ) < 0.01f, $"Rotation was {local.Rotation}" );
+		Assert.IsTrue( local.Scale.AlmostEqual( expected.Scale ), $"Scale was {local.Scale}" );
+	}
+
+	[TestMethod]
 	public void NetworkedInput()
 	{
 		Assert.IsNotNull( TypeLibrary.GetType<ModelRenderer>(), "TypeLibrary hasn't been given the game assembly" );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Proxy objects with a transform sync flag set (`NoPositionSync`, `NoRotationSync`, or `NoScaleSync`) would jitter. During interpolation the whole networked transform was applied to the proxy every frame, overwriting the component that was supposed to be driven locally.

This makes proxy interpolation per-component: a flagged component keeps its local value while the unflagged ones still interpolate from the network.

## Motivation & Context

Fixes: #11475

## Implementation Details

- `TargetLocal` now mixes per-component the same way, so the value we re-network is correct too.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

Before: https://youtu.be/iDZeVXcfgFE
After: https://youtu.be/KSIMAsOjoNw

## Checklist

- [X] Code follows existing style and conventions
- [X] No unnecessary formatting or unrelated changes
- [X] Public APIs are documented (if applicable)
- [X] Unit tests added where applicable and all passing
- [X] I’m okay with this PR being rejected or requested to change 🙂