### PR TITLE
Optimize ComponentList.Get(All)

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObject/ComponentList.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/ComponentList.cs
@@ -214,15 +214,11 @@ public class ComponentList
 	{
 		if ( go.IsDestroyed ) return Enumerable.Empty<T>();
 
-		var results = new List<T>( 16 );
-
-		CollectAll( results, find );
-
-		return results;
+		return CollectAll<T>( find );
 	}
 
 	// This is an incredibly hot code path, even the slightest change should be verified with benchmarks.
-	private void CollectAll<T>( List<T> results, FindMode find )
+	private IEnumerable<T> CollectAll<T>( FindMode find )
 	{
 		bool enabledOnly = find.Contains( FindMode.Enabled );
 		bool disabledOnly = find.Contains( FindMode.Disabled );
@@ -233,7 +229,7 @@ public class ComponentList
 			disabledOnly = false;
 		}
 
-		if ( enabledOnly && !go.Enabled ) return;
+		if ( enabledOnly && !go.Enabled ) yield break;
 
 		//
 		// Find in self
@@ -250,7 +246,7 @@ public class ComponentList
 
 				if ( component is T c )
 				{
-					results.Add( c );
+					yield return c;
 				}
 			}
 		}
@@ -275,7 +271,10 @@ public class ComponentList
 				var child = go.Children[i];
 				if ( child.IsValid() )
 				{
-					child.Components.CollectAll( results, childFlags );
+					foreach ( var childComponent in child.Components.CollectAll<T>( childFlags ) )
+					{
+						yield return childComponent;
+					}
 				}
 			}
 		}
@@ -297,7 +296,10 @@ public class ComponentList
 
 			if ( go.Parent is not null && go.Parent is PrefabScene or not Scene )
 			{
-				go.Parent.Components.CollectAll( results, parentFlags );
+				foreach ( var parentComponent in go.Parent.Components.CollectAll<T>( parentFlags ) )
+				{
+					yield return parentComponent;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR optimizes all `ComponentList.Get` and `ComponentList.GetAll` methods.

## Motivation & Context

I first noticed this while looking into performance issues with [Alasi Online](https://sbox.game/duckanddinosaur/alasi-online) and noticed that ~94% of their whole `Scene.Update` was taken by calls to `ComponentList.GetAll`
<img width="788" height="537" alt="image" src="https://github.com/user-attachments/assets/8411ca98-ee56-4895-bab3-0e8053c67ad9" />

## Implementation Details

This PR does not affect any public API but affects the internal API to `ComponentList` itself. Instead of passing `List<T>`s to the `CollectAll` method it does a lazy enumeration. This means now all `ComponentList.Get` calls will benefit from this optimization since they would fallback to `ComponentList.GetAll` and incur the full iteration cost. `ComponentList.GetAll` would also create a 16 element `List<T>` on every invocation so now getting a single component will not create lots of garbage.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂