### PR TITLE
Move snapshot MarkCreateMessageSent into SerializeNetworkObjects so we capture all objects

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/NetworkObject.cs
@@ -534,6 +534,9 @@ internal sealed partial class NetworkObject : IValid, IDeltaSnapshot
 		if ( GameObject?.IsDestroyed ?? true )
 			return;
 
+		if ( !Networking.IsHost )
+			return;
+
 		if ( !_createMessageConnections.Add( target.Id ) )
 			return;
 

--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -325,15 +325,6 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		GetSnapshot( connection, ref snapshot );
 		output.Snapshot = snapshot;
 
-		foreach ( var networkObjectData in snapshot.NetworkObjects )
-		{
-			if ( networkObjectData is not ObjectCreateMsg createMessage )
-				continue;
-
-			var networkGameObject = activeScene.Directory.FindByGuid( createMessage.Guid );
-			networkGameObject?._net?.MarkCreateMessageSent( connection );
-		}
-
 		var bs = ByteStream.Create( 256 );
 		bs.Write( InternalMessageType.Packed );
 
@@ -1133,6 +1124,13 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 				if ( source is not null && !source.IsHost && (msg.Owner != source.Id || msg.Creator != source.Id) )
 					continue;
 
+				// Drop a create for an id we already have rather than spawning a duplicate under a reassigned GUID.
+				if ( scene.Directory.FindByGuid( msg.Guid ).IsValid() )
+				{
+					Log.Warning( $"Ignoring batched ObjectCreateMsg for {msg.Guid} from {source}: an object with that id already exists." );
+					continue;
+				}
+
 				using ( BlobDataSerializer.LoadFromMemory( msg.BlobData ) )
 				{
 					var go = new GameObject();
@@ -1160,6 +1158,14 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		// Don't let clients claim ownership or creation on behalf of other connections
 		if ( source is not null && !source.IsHost && (message.Owner != source.Id || message.Creator != source.Id) )
 			return;
+
+		// We already have an object with this id. Spawning another would create a duplicate and then
+		// silently reassign its GUID, turning a single stray create into an endless duplicate generator.
+		if ( scene.Directory.FindByGuid( message.Guid ).IsValid() )
+		{
+			Log.Warning( $"Ignoring ObjectCreateMsg for {message.Guid} from {source}: an object with that id already exists." );
+			return;
+		}
 
 		var go = new GameObject();
 

--- a/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
+++ b/engine/Sandbox.Engine/Scene/Scene/Scene.Network.cs
@@ -80,6 +80,8 @@ public partial class Scene : GameObject
 
 	internal void SerializeNetworkObjects( Connection source, List<object> collection )
 	{
+		var included = new HashSet<NetworkObject>();
+
 		foreach ( var target in networkedObjects )
 		{
 			if ( target.GameObject?.IsDestroyed ?? true )
@@ -90,8 +92,32 @@ public partial class Scene : GameObject
 			if ( source is null || target.ShouldIncludeInSnapshot( source )
 				|| (root != target && (root?.ShouldIncludeInSnapshot( source ) ?? false)) )
 			{
-				collection.Add( target.GetCreateMessage() );
+				AddWithAncestors( source, target, included, collection );
 			}
+		}
+	}
+
+	/// <summary>
+	/// Emit the create message for <paramref name="target"/> and every networked ancestor above it,
+	/// each at most once. A networked child must never be sent without its parent chain.
+	/// </summary>
+	internal void AddWithAncestors( Connection source, NetworkObject target, HashSet<NetworkObject> included, List<object> collection )
+	{
+		var current = target;
+		while ( current is not null )
+		{
+			if ( current.GameObject?.IsDestroyed ?? true )
+				break;
+
+			if ( !included.Add( current ) )
+				break;
+
+			collection.Add( current.GetCreateMessage() );
+
+			if ( source is not null )
+				current.MarkCreateMessageSent( source );
+
+			current = current.GameObject.Parent?._net;
 		}
 	}
 

--- a/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/GameObjects/Network.cs
@@ -877,6 +877,53 @@ public class NetworkTest
 	}
 
 	[TestMethod]
+	public void JoinSnapshotIncludesNetworkedAncestorsOfIncludedObject()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+		clientAndHost.BecomeHost();
+
+		// A cullable parent the joining client can't see, with a child it can. The parent must still
+		// ride along in the snapshot, otherwise the child resolves a null parent and gets reparented
+		// to the scene root on the client.
+		var parent = SpawnNetworked( visible: false );
+		var child = SpawnNetworked( visible: true );
+		child.SetParent( parent );
+
+		var collection = new List<object>();
+		Game.ActiveScene.SerializeNetworkObjects( clientAndHost.Client, collection );
+
+		var guids = collection.OfType<ObjectCreateMsg>().Select( m => m.Guid ).ToList();
+
+		Assert.IsTrue( guids.Contains( child.Id ), "Visible child should be included" );
+		Assert.IsTrue( guids.Contains( parent.Id ), "Hidden parent must be pulled in so the child can resolve it" );
+		// The parent's create message carries the child's real parent id.
+		var childMsg = collection.OfType<ObjectCreateMsg>().Single( m => m.Guid == child.Id );
+		Assert.AreEqual( parent.Id, childMsg.Parent, "Child create message should reference the real parent" );
+	}
+
+	[TestMethod]
+	public void JoinSnapshotDoesNotDuplicateSharedAncestors()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+		clientAndHost.BecomeHost();
+
+		// One hidden parent, two visible children - the parent must appear exactly once.
+		var parent = SpawnNetworked( visible: false );
+		var childA = SpawnNetworked( visible: true );
+		var childB = SpawnNetworked( visible: true );
+		childA.SetParent( parent );
+		childB.SetParent( parent );
+
+		var collection = new List<object>();
+		Game.ActiveScene.SerializeNetworkObjects( clientAndHost.Client, collection );
+
+		var parentCount = collection.OfType<ObjectCreateMsg>().Count( m => m.Guid == parent.Id );
+		Assert.AreEqual( 1, parentCount, "Shared ancestor should be emitted exactly once" );
+	}
+
+	[TestMethod]
 	public void EnsureCreateMessageSentIsIdempotent()
 	{
 		using var scope = new Scene().Push();
@@ -911,6 +958,45 @@ public class NetworkTest
 
 		go.DestroyImmediate();
 		net.EnsureCreateMessageSent( clientAndHost.Client );
+
+		Assert.AreEqual( 0, CreateMsgCount( clientAndHost.Client ) );
+	}
+
+	[TestMethod]
+	public void EnsureCreateMessageSentOnlyEmitsFromHost()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+		clientAndHost.BecomeClient();
+
+		NetworkObject net;
+		using ( SceneNetworkSystem.SuppressSpawnMessages() )
+			net = SpawnNetworked( visible: false )._net;
+
+		net.EnsureCreateMessageSent( clientAndHost.Host );
+
+		Assert.AreEqual( 0, CreateMsgCount( clientAndHost.Host ),
+			"A non-host machine must not emit an ObjectCreateMsg via EnsureCreateMessageSent" );
+	}
+
+	[TestMethod]
+	public void SerializeNetworkObjectsMarksCreateMessageSent()
+	{
+		using var scope = new Scene().Push();
+		using var clientAndHost = new ClientAndHost( TypeLibrary );
+		clientAndHost.BecomeHost();
+
+		GameObject go;
+		using ( SceneNetworkSystem.SuppressSpawnMessages() )
+			go = SpawnNetworked( visible: true );
+
+		var collection = new List<object>();
+		Game.ActiveScene.SerializeNetworkObjects( clientAndHost.Client, collection );
+
+		Assert.IsTrue( collection.OfType<ObjectCreateMsg>().Any( m => m.Guid == go.Id ),
+			"Object should have been serialized into the snapshot" );
+
+		go._net.EnsureCreateMessageSent( clientAndHost.Client );
 
 		Assert.AreEqual( 0, CreateMsgCount( clientAndHost.Client ) );
 	}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

I fixed two snapshot bugs:

1. I moved `MarkCreateMessageSent` into `SerializeNetworkObjects`. Now, create messages are marked as sent for every object in a snapshot, not just during scene loading.
2. When an object goes into a snapshot, its full chain of networked parents is included too. This stops networked children from arriving without their parents.

## Motivation & Context

Before this, create messages were only marked in `OnLoadSceneRequestSnapshotMsg`. When a client joined normally, those objects were never marked as sent. Because of this, the delta system kept trying to re-send create messages for things the snapshot already had.

Also, children could sometimes be sent without their networked parents. This broke the scene hierarchy on the client side because the child had nothing to attach to.

Fixes: #11523

## Implementation Details

Create messages are now marked right where they are sent (`SerializeNetworkObjects`), replacing the old extra step. Both the handshake-join and scene-load paths use this, so both are fixed.

I added an `AddWithAncestors` helper. It checks the target object, walks up through every networked parent, and makes sure each one is added and marked as sent. A shared `HashSet` stops duplicates, and parents are always sent before their children.

## Checklist

* [X] Code follows existing style and conventions
* [X] No unnecessary formatting or unrelated changes
* [X] Public APIs are documented (if applicable)
* [X] Unit tests added where applicable and all passing
* [X] I'm okay with this PR being rejected or requested to change 🙂