### PR TITLE
Fix initialization order for editor clients connecting to dedicated servers

### DIFF
--- a/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/System/NetworkSystem.Handshake.cs
@@ -428,6 +428,11 @@ internal partial class NetworkSystem
 		};
 
 		source.SendMessage( output );
+
+		if ( Application.IsEditor )
+		{
+			IToolsDll.Current?.SetPlaying();
+		}
 	}
 
 	Task On_Handshake_ClientReady( ClientReady msg, Connection source, Guid msgId )
@@ -496,11 +501,6 @@ internal partial class NetworkSystem
 
 		if ( msg.HandshakeId != Connection.Local.HandshakeId )
 			return Task.CompletedTask;
-
-		if ( Application.IsEditor )
-		{
-			IToolsDll.Current?.SetPlaying();
-		}
 
 		Log.Trace( $"[{this}] I am spawning into the game!" );
 		LoadingScreen.IsVisible = false;


### PR DESCRIPTION
# Pull Request

## Summary

Fixes an initialization order regression when connecting to a **dedicated server from the editor**.

After the changes introduced in commit `8ca54b5dd03b96811ff13db659310ceb55ec5d36`, the editor client could enter the playing state before scene initialization had completed. As a result, RPCs sent from `OnActive(Connection channel)` could be received and executed before the client's `GameInstance.OnStart()` and `GameObject.OnStart()` callbacks had run.

This change delays entering the playing state until the client has fully initialized its scene.

## Motivation & Context

The regression was introduced by the changes in commit `8ca54b5dd03b96811ff13db659310ceb55ec5d36`, affecting the **editor → dedicated server** connection flow.

When user code sends an RPC from:

```csharp
public void OnActive( Connection channel )
{
    // Send RPC
}
```

the RPC can arrive on the editor client before scene initialization has completed, causing user code to execute before `OnStart()` has been called on the `GameInstance` and other `GameObject`s.

This results in an inconsistent initialization order that can lead to missing references or other startup issues.

Fixes: N/A

## Implementation Details

The editor client now enters the playing state only after scene loading and initialization have completed when connecting to a dedicated server.

This guarantees that:

* `GameInstance.OnStart()` has already executed.
* All `GameObject.OnStart()` callbacks have completed.
* RPCs sent from `OnActive(Connection channel)` cannot execute before the client is fully initialized.

The change only affects the timing of entering the playing state for the **editor → dedicated server** connection path.

## Screenshots / Videos (if applicable)

N/A

## Checklist

* [x] Code follows existing style and conventions
* [x] No unnecessary formatting or unrelated changes
* [ ] Public APIs are documented (if applicable)
* [ ] Unit tests added where applicable and all passing
* [x] I’m okay with this PR being rejected or requested to change 🙂
