### PR TITLE
Add Input.SetLastAction

### DIFF
--- a/engine/Sandbox.Engine/Systems/Input/Input.Actions.cs
+++ b/engine/Sandbox.Engine/Systems/Input/Input.Actions.cs
@@ -129,6 +129,9 @@ public static partial class Input
 	/// <inheritdoc cref="SetAction(int, bool)"/>
 	public static void SetAction( string action, bool down ) => SetAction( GetActionIndex( action ), down );
 
+	/// <inheritdoc cref="SetLastAction(int, bool)"/>
+	public static void SetLastAction( string action, bool down ) => SetLastAction( GetActionIndex( action ), down );
+
 	/// <summary>
 	/// Remove this action, so it's no longer being pressed.
 	/// </summary>
@@ -182,6 +185,17 @@ public static partial class Input
 	{
 		if ( down ) Actions |= 1UL << index;
 		else Actions &= ~(1UL << index);
+	}
+
+	/// <summary>
+	/// Activates / Deactivates the previous action when building input.
+	/// </summary>
+	/// <param name="index"></param>
+	/// <param name="down"></param>
+	internal static void SetLastAction( int index, bool down )
+	{
+		if ( down ) LastActions |= 1UL << index;
+		else LastActions &= ~(1UL << index);
 	}
 
 	static InputAction FindInputActionByName( string action )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

I added a "SetLastAction" method to Input. When used together with `Input.SetAction` you can make `Input.Pressed` and `Input.Released` return true or not.


## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: https://github.com/Facepunch/sbox-public/issues/10164

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

I copied the implementation of Input.SetAction but made it set LastActions instead of Actions.

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

https://github.com/user-attachments/assets/b8b6353d-1705-4af6-9540-89d3376a82fd


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂