### PR TITLE
2D sprite sorting: sort layers, sort order, sorting groups, transparency sort axis

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.Sorting.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.Sorting.cs
@@ -1,0 +1,106 @@
+namespace Sandbox;
+
+/// <summary>
+/// How sorted sprites are ordered against each other by a camera, once their sort layer and
+/// order in layer have been compared and come out equal.
+/// </summary>
+[Expose]
+public enum TransparencySortMode
+{
+	/// <summary>
+	/// Follow the camera's projection - distance from the camera when perspective, depth along
+	/// the view direction when orthographic.
+	/// </summary>
+	[Icon( "auto_awesome" )]
+	Default,
+
+	/// <summary>
+	/// Always sort by distance from the camera position, even in an orthographic view.
+	/// </summary>
+	[Icon( "videocam" )]
+	Perspective,
+
+	/// <summary>
+	/// Always sort by depth along the camera's view direction, even in a perspective view.
+	/// </summary>
+	[Icon( "crop_free" )]
+	Orthographic,
+
+	/// <summary>
+	/// Sort by position along <see cref="CameraComponent.TransparencySortAxis"/>, ignoring where
+	/// the camera is. This is how top-down and isometric games make characters occlude each other
+	/// by their feet.
+	/// </summary>
+	[Icon( "straighten" )]
+	CustomAxis,
+}
+
+public sealed partial class CameraComponent
+{
+	/// <summary>
+	/// How this camera breaks ties between sprites that share a sort layer and order in layer.
+	/// Only affects sprites with <see cref="SpriteRenderer.IsSorted"/> enabled.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( 300 )]
+	public TransparencySortMode TransparencySort { get; set; } = TransparencySortMode.Default;
+
+	/// <summary>
+	/// The axis sprites are sorted along when <see cref="TransparencySort"/> is
+	/// <see cref="TransparencySortMode.CustomAxis"/>. A sprite further along this axis draws
+	/// behind one that is less far along it - so for a top-down game the default (0,1,0) makes a
+	/// character lower on the screen walk in front of one higher up.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( 301 )]
+	[ShowIf( nameof( TransparencySort ), TransparencySortMode.CustomAxis )]
+	public Vector3 TransparencySortAxis { get; set; } = new( 0, 1, 0 );
+
+	/// <summary>
+	/// The axis handed to the sprite compute shader for a given mode. Only
+	/// <see cref="TransparencySortMode.CustomAxis"/> sorts along an axis at all, so every other
+	/// mode resolves to zero - which the shader reads as "sort by camera depth instead".
+	///
+	/// A zero axis in CustomAxis mode stays zero rather than becoming a NaN, so a half-configured
+	/// camera degrades to the old behaviour instead of corrupting the sort.
+	/// </summary>
+	internal static Vector3 ResolveSortAxis( TransparencySortMode mode, Vector3 axis )
+	{
+		if ( mode != TransparencySortMode.CustomAxis ) return Vector3.Zero;
+
+		// Normal returns the vector untouched when it is near-zero, so this cannot produce NaN.
+		return axis.Normal;
+	}
+
+	/// <summary>
+	/// Pushes the sorting settings onto the camera so the sprite compute shader can read them.
+	/// A camera that never touches these renders exactly as it did before they existed.
+	/// </summary>
+	internal void UpdateSortingAttributes( SceneCamera camera )
+	{
+		camera.Attributes.Set( "SpriteSortMode", (int)TransparencySort );
+		camera.Attributes.Set( "SpriteSortAxis", ResolveSortAxis( TransparencySort, TransparencySortAxis ) );
+	}
+
+	/// <summary>
+	/// Draws the sort axis in front of the camera while it is selected. "Which way is behind?" is
+	/// the question a custom axis immediately raises, and a number in the inspector answers it far
+	/// less well than an arrow does.
+	/// </summary>
+	private void DrawSortAxisGizmo()
+	{
+		var axis = ResolveSortAxis( TransparencySort, TransparencySortAxis );
+		if ( axis.IsNearZeroLength ) return;
+
+		// Out in front of the camera, so the arrow lands somewhere the camera can actually see
+		// rather than on top of the frustum apex.
+		var origin = WorldPosition + WorldRotation.Forward * 128f;
+		var length = 48f;
+
+		Gizmo.Draw.Color = Color.Cyan.WithAlpha( 0.9f );
+		Gizmo.Draw.Arrow( origin - axis * length, origin + axis * length, 12f, 4f );
+
+		// The arrow alone does not say which end wins, and guessing wrong inverts the whole scene.
+		Gizmo.Draw.Color = Color.Cyan.WithAlpha( 0.6f );
+		Gizmo.Draw.ScreenText( "behind", Gizmo.Camera.ToScreen( origin + axis * length ), size: 12 );
+		Gizmo.Draw.ScreenText( "in front", Gizmo.Camera.ToScreen( origin - axis * length ), size: 12 );
+	}
+}

--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Sandbox.Rendering;
 using Sandbox.UI;
 using System.Drawing;
@@ -257,6 +257,8 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 
 		Gizmo.Draw.Color = Color.White.WithAlpha( 0.4f );
 		Gizmo.Draw.LineFrustum( frustum );
+
+		DrawSortAxisGizmo();
 	}
 
 	/// <summary>
@@ -414,6 +416,9 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 
 		// Merge our global Scene attributes into the camera
 		Scene.RenderAttributes.MergeTo( camera.Attributes );
+
+		// After the merge, so the camera's own sorting settings win over any scene-wide value
+		UpdateSortingAttributes( camera );
 
 		camera.DebugMode = DebugMode;
 		camera.WireframeMode = WireframeMode;

--- a/engine/Sandbox.Engine/Scene/Components/Render/SortingGroup.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/SortingGroup.cs
@@ -1,0 +1,105 @@
+namespace Sandbox;
+
+/// <summary>
+/// Makes every <see cref="SpriteRenderer"/> beneath this object sort as one unit. The whole group
+/// takes its place in the draw order from this component's own layer and order, and its sprites
+/// sort among themselves by their individual sort orders - so nothing from outside the group can
+/// ever be drawn in between them.
+///
+/// This is what keeps a character built out of separate sprites from being sliced apart by a tree
+/// or another character standing at a similar depth.
+/// </summary>
+[Expose]
+[Title( "Sorting Group" )]
+[Category( "Rendering" )]
+[Icon( "layers" )]
+public sealed class SortingGroup : Component, Component.ExecuteInEditor
+{
+	/// <summary>
+	/// Which sort layer the whole group sits in. The sort layer on the individual sprites beneath
+	/// this group is ignored.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -150 )]
+	[Editor( "sortlayer" )]
+	public SortLayerHandle SortLayer { get; set; }
+
+	/// <summary>
+	/// Draw order of the whole group within its layer. Higher draws on top. The sort order on the
+	/// individual sprites beneath this group orders them against each other, not against the world.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -149 )]
+	public int SortOrder { get; set; }
+
+	/// <summary>
+	/// The number of sprite members, so the inspector can say whether this group is doing anything.
+	/// </summary>
+	public int MemberCount => GetComponentsInChildren<SpriteRenderer>( true ).Count();
+
+	/// <summary>
+	/// The group a sprite actually belongs to: the nearest enabled one at or above it.
+	///
+	/// Nesting is deliberately not supported - the draw order has room for one group's worth of
+	/// ordering, not a tree of it - so an inner group simply wins outright for the sprites beneath
+	/// it and the outer group never sees them.
+	/// </summary>
+	internal static SortingGroup FindFor( SpriteRenderer sprite )
+		=> sprite.GetComponentInParent<SortingGroup>();
+
+	/// <summary>
+	/// True when this group is inside another one. Reported in the editor rather than fixed,
+	/// because silently flattening someone's hierarchy is worse than telling them it won't nest.
+	/// </summary>
+	public bool IsNested => GameObject.Parent?.GetComponentInParent<SortingGroup>() is not null;
+
+	/// <summary>
+	/// The largest rank the draw order can represent. Members past this all share the last rank
+	/// and fall back to sorting against each other by depth.
+	/// </summary>
+	internal const int MaxRank = 255;
+
+	private readonly Dictionary<Guid, int> _ranks = new();
+	private readonly List<SpriteRenderer> _rankScratch = new();
+
+	/// <summary>
+	/// Rebuilds the member ordering. The draw order only has room for a small dense rank per
+	/// member, so the authored sort orders - which may be any integers at all, with gaps - are
+	/// compressed down to 0, 1, 2... in the same relative order.
+	///
+	/// Call this before reading <see cref="GetRank"/> from parallel code; it is not thread safe,
+	/// but it is deterministic, so calling it more than once in a frame is harmless.
+	/// </summary>
+	internal void RefreshRanks()
+	{
+		_ranks.Clear();
+		_rankScratch.Clear();
+
+		foreach ( var sprite in GetComponentsInChildren<SpriteRenderer>( true ) )
+		{
+			// A sprite under a nested group belongs to that group, not to this one.
+			if ( FindFor( sprite ) != this ) continue;
+
+			_rankScratch.Add( sprite );
+		}
+
+		// Id breaks ties so that two members sharing a sort order keep a stable order between
+		// frames. Without it they would swap according to component iteration order and flicker.
+		_rankScratch.Sort( ( a, b ) =>
+		{
+			var byOrder = a.SortOrder.CompareTo( b.SortOrder );
+			return byOrder != 0 ? byOrder : a.Id.CompareTo( b.Id );
+		} );
+
+		for ( var i = 0; i < _rankScratch.Count; i++ )
+		{
+			_ranks[_rankScratch[i].Id] = Math.Min( i, MaxRank );
+		}
+
+		_rankScratch.Clear();
+	}
+
+	/// <summary>
+	/// This sprite's position in the group's internal draw order. Higher draws in front.
+	/// </summary>
+	internal int GetRank( SpriteRenderer sprite )
+		=> _ranks.TryGetValue( sprite.Id, out var rank ) ? rank : 0;
+}

--- a/engine/Sandbox.Engine/Scene/Components/Render/SpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/SpriteRenderer.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Rendering;
+using Sandbox.Rendering;
 
 namespace Sandbox;
 
@@ -148,6 +148,43 @@ public sealed partial class SpriteRenderer : Renderer, Component.ExecuteInEditor
 	/// </summary>
 	[Property, Category( "Visuals" ), Order( -200 )]
 	public bool IsSorted { get; set; }
+
+	/// <summary>
+	/// Which sort layer this sprite belongs to. Sprites in a later layer always draw in front of
+	/// sprites in an earlier one. Layers are defined in the project's sorting settings.
+	/// Requires <see cref="IsSorted"/> to have any effect.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -150 )]
+	[Editor( "sortlayer" )]
+	public SortLayerHandle SortLayer { get; set; }
+
+	/// <summary>
+	/// Draw order within the sort layer. Higher values draw on top. Sprites with an equal order
+	/// fall back to sorting by depth. Requires <see cref="IsSorted"/> to have any effect.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -149 )]
+	public int SortOrder { get; set; }
+
+	/// <summary>
+	/// The <see cref="SortingGroup"/> this sprite belongs to, if any. While it has one, the
+	/// group's layer and order decide where it sits against the rest of the world, and this
+	/// sprite's own <see cref="SortOrder"/> only orders it against the group's other members.
+	/// </summary>
+	public SortingGroup SortingGroup => SortingGroup.FindFor( this );
+
+	/// <summary>
+	/// Where this sprite actually lands in the draw order, once its sorting group has had its say.
+	/// This is what gets uploaded, and what the editor reports.
+	/// </summary>
+	internal (SortLayerHandle Layer, int Order, Vector3 Origin, int Rank) ResolveSorting( SortingGroup group )
+	{
+		// The group's origin, not the sprite's, is what the whole group sorts at - that is what
+		// stops anything outside the group from being drawn in between its members.
+		if ( group is not null )
+			return (group.SortLayer, group.SortOrder, group.WorldPosition, group.GetRank( this ));
+
+		return (SortLayer, SortOrder, WorldPosition, 0);
+	}
 
 	/// <summary>
 	/// This action is invoked when an animation starts playing. The string parameter is the name of the animation that started.

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/SceneSpriteSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/SceneSpriteSystem.cs
@@ -15,7 +15,9 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 	/// <summary>Carries the data needed to configure a new <see cref="SpriteBatchSceneObject"/> from the original component state.</summary>
 	private readonly record struct RenderGroupConfig( InstanceGroupFlags Flags, RenderOptions RenderOptions, IReadOnlySet<uint> Tags );
 
-	Dictionary<ulong, SpriteBatchSceneObject> RenderGroups = [];
+	// Internal rather than private so tests can check how sprites got divided into batches - which
+	// batch a sprite lands in is what decides whether its sort layer can be honoured at all.
+	internal Dictionary<ulong, SpriteBatchSceneObject> RenderGroups = [];
 
 	public SceneSpriteSystem( Scene scene ) : base( scene )
 	{
@@ -126,7 +128,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 			var particleSystemID = particleRenderer.Id;
 			_activeParticleEmitters[i] = particleSystemID;
 
-			var rendergroup = GetRenderGroupKey( systemInfo.System, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions );
+			var rendergroup = GetRenderGroupKey( systemInfo.System, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions, allowBlendMerge: false );
 
 			// This is a very hot codepath, beware!
 			// Create span from the managed array starting at the correct offset with the correct length
@@ -168,7 +170,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 			if ( !RenderGroups.ContainsKey( rendergroup ) )
 			{
 				var particleRenderer = (ParticleRenderer)system;
-				CreateRenderGroup( rendergroup, BuildConfig( system, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions ) );
+				CreateRenderGroup( rendergroup, BuildConfig( system, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions, allowBlendMerge: false ) );
 			}
 
 			// Register in correct render group using shared block with offset and precomputed splot count
@@ -261,7 +263,22 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		}
 	}
 
-	private static ulong GetRenderGroupKey( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions )
+	/// <summary>
+	/// Whether this sprite can share a batch with sprites of a different blend state.
+	///
+	/// It has to, for sort layers to mean anything: the engine offers no way to order one scene
+	/// object against another, so two sprites in separate batches have no defined order however
+	/// their layers are set. Sprites that share a batch are ordered by the GPU sort, which leads
+	/// with the layer - so merging is what makes the layer win.
+	///
+	/// Only within the translucent pass. Opaque sprites belong to a different render pass
+	/// entirely, and a shadow caster carries a scene-object flag that additive sprites never set,
+	/// so neither can be folded in without changing what it does.
+	/// </summary>
+	private static bool CanMergeBlendModes( ISpriteRenderGroup component, bool castsShadow )
+		=> component.IsSorted && !component.Opaque && !castsShadow;
+
+	internal static ulong GetRenderGroupKey( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions, bool allowBlendMerge )
 	{
 		var flags = InstanceGroupFlags.None;
 
@@ -272,14 +289,25 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		}
 
 		// Shadows
-		if ( component.Shadows && !component.Additive )
+		var castsShadow = component.Shadows && !component.Additive;
+		if ( castsShadow )
 		{
 			flags |= InstanceGroupFlags.CastShadow;
 		}
 
-		if ( component.Additive )
+		// Leaving Additive out of the key is what lets additive and ordinary sprites land in the
+		// same batch, and so be ordered against each other by their sort layers. The batch then
+		// draws each blend state as its own run - see SpriteDrawPlan.
+		var merged = allowBlendMerge && CanMergeBlendModes( component, castsShadow );
+
+		if ( component.Additive && !merged )
 		{
 			flags |= InstanceGroupFlags.Additive;
+		}
+
+		if ( merged )
+		{
+			flags |= InstanceGroupFlags.MixedBlend;
 		}
 
 		if ( component.Opaque )
@@ -307,12 +335,20 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		return XxHash3.HashToUInt64( buf );
 	}
 
-	private static RenderGroupConfig BuildConfig( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions )
+	private static RenderGroupConfig BuildConfig( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions, bool allowBlendMerge )
 	{
 		var flags = InstanceGroupFlags.None;
 		if ( !component.Opaque && component.IsSorted ) flags |= InstanceGroupFlags.Transparent;
-		if ( component.Shadows && !component.Additive ) flags |= InstanceGroupFlags.CastShadow;
-		if ( component.Additive ) flags |= InstanceGroupFlags.Additive;
+
+		var castsShadow = component.Shadows && !component.Additive;
+		if ( castsShadow ) flags |= InstanceGroupFlags.CastShadow;
+
+		// Must stay in step with GetRenderGroupKey, or a batch gets configured for flags its key
+		// was never built from.
+		var merged = allowBlendMerge && CanMergeBlendModes( component, castsShadow );
+		if ( component.Additive && !merged ) flags |= InstanceGroupFlags.Additive;
+		if ( merged ) flags |= InstanceGroupFlags.MixedBlend;
+
 		if ( component.Opaque ) flags |= InstanceGroupFlags.Opaque;
 
 		return new RenderGroupConfig( flags, renderOptions.Clone(), tags.GetTokens().ToFrozenSet() );
@@ -360,6 +396,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		renderGroupObject.Sorted = (config.Flags & InstanceGroupFlags.Transparent) != 0;
 		renderGroupObject.Additive = (config.Flags & InstanceGroupFlags.Additive) != 0;
 		renderGroupObject.Opaque = (config.Flags & InstanceGroupFlags.Opaque) != 0;
+		renderGroupObject.MixedBlend = (config.Flags & InstanceGroupFlags.MixedBlend) != 0;
 		renderGroupObject.Tags.SetFrom( new TagSet( config.Tags.Select( StringToken.GetValue ) ) );
 		config.RenderOptions.Apply( renderGroupObject );
 
@@ -369,9 +406,9 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 
 	internal void RegisterSprite( Guid componentId, SpriteRenderer component )
 	{
-		var key = GetRenderGroupKey( component, component.Tags as GameTags, component.RenderOptions );
+		var key = GetRenderGroupKey( component, component.Tags as GameTags, component.RenderOptions, allowBlendMerge: true );
 		if ( !RenderGroups.ContainsKey( key ) )
-			CreateRenderGroup( key, BuildConfig( component, component.Tags as GameTags, component.RenderOptions ) );
+			CreateRenderGroup( key, BuildConfig( component, component.Tags as GameTags, component.RenderOptions, allowBlendMerge: true ) );
 
 		InsertInRenderGroup( componentId, component, key );
 	}
@@ -381,7 +418,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		// If found in old renderGroup, we unregister it and register it in the new one
 		if ( FindCurrentRenderGroup( componentId ) is ulong oldRenderGroup )
 		{
-			var newRenderGroup = GetRenderGroupKey( component, (GameTags)component.Tags, component.RenderOptions );
+			var newRenderGroup = GetRenderGroupKey( component, (GameTags)component.Tags, component.RenderOptions, allowBlendMerge: true );
 			if ( !oldRenderGroup.Equals( newRenderGroup ) )
 			{
 				RemoveFromRenderGroup( componentId, oldRenderGroup );
@@ -416,6 +453,9 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		CastOnlyShadow = 1 << 1,
 		Transparent = 1 << 2,
 		Additive = 1 << 3,
-		Opaque = 1 << 4
+		Opaque = 1 << 4,
+
+		/// <summary>Holds more than one blend state, drawn as one run per state in layer order.</summary>
+		MixedBlend = 1 << 5
 	}
 }

--- a/engine/Sandbox.Engine/Systems/Project/ProjectSettings/ProjectSettings.cs
+++ b/engine/Sandbox.Engine/Systems/Project/ProjectSettings/ProjectSettings.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Audio;
+using Sandbox.Audio;
 
 namespace Sandbox;
 
@@ -59,6 +59,11 @@ public class ProjectSettings
 	/// and it will return the same object. The cache is cleared automatically when the project changes, 
 	/// or when it's hotloaded.
 	/// </summary>
+	/// <summary>
+	/// Get the <see cref="SortingSettings"/> from the active project settings.
+	/// </summary>
+	public static SortingSettings Sorting => Get<SortingSettings>( "Sorting.config" );
+
 	public static T Get<T>( string filename ) where T : ConfigData, new()
 	{
 		if ( _cache.TryGetValue( filename, out var result ) && result is T t )

--- a/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortLayerHandle.cs
+++ b/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortLayerHandle.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Serialization;
+
+namespace Sandbox;
+
+/// <summary>
+/// A reference to one of the project's sprite sort layers. Stores the layer's id rather than its
+/// name or position, so renaming or reordering layers never changes what a sprite points at.
+/// </summary>
+public struct SortLayerHandle : IEquatable<SortLayerHandle>
+{
+	/// <summary>
+	/// Id of the referenced layer. Empty means the default layer.
+	/// </summary>
+	public Guid Id { get; set; }
+
+	/// <summary>
+	/// Initializes a handle pointing at the layer with the given id.
+	/// </summary>
+	public SortLayerHandle( Guid id ) => Id = id;
+
+	/// <summary>
+	/// Initializes a handle pointing at a layer.
+	/// </summary>
+	public SortLayerHandle( SortingSettings.SortLayer layer ) => Id = layer?.Id ?? Guid.Empty;
+
+	/// <summary>
+	/// The layer this handle refers to, falling back to the default layer when the referenced
+	/// layer has been deleted.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public readonly SortingSettings.SortLayer Layer
+	{
+		get
+		{
+			var settings = ProjectSettings.Sorting;
+			return settings.GetLayer( Id ) ?? settings.DefaultLayer;
+		}
+	}
+
+	/// <summary>
+	/// Position of this layer in the draw order. Higher draws in front.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public readonly int Index => ProjectSettings.Sorting.GetLayerIndex( Id );
+
+	/// <summary>
+	/// Display name of this layer.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public readonly string Name => Layer.Name;
+
+	/// <summary>
+	/// Finds a layer by name. Returns a handle to the default layer if there is no match.
+	/// </summary>
+	public static SortLayerHandle FromName( string name )
+	{
+		return new SortLayerHandle( ProjectSettings.Sorting.GetLayer( name ) );
+	}
+
+	/// <inheritdoc />
+	public readonly bool Equals( SortLayerHandle other ) => Id == other.Id;
+
+	/// <inheritdoc />
+	public readonly override bool Equals( object obj ) => obj is SortLayerHandle other && Equals( other );
+
+	/// <inheritdoc />
+	public readonly override int GetHashCode() => Id.GetHashCode();
+
+	/// <inheritdoc />
+	public readonly override string ToString() => Name;
+
+	public static bool operator ==( SortLayerHandle a, SortLayerHandle b ) => a.Equals( b );
+	public static bool operator !=( SortLayerHandle a, SortLayerHandle b ) => !a.Equals( b );
+}

--- a/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortingSettings.cs
+++ b/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortingSettings.cs
@@ -1,0 +1,184 @@
+using System.Text.Json.Serialization;
+
+namespace Sandbox;
+
+/// <summary>
+/// Project wide draw order settings for sprites. Sort layers are an ordered list - a sprite in a
+/// later layer always draws in front of a sprite in an earlier one, whatever their positions.
+/// </summary>
+[Expose]
+public class SortingSettings : ConfigData
+{
+	/// <summary>
+	/// Name given to the layer that every sprite starts in.
+	/// </summary>
+	public const string DefaultLayerName = "Default";
+
+	/// <summary>
+	/// A named position in the draw order. Sprites reference layers by <see cref="Id"/>, so a layer
+	/// can be freely renamed or moved without silently re-sorting anything that points at it.
+	/// </summary>
+	public class SortLayer
+	{
+		/// <summary>
+		/// Display name, expected to be unique within the list.
+		/// </summary>
+		[KeyProperty]
+		public string Name { get; set; } = "New Layer";
+
+		/// <summary>
+		/// Stable identity, preserved across reordering and renaming.
+		/// </summary>
+		[Hide]
+		public Guid Id { get; set; } = Guid.NewGuid();
+	}
+
+	/// <summary>
+	/// Every sort layer, back to front. The first entry draws first and so appears behind the rest.
+	/// </summary>
+	public List<SortLayer> Layers { get; set; }
+
+	private Dictionary<Guid, int> _indexById;
+
+	public SortingSettings()
+	{
+		OnValidate();
+	}
+
+	/// <summary>
+	/// The layer that sprites fall back to when they have no layer assigned, or when the layer they
+	/// reference no longer exists. Always the first layer in the list.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public SortLayer DefaultLayer => Layers[0];
+
+	/// <summary>
+	/// Finds the position of a layer in the draw order. Returns 0 - the default layer - if the id is
+	/// empty or refers to a layer that has since been deleted.
+	/// </summary>
+	public int GetLayerIndex( Guid id )
+	{
+		if ( id == Guid.Empty ) return 0;
+
+		return _indexById.TryGetValue( id, out var index ) ? index : 0;
+	}
+
+	/// <summary>
+	/// Finds a layer by its id, or null if no such layer exists.
+	/// </summary>
+	public SortLayer GetLayer( Guid id )
+	{
+		if ( id == Guid.Empty ) return null;
+
+		return _indexById.TryGetValue( id, out var index ) ? Layers[index] : null;
+	}
+
+	/// <summary>
+	/// Finds a layer by name, case insensitively, or null if no such layer exists.
+	/// </summary>
+	public SortLayer GetLayer( string name )
+	{
+		foreach ( var layer in Layers )
+		{
+			if ( string.Equals( layer.Name, name, StringComparison.OrdinalIgnoreCase ) )
+				return layer;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Adds a layer at the front of the draw order, so it draws on top of everything already there.
+	/// </summary>
+	public SortLayer AddLayer( string name )
+	{
+		var layer = new SortLayer { Name = name };
+
+		Layers.Add( layer );
+		Refresh();
+
+		return layer;
+	}
+
+	/// <summary>
+	/// Removes a layer. Sprites still pointing at it resolve back to <see cref="DefaultLayer"/> on
+	/// their own, so there is nothing to fix up afterwards.
+	///
+	/// Refuses to remove the last layer, since everything falls back to it.
+	/// </summary>
+	public bool RemoveLayer( SortLayer layer )
+	{
+		if ( Layers.Count <= 1 ) return false;
+		if ( !Layers.Remove( layer ) ) return false;
+
+		Refresh();
+		return true;
+	}
+
+	/// <summary>
+	/// Moves a layer to a new position in the draw order.
+	/// </summary>
+	public void MoveLayer( int fromIndex, int toIndex )
+	{
+		if ( fromIndex < 0 || fromIndex >= Layers.Count ) return;
+		if ( toIndex < 0 || toIndex >= Layers.Count ) return;
+		if ( fromIndex == toIndex ) return;
+
+		var layer = Layers[fromIndex];
+
+		Layers.RemoveAt( fromIndex );
+		Layers.Insert( toIndex, layer );
+
+		Refresh();
+	}
+
+	/// <summary>
+	/// Rebuilds the id lookup after the layer list has been changed.
+	///
+	/// Every lookup from a layer id to its position in the draw order goes through that map, so
+	/// leaving it stale does not throw - it quietly resolves layers to the wrong position, or to
+	/// the default. Prefer <see cref="AddLayer"/>, <see cref="RemoveLayer"/> and
+	/// <see cref="MoveLayer"/>, which cannot forget to call this.
+	/// </summary>
+	public void Refresh() => OnValidate();
+
+	protected override void OnValidate()
+	{
+		Layers ??= [new SortLayer { Name = DefaultLayerName }];
+
+		// A project with no layers at all has nothing to fall back to, so keep one alive.
+		if ( Layers.Count == 0 )
+		{
+			Layers.Add( new SortLayer { Name = DefaultLayerName } );
+		}
+
+		_indexById = new Dictionary<Guid, int>( Layers.Count );
+
+		for ( int i = 0; i < Layers.Count; i++ )
+		{
+			var layer = Layers[i];
+
+			// Layers authored by hand, or duplicated in the editor, can arrive without an id.
+			if ( layer.Id == Guid.Empty )
+			{
+				layer.Id = Guid.NewGuid();
+			}
+
+			// First one wins, so a duplicated id can never make a layer unreachable.
+			_indexById.TryAdd( layer.Id, i );
+		}
+	}
+
+	public override int GetHashCode()
+	{
+		HashCode hc = default;
+
+		foreach ( var layer in Layers )
+		{
+			hc.Add( layer.Id );
+			hc.Add( layer.Name );
+		}
+
+		return hc.ToHashCode();
+	}
+}

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
@@ -1,4 +1,4 @@
-﻿namespace Sandbox.Rendering;
+namespace Sandbox.Rendering;
 
 using NativeEngine;
 using System.Buffers;
@@ -33,6 +33,21 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		AddressModeU = TextureAddressMode.Clamp,
 		AddressModeV = TextureAddressMode.Clamp,
 	};
+
+	/// <summary>
+	/// A sprite's place in the draw order, compared lexicographically on the GPU. Splitting this
+	/// across two integers keeps the comparison exact - a single float could not hold the full
+	/// layer/order range alongside a distance without silently losing precision.
+	/// </summary>
+	[StructLayout( LayoutKind.Sequential, Pack = 4 )]
+	internal struct SpriteSortKey
+	{
+		/// <summary>Sort layer and order in layer, inverted on the GPU so higher draws in front.</summary>
+		public uint Coarse;
+
+		/// <summary>Distance along the transparency sort axis, made unsigned-comparable.</summary>
+		public uint Fine;
+	}
 
 	/// <summary>
 	/// Flags for sprite rendering, must match SpriteFlags in sprite_ps.shader
@@ -71,6 +86,30 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		public Vector3 Velocity = Vector3.Zero;
 		public Vector4 BlendSheetUV;
 		public Vector2 Offset;
+
+		/// <summary>
+		/// Coarse draw order, packed by <see cref="PackSortKey"/>. Compared before the sort axis
+		/// distance, so it wins over any positional ordering.
+		/// </summary>
+		public uint SortKey = 0;
+
+		/// <summary>
+		/// Moves the point this sprite sorts at, relative to <see cref="Position"/>. Set to a
+		/// sorting group's origin so every member of the group resolves to one depth and nothing
+		/// outside it can be drawn in between them.
+		///
+		/// Deliberately an offset rather than an absolute position: zero means "sort where I am",
+		/// so every sprite built without knowing about sorting groups - particles especially -
+		/// keeps sorting exactly as it did.
+		/// </summary>
+		public Vector3 SortOriginOffset = Vector3.Zero;
+
+		/// <summary>
+		/// Order within the sorting group, densely ranked from 0. Occupies the low bits of the
+		/// sort key's distance term, so it only ever decides between sprites at the same depth.
+		/// </summary>
+		public uint SortRank = 0;
+
 		public SpriteData()
 		{
 
@@ -84,6 +123,29 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			byte b = (byte)(color.b * 255f);
 			byte a = (byte)(color.a * 255f);
 			return (uint)(r | (g << 8) | (b << 16) | (a << 24));
+		}
+
+		/// <summary>Bits of the sort key given over to the layer index. 16k layers is far past useful.</summary>
+		internal const int SortKeyLayerBits = 14;
+
+		/// <summary>
+		/// Packs a sprite's layer, blend state and order within the layer into a single value that
+		/// orders correctly under plain unsigned comparison.
+		///
+		/// Layer is the most significant term, so it beats everything. Blend comes next, above
+		/// order: sprites needing different blend states cannot share a draw call, so grouping
+		/// them is what lets a layer be drawn as a small run of draws instead of being broken up.
+		/// The cost is that order-in-layer only ranks a sprite against others of the same blend
+		/// state - which is the same trade the renderer is already forced into.
+		/// </summary>
+		internal static uint PackSortKey( int layerIndex, SpriteBlendMode blend, int sortOrder )
+		{
+			var layer = (uint)Math.Clamp( layerIndex, 0, (1 << SortKeyLayerBits) - 1 );
+
+			// Bias the signed order so that negative orders still compare below positive ones.
+			var order = (uint)(Math.Clamp( sortOrder, short.MinValue, short.MaxValue ) - short.MinValue);
+
+			return (layer << 18) | ((uint)blend << 16) | order;
 		}
 
 		// Pack fog strength and alpha cutout into a single uint
@@ -175,7 +237,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 	GpuBuffer<SpriteVertex> VertexBuffer;
 	GpuBuffer<int> IndexBuffer;
 	GpuBuffer<uint> GPUSortingBuffer;
-	GpuBuffer<float> GPUDistanceBuffer;
+	GpuBuffer<SpriteSortKey> GPUSortKeyBuffer;
 
 	SpriteData[] SpriteDataBuffer = null!;
 	bool SpriteDataBufferRented = false;
@@ -195,7 +257,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		SpriteBuffer = new( CurrentBufferSize );
 		SpriteBufferOut = new( CurrentBufferSize );
 		GPUSortingBuffer = new( CurrentBufferSize );
-		GPUDistanceBuffer = new( CurrentBufferSize );
+		GPUSortKeyBuffer = new( CurrentBufferSize );
 		SpriteAtomicCounter = new( 1 );
 	}
 
@@ -255,18 +317,111 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		SpriteBuffer?.Dispose();
 		SpriteBufferOut?.Dispose();
 		GPUSortingBuffer?.Dispose();
-		GPUDistanceBuffer?.Dispose();
+		GPUSortKeyBuffer?.Dispose();
 
 		SpriteBuffer = new( CurrentBufferSize );
 		SpriteBufferOut = new( CurrentBufferSize );
 		GPUSortingBuffer = new( CurrentBufferSize );
-		GPUDistanceBuffer = new( CurrentBufferSize );
+		GPUSortKeyBuffer = new( CurrentBufferSize );
 	}
 
 	private readonly Dictionary<Guid, int> _precomputedSplotCounts = [];
 
 	// Pre-allocated buffer to avoid GC allocations in hot path
 	private SpriteRenderer[] _componentBuffer = new SpriteRenderer[16];
+	private SortingGroup[] _spriteGroupBuffer = new SortingGroup[16];
+	private int[] _bucketLayers = new int[16];
+	private SpriteBlendMode[] _bucketBlends = new SpriteBlendMode[16];
+	private int[] _bucketCounts = [];
+	private readonly HashSet<SortingGroup> _rankedGroups = new();
+
+	/// <summary>
+	/// The runs being built by the current upload, on the main thread.
+	///
+	/// Double buffered against <see cref="_renderBuckets"/> because RenderSceneObject runs on the
+	/// render thread: handing it the list being rebuilt lets it walk half-written offsets and draw
+	/// sprites from the wrong part of the buffer. Same reason the counts below are snapshotted.
+	/// </summary>
+	private List<SpriteDrawBucket> _drawBuckets = new();
+
+	/// <summary>
+	/// The finished runs, swapped in at the end of an upload and only read by the render thread.
+	/// Empty when this batch holds a single blend state, which draws in one call as before.
+	/// </summary>
+	private List<SpriteDrawBucket> _renderBuckets = new();
+
+	/// <summary>
+	/// True when this batch mixes blend states so that sort layers can order across them. Set from
+	/// the render group's flags - see <see cref="SceneSpriteSystem"/>.
+	/// </summary>
+	public bool MixedBlend { get; set; } = false;
+
+	/// <summary>
+	/// Works out the runs this batch has to draw, when it holds more than one blend state.
+	///
+	/// The GPU sort orders by layer first and blend second, so sprites sharing a layer and a blend
+	/// state end up next to each other - which means a run's position is just how many sprites
+	/// sort ahead of it. Counting that on the CPU is what avoids reading the sort result back.
+	///
+	/// Leaves the list empty for every other case, and the batch then draws in one call as before.
+	/// </summary>
+	private void BuildDrawBuckets( int componentCount, int spriteCount, int splotCount, bool sorted )
+	{
+		_drawBuckets.Clear();
+
+		// Unsorted batches have no meaningful order to divide up, and the runs are only in step
+		// with the buffer if every sprite in it came through the component path - particles set no
+		// sort key, and motion blur adds instances the count above never saw.
+		if ( !MixedBlend || !sorted ) return;
+		if ( spriteCount != componentCount || splotCount != 0 ) return;
+
+		var layerCount = ProjectSettings.Sorting.Layers.Count;
+		var requiredCounts = Math.Max( layerCount, 1 ) * SpriteDrawPlan.BlendModeCount;
+
+		if ( _bucketCounts.Length < requiredCounts )
+		{
+			_bucketCounts = new int[requiredCounts];
+		}
+
+		SpriteDrawPlan.BuildBuckets(
+			_bucketLayers.AsSpan( 0, componentCount ),
+			_bucketBlends.AsSpan( 0, componentCount ),
+			layerCount,
+			_drawBuckets,
+			_bucketCounts );
+	}
+
+	/// <summary>
+	/// Works out which sorting group each sprite belongs to and gets every one of those groups to
+	/// rebuild its member ordering.
+	///
+	/// This has to happen before the parallel upload pass rather than inside it: ranking reads a
+	/// whole group's members at once, and walking a sprite's ancestors is not safe to do from
+	/// several threads at the same time. Scenes with no sorting groups pay a single null check
+	/// per sprite for it.
+	/// </summary>
+	private void ResolveSortingGroups( int componentCount )
+	{
+		if ( _spriteGroupBuffer.Length < componentCount )
+		{
+			_spriteGroupBuffer = new SortingGroup[componentCount * 2];
+		}
+
+		_rankedGroups.Clear();
+
+		for ( var i = 0; i < componentCount; i++ )
+		{
+			var group = SortingGroup.FindFor( _componentBuffer[i] );
+
+			_spriteGroupBuffer[i] = group;
+
+			// Rebuild each group once, however many of its members are in this batch.
+			if ( group is not null && _rankedGroups.Add( group ) )
+			{
+				group.RefreshRanks();
+			}
+		}
+	}
 	private readonly object _boundsLock = new();
 
 	public void RegisterSprite( Guid ownerId, SpriteData[] sharedSprites, int offset, int count, int splotCount, BBox bounds )
@@ -366,6 +521,8 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			if ( _componentBuffer.Length < componentCount )
 			{
 				_componentBuffer = new SpriteRenderer[componentCount * 2];
+				_bucketLayers = new int[componentCount * 2];
+				_bucketBlends = new SpriteBlendMode[componentCount * 2];
 			}
 
 			int index = 0;
@@ -373,6 +530,12 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			{
 				_componentBuffer[index++] = component;
 			}
+
+			// Hoisted out of the loop - resolving a layer id to its position in the draw order is a
+			// lookup into this, and it must not change underneath the parallel pass.
+			var sorting = ProjectSettings.Sorting;
+
+			ResolveSortingGroups( componentCount );
 
 			object boundsLock = _boundsLock;
 			Parallel.For<(Vector3 mins, Vector3 maxs)>(
@@ -425,6 +588,14 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 
 					uint packedFogAndAlpha = SpriteData.PackFogAndAlphaCutout( c.FogStrength, c.AlphaCutoff );
 
+					// Ranks were built in the sequential pass above, so this only reads them.
+					var (sortLayer, sortOrder, sortOrigin, sortRank) = c.ResolveSorting( _spriteGroupBuffer[i] );
+
+					// Recorded per sprite so the draw runs can be counted once the loop is done.
+					// Each iteration owns its own slot, so this is safe to write from here.
+					_bucketLayers[i] = sorting.GetLayerIndex( sortLayer.Id );
+					_bucketBlends[i] = SpriteDrawPlan.GetBlendMode( c.Opaque, c.Additive );
+
 					var spritePos = transform.Position;
 					var spriteScale = new Vector2( transform.Scale.x, transform.Scale.z );
 
@@ -442,7 +613,10 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 						Lighting = packedExponent,
 						DepthFeather = c.DepthFeather,
 						SamplerIndex = SamplerState.GetBindlessIndex( sampler with { Filter = c.TextureFilter } ),
-						Offset = c.Pivot
+						Offset = c.Pivot,
+						SortKey = SpriteData.PackSortKey( sorting.GetLayerIndex( sortLayer.Id ), SpriteDrawPlan.GetBlendMode( c.Opaque, c.Additive ), sortOrder ),
+						SortOriginOffset = sortOrigin - spritePos,
+						SortRank = (uint)sortRank
 					};
 
 					var pivot = c.Pivot;
@@ -508,6 +682,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		}
 
 		bool sorted = Sorted;
+		BuildDrawBuckets( componentCount, SpriteCount, SplotCount, sorted );
 		bool filtered = Filtered;
 		bool additive = Additive;
 		bool opaque = Opaque;
@@ -519,25 +694,25 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		if ( sorted && totalInstances >= 2 )
 		{
 			_commandList.Attributes.Set( "SortBuffer", (GpuBuffer)GPUSortingBuffer );
-			_commandList.Attributes.Set( "DistanceBuffer", (GpuBuffer)GPUDistanceBuffer );
+			_commandList.Attributes.Set( "SortKeyBuffer", (GpuBuffer)GPUSortKeyBuffer );
 			_commandList.Attributes.Set( "Count", bufferSize );
 			_commandList.Attributes.SetCombo( "D_CLEAR", 1 );
 			_commandList.DispatchCompute( SortComputeShader, bufferSize, 1, 1 );
 
 			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortingBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
-			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
+			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
 		}
 
 		_commandList.ResourceBarrierTransition( SpriteAtomicCounter, ResourceState.Common );
 		_commandList.ResourceBarrierTransition( (GpuBuffer)SpriteBuffer, ResourceState.Common );
 		_commandList.ResourceBarrierTransition( (GpuBuffer)SpriteBufferOut, ResourceState.Common );
-		_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.Common );
+		_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.Common );
 
 		_commandList.Attributes.Set( "Sprites", (GpuBuffer)SpriteBuffer );
 		_commandList.Attributes.Set( "SpriteBufferOut", (GpuBuffer)SpriteBufferOut );
 		_commandList.Attributes.Set( "SpriteCount", spriteCount );
 		_commandList.Attributes.Set( "AtomicCounter", SpriteAtomicCounter );
-		_commandList.Attributes.Set( "DistanceBuffer", (GpuBuffer)GPUDistanceBuffer );
+		_commandList.Attributes.Set( "SortKeyBuffer", (GpuBuffer)GPUSortKeyBuffer );
 		_commandList.DispatchCompute( SpriteComputeShader, spriteCount, 1, 1 );
 
 		_commandList.ResourceBarrierTransition( SpriteAtomicCounter, ResourceState.Common );
@@ -545,7 +720,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 
 		if ( sorted && totalInstances >= 2 )
 		{
-			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.Common );
+			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.Common );
 			_commandList.Attributes.SetCombo( "D_CLEAR", 0 );
 
 			var x = Math.Min( bufferSize, MaxDimThreads );
@@ -561,7 +736,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 					_commandList.DispatchCompute( SortComputeShader, x, y, 1 );
 
 					_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortingBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
-					_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
+					_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
 				}
 			}
 		}
@@ -573,6 +748,11 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		_renderFiltered = filtered;
 		_renderAdditive = additive;
 		_renderOpaque = opaque;
+
+		// Publish the runs alongside the counts they were built against. Swapping the reference
+		// hands the render thread a finished list, and gives us the old one back to build into
+		// next frame without allocating.
+		(_renderBuckets, _drawBuckets) = (_drawBuckets, _renderBuckets);
 	}
 
 	public override void RenderSceneObject()
@@ -588,7 +768,6 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		var attributes = RenderAttributes.Pool.Get();
 		try
 		{
-			attributes.SetCombo( "D_BLEND", _renderAdditive ? 1 : 0 );
 			attributes.SetCombo( "D_OPAQUE", _renderOpaque ? 1 : 0 );
 			attributes.Set( "IsSorted", _renderIsSorted ? 1 : 0 );
 			attributes.Set( "SpriteCount", _renderInstanceCount );
@@ -598,7 +777,32 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			attributes.Set( "Vertices", (GpuBuffer)VertexBuffer );
 			attributes.Set( "g_bNonDirectionalDiffuseLighting", true );
 
-			Graphics.DrawIndexedInstanced( (GpuBuffer)IndexBuffer, SpriteMaterial, _renderInstanceCount, attributes );
+			// Read once - the main thread may swap this reference between uploads.
+			var buckets = _renderBuckets;
+
+			if ( buckets.Count == 0 )
+			{
+				attributes.SetCombo( "D_BLEND", _renderAdditive ? 1 : 0 );
+				attributes.Set( "SortLUTOffset", 0 );
+
+				Graphics.DrawIndexedInstanced( (GpuBuffer)IndexBuffer, SpriteMaterial, _renderInstanceCount, attributes );
+			}
+			else
+			{
+				// One draw per run, walked in order, so a lower sort layer is finished before a
+				// higher one starts. This is the whole reason the batch holds mixed blend states:
+				// ordering between scene objects is not ours to control, ordering within one is.
+				foreach ( var bucket in buckets )
+				{
+					attributes.SetCombo( "D_BLEND", bucket.Blend == SpriteBlendMode.Additive ? 1 : 0 );
+
+					// The shader walks the sort table backwards from the end, so a run starting
+					// this far into the draw order starts this far back from the end.
+					attributes.Set( "SortLUTOffset", bucket.Offset );
+
+					Graphics.DrawIndexedInstanced( (GpuBuffer)IndexBuffer, SpriteMaterial, bucket.Count, attributes );
+				}
+			}
 		}
 		finally
 		{

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
@@ -711,6 +711,11 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		_commandList.Attributes.Set( "Sprites", (GpuBuffer)SpriteBuffer );
 		_commandList.Attributes.Set( "SpriteBufferOut", (GpuBuffer)SpriteBufferOut );
 		_commandList.Attributes.Set( "SpriteCount", spriteCount );
+
+		// The motion blur trails are placed by an atomic counter rather than by thread index, so the
+		// shader has no other way to tell where the buffers end.
+		_commandList.Attributes.Set( "BufferCapacity", bufferSize );
+
 		_commandList.Attributes.Set( "AtomicCounter", SpriteAtomicCounter );
 		_commandList.Attributes.Set( "SortKeyBuffer", (GpuBuffer)GPUSortKeyBuffer );
 		_commandList.DispatchCompute( SpriteComputeShader, spriteCount, 1, 1 );

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteDrawPlan.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteDrawPlan.cs
@@ -1,0 +1,128 @@
+namespace Sandbox.Rendering;
+
+/// <summary>
+/// The blend state a sprite has to be drawn with. Sprites needing different states cannot share a
+/// draw call, so this is the second axis - after the sort layer - that the draw order is cut along.
+/// </summary>
+internal enum SpriteBlendMode
+{
+	/// <summary>Writes depth and occludes. Drawn before the see-through work in the same layer.</summary>
+	Opaque = 0,
+
+	/// <summary>Ordinary alpha blending.</summary>
+	Transparent = 1,
+
+	/// <summary>Additive blending, which has no meaningful order against itself.</summary>
+	Additive = 2,
+}
+
+/// <summary>
+/// One run of sprites sharing a sort layer and a blend state, drawn as a single instanced call.
+/// </summary>
+internal readonly record struct SpriteDrawBucket( int LayerIndex, SpriteBlendMode Blend, int Offset, int Count );
+
+/// <summary>
+/// Works out the order sprites have to be drawn in, and where each run of them lives in the buffer.
+///
+/// The problem this solves: a sort layer is meant to beat everything, but sprites needing different
+/// blend states cannot be drawn together, and the engine gives no way to order one scene object
+/// against another. So the ordering has to happen *inside* a single scene object, by laying the
+/// sprites out grouped by layer and blend and then issuing one draw per group, layer by layer.
+///
+/// Grouping on the CPU is what keeps this verifiable: the run boundaries are known before anything
+/// reaches the GPU, so no read-back or indirect draw is needed, and the draw order is a pure
+/// function of the sprites - which is what <c>SpriteDrawPlanTest</c> pins down.
+/// </summary>
+internal static class SpriteDrawPlan
+{
+	/// <summary>Number of distinct blend states, and so the number of buckets a layer can hold.</summary>
+	internal const int BlendModeCount = 3;
+
+	/// <summary>
+	/// The blend state a sprite's flags call for. Opaque wins over additive, because an opaque
+	/// sprite is never blended whatever else it asks for.
+	/// </summary>
+	internal static SpriteBlendMode GetBlendMode( bool opaque, bool additive )
+	{
+		if ( opaque ) return SpriteBlendMode.Opaque;
+
+		return additive ? SpriteBlendMode.Additive : SpriteBlendMode.Transparent;
+	}
+
+	/// <summary>
+	/// The position of a sprite's bucket in the draw order. Layer is the more significant term, so
+	/// every bucket of a lower layer is drawn before any bucket of a higher one - which is exactly
+	/// the guarantee sort layers are supposed to make.
+	/// </summary>
+	internal static int GetBucketIndex( int layerIndex, SpriteBlendMode blend )
+		=> layerIndex * BlendModeCount + (int)blend;
+
+	/// <summary>
+	/// Works out where each run of sprites will land in the sorted draw order.
+	///
+	/// Nothing is rearranged here. The GPU sort already puts sprites in key order, and the key
+	/// leads with layer then blend - so a run's *position* is simply how many sprites sort ahead
+	/// of it, which is a matter of counting. That is what removes any need to read the sort result
+	/// back or to permute the buffer on the CPU.
+	///
+	/// Linear time, because this is on the per-frame upload path.
+	/// </summary>
+	/// <param name="layerIndices">Each sprite's resolved sort layer index.</param>
+	/// <param name="blendModes">Each sprite's blend state, parallel to <paramref name="layerIndices"/>.</param>
+	/// <param name="layerCount">Number of layers in the project, sizing the counting pass.</param>
+	/// <param name="buckets">Receives the non-empty runs in draw order, cleared first.</param>
+	/// <param name="counts">Scratch of at least <paramref name="layerCount"/> * <see cref="BlendModeCount"/> entries.</param>
+	internal static void BuildBuckets(
+		ReadOnlySpan<int> layerIndices,
+		ReadOnlySpan<SpriteBlendMode> blendModes,
+		int layerCount,
+		List<SpriteDrawBucket> buckets,
+		Span<int> counts )
+	{
+		buckets.Clear();
+
+		var spriteCount = layerIndices.Length;
+		var bucketCount = Math.Max( layerCount, 1 ) * BlendModeCount;
+
+		counts = counts[..bucketCount];
+		counts.Clear();
+
+		for ( var i = 0; i < spriteCount; i++ )
+		{
+			counts[BucketOf( layerIndices[i], blendModes[i], layerCount )]++;
+		}
+
+		// Turn the counts into start offsets. Empty buckets are skipped rather than emitted as
+		// zero-length draws - layers are project-wide, so most scenes leave most of them unused.
+		var running = 0;
+
+		for ( var bucket = 0; bucket < counts.Length; bucket++ )
+		{
+			if ( counts[bucket] > 0 )
+			{
+				buckets.Add( new SpriteDrawBucket(
+					LayerIndex: bucket / BlendModeCount,
+					Blend: (SpriteBlendMode)(bucket % BlendModeCount),
+					Offset: running,
+					Count: counts[bucket] ) );
+			}
+
+			running += counts[bucket];
+		}
+	}
+
+	/// <summary>
+	/// A sprite's bucket, with an out-of-range layer sent back to the default one.
+	///
+	/// A layer index can outlive the layer it referred to, if one is deleted while sprites still
+	/// point at it. Falling back to layer 0 matches how <see cref="SortingSettings.GetLayerIndex"/>
+	/// already resolves an unknown id - and it fails in the quieter direction, leaving the orphan
+	/// at the back rather than promoting it in front of everything.
+	/// </summary>
+	private static int BucketOf( int layerIndex, SpriteBlendMode blend, int layerCount )
+	{
+		var resolved = layerIndex >= 0 && layerIndex < layerCount ? layerIndex : 0;
+
+		return GetBucketIndex( resolved, blend );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
@@ -1,0 +1,122 @@
+using Sandbox.Resources;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace SceneTests.Components;
+
+/// <summary>
+/// Multi-editing sprites whose Sprite is an *embedded* resource, which is what dragging an image
+/// into the scene actually produces.
+///
+/// An earlier test used a plain <c>new Sprite()</c> and found nothing wrong. That was the wrong
+/// shape: <c>TextureDropObject.CreateSpriteFromTexture</c> stamps
+/// <c>EmbeddedResource { ResourceCompiler = "embed" }</c>, and embedded resources take a completely
+/// different path through serialization - they are written inline and rebuilt by
+/// <c>Activator.CreateInstance</c> on the way back, rather than being referenced by path.
+/// </summary>
+[TestClass]
+public class EmbeddedSpriteMultiEditTest
+{
+	/// <summary>Builds a sprite the same way the editor's drop handler does.</summary>
+	static Sprite CreateEmbeddedSprite( string name )
+	{
+		var sprite = new Sprite
+		{
+			Animations =
+			[
+				new Sprite.Animation
+				{
+					Name = name,
+					Frames = [new Sprite.Frame { Texture = Texture.White }]
+				}
+			]
+		};
+
+		sprite.EmbeddedResource = new EmbeddedResource
+		{
+			ResourceCompiler = "embed",
+			Data = new JsonObject()
+		};
+
+		return sprite;
+	}
+
+	static (SpriteRenderer A, SpriteRenderer B, Sprite SpriteA, Sprite SpriteB) TwoEmbedded( Scene scene )
+	{
+		var a = scene.CreateObject().Components.Create<SpriteRenderer>();
+		var b = scene.CreateObject().Components.Create<SpriteRenderer>();
+
+		var sa = CreateEmbeddedSprite( "first" );
+		var sb = CreateEmbeddedSprite( "second" );
+
+		a.Sprite = sa;
+		b.Sprite = sb;
+
+		return (a, b, sa, sb);
+	}
+
+	[TestMethod]
+	public void TwoEmbeddedSpritesStartDistinct()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, sb) = TwoEmbedded( scene );
+
+		Assert.AreNotSame( sa, sb );
+		Assert.AreSame( sa, a.Sprite );
+		Assert.AreSame( sb, b.Sprite );
+		Assert.AreNotEqual( a.Sprite.Animations[0].Name, b.Sprite.Animations[0].Name );
+	}
+
+	/// <summary>
+	/// Multi-selecting builds a MultiSerializedObject over both, exactly as the inspector does.
+	/// Reading every property must not disturb either sprite.
+	/// </summary>
+	[TestMethod]
+	public void MultiSelectingEmbeddedSpritesDoesNotMergeThem()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, sb) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		foreach ( var property in mso )
+		{
+			_ = property.GetValue<object>();
+		}
+
+		var sb2 = new StringBuilder();
+		sb2.Append( $"A={a.Sprite?.Animations?[0]?.Name} B={b.Sprite?.Animations?[0]?.Name} " );
+		sb2.Append( $"same={ReferenceEquals( a.Sprite, b.Sprite )}" );
+
+		Assert.AreSame( sa, a.Sprite, sb2.ToString() );
+		Assert.AreSame( sb, b.Sprite, sb2.ToString() );
+	}
+
+	/// <summary>
+	/// The undo system serializes whole components when an edit starts. Round-tripping both through
+	/// that is where two embedded resources could collapse into one, since neither has a path to
+	/// tell them apart.
+	/// </summary>
+	[TestMethod]
+	public void SerializingBothEmbeddedSpritesKeepsThemDistinct()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, _, _) = TwoEmbedded( scene );
+
+		var jsonA = Json.Serialize( a.Sprite );
+		var jsonB = Json.Serialize( b.Sprite );
+
+		Assert.AreNotEqual( jsonA, jsonB,
+			$"two embedded sprites serialized identically, so nothing can tell them apart: {jsonA}" );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
@@ -119,4 +119,95 @@ public class EmbeddedSpriteMultiEditTest
 		Assert.AreNotEqual( jsonA, jsonB,
 			$"two embedded sprites serialized identically, so nothing can tell them apart: {jsonA}" );
 	}
+
+	/// <summary>
+	/// Control widgets reach each selected object's own property through <c>MultipleProperties</c>.
+	/// Pin that it enumerates every target, and collapses to just itself for a single selection -
+	/// widgets use one loop for both cases.
+	/// </summary>
+	[TestMethod]
+	public void MultiplePropertiesEnumeratesEveryTarget()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, _, _) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		var multi = mso.GetProperty( nameof( SpriteRenderer.Sprite ) );
+		Assert.AreEqual( 2, multi.MultipleProperties.Count() );
+
+		var single = a.GetSerialized().GetProperty( nameof( SpriteRenderer.Sprite ) );
+		Assert.AreEqual( 1, single.MultipleProperties.Count() );
+		Assert.AreSame( single, single.MultipleProperties.Single() );
+	}
+
+	/// <summary>
+	/// The trap behind the multi-select merge: GetValue returns only the first selection, while
+	/// SetValue writes that one instance to every selected object. So a control widget that reads a
+	/// value and writes it back - even completely unchanged - permanently aliases the whole selection
+	/// on to the first object's sprite. This pins the engine behaviour widgets have to work around.
+	/// </summary>
+	[TestMethod]
+	public void SetValueOnAMultiSelectionAliasesEveryTarget()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, _) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		var property = mso.GetProperty( nameof( SpriteRenderer.Sprite ) );
+
+		Assert.AreSame( sa, property.GetValue<Sprite>( null ), "GetValue should return the first selection" );
+
+		property.SetValue( property.GetValue<Sprite>( null ) );
+
+		Assert.AreSame( sa, a.Sprite );
+		Assert.AreSame( sa, b.Sprite,
+			"SetValue is expected to fan out - this is why widgets must write to each target instead" );
+	}
+
+	/// <summary>
+	/// What <c>EmbeddedSpriteControlWidget</c>'s Texture setter does now: update each selected
+	/// object's own sprite instead of broadcasting one instance. Both keep their own Sprite, and both
+	/// receive the new texture.
+	/// </summary>
+	[TestMethod]
+	public void PerTargetWriteKeepsSpritesDistinct()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, sb) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		var property = mso.GetProperty( nameof( SpriteRenderer.Sprite ) );
+		var newTexture = Texture.Transparent;
+
+		foreach ( var target in property.MultipleProperties )
+		{
+			var sprite = target.GetValue<Sprite>( null ) ?? new Sprite();
+			sprite.Animations[0].Frames[0].Texture = newTexture;
+			target.SetValue( sprite );
+		}
+
+		Assert.AreSame( sa, a.Sprite );
+		Assert.AreSame( sb, b.Sprite );
+		Assert.AreNotSame( a.Sprite, b.Sprite );
+		Assert.AreSame( newTexture, a.Sprite.Animations[0].Frames[0].Texture );
+		Assert.AreSame( newTexture, b.Sprite.Animations[0].Frames[0].Texture );
+	}
 }

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
@@ -138,4 +138,103 @@ public class SpriteMultiEditTests
 		Assert.AreEqual( Color.Red, first.Tint );
 		Assert.AreEqual( Color.Blue, second.Tint );
 	}
+
+	/// <summary>
+	/// Sort layers have to survive a multi-selection like anything else. This is what
+	/// <c>SortLayerControlWidget</c> reads to decide between showing a layer and showing
+	/// "Multiple Values" - showing the first sprite's layer while the others disagree would claim
+	/// they all share it.
+	/// </summary>
+	[TestMethod]
+	public void SortLayersThatDifferAreReportedAsMultipleValues()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		var background = settings.AddLayer( "MultiEditBackground" );
+		var foreground = settings.AddLayer( "MultiEditForeground" );
+
+		var (first, second, _, _) = TwoDistinctSprites( scene );
+
+		first.SortLayer = new SortLayerHandle( background );
+		second.SortLayer = new SortLayerHandle( foreground );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.SortLayer ), out var property ) );
+		Assert.IsTrue( property.IsMultipleDifferentValues );
+
+		// Selecting them must not have merged the layers.
+		Assert.AreEqual( background.Id, first.SortLayer.Id );
+		Assert.AreEqual( foreground.Id, second.SortLayer.Id );
+	}
+
+	/// <summary>
+	/// Picking a layer with several sprites selected applies it to all of them. Unlike the sprite
+	/// texture, fanning out here is the whole point - the value written is the one that was picked,
+	/// not one read back off the first selection.
+	/// </summary>
+	[TestMethod]
+	public void PickingASortLayerAppliesItToEverySelectedSprite()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		var target = settings.AddLayer( "MultiEditTarget" );
+
+		var (first, second, firstSprite, secondSprite) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.SortLayer ), out var property ) );
+
+		property.SetValue( new SortLayerHandle( target ) );
+
+		Assert.AreEqual( target.Id, first.SortLayer.Id );
+		Assert.AreEqual( target.Id, second.SortLayer.Id );
+
+		// The two features have to coexist: setting a sort layer across the selection must leave
+		// each sprite holding its own Sprite, which is exactly what the embedded sprite widget was
+		// getting wrong.
+		Assert.AreSame( firstSprite, first.Sprite );
+		Assert.AreSame( secondSprite, second.Sprite );
+		Assert.AreNotSame( first.Sprite, second.Sprite );
+	}
+
+	/// <summary>
+	/// The other direction of the same requirement: editing the sprites must not flatten sorting
+	/// state that was deliberately different between them.
+	/// </summary>
+	[TestMethod]
+	public void EditingSpritesLeavesDifferingSortOrdersAlone()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, _, _) = TwoDistinctSprites( scene );
+
+		first.SortOrder = 3;
+		second.SortOrder = 9;
+
+		var mso = SelectBoth( first, second );
+
+		// Whatever the inspector reads while building rows must not disturb anything.
+		foreach ( var property in mso )
+		{
+			_ = property.GetValue<object>();
+		}
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.Sprite ), out var spriteProperty ) );
+
+		// Write each sprite through its own property, the way the fixed widget does.
+		foreach ( var target in spriteProperty.MultipleProperties )
+		{
+			target.SetValue( target.GetValue<Sprite>( null ) ?? new Sprite() );
+		}
+
+		Assert.AreEqual( 3, first.SortOrder );
+		Assert.AreEqual( 9, second.SortOrder );
+	}
 }

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
@@ -1,0 +1,141 @@
+namespace SceneTests.Components;
+
+/// <summary>
+/// Reproduces what the inspector does when several sprites are selected at once, to settle whether
+/// selecting them changes their values or merely displays one of them.
+///
+/// Built the same way <c>ComponentListWidget</c> builds it: a <see cref="MultiSerializedObject"/>
+/// holding each component's serialized form, rebuilt into shared properties.
+/// </summary>
+[TestClass]
+public class SpriteMultiEditTests
+{
+	static MultiSerializedObject SelectBoth( params Component[] components )
+	{
+		var mso = new MultiSerializedObject();
+
+		foreach ( var component in components )
+		{
+			mso.Add( component.GetSerialized() );
+		}
+
+		mso.Rebuild();
+
+		return mso;
+	}
+
+	static (SpriteRenderer First, SpriteRenderer Second, Sprite FirstSprite, Sprite SecondSprite) TwoDistinctSprites( Scene scene )
+	{
+		var firstSprite = new Sprite();
+		var secondSprite = new Sprite();
+
+		var first = scene.CreateObject().Components.Create<SpriteRenderer>();
+		var second = scene.CreateObject().Components.Create<SpriteRenderer>();
+
+		first.Sprite = firstSprite;
+		second.Sprite = secondSprite;
+
+		return (first, second, firstSprite, secondSprite);
+	}
+
+	/// <summary>
+	/// The question that matters: does selecting two sprites overwrite one with the other?
+	///
+	/// Displaying a shared value is survivable. Silently reassigning artwork because someone
+	/// clicked two objects is not, so this is worth pinning down on its own.
+	/// </summary>
+	[TestMethod]
+	public void SelectingTwoSpritesDoesNotChangeEither()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, firstSprite, secondSprite) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		// Read every property, the way an inspector populating its widgets would.
+		foreach ( var property in mso )
+		{
+			_ = property.GetValue<object>();
+		}
+
+		Assert.AreSame( firstSprite, first.Sprite, "the first sprite must be left alone" );
+		Assert.AreSame( secondSprite, second.Sprite, "the second sprite must be left alone" );
+	}
+
+	/// <summary>
+	/// What a multi-selection reports for a property the two sprites disagree on. This is display
+	/// behaviour, not corruption - but it is why both rows appear to show the same artwork.
+	/// </summary>
+	[TestMethod]
+	public void MultiSelectionReportsTheFirstValueForDifferingProperties()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, firstSprite, secondSprite) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.Sprite ), out var property ) );
+
+		Assert.IsTrue( property.IsMultipleDifferentValues,
+			"the two sprites differ, and the property knows it - nothing acts on that yet" );
+
+		Assert.AreSame( firstSprite, property.GetValue<Sprite>(),
+			"GetValue reports the first selected object, which is why both rows look identical" );
+
+		Assert.AreNotSame( secondSprite, property.GetValue<Sprite>() );
+	}
+
+	/// <summary>
+	/// Editing through a multi-selection writes to every selected object. Expected, and the reason
+	/// one edit appears to set the other.
+	/// </summary>
+	[TestMethod]
+	public void EditingThroughAMultiSelectionWritesToEverySelectedSprite()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, _, _) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.SortOrder ), out var property ) );
+
+		property.SetValue( 7 );
+
+		Assert.AreEqual( 7, first.SortOrder );
+		Assert.AreEqual( 7, second.SortOrder );
+	}
+
+	/// <summary>
+	/// The same reporting behaviour on a component that has nothing to do with sprites, which is
+	/// what makes this a property of the inspector rather than of sprite sorting.
+	/// </summary>
+	[TestMethod]
+	public void TheSameHappensForAnyComponent()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var first = scene.CreateObject().Components.Create<ModelRenderer>();
+		var second = scene.CreateObject().Components.Create<ModelRenderer>();
+
+		first.Tint = Color.Red;
+		second.Tint = Color.Blue;
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( ModelRenderer.Tint ), out var property ) );
+
+		Assert.IsTrue( property.IsMultipleDifferentValues );
+		Assert.AreEqual( Color.Red, property.GetValue<Color>(), "the first selected object again" );
+
+		// And the values themselves are untouched by having been selected.
+		Assert.AreEqual( Color.Red, first.Tint );
+		Assert.AreEqual( Color.Blue, second.Tint );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteSortingTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteSortingTests.cs
@@ -1,0 +1,310 @@
+using Sandbox.Rendering;
+
+namespace SceneTests.Components;
+
+/// <summary>
+/// Sprite sorting against a real scene and a real engine.
+///
+/// The unit tests cover the arithmetic - key packing, draw runs, index math. What they cannot
+/// reach is the thing the arithmetic depends on: which batch a sprite is actually put in. Sprites
+/// in different batches have no defined order however their layers are set, because nothing orders
+/// one scene object against another. So "did these two sprites end up in the same batch" is the
+/// question that decides whether sort layers work at all, and it needs a live scene to answer.
+/// </summary>
+[TestClass]
+public class SpriteSortingTests
+{
+	static SpriteRenderer CreateSprite( Scene scene, bool sorted = true, bool additive = false, bool opaque = false, bool shadows = false )
+	{
+		var go = scene.CreateObject();
+		var sprite = go.Components.Create<SpriteRenderer>();
+
+		sprite.IsSorted = sorted;
+		sprite.Additive = additive;
+		sprite.Opaque = opaque;
+		sprite.Shadows = shadows;
+
+		return sprite;
+	}
+
+	/// <summary>
+	/// The batch a sprite would be put in.
+	///
+	/// Asking the system to actually build its batches is not possible here - a batch allocates GPU
+	/// buffers in its constructor and these tests run without a graphics device. But the batch a
+	/// sprite lands in is decided entirely by this key, so comparing keys answers the same question
+	/// without needing one.
+	/// </summary>
+	static ulong BatchKey( SpriteRenderer sprite )
+		=> SceneSpriteSystem.GetRenderGroupKey( sprite, sprite.Tags as GameTags, sprite.RenderOptions, allowBlendMerge: true );
+
+	/// <summary>
+	/// The fix this whole change exists for. An additive sprite and an ordinary one used to be put
+	/// in separate scene objects, and no sort layer could order them against each other. They have
+	/// to share a batch now.
+	/// </summary>
+	[TestMethod]
+	public void AdditiveAndTransparentSpritesShareOneBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var transparent = CreateSprite( scene, additive: false );
+		var additive = CreateSprite( scene, additive: true );
+
+		Assert.AreEqual( BatchKey( transparent ), BatchKey( additive ),
+			"additive and transparent sprites must batch together, or their sort layers cannot be honoured" );
+	}
+
+	/// <summary>
+	/// Opaque sprites belong to a different render pass, so folding them in would change when they
+	/// draw. They stay separate on purpose.
+	/// </summary>
+	[TestMethod]
+	public void OpaqueSpritesStayInTheirOwnBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		Assert.AreNotEqual( BatchKey( CreateSprite( scene, opaque: false ) ), BatchKey( CreateSprite( scene, opaque: true ) ) );
+	}
+
+	/// <summary>
+	/// A shadow caster carries a scene object flag that additive sprites never set, so it cannot be
+	/// merged without silently changing whether it casts a shadow.
+	/// </summary>
+	[TestMethod]
+	public void ShadowCastingSpritesStayInTheirOwnBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		Assert.AreNotEqual( BatchKey( CreateSprite( scene, shadows: false ) ), BatchKey( CreateSprite( scene, shadows: true ) ) );
+	}
+
+	/// <summary>
+	/// Unsorted sprites opted out of ordering entirely, so there is nothing to gain by merging them
+	/// and the old batching is left exactly as it was.
+	/// </summary>
+	[TestMethod]
+	public void UnsortedSpritesAreNotMerged()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var plain = CreateSprite( scene, sorted: false, additive: false );
+		var additive = CreateSprite( scene, sorted: false, additive: true );
+
+		Assert.AreNotEqual( BatchKey( plain ), BatchKey( additive ) );
+	}
+
+	/// <summary>
+	/// Sprites differing only in sort layer must stay together - splitting by layer would put each
+	/// layer in a scene object whose draw order against the others is undefined, which is worse
+	/// than not having layers at all.
+	/// </summary>
+	[TestMethod]
+	public void SortLayerDoesNotSplitTheBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		settings.AddLayer( "Foreground" );
+
+		var back = CreateSprite( scene );
+		var front = CreateSprite( scene );
+		front.SortLayer = new SortLayerHandle( settings.Layers[^1] );
+
+		Assert.AreEqual( BatchKey( back ), BatchKey( front ) );
+		Assert.AreNotEqual( back.SortLayer.Index, front.SortLayer.Index );
+	}
+
+	// ---- sorting groups, against a real hierarchy --------------------------------------------
+
+	/// <summary>
+	/// Authored sort orders can be any integers with gaps. The draw order only has room for a small
+	/// dense rank, so they have to be compressed while keeping their relative order.
+	/// </summary>
+	[TestMethod]
+	public void GroupRanksCompressArbitraryOrders()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var root = scene.CreateObject();
+		var group = root.Components.Create<SortingGroup>();
+
+		var legs = CreateSprite( scene );
+		var body = CreateSprite( scene );
+		var head = CreateSprite( scene );
+
+		legs.GameObject.SetParent( root );
+		body.GameObject.SetParent( root );
+		head.GameObject.SetParent( root );
+
+		legs.SortOrder = -500;
+		body.SortOrder = 0;
+		head.SortOrder = 9000;
+
+		group.RefreshRanks();
+
+		Assert.AreEqual( 0, group.GetRank( legs ) );
+		Assert.AreEqual( 1, group.GetRank( body ) );
+		Assert.AreEqual( 2, group.GetRank( head ) );
+	}
+
+	/// <summary>
+	/// A grouped sprite takes its place in the world from the group, and keeps its own order only
+	/// for ranking against the group's other members.
+	/// </summary>
+	[TestMethod]
+	public void GroupedSpriteResolvesToTheGroupsPlaceInTheOrder()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		settings.AddLayer( "Characters" );
+
+		var root = scene.CreateObject();
+		root.WorldPosition = new Vector3( 100, 200, 300 );
+
+		var group = root.Components.Create<SortingGroup>();
+		group.SortLayer = new SortLayerHandle( settings.Layers[^1] );
+		group.SortOrder = 42;
+
+		var sprite = CreateSprite( scene );
+		sprite.GameObject.SetParent( root );
+		sprite.GameObject.WorldPosition = new Vector3( 0, 0, 0 );
+		sprite.SortOrder = 7;
+
+		group.RefreshRanks();
+
+		var (layer, order, origin, rank) = sprite.ResolveSorting( group );
+
+		Assert.AreEqual( group.SortLayer.Id, layer.Id, "the group decides the layer" );
+		Assert.AreEqual( 42, order, "the group decides the order against the rest of the world" );
+		Assert.AreEqual( root.WorldPosition, origin, "every member sorts at the group's origin" );
+		Assert.AreEqual( 0, rank, "the sprite's own order only ranks it inside the group" );
+	}
+
+	/// <summary>
+	/// Groups do not nest. A sprite belongs to the nearest one above it, and the outer group never
+	/// sees it - reported rather than silently flattened.
+	/// </summary>
+	[TestMethod]
+	public void NestedGroupsResolveToTheNearestOne()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var outer = scene.CreateObject();
+		var outerGroup = outer.Components.Create<SortingGroup>();
+
+		var inner = scene.CreateObject();
+		inner.SetParent( outer );
+		var innerGroup = inner.Components.Create<SortingGroup>();
+
+		var sprite = CreateSprite( scene );
+		sprite.GameObject.SetParent( inner );
+
+		Assert.AreEqual( innerGroup, SortingGroup.FindFor( sprite ) );
+		Assert.IsTrue( innerGroup.IsNested, "the inner group has to know it is nested so it can say so" );
+		Assert.IsFalse( outerGroup.IsNested );
+
+		// The outer group must not claim the sprite, or it would be ranked in two places at once.
+		outerGroup.RefreshRanks();
+		Assert.AreEqual( 0, outerGroup.GetRank( sprite ) );
+	}
+
+	/// <summary>
+	/// An ungrouped sprite keeps its own layer, order and position.
+	/// </summary>
+	[TestMethod]
+	public void UngroupedSpriteKeepsItsOwnSorting()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var sprite = CreateSprite( scene );
+		sprite.GameObject.WorldPosition = new Vector3( 10, 20, 30 );
+		sprite.SortOrder = 5;
+
+		Assert.IsNull( sprite.SortingGroup );
+
+		var (layer, order, origin, rank) = sprite.ResolveSorting( null );
+
+		Assert.AreEqual( sprite.SortLayer.Id, layer.Id );
+		Assert.AreEqual( 5, order );
+		Assert.AreEqual( sprite.WorldPosition, origin );
+		Assert.AreEqual( 0, rank );
+	}
+
+	// ---- the layer list is mutable at runtime, and the id lookup must keep up ----------------
+
+	/// <summary>
+	/// A layer added through the editor has to be usable straight away. Adding it to the list
+	/// without rebuilding the id lookup does not throw - the new layer simply resolves to the
+	/// default, so sprites assigned to it quietly render in the wrong place.
+	/// </summary>
+	[TestMethod]
+	public void NewlyAddedLayerResolvesImmediately()
+	{
+		var settings = new SortingSettings();
+		var added = settings.AddLayer( "Foreground" );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( added.Id ) );
+		Assert.AreEqual( added, settings.GetLayer( added.Id ) );
+	}
+
+	/// <summary>
+	/// Reordering is the whole point of the layer editor, and it changes what every id maps to. A
+	/// stale lookup here would draw every sprite in the scene in the wrong layer.
+	/// </summary>
+	[TestMethod]
+	public void ReorderingLayersUpdatesEveryIndex()
+	{
+		var settings = new SortingSettings();
+		var first = settings.AddLayer( "First" );
+		var second = settings.AddLayer( "Second" );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( first.Id ) );
+		Assert.AreEqual( 2, settings.GetLayerIndex( second.Id ) );
+
+		settings.MoveLayer( 2, 1 );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( second.Id ), "the moved layer has to report its new position" );
+		Assert.AreEqual( 2, settings.GetLayerIndex( first.Id ), "and the one it displaced has to report its new one" );
+	}
+
+	/// <summary>
+	/// Deleting a layer shifts everything after it, and orphaned sprites must land on the default
+	/// rather than on whichever layer happens to have inherited the index.
+	/// </summary>
+	[TestMethod]
+	public void DeletingALayerReindexesAndOrphansFallBack()
+	{
+		var settings = new SortingSettings();
+		var doomed = settings.AddLayer( "Doomed" );
+		var after = settings.AddLayer( "After" );
+
+		Assert.IsTrue( settings.RemoveLayer( doomed ) );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( after.Id ), "later layers move down" );
+		Assert.AreEqual( 0, settings.GetLayerIndex( doomed.Id ), "the deleted layer falls back to the default" );
+		Assert.IsNull( settings.GetLayer( doomed.Id ) );
+	}
+
+	/// <summary>
+	/// Everything falls back to the first layer, so it cannot be removed.
+	/// </summary>
+	[TestMethod]
+	public void TheLastLayerCannotBeRemoved()
+	{
+		var settings = new SortingSettings();
+
+		Assert.IsFalse( settings.RemoveLayer( settings.DefaultLayer ) );
+		Assert.AreEqual( 1, settings.Layers.Count );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/TextureGeneratorIdentityTest.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/TextureGeneratorIdentityTest.cs
@@ -1,0 +1,40 @@
+using Sandbox.Resources;
+
+namespace SceneTests.Components;
+
+/// <summary>
+/// Where a dragged-in image gets its identity from.
+///
+/// Dropping an image builds an <see cref="ImageFileGenerator"/> and generates a texture from it.
+/// That texture is looked up later through a process-wide cache keyed by
+/// <see cref="ResourceGenerator.GetHash"/>, which is a CRC64 of the generator serialized to JSON.
+/// If two different images hash the same, both resolve to one texture - which is what "the sprites
+/// swap to a single image" would look like.
+/// </summary>
+[TestClass]
+public class TextureGeneratorIdentityTest
+{
+	static ImageFileGenerator ForFile( string path ) => new() { FilePath = path };
+
+	/// <summary>
+	/// The property that has to hold: two different files must never share an identity.
+	/// </summary>
+	[TestMethod]
+	public void DifferentFilesMustHashDifferently()
+	{
+		var a = ForFile( "textures/one.png" );
+		var b = ForFile( "textures/two.png" );
+
+		Assert.AreNotEqual( a.GetHash(), b.GetHash(),
+			"two different image files resolved to the same generated-texture identity" );
+	}
+
+	/// <summary>
+	/// And the same file must hash stably, or the cache never hits and every load regenerates.
+	/// </summary>
+	[TestMethod]
+	public void SameFileHashesStably()
+	{
+		Assert.AreEqual( ForFile( "textures/one.png" ).GetHash(), ForFile( "textures/one.png" ).GetHash() );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawIndexingTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawIndexingTest.cs
@@ -1,0 +1,293 @@
+using Sandbox.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace SceneTests;
+
+/// <summary>
+/// The one part of sprite sorting that no other test reaches: whether the index arithmetic on the
+/// GPU actually lines up.
+///
+/// Three separate pieces have to agree - the bitonic sort in <c>sort_cs.shader</c>, the draw runs
+/// worked out by <see cref="SpriteDrawPlan"/>, and the backwards walk of the sort table in
+/// <c>sprite_ps.shader</c>. Each is defensible on its own and the combination is easy to get off
+/// by one, which would draw sprites with the wrong blend state or read past the real entries into
+/// the padding. Neither shows up as a failure anywhere - just as a wrong picture.
+///
+/// So the shader code is transcribed here and run over real keys. This proves the arithmetic, not
+/// the HLSL: it cannot tell us the shaders compile to this or that the attributes arrive. But the
+/// arithmetic is the part that was only ever argued for.
+/// </summary>
+[TestClass]
+public class SpriteDrawIndexingTest
+{
+	record struct Sprite( int Layer, SpriteBlendMode Blend, int Order, float Depth );
+
+	// ---- transcribed from the shaders -------------------------------------------------------
+
+	/// <summary>SORTKEY_MAX in sort_cs.shader. Sorts after every real sprite.</summary>
+	static readonly (uint X, uint Y) SortKeyMax = (0xFFFFFFFFu, 0xFFFFFFFFu);
+
+	/// <summary>FloatToSortableUint in sprite_cs.shader.</summary>
+	static uint FloatToSortableUint( float value )
+	{
+		var bits = BitConverter.SingleToUInt32Bits( value );
+		return (bits & 0x80000000u) != 0 ? ~bits : bits | 0x80000000u;
+	}
+
+	/// <summary>CalculateSortKey in sprite_cs.shader, for a sprite with no sorting group.</summary>
+	static (uint X, uint Y) CalculateSortKey( Sprite sprite )
+	{
+		var packed = SpriteBatchSceneObject.SpriteData.PackSortKey( sprite.Layer, sprite.Blend, sprite.Order );
+		var quantized = FloatToSortableUint( sprite.Depth ) & ~0xFFu;
+
+		return (~packed, quantized | 0xFFu);
+	}
+
+	/// <summary>The lexicographic comparison in sort_cs.shader.</summary>
+	static bool Greater( (uint X, uint Y) a, (uint X, uint Y) b )
+		=> a.X != b.X ? a.X > b.X : a.Y > b.Y;
+
+	static bool Less( (uint X, uint Y) a, (uint X, uint Y) b )
+		=> a.X != b.X ? a.X < b.X : a.Y < b.Y;
+
+	/// <summary>
+	/// MainCs in sort_cs.shader, both the D_CLEAR pass and the sort passes, driven by the dispatch
+	/// loop in SpriteBatchSceneObject.UploadOnHost.
+	///
+	/// Running the threads of a stage in sequence matches the GPU here: a stage only ever swaps
+	/// disjoint pairs, and the shader's own <c>compareIndex &lt; currentIndex</c> guard means just
+	/// one thread of each pair does the work.
+	/// </summary>
+	static uint[] RunBitonicSort( IReadOnlyList<Sprite> sprites )
+	{
+		var bufferSize = (int)BitOperations.RoundUpToPowerOf2( (uint)Math.Max( sprites.Count, 1 ) );
+
+		// D_CLEAR: every slot is seeded, so the padding carries SORTKEY_MAX and sorts to the end.
+		var sortBuffer = new uint[bufferSize];
+		var keys = new (uint X, uint Y)[bufferSize];
+
+		for ( var i = 0; i < bufferSize; i++ )
+		{
+			sortBuffer[i] = (uint)i;
+			keys[i] = SortKeyMax;
+		}
+
+		// sprite_cs writes a real key for each live sprite; the rest keep SORTKEY_MAX.
+		for ( var i = 0; i < sprites.Count; i++ )
+		{
+			keys[i] = CalculateSortKey( sprites[i] );
+		}
+
+		for ( var dim = 2; dim <= bufferSize; dim <<= 1 )
+		{
+			for ( var block = dim >> 1; block > 0; block >>= 1 )
+			{
+				for ( var currentIndex = 0; currentIndex < bufferSize; currentIndex++ )
+				{
+					var compareIndex = currentIndex ^ block;
+
+					if ( compareIndex >= bufferSize || compareIndex < currentIndex ) continue;
+
+					var indexA = sortBuffer[currentIndex];
+					var indexB = sortBuffer[compareIndex];
+
+					var keyA = keys[indexA];
+					var keyB = keys[indexB];
+
+					var ascending = (currentIndex & dim) == 0;
+
+					if ( ascending ? Greater( keyA, keyB ) : Less( keyA, keyB ) )
+					{
+						sortBuffer[currentIndex] = indexB;
+						sortBuffer[compareIndex] = indexA;
+					}
+				}
+			}
+		}
+
+		return sortBuffer;
+	}
+
+	/// <summary>
+	/// GetSprite in sprite_ps.shader. <paramref name="instanceId"/> is relative to the draw, which
+	/// is why the run's offset comes into it.
+	/// </summary>
+	static int GetSpriteIndex( uint[] sortLut, int instanceCount, int sortLutOffset, int instanceId )
+		=> (int)sortLut[instanceCount - 1 - instanceId - sortLutOffset];
+
+	// ---- the actual pipeline ----------------------------------------------------------------
+
+	/// <summary>
+	/// Everything the renderer would do, end to end: build the runs, sort, then walk each run the
+	/// way the shader does. Returns each drawn sprite paired with the blend state its draw call
+	/// was configured for.
+	/// </summary>
+	static List<(Sprite Sprite, SpriteBlendMode DrawnAs)> Draw( IReadOnlyList<Sprite> sprites, int layerCount )
+	{
+		var buckets = new List<SpriteDrawBucket>();
+
+		SpriteDrawPlan.BuildBuckets(
+			sprites.Select( s => s.Layer ).ToArray(),
+			sprites.Select( s => s.Blend ).ToArray(),
+			layerCount,
+			buckets,
+			new int[layerCount * SpriteDrawPlan.BlendModeCount] );
+
+		var sortLut = RunBitonicSort( sprites );
+		var drawn = new List<(Sprite, SpriteBlendMode)>();
+
+		foreach ( var bucket in buckets )
+		{
+			for ( var instanceId = 0; instanceId < bucket.Count; instanceId++ )
+			{
+				var index = GetSpriteIndex( sortLut, sprites.Count, bucket.Offset, instanceId );
+
+				Assert.IsTrue( index >= 0 && index < sprites.Count,
+					$"read index {index} outside the {sprites.Count} live sprites - the walk ran into the padding" );
+
+				drawn.Add( (sprites[index], bucket.Blend) );
+			}
+		}
+
+		return drawn;
+	}
+
+	// ---- tests ------------------------------------------------------------------------------
+
+	[TestMethod]
+	public void EverySpriteIsDrawnUnderItsOwnBlendState()
+	{
+		// The failure this exists for. If a run's offset is off by even one, sprites are handed to
+		// a draw call set up for someone else's blend state - additive artwork rendered opaque, or
+		// the reverse. Nothing errors; the picture is just wrong.
+		var sprites = new List<Sprite>();
+		var random = new Random( 4242 );
+
+		for ( var i = 0; i < 120; i++ )
+		{
+			sprites.Add( new Sprite(
+				random.Next( 0, 5 ),
+				(SpriteBlendMode)random.Next( 0, SpriteDrawPlan.BlendModeCount ),
+				random.Next( -50, 50 ),
+				random.NextSingle() * 2000f - 1000f ) );
+		}
+
+		foreach ( var (sprite, drawnAs) in Draw( sprites, layerCount: 5 ) )
+		{
+			Assert.AreEqual( sprite.Blend, drawnAs );
+		}
+	}
+
+	[TestMethod]
+	public void EverySpriteIsDrawnExactlyOnce()
+	{
+		// Catches the walk overlapping itself or skipping a slot between runs.
+		var sprites = Enumerable.Range( 0, 64 )
+			.Select( i => new Sprite( i % 3, (SpriteBlendMode)(i % 3), i, i * 10f ) )
+			.ToList();
+
+		var drawn = Draw( sprites, layerCount: 3 );
+
+		Assert.AreEqual( sprites.Count, drawn.Count );
+		CollectionAssert.AreEquivalent( sprites, drawn.Select( d => d.Sprite ).ToList() );
+	}
+
+	[TestMethod]
+	public void DrawOrderIsBackToFront()
+	{
+		// The order the whole feature is for: layer, then blend, then order in layer, then depth
+		// with the furthest away drawn first.
+		var sprites = new List<Sprite>
+		{
+			new( 1, SpriteBlendMode.Transparent, 0, 100f ),
+			new( 0, SpriteBlendMode.Additive, 5, 50f ),
+			new( 0, SpriteBlendMode.Transparent, 5, 10f ),
+			new( 0, SpriteBlendMode.Transparent, 5, 900f ),
+			new( 0, SpriteBlendMode.Transparent, -3, 20f ),
+			new( 2, SpriteBlendMode.Opaque, 0, 30f ),
+		};
+
+		var expected = sprites
+			.OrderBy( s => s.Layer )
+			.ThenBy( s => (int)s.Blend )
+			.ThenBy( s => s.Order )
+			.ThenByDescending( s => s.Depth )
+			.ToList();
+
+		CollectionAssert.AreEqual( expected, Draw( sprites, layerCount: 3 ).Select( d => d.Sprite ).ToList() );
+	}
+
+	[TestMethod]
+	public void PaddingIsNeverDrawn()
+	{
+		// A sprite count just past a power of two leaves the buffer mostly padding. If the walk
+		// started from the padded size instead of the live count, this is where it would show.
+		foreach ( var count in new[] { 1, 2, 3, 5, 9, 17, 33, 65 } )
+		{
+			var sprites = Enumerable.Range( 0, count )
+				.Select( i => new Sprite( i % 2, SpriteBlendMode.Transparent, i, i ) )
+				.ToList();
+
+			var drawn = Draw( sprites, layerCount: 2 );
+
+			Assert.AreEqual( count, drawn.Count, $"{count} sprites" );
+			CollectionAssert.AreEquivalent( sprites, drawn.Select( d => d.Sprite ).ToList(), $"{count} sprites" );
+		}
+	}
+
+	[TestMethod]
+	public void SingleDrawPathMatchesTheBucketedPath()
+	{
+		// A batch with one blend state takes the old single-draw path with offset 0. It has to
+		// produce the same order as the bucketed path, or enabling the merge would change how
+		// existing scenes look.
+		var sprites = Enumerable.Range( 0, 40 )
+			.Select( i => new Sprite( i % 3, SpriteBlendMode.Transparent, i % 7, (i * 37) % 500 ) )
+			.ToList();
+
+		var sortLut = RunBitonicSort( sprites );
+
+		var singleDraw = Enumerable.Range( 0, sprites.Count )
+			.Select( i => sprites[GetSpriteIndex( sortLut, sprites.Count, 0, i )] )
+			.ToList();
+
+		CollectionAssert.AreEqual( singleDraw, Draw( sprites, layerCount: 3 ).Select( d => d.Sprite ).ToList() );
+	}
+
+	[TestMethod]
+	public void ArbitraryScenesKeepEveryGuarantee()
+	{
+		var random = new Random( 20260719 );
+
+		for ( var iteration = 0; iteration < 300; iteration++ )
+		{
+			var layerCount = random.Next( 1, 6 );
+			var count = random.Next( 1, 130 );
+
+			var sprites = Enumerable.Range( 0, count )
+				.Select( _ => new Sprite(
+					random.Next( 0, layerCount ),
+					(SpriteBlendMode)random.Next( 0, SpriteDrawPlan.BlendModeCount ),
+					random.Next( -20, 20 ),
+					random.NextSingle() * 400f - 200f ) )
+				.ToList();
+
+			var drawn = Draw( sprites, layerCount );
+			var context = $"iteration {iteration}, {count} sprites over {layerCount} layers";
+
+			Assert.AreEqual( count, drawn.Count, context );
+
+			foreach ( var (sprite, drawnAs) in drawn )
+			{
+				Assert.AreEqual( sprite.Blend, drawnAs, context );
+			}
+
+			// Layers must come out non-decreasing however the blend states are mixed in.
+			var layers = drawn.Select( d => d.Sprite.Layer ).ToArray();
+			CollectionAssert.AreEqual( layers.OrderBy( l => l ).ToArray(), layers, context );
+		}
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawPlanTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawPlanTest.cs
@@ -1,0 +1,194 @@
+using Sandbox.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SceneTests;
+
+// Sort layers are supposed to beat everything, and until now they did not: sprites needing
+// different blend states ended up in different scene objects, and nothing in the engine orders one
+// scene object against another. They now share a batch and are drawn as one run per
+// (layer, blend) - so the layer wins, at the price of a few extra draw calls.
+//
+// This pins down where those runs land. The other half - that the GPU sort actually puts each
+// sprite in the run these offsets claim - is what the key packing in SpriteSortKeyTest guarantees.
+[TestClass]
+public class SpriteDrawPlanTest
+{
+	record struct Sprite( int Layer, SpriteBlendMode Blend );
+
+	// layerCount defaults to "every layer these sprites mention exists". Pass it explicitly to
+	// model a project with fewer layers than the sprites are asking for.
+	static List<SpriteDrawBucket> BuildPlan( Sprite[] sprites, int? layerCountOverride = null )
+	{
+		var layerCount = layerCountOverride
+			?? (sprites.Length == 0 ? 1 : sprites.Max( s => s.Layer ) + 1);
+
+		var buckets = new List<SpriteDrawBucket>();
+
+		SpriteDrawPlan.BuildBuckets(
+			sprites.Select( s => s.Layer ).ToArray(),
+			sprites.Select( s => s.Blend ).ToArray(),
+			layerCount,
+			buckets,
+			new int[layerCount * SpriteDrawPlan.BlendModeCount] );
+
+		return buckets;
+	}
+
+	// The whole point of the change. Before it, these two lived in separate scene objects and the
+	// additive one could be drawn either side of the other, whatever the layers said.
+	[TestMethod]
+	public void LayerBeatsBlendMode()
+	{
+		var plan = BuildPlan( [
+			new Sprite( 1, SpriteBlendMode.Additive ),
+			new Sprite( 0, SpriteBlendMode.Transparent )] );
+
+		Assert.AreEqual( 0, plan[0].LayerIndex, "the lower layer has to be drawn first, at the back" );
+		Assert.AreEqual( 1, plan[1].LayerIndex );
+	}
+
+	[TestMethod]
+	public void EveryLowerLayerIsFullyDrawnBeforeAnyHigherOne()
+	{
+		var plan = BuildPlan( [
+			new Sprite( 2, SpriteBlendMode.Transparent ),
+			new Sprite( 0, SpriteBlendMode.Additive ),
+			new Sprite( 1, SpriteBlendMode.Opaque ),
+			new Sprite( 2, SpriteBlendMode.Additive ),
+			new Sprite( 0, SpriteBlendMode.Transparent ),
+			new Sprite( 1, SpriteBlendMode.Additive )] );
+
+		var layers = plan.Select( b => b.LayerIndex ).ToArray();
+
+		CollectionAssert.AreEqual( layers.OrderBy( l => l ).ToArray(), layers,
+			"runs must come out in layer order, whatever blend states are mixed in" );
+	}
+
+	[TestMethod]
+	public void OpaqueIsDrawnBeforeBlendedWorkInTheSameLayer()
+	{
+		// Opaque sprites occlude, so drawing them first lets the depth test reject what is behind
+		// them instead of blending over it.
+		var plan = BuildPlan( [
+			new Sprite( 0, SpriteBlendMode.Additive ),
+			new Sprite( 0, SpriteBlendMode.Transparent ),
+			new Sprite( 0, SpriteBlendMode.Opaque )] );
+
+		CollectionAssert.AreEqual(
+			new[] { SpriteBlendMode.Opaque, SpriteBlendMode.Transparent, SpriteBlendMode.Additive },
+			plan.Select( b => b.Blend ).ToArray() );
+	}
+
+	[TestMethod]
+	public void EverySpriteIsAccountedForExactlyOnce()
+	{
+		// A miscount here would leave sprites outside every run, so they would simply never draw.
+		var sprites = Enumerable.Range( 0, 50 )
+			.Select( i => new Sprite( i % 4, (SpriteBlendMode)(i % 3) ) )
+			.ToArray();
+
+		Assert.AreEqual( sprites.Length, BuildPlan( sprites ).Sum( b => b.Count ) );
+	}
+
+	[TestMethod]
+	public void RunsAreContiguousAndInDrawOrder()
+	{
+		// Each run becomes one instanced draw over [Offset, Offset+Count), so a gap or an overlap
+		// between them would silently skip or repeat sprites.
+		var sprites = Enumerable.Range( 0, 30 )
+			.Select( i => new Sprite( i % 3, (SpriteBlendMode)(i % 3) ) )
+			.ToArray();
+
+		var expectedOffset = 0;
+
+		foreach ( var bucket in BuildPlan( sprites ) )
+		{
+			Assert.AreEqual( expectedOffset, bucket.Offset, "runs must tile the buffer with no holes" );
+			expectedOffset += bucket.Count;
+		}
+
+		Assert.AreEqual( sprites.Length, expectedOffset );
+	}
+
+	[TestMethod]
+	public void EmptyRunsAreNotDrawn()
+	{
+		// Layers are project-wide, so most scenes leave most of them unused. A draw call per empty
+		// layer would cost more than the ordering is worth.
+		var plan = BuildPlan( [new Sprite( 3, SpriteBlendMode.Transparent )] );
+
+		Assert.AreEqual( 1, plan.Count );
+		Assert.AreEqual( 3, plan[0].LayerIndex );
+		Assert.AreEqual( 1, plan[0].Count );
+	}
+
+	[TestMethod]
+	public void LayersPastTheEndFallBackToTheFirst()
+	{
+		// A sprite can outlive the layer it pointed at - delete a layer and its sprites keep the
+		// old index. It must still be drawn; dropping it would make deleting a layer look like
+		// deleting the artwork.
+		var plan = BuildPlan( [new Sprite( 99, SpriteBlendMode.Transparent )], layerCountOverride: 2 );
+
+		Assert.AreEqual( 1, plan.Sum( b => b.Count ) );
+		Assert.AreEqual( 0, plan[0].LayerIndex );
+	}
+
+	[TestMethod]
+	public void OpaqueWinsOverAdditive()
+	{
+		// An opaque sprite is never blended, whatever else it asks for.
+		Assert.AreEqual( SpriteBlendMode.Opaque, SpriteDrawPlan.GetBlendMode( opaque: true, additive: true ) );
+		Assert.AreEqual( SpriteBlendMode.Additive, SpriteDrawPlan.GetBlendMode( opaque: false, additive: true ) );
+		Assert.AreEqual( SpriteBlendMode.Transparent, SpriteDrawPlan.GetBlendMode( opaque: false, additive: false ) );
+	}
+
+	[TestMethod]
+	public void NoSpritesProducesNoDraws()
+	{
+		Assert.AreEqual( 0, BuildPlan( [] ).Count );
+	}
+
+	// The cases above are the ones worth reading. This is the one worth trusting: arbitrary mixes,
+	// re-checking the invariants that must hold for every scene rather than the shapes someone
+	// thought to write down. Seeded, so a failure reproduces.
+	[TestMethod]
+	public void InvariantsHoldAcrossArbitraryScenes()
+	{
+		var random = new Random( 20260719 );
+
+		for ( var iteration = 0; iteration < 500; iteration++ )
+		{
+			var layerCount = random.Next( 1, 9 );
+			var spriteCount = random.Next( 0, 200 );
+
+			var sprites = Enumerable.Range( 0, spriteCount )
+				.Select( _ => new Sprite(
+					random.Next( 0, layerCount ),
+					(SpriteBlendMode)random.Next( 0, SpriteDrawPlan.BlendModeCount ) ) )
+				.ToArray();
+
+			var plan = BuildPlan( sprites, layerCount );
+			var context = $"iteration {iteration}, {spriteCount} sprites over {layerCount} layers";
+
+			// Nothing left outside a run.
+			Assert.AreEqual( spriteCount, plan.Sum( b => b.Count ), context );
+
+			// The runs tile the buffer exactly, since each becomes a draw over its own range.
+			var expectedOffset = 0;
+			foreach ( var bucket in plan )
+			{
+				Assert.AreEqual( expectedOffset, bucket.Offset, context );
+				Assert.IsTrue( bucket.Count > 0, context );
+				expectedOffset += bucket.Count;
+			}
+
+			// The guarantee the whole feature rests on: a lower layer is never drawn after a
+			// higher one, whatever blend states are mixed into either.
+			var keys = plan.Select( b => SpriteDrawPlan.GetBucketIndex( b.LayerIndex, b.Blend ) ).ToArray();
+			CollectionAssert.AreEqual( keys.OrderBy( k => k ).ToArray(), keys, context );
+		}
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Scene/SpriteSortKeyTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Scene/SpriteSortKeyTest.cs
@@ -1,0 +1,313 @@
+using Sandbox.Rendering;
+using System;
+using System.Collections.Generic;
+
+namespace SceneTests;
+
+// The sprite draw order is a lexicographic comparison of a packed layer/blend/order key and a
+// distance, resolved on the GPU. These tests pin down the CPU half of that key: the packing has to
+// be monotonic, because a non-monotonic key sorts wrongly with no visible error anywhere.
+[TestClass]
+public class SpriteSortKeyTest
+{
+	// Blend sits between layer and order in the key. Most of these cases only care about layer and
+	// order, so they hold blend fixed at Transparent - what an ordinary 2D sprite is.
+	static uint Pack( int layer, int order, SpriteBlendMode blend = SpriteBlendMode.Transparent )
+		=> SpriteBatchSceneObject.SpriteData.PackSortKey( layer, blend, order );
+
+	[TestMethod]
+	public void SpritesWithNoSortingSetUpCompareEqual()
+	{
+		// Existing content has no layer or order, so every such sprite has to pack identically and
+		// leave the distance term to decide - exactly the behaviour before sorting existed.
+		Assert.AreEqual( Pack( 0, 0 ), Pack( 0, 0 ) );
+
+		// And it must sit at the bottom of its blend state's range, so anything explicitly ordered
+		// rises above it.
+		Assert.AreEqual( Pack( 0, short.MinValue ), Pack( 0, 0 ) & 0xFFFF0000u );
+	}
+
+	[TestMethod]
+	public void LayerOutranksOrder()
+	{
+		// A higher layer beats any order within a lower layer, however extreme.
+		Assert.IsTrue( Pack( 1, short.MinValue ) > Pack( 0, short.MaxValue ) );
+	}
+
+	[TestMethod]
+	public void OrderIsMonotonicWithinLayer()
+	{
+		int[] orders = [short.MinValue, -1000, -1, 0, 1, 1000, short.MaxValue];
+
+		for ( int i = 1; i < orders.Length; i++ )
+		{
+			Assert.IsTrue( Pack( 5, orders[i - 1] ) < Pack( 5, orders[i] ),
+				$"order {orders[i - 1]} should pack below {orders[i]}" );
+		}
+	}
+
+	[TestMethod]
+	public void NegativeOrderSortsBelowZero()
+	{
+		// The signed-to-unsigned bias exists for this case, so test it on its own.
+		Assert.IsTrue( Pack( 3, -1 ) < Pack( 3, 0 ) );
+	}
+
+	[TestMethod]
+	public void LayerIsMonotonic()
+	{
+		int[] layers = [0, 1, 2, 255, 256, 1000, ushort.MaxValue];
+
+		for ( int i = 1; i < layers.Length; i++ )
+		{
+			Assert.IsTrue( Pack( layers[i - 1], 0 ) < Pack( layers[i], 0 ),
+				$"layer {layers[i - 1]} should pack below {layers[i]}" );
+		}
+	}
+
+	[TestMethod]
+	public void OutOfRangeValuesClamp()
+	{
+		// Clamping rather than wrapping - a wrapped key would sort an extreme value to the
+		// opposite end of the scene, which is the worst possible failure.
+		Assert.AreEqual( Pack( 0, short.MinValue ), Pack( 0, int.MinValue ) );
+		Assert.AreEqual( Pack( 0, short.MaxValue ), Pack( 0, int.MaxValue ) );
+		Assert.AreEqual( Pack( 0, 0 ), Pack( int.MinValue, 0 ) );
+	}
+
+	[TestMethod]
+	public void PackingIsUniqueAcrossTheGrid()
+	{
+		var seen = new HashSet<uint>();
+
+		for ( int layer = 0; layer < 40; layer++ )
+		{
+			for ( int order = -20; order <= 20; order++ )
+			{
+				Assert.IsTrue( seen.Add( Pack( layer, order ) ),
+					$"layer {layer} order {order} collided with another key" );
+			}
+		}
+	}
+
+	[TestMethod]
+	public void LayerOutranksBlendMode()
+	{
+		// Blend state groups sprites into drawable runs, but it must never override a layer -
+		// otherwise every additive sprite in the scene would jump in front of every ordinary one.
+		Assert.IsTrue( Pack( 1, 0, SpriteBlendMode.Opaque ) > Pack( 0, 0, SpriteBlendMode.Additive ) );
+	}
+
+	[TestMethod]
+	public void BlendModeOutranksOrderWithinALayer()
+	{
+		// The trade the renderer forces: sprites needing different blend states cannot share a
+		// draw call, so within one layer they are grouped by blend before order is considered.
+		Assert.IsTrue( Pack( 2, short.MinValue, SpriteBlendMode.Additive ) > Pack( 2, short.MaxValue, SpriteBlendMode.Transparent ) );
+	}
+
+	[TestMethod]
+	public void BlendModesGroupIntoContiguousRuns()
+	{
+		// Each blend state has to occupy one unbroken run of the key space, or a run could not be
+		// drawn as a single call over a contiguous range.
+		//
+		// int, not var: var would infer short here, and short arithmetic wraps silently at 32767
+		// rather than throwing - which turns this into an infinite loop.
+		for ( int order = short.MinValue; order < short.MaxValue; order += 4096 )
+		{
+			Assert.IsTrue( Pack( 7, order, SpriteBlendMode.Opaque ) < Pack( 7, short.MinValue, SpriteBlendMode.Transparent ) );
+			Assert.IsTrue( Pack( 7, order, SpriteBlendMode.Transparent ) < Pack( 7, short.MinValue, SpriteBlendMode.Additive ) );
+		}
+	}
+
+	// The compute shader inverts the packed key, because the pixel shader walks the sort LUT
+	// backwards. Getting this backwards would put the front layer at the back.
+	static uint Coarse( int layer, int order, SpriteBlendMode blend = SpriteBlendMode.Transparent ) => ~Pack( layer, order, blend );
+
+	[TestMethod]
+	public void InvertedKeyPutsHigherLayersInFront()
+	{
+		// Drawn back to front, so "in front" means a smaller sorted key.
+		Assert.IsTrue( Coarse( 2, 0 ) < Coarse( 1, 0 ) );
+		Assert.IsTrue( Coarse( 1, 10 ) < Coarse( 1, 9 ) );
+	}
+
+	// Mirror of FloatToSortableUint in sprite_cs.shader. The GPU compares distances as unsigned
+	// integers so they can share a comparison with the packed key, and that mapping has to
+	// preserve float ordering across the sign boundary.
+	static uint FloatToSortableUint( float value )
+	{
+		var bits = BitConverter.SingleToUInt32Bits( value );
+		return (bits & 0x80000000u) != 0 ? ~bits : bits | 0x80000000u;
+	}
+
+	[TestMethod]
+	public void FloatMappingPreservesOrder()
+	{
+		float[] values = [-1e30f, -1000f, -1f, -0.001f, 0f, 0.001f, 1f, 1000f, 1e30f];
+
+		for ( int i = 1; i < values.Length; i++ )
+		{
+			Assert.IsTrue( FloatToSortableUint( values[i - 1] ) < FloatToSortableUint( values[i] ),
+				$"{values[i - 1]} should map below {values[i]}" );
+		}
+	}
+
+	// Only CustomAxis sorts along an axis. Every other mode has to resolve to zero, because the
+	// shader reads a zero axis as "use camera depth" - that fallback is what keeps existing
+	// cameras rendering unchanged.
+	[TestMethod]
+	public void OnlyCustomAxisModeResolvesAnAxis()
+	{
+		var axis = new Vector3( 0, 1, 0 );
+
+		Assert.AreEqual( Vector3.Zero, CameraComponent.ResolveSortAxis( TransparencySortMode.Default, axis ) );
+		Assert.AreEqual( Vector3.Zero, CameraComponent.ResolveSortAxis( TransparencySortMode.Perspective, axis ) );
+		Assert.AreEqual( Vector3.Zero, CameraComponent.ResolveSortAxis( TransparencySortMode.Orthographic, axis ) );
+		Assert.AreEqual( axis, CameraComponent.ResolveSortAxis( TransparencySortMode.CustomAxis, axis ) );
+	}
+
+	[TestMethod]
+	public void SortAxisIsNormalized()
+	{
+		// Length would otherwise scale every distance, which changes nothing about the ordering
+		// but makes the numbers meaningless to anyone reading them back.
+		var resolved = CameraComponent.ResolveSortAxis( TransparencySortMode.CustomAxis, new Vector3( 0, 12, 0 ) );
+
+		Assert.AreEqual( 1f, resolved.Length, 0.0001f );
+	}
+
+	[TestMethod]
+	public void ZeroSortAxisStaysZeroRatherThanBecomingNaN()
+	{
+		// A camera switched to CustomAxis before an axis is typed in. Degrading to camera depth is
+		// survivable; a NaN axis would poison every key in the batch.
+		var resolved = CameraComponent.ResolveSortAxis( TransparencySortMode.CustomAxis, Vector3.Zero );
+
+		Assert.AreEqual( Vector3.Zero, resolved );
+		Assert.IsFalse( float.IsNaN( resolved.x ) );
+	}
+
+	// Mirror of the fine key in sprite_cs.shader: the depth with its low bits traded away for a
+	// sorting group member's rank.
+	const uint RankMask = 0xFFu;
+
+	static uint Fine( float depth, int rank )
+	{
+		var quantized = FloatToSortableUint( depth ) & ~RankMask;
+		var inverted = RankMask - Math.Min( (uint)rank, RankMask );
+
+		return quantized | inverted;
+	}
+
+	// The full key as the GPU compares it: coarse first, axis distance only as a tiebreak.
+	static (uint Coarse, uint Fine) Key( int layer, int order, float axisDistance, int rank = 0 )
+		=> (Coarse( layer, order ), Fine( axisDistance, rank ));
+
+	static bool DrawsInFrontOf( (uint Coarse, uint Fine) a, (uint Coarse, uint Fine) b )
+		=> a.Coarse != b.Coarse ? a.Coarse < b.Coarse : a.Fine < b.Fine;
+
+	[TestMethod]
+	public void HigherAlongSortAxisDrawsBehind()
+	{
+		// The whole point of Y-sorting: a character lower on the screen walks in front of one
+		// higher up. Same layer, same order, so only the axis distance decides.
+		var nearer = Key( 0, 0, axisDistance: 10f );
+		var further = Key( 0, 0, axisDistance: 90f );
+
+		Assert.IsTrue( DrawsInFrontOf( nearer, further ) );
+	}
+
+	[TestMethod]
+	public void SortAxisWorksAcrossTheOrigin()
+	{
+		// Unlike camera distance, an axis dot product is signed - sprites on the far side of the
+		// world origin produce negative distances and still have to order correctly.
+		var below = Key( 0, 0, axisDistance: -500f );
+		var above = Key( 0, 0, axisDistance: 500f );
+
+		Assert.IsTrue( DrawsInFrontOf( below, above ) );
+	}
+
+	[TestMethod]
+	public void SortLayerBeatsSortAxis()
+	{
+		// A sprite explicitly placed in a higher layer must draw in front no matter how far along
+		// the sort axis it sits. If the axis could ever win, layers would be advisory.
+		var highLayerFarBack = Key( 3, 0, axisDistance: 1e6f );
+		var lowLayerFarFront = Key( 0, 0, axisDistance: -1e6f );
+
+		Assert.IsTrue( DrawsInFrontOf( highLayerFarBack, lowLayerFarFront ) );
+	}
+
+	[TestMethod]
+	public void HigherRankDrawsInFrontWithinAGroup()
+	{
+		// Every member of a group resolves to the group's own depth, so rank is the only thing
+		// separating them.
+		var back = Key( 0, 0, axisDistance: 100f, rank: 0 );
+		var front = Key( 0, 0, axisDistance: 100f, rank: 5 );
+
+		Assert.IsTrue( DrawsInFrontOf( front, back ) );
+	}
+
+	// The property sorting groups exist for: nothing from outside a group may be drawn in between
+	// its members. This is the test that would catch the rank bits being too few, or the depth
+	// quantization being finer than the rank field.
+	[TestMethod]
+	public void OutsideSpriteCannotLandBetweenGroupMembers()
+	{
+		const float groupDepth = 500f;
+
+		var first = Key( 0, 0, groupDepth, rank: 0 );
+		var last = Key( 0, 0, groupDepth, rank: 20 );
+
+		// Depths within the group's own quantization bucket are the dangerous ones - anything
+		// further away is separated by the depth term and was never a risk.
+		float[] nearbyDepths = [groupDepth, groupDepth + 0.001f, groupDepth - 0.001f, groupDepth + 0.01f];
+
+		foreach ( var depth in nearbyDepths )
+		{
+			var outsider = Key( 0, 0, depth, rank: 0 );
+
+			var isBetween = DrawsInFrontOf( outsider, first ) && DrawsInFrontOf( last, outsider );
+
+			Assert.IsFalse( isBetween, $"a sprite at depth {depth} sliced the group apart" );
+		}
+	}
+
+	[TestMethod]
+	public void QuantizationNeverReordersSeparatedDepths()
+	{
+		// Trading the low bits away may make two near-equal depths tie, but it must never swap
+		// them. Anything coarser than the quantization step has to survive intact.
+		float[] depths = [-1e5f, -1f, 0f, 1f, 100f, 1e5f];
+
+		for ( var i = 1; i < depths.Length; i++ )
+		{
+			Assert.IsTrue( Fine( depths[i - 1], 0 ) <= Fine( depths[i], 0 ),
+				$"depth {depths[i - 1]} must not quantize above {depths[i]}" );
+		}
+	}
+
+	[TestMethod]
+	public void RanksBeyondTheLastRungShareIt()
+	{
+		// Groups larger than the rank field degrade to a tie rather than wrapping around, which
+		// would otherwise send the 256th member to the very back of the group.
+		var last = Key( 0, 0, 10f, rank: SortingGroup.MaxRank );
+		var overflow = Key( 0, 0, 10f, rank: SortingGroup.MaxRank + 50 );
+
+		Assert.AreEqual( last.Fine, overflow.Fine );
+		Assert.IsFalse( DrawsInFrontOf( overflow, last ) );
+	}
+
+	[TestMethod]
+	public void UngroupedSpritesAllShareTheBottomRung()
+	{
+		// Rank 0 is what every ungrouped sprite gets, so the rank bits must be a constant for
+		// them and leave the depth entirely in charge.
+		Assert.AreEqual( Fine( 42f, 0 ) & RankMask, Fine( 99f, 0 ) & RankMask );
+	}
+}

--- a/game/addons/base/Assets/shaders/sort_cs.shader
+++ b/game/addons/base/Assets/shaders/sort_cs.shader
@@ -23,10 +23,14 @@ CS
 	#define GROUP_SIZE 256
 	#define MAX_DIM_GROUPS 1024
 	#define MAX_DIM_THREADS ( GROUP_SIZE * MAX_DIM_GROUPS )
-	#define FLT_MAX 3.402823466e+38f;
+	// Sorts after every real sprite, so padding entries end up outside the drawn range.
+	#define SORTKEY_MAX uint2( 0xFFFFFFFFu, 0xFFFFFFFFu )
 
 	RWStructuredBuffer<uint> SortBuffer < Attribute( "SortBuffer" ); >;
-	RWStructuredBuffer<float> DistanceBuffer < Attribute( "DistanceBuffer" ); >;
+
+	// Sort keys are compared lexicographically: .x is the coarse key (sort layer and order in
+	// layer, packed and inverted), .y is the fine key (sort axis distance, made unsigned-comparable).
+	RWStructuredBuffer<uint2> SortKeyBuffer < Attribute( "SortKeyBuffer" ); >;
 	int Count < Attribute( "Count" ); >;
 	int Block < Attribute( "Block" ); >;
 	int Dim < Attribute( "Dim" ); >;
@@ -44,7 +48,7 @@ CS
 				return;
 
 			SortBuffer[currentIndex] = currentIndex;
-			DistanceBuffer[currentIndex] = FLT_MAX;
+			SortKeyBuffer[currentIndex] = SORTKEY_MAX;
 		}
 		#else
 		{
@@ -55,13 +59,17 @@ CS
 			uint indexA = SortBuffer[currentIndex];
 			uint indexB = SortBuffer[compareIndex];
 
-			float distanceA = DistanceBuffer[indexA];
-			float distanceB = DistanceBuffer[indexB];
+			uint2 keyA = SortKeyBuffer[indexA];
+			uint2 keyB = SortKeyBuffer[indexB];
+
+			// Lexicographic: the fine key only breaks ties in the coarse key.
+			// Equal keys must not swap, so compare both directions explicitly.
+			bool greater = ( keyA.x != keyB.x ) ? ( keyA.x > keyB.x ) : ( keyA.y > keyB.y );
+			bool less = ( keyA.x != keyB.x ) ? ( keyA.x < keyB.x ) : ( keyA.y < keyB.y );
 
 			bool ascending = ( currentIndex & Dim ) == 0;
-			float comparison = ( distanceA - distanceB ) * ( ascending ? 1 : -1 );
 
-			if ( comparison > 0 )
+			if ( ascending ? greater : less )
 			{
 				SortBuffer[currentIndex] = indexB;
 				SortBuffer[compareIndex] = indexA;

--- a/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
@@ -88,6 +88,13 @@ CS
 	#define SPRITE_SORT_CUSTOM_AXIS 3
 
 	int SpriteCount < Attribute( "SpriteCount"); >;
+
+	// How many entries SpriteBufferOut and SortKeyBuffer actually hold. Larger than SpriteCount -
+	// the batch is sized for the motion blur trails too, and rounded up to a power of two. Needed
+	// because the splot writes below are placed by a running atomic counter rather than by thread
+	// index, so nothing else bounds them.
+	int BufferCapacity < Attribute( "BufferCapacity" ); >;
+
 	RWStructuredBuffer<int> AtomicCounter < Attribute( "AtomicCounter" ); >;
 
 	// Motion blur
@@ -251,10 +258,15 @@ CS
 			SortKeyBuffer[i] = CalculateSortKey(sprite.SortKey, sprite.Position, sprite.SortOriginOffset, sprite.SortRank);
 			SpriteBufferOut[i] = sprite;
 		}
-		else
-		{
-			SortKeyBuffer[i] = SORTKEY_MAX;
-		}
+
+		// Nothing is written for the idle threads. The dispatch is rounded up to a whole group, so
+		// a scene with two sprites still starts 64 threads, while the key buffer only holds as many
+		// entries as the batch was sized for - 16 at the smallest. Padding the tail from here ran
+		// off the end of the buffer, and the stray writes landed on whatever followed it.
+		//
+		// The padding still happens, just where the buffer's size is actually known: sort_cs fills
+		// the whole thing with SORTKEY_MAX in its D_CLEAR pass, which is dispatched just before this
+		// shader and under the same condition that makes these keys get read at all.
 
 		int writeSize = 0;
 		int splotCount = 0;
@@ -327,9 +339,16 @@ CS
 					pos += moveStep;
 
 					b.Position = pos;
-					// We fill the sort key buffer for sorting
-					SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
-					SpriteBufferOut[writeLocation] = b;
+
+					// Placed by the atomic counter, so the only thing keeping this inside the
+					// buffer is the counter agreeing with how the batch was sized. Checked rather
+					// than assumed - overrunning a UAV here hangs the GPU rather than failing.
+					if ( writeLocation < (uint)BufferCapacity )
+					{
+						// We fill the sort key buffer for sorting
+						SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
+						SpriteBufferOut[writeLocation] = b;
+					}
 
 					index++;
 				}
@@ -338,11 +357,14 @@ CS
 				spritePosition -= moveStep;
 				b.Position = spritePosition;
 
-				// Fill the sort key buffer for sorting
 				writeLocation = writeOffset + index;
-				SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
 
-				SpriteBufferOut[writeLocation] = b;
+				if ( writeLocation < (uint)BufferCapacity )
+				{
+					// Fill the sort key buffer for sorting
+					SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
+					SpriteBufferOut[writeLocation] = b;
+				}
 
 				index++;
 			}

--- a/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
@@ -63,13 +63,29 @@ CS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
+		uint SortKey;
+		float3 SortOriginOffset;
+		uint SortRank;
 	};
 	StructuredBuffer<SpriteData> SpriteBuffer < Attribute( "Sprites" ); >;
 	RWStructuredBuffer<SpriteData> SpriteBufferOut < Attribute( "SpriteBufferOut" ); >;
 
 	// Sorting related
-	RWStructuredBuffer<float> DistanceBuffer < Attribute( "DistanceBuffer" ); >;
+	RWStructuredBuffer<uint2> SortKeyBuffer < Attribute( "SortKeyBuffer" ); >;
 	float3 CameraPosition < Attribute ("CameraPosition"); >;
+
+	// How the fine half of the sort key is measured. Matches TransparencySortMode on the camera.
+	// Defaults to 0 (Default) when unset, which is the behaviour from before sort modes existed.
+	int SpriteSortMode < Attribute( "SpriteSortMode" ); >;
+
+	// Only set in CustomAxis mode, and always normalized. Left at zero otherwise, which every
+	// path below treats as "no axis given, sort by camera depth".
+	float3 SpriteSortAxis < Attribute( "SpriteSortAxis" ); >;
+
+	#define SPRITE_SORT_DEFAULT 0
+	#define SPRITE_SORT_PERSPECTIVE 1
+	#define SPRITE_SORT_ORTHOGRAPHIC 2
+	#define SPRITE_SORT_CUSTOM_AXIS 3
 
 	int SpriteCount < Attribute( "SpriteCount"); >;
 	RWStructuredBuffer<int> AtomicCounter < Attribute( "AtomicCounter" ); >;
@@ -130,6 +146,7 @@ CS
 	}
 
 	#define FLT_MAX 3.402823466e+38f
+	#define SORTKEY_MAX uint2( 0xFFFFFFFFu, 0xFFFFFFFFu )
 
 	groupshared int groupWriteSize[64];
     groupshared int groupWriteOffset[64];
@@ -141,13 +158,71 @@ CS
 	{
 		float3 delta = (worldPosition - CameraPosition);
 
-		// Check if orthographic
-		if ( g_matViewToProjection[3].w != 0.0f )
+		bool isOrthographic = g_matViewToProjection[3].w != 0.0f;
+
+		// The projection decides only in Default mode; the other two modes name a measure outright.
+		bool useViewDepth = ( SpriteSortMode == SPRITE_SORT_ORTHOGRAPHIC ) ||
+			( SpriteSortMode == SPRITE_SORT_DEFAULT && isOrthographic );
+
+		if ( useViewDepth )
 		{
 			return dot( delta, g_vCameraDirWs.xyz );
 		}
 
 		return dot(delta, delta);
+	}
+
+	// The value the fine half of the sort key is built from. Larger means further back.
+	float CalculateSortDepth(float3 worldPosition)
+	{
+		// A zero axis means the mode never supplied one, so there is nothing to sort along and
+		// camera depth is the only sensible answer. This is also what keeps a camera that has
+		// never been told about sort modes rendering exactly as it always did.
+		if ( SpriteSortMode == SPRITE_SORT_CUSTOM_AXIS && any( SpriteSortAxis != 0.0f ) )
+		{
+			// Position along the axis, with no reference to the camera at all - that is the whole
+			// point. Further along the axis sorts larger, so it draws first and ends up behind.
+			return dot( worldPosition, SpriteSortAxis );
+		}
+
+		return CalculateDistance( worldPosition );
+	}
+
+	// Maps a float onto a uint whose unsigned ordering matches the float's signed ordering,
+	// so distances can be compared alongside the integer part of the key.
+	uint FloatToSortableUint( float value )
+	{
+		uint bits = asuint( value );
+
+		// Negative floats compare in reverse as raw bits, so flip them entirely.
+		// Positive floats only need their sign bit set to sort above every negative.
+		return ( bits & 0x80000000u ) ? ~bits : ( bits | 0x80000000u );
+	}
+
+	// The bottom of the fine key is given over to a sorting group member's rank. 8 bits leaves
+	// 15 bits of float mantissa for the depth, which is finer than a sprite's own size at any
+	// sane world scale. Must match SortingGroup.MaxRank on the CPU.
+	#define SPRITE_SORT_RANK_MASK 0xFFu
+
+	// Sprites are drawn back-to-front - the pixel shader walks the sort LUT in reverse - so a
+	// LARGER key is drawn EARLIER, further back. The coarse key is therefore inverted: a higher
+	// sort layer or order has to draw LATER, which means it has to sort SMALLER.
+	uint2 CalculateSortKey( uint packedSortKey, float3 worldPosition, float3 sortOriginOffset, uint sortRank )
+	{
+		// Zero offset means the sprite sorts where it is; a sorting group moves every one of its
+		// members onto the group's own origin so they resolve to a single depth.
+		float depth = CalculateSortDepth( worldPosition + sortOriginOffset );
+
+		// Trading the low bits of the depth away for the rank is a monotonic quantization: it can
+		// only make two near-equal depths tie, never reorder them. And a tie is precisely where
+		// the group's own ordering should be taking over anyway.
+		uint quantized = FloatToSortableUint( depth ) & ~SPRITE_SORT_RANK_MASK;
+
+		// Inverted for the same reason as the coarse key - a higher rank draws later, so it has
+		// to sort smaller. Ungrouped sprites are rank 0 and all land on the same bottom rung.
+		uint rank = SPRITE_SORT_RANK_MASK - min( sortRank, SPRITE_SORT_RANK_MASK );
+
+		return uint2( ~packedSortKey, quantized | rank );
 	}
 
 	[numthreads( 64, 1, 1 ) ]
@@ -173,12 +248,12 @@ CS
 			}
 
 
-			DistanceBuffer[i] = CalculateDistance(sprite.Position);
+			SortKeyBuffer[i] = CalculateSortKey(sprite.SortKey, sprite.Position, sprite.SortOriginOffset, sprite.SortRank);
 			SpriteBufferOut[i] = sprite;
 		}
 		else
 		{
-			DistanceBuffer[i] = FLT_MAX;
+			SortKeyBuffer[i] = SORTKEY_MAX;
 		}
 
 		int writeSize = 0;
@@ -252,8 +327,8 @@ CS
 					pos += moveStep;
 
 					b.Position = pos;
-					// We fill distance buffer for sorting
-					DistanceBuffer[writeLocation] = CalculateDistance(b.Position);
+					// We fill the sort key buffer for sorting
+					SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
 					SpriteBufferOut[writeLocation] = b;
 
 					index++;
@@ -263,9 +338,9 @@ CS
 				spritePosition -= moveStep;
 				b.Position = spritePosition;
 
-				// Fil distance buffer for sorting
+				// Fill the sort key buffer for sorting
 				writeLocation = writeOffset + index;
-				DistanceBuffer[writeLocation] = CalculateDistance(b.Position);
+				SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
 
 				SpriteBufferOut[writeLocation] = b;
 

--- a/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
@@ -54,6 +54,9 @@ COMMON
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
+		uint SortKey;
+		float3 SortOriginOffset;
+		uint SortRank;
 	};
 
 	StructuredBuffer<SpriteData> Sprites < Attribute( "Sprites" ); >;
@@ -61,12 +64,19 @@ COMMON
 	int IsSorted < Attribute( "IsSorted" ); >;
 	int CurrentBufferSize < Attribute( "SpriteCount" ); >;
 
+	// Where in the draw order this call starts. A batch holding more than one blend state is drawn
+	// as several calls, each covering one run of the sorted order, so the instance id is relative
+	// to the run rather than to the whole batch.
+	int SortLUTOffset < Attribute( "SortLUTOffset" ); >;
+
 	SpriteData GetSprite( uint index )
 	{
 		int spriteIndex = index;
 		if ( IsSorted == 1 )
 		{
-			spriteIndex = SortLUT[CurrentBufferSize - 1 - index];
+			// The table is walked from the end because sprites are drawn back to front, and the
+			// furthest away sorts largest.
+			spriteIndex = SortLUT[CurrentBufferSize - 1 - index - SortLUTOffset];
 		}
 		return Sprites[spriteIndex];
 	}

--- a/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
+++ b/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Linq;
+
+namespace Editor;
+
+/// <summary>
+/// Picks one of the project's sprite sort layers. Offers a way through to the layer editor
+/// inline, so needing a new layer doesn't mean going hunting through project settings.
+/// </summary>
+[CustomEditor( typeof( SortLayerHandle ), NamedEditor = "sortlayer" )]
+public class SortLayerControlWidget : ControlWidget
+{
+	public SortLayerControlWidget( SerializedProperty property ) : base( property )
+	{
+		Layout = Layout.Column();
+		Layout.Spacing = 2;
+		AcceptDrops = false;
+
+		Rebuild();
+	}
+
+	void Rebuild()
+	{
+		Layout.Clear( true );
+
+		var settings = ProjectSettings.Sorting;
+		var current = SerializedProperty.GetValue<SortLayerHandle>();
+
+		var comboBox = new ComboBox( this );
+
+		foreach ( var layer in settings.Layers )
+		{
+			// Captured per iteration so each entry writes back its own id.
+			var id = layer.Id;
+
+			comboBox.AddItem( layer.Name,
+				onSelected: () => SerializedProperty.SetValue( new SortLayerHandle( id ) ),
+				selected: current.Id == id || (current.Id == Guid.Empty && layer == settings.DefaultLayer) );
+		}
+
+		comboBox.AddItem( "Edit Layers…", "tune", onSelected: OpenLayerEditor );
+
+		Layout.Add( comboBox );
+
+		AddUnsortedWarning();
+		AddGroupWarnings();
+	}
+
+	/// <summary>
+	/// The two ways a sorting group silently does nothing: it is nested inside another one, or its
+	/// sprites never opted into sorting. Both look identical from the viewport - the group is
+	/// simply ignored - so neither is discoverable without being told.
+	/// </summary>
+	void AddGroupWarnings()
+	{
+		if ( SerializedProperty.Parent?.Targets.FirstOrDefault() is not SortingGroup group ) return;
+
+		if ( group.IsNested )
+		{
+			Layout.Add( new Label( "Inside another Sorting Group - the inner group wins, and this one will not see these sprites." )
+			{
+				Color = Theme.Yellow,
+				WordWrap = true
+			} );
+		}
+
+		if ( group.MemberCount == 0 )
+		{
+			Layout.Add( new Label( "No Sprite Renderers beneath this object, so this group has nothing to order." )
+			{
+				Color = Theme.Yellow,
+				WordWrap = true
+			} );
+		}
+	}
+
+	/// <summary>
+	/// Sorting does nothing at all while Is Sorted is off, and it is off by default. Without this,
+	/// the most likely first experience of the feature is picking a layer and seeing no change.
+	/// </summary>
+	void AddUnsortedWarning()
+	{
+		if ( !TryGetIsSorted( out var isSorted ) || isSorted ) return;
+
+		var fix = new Button.Primary( "Enable sorting on this sprite", "sort" );
+		fix.ToolTip = "Sort layers and sort order are ignored until Is Sorted is enabled.";
+		fix.Clicked = EnableSorting;
+
+		Layout.Add( new Label( "Is Sorted is off - this layer is being ignored." )
+		{
+			Color = Theme.Yellow
+		} );
+
+		Layout.Add( fix );
+	}
+
+	bool TryGetIsSorted( out bool value )
+	{
+		value = false;
+
+		if ( SerializedProperty.Parent is not { } parent ) return false;
+		if ( !parent.TryGetProperty( "IsSorted", out var property ) ) return false;
+
+		// With several sprites selected, GetValue only reports the first one. The warning is about
+		// sorting silently doing nothing, so it has to appear if *any* of them has it switched off.
+		if ( property.IsMultipleValues )
+		{
+			value = property.MultipleProperties.All( p => p.GetValue<bool>() );
+			return true;
+		}
+
+		value = property.GetValue<bool>();
+		return true;
+	}
+
+	void EnableSorting()
+	{
+		if ( SerializedProperty.Parent is not { } parent ) return;
+		if ( !parent.TryGetProperty( "IsSorted", out var property ) ) return;
+
+		property.SetValue( true );
+
+		Rebuild();
+	}
+
+	static void OpenLayerEditor()
+	{
+		var project = Project.Current;
+		if ( project is null ) return;
+
+		ProjectSettingsWindow.OpenForProject( project );
+	}
+
+	protected override int ValueHash
+	{
+		get
+		{
+			var hc = new HashCode();
+			hc.Add( base.ValueHash );
+
+			// Rebuild when layers are added, removed, renamed or reordered.
+			hc.Add( ProjectSettings.Sorting.GetHashCode() );
+
+			// Rebuild when Is Sorted is toggled, so the warning appears and clears with it.
+			hc.Add( TryGetIsSorted( out var isSorted ) && isSorted );
+
+			return hc.ToHashCode();
+		}
+	}
+
+	protected override void OnValueChanged()
+	{
+		Rebuild();
+	}
+
+	protected override void OnPaint()
+	{
+		// Combo box paints itself
+	}
+}

--- a/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
+++ b/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
@@ -10,6 +10,22 @@ namespace Editor;
 [CustomEditor( typeof( SortLayerHandle ), NamedEditor = "sortlayer" )]
 public class SortLayerControlWidget : ControlWidget
 {
+	/// <summary>
+	/// Picking a layer writes that one layer to every selected object, which is what multi-editing
+	/// this should mean. Without this the whole row is replaced by "Multi Edit Not Supported" and a
+	/// selection cannot be given a layer at all.
+	/// </summary>
+	public override bool SupportsMultiEdit => true;
+
+	/// <summary>
+	/// Set while the combo box is being filled in. Adding an entry with <c>selected</c> assigns
+	/// CurrentIndex, and that reaches the item's action whether or not anybody picked it - so
+	/// without this a rebuild can write a layer to the whole selection on its own. On a
+	/// multi-selection that would quietly copy the first object's layer over all the others, which
+	/// is the same way the sprite texture used to get aliased.
+	/// </summary>
+	bool _building;
+
 	public SortLayerControlWidget( SerializedProperty property ) : base( property )
 	{
 		Layout = Layout.Column();
@@ -21,12 +37,37 @@ public class SortLayerControlWidget : ControlWidget
 
 	void Rebuild()
 	{
+		_building = true;
+
+		try
+		{
+			RebuildLayout();
+		}
+		finally
+		{
+			_building = false;
+		}
+	}
+
+	void RebuildLayout()
+	{
 		Layout.Clear( true );
 
 		var settings = ProjectSettings.Sorting;
+
+		// GetValue only reports the first selected object, so it only describes the selection when
+		// they all agree.
+		var mixed = SerializedProperty.IsMultipleDifferentValues;
 		var current = SerializedProperty.GetValue<SortLayerHandle>();
 
 		var comboBox = new ComboBox( this );
+
+		if ( mixed )
+		{
+			// Nothing else is pre-selected in this case, and an empty selection makes the combo
+			// settle on the first layer - which would read as though everything already shared it.
+			comboBox.AddItem( "Multiple Values", onSelected: () => { }, selected: true );
+		}
 
 		foreach ( var layer in settings.Layers )
 		{
@@ -34,8 +75,8 @@ public class SortLayerControlWidget : ControlWidget
 			var id = layer.Id;
 
 			comboBox.AddItem( layer.Name,
-				onSelected: () => SerializedProperty.SetValue( new SortLayerHandle( id ) ),
-				selected: current.Id == id || (current.Id == Guid.Empty && layer == settings.DefaultLayer) );
+				onSelected: () => SetLayer( id ),
+				selected: !mixed && (current.Id == id || (current.Id == Guid.Empty && layer == settings.DefaultLayer)) );
 		}
 
 		comboBox.AddItem( "Edit Layers…", "tune", onSelected: OpenLayerEditor );
@@ -46,6 +87,13 @@ public class SortLayerControlWidget : ControlWidget
 		AddGroupWarnings();
 	}
 
+	void SetLayer( Guid id )
+	{
+		if ( _building ) return;
+
+		SerializedProperty.SetValue( new SortLayerHandle( id ) );
+	}
+
 	/// <summary>
 	/// The two ways a sorting group silently does nothing: it is nested inside another one, or its
 	/// sprites never opted into sorting. Both look identical from the viewport - the group is
@@ -53,26 +101,43 @@ public class SortLayerControlWidget : ControlWidget
 	/// </summary>
 	void AddGroupWarnings()
 	{
-		if ( SerializedProperty.Parent?.Targets.FirstOrDefault() is not SortingGroup group ) return;
+		// Every selected group, not just the first. These warn about a group silently doing nothing,
+		// so one bad group in a selection is still worth saying out loud.
+		var groups = SerializedProperty.Parent?.Targets.OfType<SortingGroup>().ToList();
+		if ( groups is not { Count: > 0 } ) return;
 
-		if ( group.IsNested )
+		var nested = groups.Count( x => x.IsNested );
+		var empty = groups.Count( x => x.MemberCount == 0 );
+
+		if ( nested > 0 )
 		{
-			Layout.Add( new Label( "Inside another Sorting Group - the inner group wins, and this one will not see these sprites." )
+			Layout.Add( new Label( groups.Count > 1
+				? $"{Describe( nested, groups.Count )} are inside another Sorting Group - the inner group wins, and the outer one will not see those sprites."
+				: "Inside another Sorting Group - the inner group wins, and this one will not see these sprites." )
 			{
 				Color = Theme.Yellow,
 				WordWrap = true
 			} );
 		}
 
-		if ( group.MemberCount == 0 )
+		if ( empty > 0 )
 		{
-			Layout.Add( new Label( "No Sprite Renderers beneath this object, so this group has nothing to order." )
+			Layout.Add( new Label( groups.Count > 1
+				? $"{Describe( empty, groups.Count )} have no Sprite Renderers beneath them, so they have nothing to order."
+				: "No Sprite Renderers beneath this object, so this group has nothing to order." )
 			{
 				Color = Theme.Yellow,
 				WordWrap = true
 			} );
 		}
 	}
+
+	/// <summary>
+	/// Names how much of a selection a warning applies to, so it is clear whether it is about all of
+	/// them or only some.
+	/// </summary>
+	static string Describe( int matching, int total )
+		=> matching == total ? $"All {total} selected groups" : $"{matching} of {total} selected groups";
 
 	/// <summary>
 	/// Sorting does nothing at all while Is Sorted is off, and it is off by default. Without this,
@@ -82,13 +147,21 @@ public class SortLayerControlWidget : ControlWidget
 	{
 		if ( !TryGetIsSorted( out var isSorted ) || isSorted ) return;
 
-		var fix = new Button.Primary( "Enable sorting on this sprite", "sort" );
+		// EnableSorting writes to every selected object, so the button has to say that rather than
+		// claim it only touches one of them.
+		var total = SerializedProperty.MultipleProperties.Count();
+		var many = total > 1;
+
+		var fix = new Button.Primary( many ? $"Enable sorting on all {total} sprites" : "Enable sorting on this sprite", "sort" );
 		fix.ToolTip = "Sort layers and sort order are ignored until Is Sorted is enabled.";
 		fix.Clicked = EnableSorting;
 
-		Layout.Add( new Label( "Is Sorted is off - this layer is being ignored." )
+		Layout.Add( new Label( many
+			? "Is Sorted is off on at least one of these - the layer is being ignored there."
+			: "Is Sorted is off - this layer is being ignored." )
 		{
-			Color = Theme.Yellow
+			Color = Theme.Yellow,
+			WordWrap = true
 		} );
 
 		Layout.Add( fix );

--- a/game/addons/tools/Code/Editor/ProjectSettings/ProjectSettingsWindow.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/ProjectSettingsWindow.cs
@@ -175,6 +175,8 @@ internal sealed class ProjectSettingsWindow : Window
 
 			AddCategoryToList( typeof( PhysicsCategory ), "Physics" );
 
+			AddCategoryToList( typeof( SortingCategory ), "Rendering" );
+
 			AddCategoryToList( typeof( InputCategory ), "Input" );
 
 			AddCategoryToList( typeof( MultiplayerCategory ), "Networking" );

--- a/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerListWidget.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerListWidget.cs
@@ -1,0 +1,125 @@
+namespace Editor.ProjectSettingPages;
+
+/// <summary>
+/// The ordered list of sprite sort layers, back to front.
+/// </summary>
+internal sealed class SortLayerListWidget : Widget
+{
+	public SortingSettings Settings { get; }
+
+	/// <summary>
+	/// Raised whenever a layer is added, removed, renamed or moved.
+	/// </summary>
+	public Action ValueChanged { get; set; }
+
+	private Layout _rows;
+
+	public SortLayerListWidget( SortingSettings settings ) : base( null )
+	{
+		Settings = settings;
+
+		Layout = Layout.Column();
+		Layout.Spacing = 2;
+
+		_rows = Layout.AddColumn();
+		_rows.Spacing = 1;
+
+		var addButton = new Button( "Add Layer", "add" );
+		addButton.Clicked = AddLayer;
+		Layout.AddSpacingCell( 4 );
+		Layout.Add( addButton );
+
+		// Which end of the list is the front is the single most common point of confusion with
+		// layer lists anywhere, so say it outright rather than leaving it to be discovered.
+		Layout.AddSpacingCell( 4 );
+		Layout.Add( new Label( "Drawn first, at the back  →  drawn last, in front" )
+		{
+			Color = Theme.Text.WithAlpha( 0.5f )
+		} );
+
+		Rebuild();
+	}
+
+	public void Rebuild()
+	{
+		_rows.Clear( true );
+
+		foreach ( var layer in Settings.Layers )
+		{
+			_rows.Add( new SortLayerRow( this, layer ) );
+		}
+	}
+
+	public void NotifyChanged()
+	{
+		ValueChanged?.Invoke();
+	}
+
+	private void AddLayer()
+	{
+		// Through the settings rather than the list, so the id lookup is rebuilt with it.
+		Settings.AddLayer( UniqueName( "New Layer" ) );
+
+		NotifyChanged();
+		Rebuild();
+	}
+
+	/// <summary>
+	/// Removes a layer, warning first if any sprite in the open scene still points at it.
+	/// </summary>
+	public void RemoveLayer( SortingSettings.SortLayer layer )
+	{
+		var users = CountUsers( layer );
+
+		if ( users > 0 )
+		{
+			var confirm = new PopupWindow(
+				$"Delete \"{layer.Name}\"?",
+				$"{users} sprite{(users == 1 ? "" : "s")} in the open scene {(users == 1 ? "is" : "are")} using this layer. " +
+				$"They will fall back to \"{Settings.DefaultLayer.Name}\".",
+				"Cancel",
+				new Dictionary<string, Action> { { "Delete", () => DoRemoveLayer( layer ) } } );
+
+			confirm.Show();
+			return;
+		}
+
+		DoRemoveLayer( layer );
+	}
+
+	private void DoRemoveLayer( SortingSettings.SortLayer layer )
+	{
+		// Sprites referencing this id resolve back to the default layer on their own, so there is
+		// nothing to fix up - GetLayerIndex already treats an unknown id as the default.
+		Settings.RemoveLayer( layer );
+
+		NotifyChanged();
+		Rebuild();
+	}
+
+	private static int CountUsers( SortingSettings.SortLayer layer )
+	{
+		var scene = SceneEditorSession.Active?.Scene;
+		if ( scene is null ) return 0;
+
+		var count = 0;
+
+		foreach ( var sprite in scene.GetAllComponents<SpriteRenderer>() )
+		{
+			if ( sprite.SortLayer.Id == layer.Id ) count++;
+		}
+
+		return count;
+	}
+
+	private string UniqueName( string baseName )
+	{
+		if ( Settings.GetLayer( baseName ) is null ) return baseName;
+
+		for ( var i = 2; ; i++ )
+		{
+			var candidate = $"{baseName} {i}";
+			if ( Settings.GetLayer( candidate ) is null ) return candidate;
+		}
+	}
+}

--- a/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerRow.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerRow.cs
@@ -1,0 +1,159 @@
+namespace Editor.ProjectSettingPages;
+
+/// <summary>
+/// One layer in the sort layer list. Draggable, because reordering is the whole point of the list -
+/// the position of a layer is what decides draw order.
+/// </summary>
+internal sealed class SortLayerRow : Widget
+{
+	private readonly SortLayerListWidget _list;
+
+	public SortingSettings.SortLayer Layer { get; }
+
+	private Drag _dragData;
+	private bool _draggingAbove;
+	private bool _draggingBelow;
+
+	public SortLayerRow( SortLayerListWidget list, SortingSettings.SortLayer layer ) : base( null )
+	{
+		_list = list;
+		Layer = layer;
+
+		FixedHeight = 30;
+		Cursor = CursorShape.Finger;
+
+		Layout = Layout.Row();
+		Layout.Margin = new Sandbox.UI.Margin( 24, 3, 4, 3 );
+		Layout.Spacing = 4;
+
+		var nameEntry = new LineEdit( layer.Name );
+		nameEntry.PlaceholderText = "Layer name";
+		nameEntry.TextEdited += OnNameEdited;
+		Layout.Add( nameEntry, 1 );
+
+		// The first layer is what everything falls back to, so it must always exist.
+		if ( !IsDefaultLayer )
+		{
+			var deleteButton = new IconButton( "close" );
+			deleteButton.ToolTip = "Delete";
+			deleteButton.StatusTip = $"Delete sort layer \"{layer.Name}\"";
+			deleteButton.OnClick += () => _list.RemoveLayer( Layer );
+			Layout.Add( deleteButton );
+		}
+		else
+		{
+			Layout.AddSpacingCell( 24 );
+		}
+
+		IsDraggable = true;
+		AcceptDrops = true;
+	}
+
+	private bool IsDefaultLayer => _list.Settings.Layers.IndexOf( Layer ) == 0;
+
+	private void OnNameEdited( string value )
+	{
+		// Renaming is free - sprites reference layers by id, so nothing needs fixing up.
+		Layer.Name = value;
+		_list.NotifyChanged();
+	}
+
+	protected override void OnPaint()
+	{
+		if ( IsUnderMouse )
+		{
+			Paint.SetBrushAndPen( Theme.Highlight.WithAlpha( 0.1f ) );
+			Paint.DrawRect( LocalRect, 3 );
+		}
+
+		if ( _dragData?.IsValid ?? false )
+		{
+			Paint.SetBrushAndPen( Theme.WindowBackground.WithAlpha( 0.5f ) );
+			Paint.DrawRect( LocalRect, 3 );
+		}
+
+		// Drag handle, hinting that the row can be moved without needing a tooltip to say so.
+		Paint.SetPen( Theme.Text.WithAlpha( IsUnderMouse ? 0.6f : 0.3f ) );
+		Paint.DrawIcon( new Rect( 4, 0, 20, LocalRect.Height ), "drag_indicator", 16, TextFlag.Center );
+
+		base.OnPaint();
+
+		if ( _draggingAbove )
+		{
+			Paint.SetPen( Theme.Primary, 2f, PenStyle.Dot );
+			Paint.DrawLine( LocalRect.TopLeft, LocalRect.TopRight );
+			_draggingAbove = false;
+		}
+		else if ( _draggingBelow )
+		{
+			Paint.SetPen( Theme.Primary, 2f, PenStyle.Dot );
+			Paint.DrawLine( LocalRect.BottomLeft, LocalRect.BottomRight );
+			_draggingBelow = false;
+		}
+	}
+
+	protected override void OnDragStart()
+	{
+		base.OnDragStart();
+
+		_dragData = new Drag( this );
+		_dragData.Data.Object = Layer;
+		_dragData.Execute();
+	}
+
+	public override void OnDragHover( DragEvent ev )
+	{
+		base.OnDragHover( ev );
+
+		if ( !TryDragOperation( ev, out var delta ) )
+		{
+			_draggingAbove = false;
+			_draggingBelow = false;
+			return;
+		}
+
+		_draggingAbove = delta > 0;
+		_draggingBelow = delta < 0;
+	}
+
+	public override void OnDragDrop( DragEvent ev )
+	{
+		base.OnDragDrop( ev );
+
+		if ( !TryDragOperation( ev, out var delta ) ) return;
+
+		var index = _list.Settings.Layers.IndexOf( Layer );
+
+		// Through the settings rather than the list: reordering changes what every layer id maps
+		// to, and a stale lookup would silently draw every sprite in the wrong layer.
+		_list.Settings.MoveLayer( index + delta, index );
+
+		_list.NotifyChanged();
+		_list.Rebuild();
+	}
+
+	public override void OnDragLeave()
+	{
+		base.OnDragLeave();
+
+		_draggingAbove = false;
+		_draggingBelow = false;
+	}
+
+	private bool TryDragOperation( DragEvent ev, out int delta )
+	{
+		delta = 0;
+
+		var other = ev.Data.OfType<SortingSettings.SortLayer>().FirstOrDefault();
+		if ( other is null || other == Layer ) return false;
+
+		var layers = _list.Settings.Layers;
+		var myIndex = layers.IndexOf( Layer );
+		var otherIndex = layers.IndexOf( other );
+
+		if ( myIndex < 0 || otherIndex < 0 || myIndex == otherIndex ) return false;
+
+		delta = otherIndex - myIndex;
+		return true;
+	}
+}

--- a/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortingCategory.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortingCategory.cs
@@ -1,0 +1,39 @@
+namespace Editor.ProjectSettingPages;
+
+[Title( "Sorting" ), Icon( "layers" )]
+internal sealed class SortingCategory : ProjectSettingsWindow.Category
+{
+	public override void OnInit( Project project )
+	{
+		var col = BodyLayout.AddColumn();
+		col.Spacing = 8;
+
+		{
+			col.Add( new Label.Header( "Sort Layers" ) );
+
+			var list = col.Add( new SortLayerListWidget( ProjectSettings.Sorting ) );
+			list.ValueChanged = () => StateHasChanged();
+		}
+
+		{
+			col.Add( new InformationBox(
+				"""
+				<p>Sort layers control which sprites draw in front of which, regardless of where they are in the world.</p>
+				<ul style="-qt-list-indent: 0; margin-left: 10px;" >
+					<li>A sprite in a later layer always draws in front of a sprite in an earlier one
+					<li>Within a layer, <b>Sort Order</b> on the Sprite Renderer decides - higher draws on top
+					<li>Sprites with the same layer and order fall back to sorting by depth
+					<li>Sprites only sort at all when <b>Is Sorted</b> is enabled on the renderer
+				</ul>
+				<p>Layers are referenced by identity, so renaming or reordering them will not re-sort anything unexpectedly.</p>
+				""" ) );
+		}
+	}
+
+	public override void OnSave()
+	{
+		EditorUtility.SaveProjectSettings( ProjectSettings.Sorting, "Sorting.config" );
+
+		base.OnSave();
+	}
+}

--- a/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedResourceControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedResourceControlWidget.cs
@@ -35,16 +35,34 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 		// If we're opening the popup editor, we need to ensure that the resource is valid
 		//
 
-		var resource = Resource;
-		if ( resource is null && !SerializedProperty.PropertyType.IsAbstract )
+		if ( !SerializedProperty.PropertyType.IsAbstract )
 		{
-			resource = EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name );
-			SerializedProperty.SetValue( resource );
+			//
+			// One resource per selected object. SerializedProperty.SetValue writes a single instance
+			// to every selected object, which would both alias them together and wipe out any
+			// selection that already had a resource of its own.
+			//
+			foreach ( var target in SerializedProperty.MultipleProperties )
+			{
+				if ( target.GetValue<Resource>( null ) is not null )
+					continue;
+
+				target.SetValue( EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name ) );
+			}
 		}
 
 		SerializedProperty.OnChanged = OnChanged;
 
-		Reset( resource, SerializedProperty );
+		Reset( Resource, SerializedProperty );
+
+		//
+		// Reset only stamps the first selection's resource - the others hold their own instances
+		//
+		foreach ( var target in SerializedProperty.MultipleProperties )
+		{
+			MarkAsEmbedded( target.GetValue<Resource>( null ), target );
+		}
+
 		InitializeInlineEditor();
 	}
 
@@ -58,25 +76,34 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 		//
 		// This can be null if the resource's type is abstract
 		//
-		if ( resource.IsValid() )
-		{
-			var type = Game.TypeLibrary.GetType( resource.GetType() );
-			string typeName = null;
-
-			if ( !property.PropertyType.Equals( type.TargetType ) )
-			{
-				typeName = type.Name;
-			}
-
-			resource.EmbeddedResource = new()
-			{
-				ResourceCompiler = "embed",
-				TypeName = typeName
-			};
-		}
+		MarkAsEmbedded( resource, property );
 
 		_typeDescription = Game.TypeLibrary.GetType( resource.IsValid() ? resource.GetType() : property.PropertyType );
 		_assetType = AssetType.FromType( _typeDescription?.TargetType ?? property.PropertyType );
+	}
+
+	/// <summary>
+	/// Stamp embed info on to a resource. Every selected object holds its own resource instance, so
+	/// this has to be done for each of them individually.
+	/// </summary>
+	private static void MarkAsEmbedded( Resource resource, SerializedProperty property )
+	{
+		if ( !resource.IsValid() )
+			return;
+
+		var type = Game.TypeLibrary.GetType( resource.GetType() );
+		string typeName = null;
+
+		if ( !property.PropertyType.Equals( type.TargetType ) )
+		{
+			typeName = type.Name;
+		}
+
+		resource.EmbeddedResource = new()
+		{
+			ResourceCompiler = "embed",
+			TypeName = typeName
+		};
 	}
 
 	void OnChanged( SerializedProperty prop )
@@ -124,12 +151,18 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 		PropertyStartEdit();
 
 		//
-		// Clean slate
+		// Clean slate - a fresh resource each, so clearing a multi-selection doesn't leave every
+		// selected object sharing one instance
 		//
-		var newResource = EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name );
-		Reset( newResource, SerializedProperty );
+		foreach ( var property in SerializedProperty.MultipleProperties )
+		{
+			var newResource = EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name );
+			MarkAsEmbedded( newResource, property );
 
-		SerializedProperty.SetValue( newResource );
+			property.SetValue( newResource );
+		}
+
+		Reset( Resource, SerializedProperty );
 
 		SignalValuesChanged();
 		PropertyFinishEdit();
@@ -141,9 +174,18 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 	{
 		PropertyStartEdit();
 
-		var resource = EditorTypeLibrary.Create<Resource>( type.Name );
-		Reset( resource, SerializedProperty );
-		SerializedProperty.SetValue( resource );
+		//
+		// One instance per selected object, otherwise they all end up sharing this one
+		//
+		foreach ( var property in SerializedProperty.MultipleProperties )
+		{
+			var resource = EditorTypeLibrary.Create<Resource>( type.Name );
+			MarkAsEmbedded( resource, property );
+
+			property.SetValue( resource );
+		}
+
+		Reset( Resource, SerializedProperty );
 
 		RebuildEditor();
 		SignalValuesChanged();
@@ -277,23 +319,30 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 	{
 		if ( target.PropertyType.IsAbstract ) return null;
 
-		var data = source.Serialize();
+		GameResource first = null;
 
 		//
-		// Create a fresh resource when switching to embedded
+		// Create a fresh resource when switching to embedded - one per selected object, with its own
+		// copy of the data. Sharing a single instance between them means editing any one of them
+		// silently edits all of the others.
 		//
-		var resource = EditorTypeLibrary.Create<GameResource>( target.PropertyType.Name );
-		resource.CopyFrom( source );
-
-		resource.EmbeddedResource = new()
+		foreach ( var property in target.MultipleProperties )
 		{
-			ResourceCompiler = "embed",
-			Data = data
-		};
+			var resource = EditorTypeLibrary.Create<GameResource>( target.PropertyType.Name );
+			resource.CopyFrom( source );
 
-		target.SetValue( resource );
+			resource.EmbeddedResource = new()
+			{
+				ResourceCompiler = "embed",
+				Data = source.Serialize()
+			};
 
-		return resource;
+			property.SetValue( resource );
+
+			first ??= resource;
+		}
+
+		return first;
 	}
 
 	void OpenInEditor()

--- a/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedSpriteControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedSpriteControlWidget.cs
@@ -8,8 +8,10 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 	/// <summary>
 	/// Whether or not we are displaying an advanced version of the control
 	/// </summary>
-	public bool AdvancedMode => (Sprite?.Animations?.Count ?? 0) > 1
-							 || (Sprite?.Animations?.FirstOrDefault()?.Frames?.Count ?? 0) > 1;
+	public bool AdvancedMode => IsAdvanced( Sprite );
+
+	static bool IsAdvanced( Sprite sprite ) => (sprite?.Animations?.Count ?? 0) > 1
+										   || (sprite?.Animations?.FirstOrDefault()?.Frames?.Count ?? 0) > 1;
 
 	/// <summary>
 	/// An easy accessor for the first texture in the sprite, great for embedded sprites
@@ -18,22 +20,38 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 	{
 		get
 		{
-			var sprite = Sprite;
-			CheckForSpriteTexture( sprite ); // Ensure frame/animation exists
-			return sprite.Animations[0].Frames[0].Texture;
+			//
+			// Never write from here. This is read while the inspector is being built, and again on a
+			// timer for as long as it stays open. On a multi-selection SerializedProperty.SetValue
+			// writes to every selected object, so a write here would copy the first selection's
+			// sprite on to all of the others without anyone touching anything.
+			//
+			return Sprite?.Animations?.FirstOrDefault()?.Frames?.FirstOrDefault()?.Texture;
 		}
 		set
 		{
 			PropertyStartEdit();
-			var sprite = Sprite;
-			if ( sprite == null || AdvancedMode )
+
+			//
+			// Update each selected object's own sprite. SerializedProperty.SetValue would write one
+			// instance to all of them, permanently aliasing every selected SpriteRenderer on to
+			// whichever sprite happened to be first in the selection.
+			//
+			foreach ( var property in SerializedProperty.MultipleProperties )
 			{
-				// Create a new sprite if we don't have one, or if we're in advanced mode to avoid setting texture of pre-existing sprite
-				sprite = new Sprite();
+				var sprite = property.GetValue<Sprite>( null );
+
+				if ( sprite is null || IsAdvanced( sprite ) )
+				{
+					// Create a new sprite if we don't have one, or if we're in advanced mode to avoid setting texture of pre-existing sprite
+					sprite = new Sprite();
+				}
+
+				EnsureFirstFrame( sprite ); // Ensure frame/animation exists
+				sprite.Animations[0].Frames[0].Texture = value;
+				property.SetValue( sprite );
 			}
-			CheckForSpriteTexture( sprite ); // Ensure frame/animation exists
-			sprite.Animations[0].Frames[0].Texture = value;
-			SerializedProperty.SetValue( sprite );
+
 			PropertyFinishEdit();
 		}
 	}
@@ -92,8 +110,6 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 			OpenPopupEditor();
 		};
 		ContentWidget.Layout.Add( btnAdvanced );
-
-		System.HashCode.Combine( Texture, AdvancedMode );
 	}
 
 	public override void OnDragHover( DragEvent ev )
@@ -180,14 +196,12 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 		base.OnMouseReleased( e );
 	}
 
-	private void CheckForSpriteTexture( Sprite sprite )
+	/// <summary>
+	/// Make sure the sprite has an animation and a frame for us to put a texture in. Mutates the
+	/// sprite in place - the caller is responsible for writing it back to its own property.
+	/// </summary>
+	private static void EnsureFirstFrame( Sprite sprite )
 	{
-		if ( sprite is null )
-		{
-			sprite = new();
-			SerializedProperty.SetValue( sprite );
-		}
-
 		// Ensure first animation exists
 		if ( (sprite.Animations?.Count ?? 0) == 0 )
 		{
@@ -198,7 +212,6 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 		if ( (anim.Frames?.Count ?? 0) == 0 )
 		{
 			anim.Frames = [new Sprite.Frame()];
-			SerializedProperty.SetValue( sprite );
 		}
 	}
 

--- a/game/addons/tools/Code/Widgets/ControlWidgets/ResourceGeneratorControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/ResourceGeneratorControlWidget.cs
@@ -27,7 +27,7 @@ public class ResourceGeneratorControlWidget : ControlWidget
 		var generatorObject = generator.GetSerialized();
 		Generator = generator;
 
-		LoadFromResource( property.GetValue<Resource>() );
+		var loadedFromProperty = LoadFromResource( property.GetValue<Resource>() );
 
 		var prop = EditorTypeLibrary.CreateProperty<ResourceGenerator>( "Generator", generatorObject );
 
@@ -36,7 +36,7 @@ public class ResourceGeneratorControlWidget : ControlWidget
 
 		BuildContent();
 
-		_ = UpdateGenerator();
+		_ = UpdateGenerator( writeBack: !loadedFromProperty );
 	}
 
 	protected virtual void BuildContent()
@@ -51,22 +51,24 @@ public class ResourceGeneratorControlWidget : ControlWidget
 	/// We might want existing data from an embedded resource - in that case, deserialize it
 	/// </summary>
 	/// <param name="resource"></param>
-	void LoadFromResource( Resource resource )
+	/// <returns>True if our config came from the resource the property is already holding.</returns>
+	bool LoadFromResource( Resource resource )
 	{
 		var embeddedResource = resource?.EmbeddedResource;
 
 		if ( embeddedResource is null )
 		{
-			return;
+			return false;
 		}
 
 		// Not a matching compiler
 		if ( embeddedResource.Value.ResourceGenerator != EditorTypeLibrary.GetType( Generator.GetType() ).ClassName )
 		{
-			return;
+			return false;
 		}
 
 		Generator.Deserialize( embeddedResource.Value.Data );
+		return true;
 	}
 
 	void MakeDirty()
@@ -74,14 +76,29 @@ public class ResourceGeneratorControlWidget : ControlWidget
 		_isDirty = true;
 	}
 
-	async Task UpdateGenerator()
+	/// <param name="writeBack">
+	/// Whether the generated resource should be written back to the property. False when we only
+	/// materialised what the property was already describing.
+	/// </param>
+	async Task UpdateGenerator( bool writeBack = true )
 	{
 		_isGenerating = true;
 
 		try
 		{
 			var resource = await Generator.FindOrCreateObjectAsync( ResourceGenerator.Options.Default, default );
-			SerializedProperty.SetValue( resource );
+
+			//
+			// Only write when this is actually a change. On a multi-selection SerializedProperty.SetValue
+			// writes to every selected object, so writing back a resource we just loaded out of the
+			// property would copy the first selection's resource on to all of the others - just from
+			// opening the inspector, with nothing edited.
+			//
+			if ( writeBack )
+			{
+				SerializedProperty.SetValue( resource );
+			}
+
 			OnResourceChanged( resource );
 			Update();
 		}


### PR DESCRIPTION
## What this adds

Deterministic draw order for 2D sprites, following the model most 2D engines use.

**Sort layers.** Named layers defined per project in Project Settings, under a new Sorting section. Sprites reference a layer rather than a raw depth number, so reordering the project's layer list reorders the scene.

**Sort order.** An integer within a layer, for ordering sprites that share one.

**Sorting groups.** A component that makes a subtree sort as a single unit, so a character assembled from many sprites keeps its internal order while sorting against the rest of the scene as one object.

**Transparency sort axis.** A per camera vector controlling how distance is projected when ordering transparent sprites, which is what makes isometric and 2.5D scenes order correctly.

`SpriteRenderer` gains `IsSorted`, `SortLayer` and `SortOrder`. Sorting is opt in and off by default, so existing scenes render exactly as they do today.

### How it works

Ordering is decided on the GPU. `SpriteDrawPlan` builds the per batch plan on the C# side, `sprite_cs.shader` writes a sort key per sprite, and `sort_cs.shader` sorts them. Sort keys pack layer, order and projected distance so one comparison resolves the whole ordering.

## What this fixes

**Multi edit writing one object's value across a whole selection.** Selecting several objects and editing an embedded resource, sprite or generator field wrote a single target's value to every selected object, losing the others. The cause is in the control widgets, which produced their value from a shared rebuild path rather than per target. `EmbeddedResourceControlWidget`, `EmbeddedSpriteControlWidget` and `ResourceGeneratorControlWidget` now write per target, and rebuild time side effects that could overwrite the selection are suppressed.

This is independent of the sorting work and reproduces without it.

## On the second commit

The second commit also passes buffer capacity into `sprite_cs.shader` and guards the atomic counter trail writes against it. To be clear about what that is: it bounds the sort key buffer that the first commit introduces, so it is internal to this pull request rather than a fix to anything already shipped. Without it a scene with two sorted sprites could lose the second, and three could hang the GPU.

I kept it separate to keep the review diff honest, but I am happy to squash it into the first commit if you would rather review a single clean one.

## Tests

Unit tests covering sort key packing, the draw plan and its indexing:
`SpriteSortKeyTest`, `SpriteDrawPlanTest`, `SpriteDrawIndexingTest`.

Integration tests covering sorting behaviour and the multi edit fix:
`SpriteSortingTests`, `SpriteMultiEditTests`, `EmbeddedSpriteMultiEditTest`, `TextureGeneratorIdentityTest`.

## Notes

There is no proposal issue behind this. Happy to open one and discuss the design first if you would rather do that before spending review time on it.
