### PR TITLE
Fix MeshComponents loading empty from scene maps via MapInstance

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -425,6 +425,11 @@ public partial class MapInstance : Component, Component.ExecuteInEditor
 
 		using var optionsScope = ActionGraph.PushSerializationOptions( sceneFile.SerializationOptions with { ForceUpdateCached = Scene.IsEditor } );
 		using var sceneScope = Scene.Push();
+
+		// Blob data (eg. MeshComponent geometry) is referenced by guid from the scene json -
+		// deserializing without an open scope silently yields empty blobs. Declared before the
+		// batch so it outlives the deferred property flush (usings dispose in reverse order).
+		using var blobs = BlobDataSerializer.Load( sceneFile.BinaryData, sceneFile.ResourcePath );
 		using var batchGroup = CallbackBatch.Batch();
 
 		foreach ( var json in sceneFile.GameObjects )


### PR DESCRIPTION
# Pull Request

## Summary

`MapInstance.LoadMapSceneGameObjects` deserializes a scene map's GameObjects without an open `BlobDataSerializer` scope. Every `{"$blob": guid}` reference resolves to `null` (`ReadBlob` returns null when no context is active), `PolygonMesh.JsonRead` quietly skips the null blob, and every `MeshComponent` instantiates with an **empty mesh** — silently: hierarchy, names and transforms are all correct, `LocalBounds` is zero, `MapInstance.IsLoaded` is true, nothing is logged. Non-blob components from the same scene (SkyBox2D, lights, ModelRenderer) load fine, which makes the geometry loss look like a content problem rather than an engine one.

Since PolygonMesh moved its geometry to blob data (proposed in #11324; on master in a reworked form), this hits **every scene-based map with MeshComponent geometry** loaded through `MapInstance` — including cloud map packages: a map republished with a current editor saves `$blob` refs and loads invisible in any game that mounts it.

The fix mirrors `Scene.Load` (`Scene.LoadSave.cs`), which opens the scope over the same deferred deserialize:

```csharp
using var sceneScope = Push();
using var blobs = BlobDataSerializer.Load( sceneFile.BinaryData, sceneFile.ResourcePath );
using var batchGroup = CallbackBatch.Batch();
```

Same invariant as #11455: the scope is declared before the `CallbackBatch` so it disposes after the batch flush, where the deferred property application actually reads the blobs.

## Motivation & Context

Hit in production with a cloud scene map (`rebornteam.zombie_city`, 332 MeshComponents): after it was republished with a post-blob-format editor, the map loaded as named empty objects for every player. Two things isolate the failure to blob-ref resolution rather than the data or the package:

- an older revision of the same package (saved before the blob format, geometry inline as JSON arrays) still renders through the unchanged legacy read path;
- rewriting the current scene's `"Data"` values from `$blob` refs to the inline base64 form renders correctly through this exact unpatched code path.

The compiled scene does ship the blob container (DBLOB block — verified present in the CDN-served `.scene_c`), so the `ResourcePath` fallback in `BlobDataSerializer.Load` reaches it for mounted packages, and `BinaryData` covers the in-memory case.

Repro:
1. Make a scene with MeshComponent geometry (editor mesh tools) and save it with a current build (`$blob` refs + `_d` sidecar).
2. Publish it as a map package.
3. In another project, point `MapInstance.MapName` at it.
4. The hierarchy loads; every mesh is empty (`LocalBounds` = 0,0,0), no errors logged.

Note: I couldn't build the engine locally to runtime-test the patch — the diagnosis and the fix pattern are validated as described above.

## Screenshots

<img width="2552" height="1134" alt="map" src="https://github.com/user-attachments/assets/ad6adddf-1463-45c2-a948-4d5442ba1177"/>

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (no API change)
- [x] I'm okay with this PR being rejected or requested to change 🙂