### PR TITLE
Fix off-by-one in Texture.GetPixels dest array bounds check

### DIFF
--- a/engine/Sandbox.Engine/Resources/Textures/Texture.Read.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Texture.Read.cs
@@ -229,7 +229,7 @@ public partial class Texture
 		}
 
 		var maxLength = (dstRect.Y + dstRect.H - 1) * dstStride + dstRect.X + dstRect.W;
-		if ( maxLength >= dstData.Length )
+		if ( maxLength > dstData.Length )
 			throw new ArgumentException( $"Output rect size ({maxLength}) exceeds destination array size {dstData.Length}" );
 
 		if ( maxLength <= 0 )

--- a/engine/Tests/Sandbox.Test.Integration/Texture/TextureTest.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Texture/TextureTest.cs
@@ -159,4 +159,34 @@ public class TextureTest
 			texture.GetPixelsAsync3D<Color32>( _ => { }, ImageFormat.RGBA8888, (0, 0, 0, 1, 1, -1), 0 );
 		} );
 	}
+
+	[TestMethod]
+	public void GetPixelsDestArrayBoundsCheck()
+	{
+		var texture = Texture.Create( 4, 4 ).Finish();
+
+		// Exactly-sized buffer for the whole texture should not trigger the bounds check.
+		// The native ReadTexturePixels fails in headless mode. However, we only want to
+		// validate that the ArgumentExcpetion does not get thrown for getting the entire
+		// texture.
+		var exactBuffer = new Color32[4 * 4];
+		try
+		{
+			texture.GetPixels( (0, 0, 4, 4), 0, 0, exactBuffer.AsSpan(), ImageFormat.RGBA8888, (0, 0, 4, 4), 4 );
+		}
+		catch ( ArgumentException )
+		{
+			Assert.Fail( "Should not reject a dest array that exactly fits the requested rect" );
+		}
+		catch ( Exception )
+		{
+		}
+
+		// Undersized buffer should throw
+		var tooSmallBuffer = new Color32[4 * 4 - 1];
+		Assert.ThrowsException<ArgumentException>( () =>
+		{
+			texture.GetPixels( (0, 0, 4, 4), 0, 0, tooSmallBuffer.AsSpan(), ImageFormat.RGBA8888, (0, 0, 4, 4), 4 );
+		} );
+	}
 }


### PR DESCRIPTION
The bounds check in GetPixels was rejecting valid destination arrays that exactly fit the requested source rectangle.

# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Texture.GetPixels when passed with a stride would reject valid calls when trying to read the entire texture.

## Motivation & Context

https://github.com/Facepunch/sbox-public/commit/e8eb99a21823a894659e3cdf09f7cbb03bb153b8#diff-c08134d7efeb1290fb11ab320969825b62bb01e4ba1402e9092cb885e11d4800R27

When this was merged it fixed one bug where the last row and column of the texture would be silently striped. Fixing that bug revealed another bug when calling Terrain.SyncCPUTexture() where an argument exception would be thrown for a valid GetPixels call.

## Implementation Details

Just a change in operator.

## Screenshots / Videos (if applicable)

<img width="848" height="294" alt="image" src="https://github.com/user-attachments/assets/c8149a40-3298-4d15-9d43-fec283cdfe8a" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂