### PR TITLE
Sprite sheet slicing and cutout rigging

### DIFF
--- a/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
+++ b/engine/Sandbox.Engine/Resources/GameResourceAttribute.cs
@@ -57,6 +57,25 @@ public class AssetTypeAttribute : System.Attribute, ITypeAttribute, IUninheritab
 	void ITypeAttribute.TypeRegister()
 	{
 		Name ??= TargetType.Name;
+
+		// The same rules GameResourceAttribute's constructor enforces, applied here too so setting
+		// Extension through an object initializer cannot skip them.
+		//
+		// Worth being loud about: an over-long extension still registers as a managed type, so the
+		// asset browser will happily create the file, and only the native compiler quietly declines
+		// to produce anything. All you see is "couldn't get compiled file" somewhere else entirely.
+		if ( string.IsNullOrEmpty( Extension ) )
+			return;
+
+		if ( Extension.Length > 8 )
+		{
+			Log.Error( $"Resource extensions should be under 8 characters ({TargetType}: \"{Extension}\")" );
+		}
+
+		if ( !Extension.All( char.IsLetter ) )
+		{
+			Log.Error( $"Resource extensions can only contain letters ({TargetType}: \"{Extension}\")" );
+		}
 	}
 }
 

--- a/engine/Sandbox.Engine/Resources/SpriteSheet/SpriteSheet.Slice.cs
+++ b/engine/Sandbox.Engine/Resources/SpriteSheet/SpriteSheet.Slice.cs
@@ -1,0 +1,160 @@
+using Sandbox.UI;
+using System.Text.Json.Serialization;
+
+namespace Sandbox;
+
+public partial class SpriteSheet
+{
+	/// <summary>
+	/// Where a slice's pivot sits, as one of the nine usual spots or somewhere chosen by hand.
+	/// </summary>
+	public enum PivotAlignment
+	{
+		[Icon( "filter_center_focus" )] Center,
+		[Icon( "north_west" )] TopLeft,
+		[Icon( "north" )] Top,
+		[Icon( "north_east" )] TopRight,
+		[Icon( "west" )] Left,
+		[Icon( "east" )] Right,
+		[Icon( "south_west" )] BottomLeft,
+		[Icon( "south" )] Bottom,
+		[Icon( "south_east" )] BottomRight,
+		[Icon( "edit_location" )] Custom
+	}
+
+	/// <summary>
+	/// One rectangle cut out of the sheet, with the pivot it turns around.
+	/// </summary>
+	public class Slice
+	{
+		/// <summary>
+		/// Stable identity for this slice, generated once and never reused.
+		/// </summary>
+		/// <remarks>
+		/// Everything that points at a slice points at this, <b>not</b> the name and not the index.
+		/// Renaming is a required step of rigging a character - parts get labelled <c>L_Thigh</c>,
+		/// <c>R_Calf</c> and so on after they are cut - and re-slicing reorders things freely. If
+		/// references were by name, the rename that makes a sheet usable would break every sprite
+		/// already built from it.
+		/// </remarks>
+		[Hide]
+		public Guid Id { get; set; } = Guid.NewGuid();
+
+		/// <summary>
+		/// What this slice is called. Names are for humans and for matching slices back up across a
+		/// re-slice; they are not identity. Keep them unique with
+		/// <see cref="SpriteSheet.GetUniqueName"/> so the list stays readable.
+		/// </summary>
+		[KeyProperty]
+		public string Name { get; set; } = "slice";
+
+		/// <summary>
+		/// The area of the source image this slice covers, in pixels.
+		/// <para>
+		/// Image space: the origin is the <b>top-left</b> and Y increases <b>downwards</b>, matching
+		/// how the existing spritesheet importer lays out its grid and how <c>Bitmap.Crop</c> reads
+		/// its rect. Note this is the opposite of <see cref="Pivot"/> - see the warning there.
+		/// </para>
+		/// </summary>
+		public Rect Rect { get; set; }
+
+		/// <summary>
+		/// Where the slice turns around, normalized within <see cref="Rect"/>. This is copied
+		/// straight into <c>Sprite.Animation.Origin</c>, so it is stored in that property's units.
+		/// </summary>
+		/// <remarks>
+		/// <b>Y points up here.</b> (0,0) is the bottom-left of the slice and (1,1) the top-right,
+		/// which is Unity's convention and the one a default <c>SpriteRenderer</c> (Billboard =
+		/// Always) actually renders. <see cref="Rect"/> is the other way up, so converting between
+		/// the two needs a flip - use <see cref="PivotToImagePixels"/> rather than doing it by hand.
+		/// <para>
+		/// Worth knowing: the sprite shader's no-billboard path applies this offset with the opposite
+		/// sign to its billboard paths, so a non-billboarded sprite mirrors its pivot vertically.
+		/// That is pre-existing engine behaviour, not something this asset introduces.
+		/// </para>
+		/// </remarks>
+		[Range( 0, 1 )]
+		public Vector2 Pivot { get; set; } = new Vector2( 0.5f, 0.5f );
+
+		/// <summary>
+		/// Which of the nine standard spots the pivot is locked to. <see cref="PivotAlignment.Custom"/>
+		/// means it was placed by hand and should be left alone.
+		/// </summary>
+		public PivotAlignment Alignment { get; set; } = PivotAlignment.Center;
+
+		/// <summary>
+		/// Edge widths for nine-slice scaling. Authored and saved, but nothing consumes it yet.
+		/// </summary>
+		public Margin Border { get; set; }
+
+		/// <summary>
+		/// The slice this one hangs off when the sheet is built into a rig - a calf's parent is a
+		/// thigh. <see cref="Guid.Empty"/> means it is a root.
+		/// </summary>
+		/// <remarks>
+		/// Kept on the sheet rather than worked out at build time so that a rig only has to be
+		/// described once. Re-slicing, rebuilding after moving a pivot, or building the same character
+		/// into a second scene all reuse it.
+		/// </remarks>
+		[Hide]
+		public Guid ParentId { get; set; }
+
+		/// <summary>
+		/// The pivot as a position in source-image pixels, flipping Y from the pivot's bottom-up
+		/// space into the image's top-down space.
+		/// </summary>
+		[JsonIgnore, Hide]
+		public Vector2 PivotToImagePixels => new(
+			Rect.Left + (Pivot.x * Rect.Width),
+			Rect.Top + ((1f - Pivot.y) * Rect.Height) );
+
+		/// <summary>
+		/// The normalized pivot for one of the nine standard spots.
+		/// </summary>
+		/// <param name="alignment">The spot to resolve. <see cref="PivotAlignment.Custom"/> returns the centre.</param>
+		public static Vector2 GetPivot( PivotAlignment alignment ) => alignment switch
+		{
+			PivotAlignment.TopLeft => new Vector2( 0f, 1f ),
+			PivotAlignment.Top => new Vector2( 0.5f, 1f ),
+			PivotAlignment.TopRight => new Vector2( 1f, 1f ),
+			PivotAlignment.Left => new Vector2( 0f, 0.5f ),
+			PivotAlignment.Right => new Vector2( 1f, 0.5f ),
+			PivotAlignment.BottomLeft => new Vector2( 0f, 0f ),
+			PivotAlignment.Bottom => new Vector2( 0.5f, 0f ),
+			PivotAlignment.BottomRight => new Vector2( 1f, 0f ),
+			_ => new Vector2( 0.5f, 0.5f ),
+		};
+
+		/// <summary>
+		/// Move the pivot onto one of the nine standard spots. Passing
+		/// <see cref="PivotAlignment.Custom"/> records that it was placed by hand and leaves it where
+		/// it is.
+		/// </summary>
+		/// <param name="alignment">The spot to snap to</param>
+		public void SetAlignment( PivotAlignment alignment )
+		{
+			Alignment = alignment;
+			if ( alignment == PivotAlignment.Custom ) return;
+
+			Pivot = GetPivot( alignment );
+		}
+
+		/// <summary>
+		/// Place the pivot by hand, given a position in source-image pixels. Flips Y back out of
+		/// image space and marks the slice as custom.
+		/// </summary>
+		/// <param name="imagePixels">The desired pivot position, in source-image pixels</param>
+		public void SetPivotFromImagePixels( Vector2 imagePixels )
+		{
+			if ( Rect.Width <= 0 || Rect.Height <= 0 ) return;
+
+			Pivot = new Vector2(
+				(imagePixels.x - Rect.Left) / Rect.Width,
+				1f - ((imagePixels.y - Rect.Top) / Rect.Height) );
+
+			Alignment = PivotAlignment.Custom;
+		}
+
+		public override string ToString() => Name;
+	}
+}

--- a/engine/Sandbox.Engine/Resources/SpriteSheet/SpriteSheet.Slicing.cs
+++ b/engine/Sandbox.Engine/Resources/SpriteSheet/SpriteSheet.Slicing.cs
@@ -1,0 +1,579 @@
+using System.Text.Json.Serialization;
+
+namespace Sandbox;
+
+public partial class SpriteSheet
+{
+	/// <summary>
+	/// How a sheet gets cut up.
+	/// </summary>
+	public enum SliceType
+	{
+		/// <summary>
+		/// Find the artwork by looking for islands of non-transparent pixels. Best for a sheet of
+		/// loose parts with space between them, like a character cut into limbs.
+		/// </summary>
+		[Icon( "auto_fix_high" )] Automatic,
+
+		/// <summary>
+		/// A regular grid, where you give the size of one cell.
+		/// </summary>
+		[Icon( "grid_on" )] GridByCellSize,
+
+		/// <summary>
+		/// A regular grid, where you give the number of columns and rows and the cell size is worked
+		/// out from the image.
+		/// </summary>
+		[Icon( "grid_4x4" )] GridByCellCount
+	}
+
+	/// <summary>
+	/// What happens to slices that are already there when you slice again.
+	/// </summary>
+	public enum SliceMethod
+	{
+		/// <summary>
+		/// Throw away every existing slice and start over. Names and ids are lost, so anything
+		/// pointing at them breaks.
+		/// </summary>
+		[Icon( "delete_sweep" )] DeleteExisting,
+
+		/// <summary>
+		/// Reshape existing slices to match the new cut where they clearly correspond, and add the
+		/// rest. Keeps names and ids, so references survive. This is the one to use after renaming.
+		/// </summary>
+		[Icon( "auto_awesome" )] Smart,
+
+		/// <summary>
+		/// Only add slices in space nothing already occupies. Never changes or removes what is there.
+		/// </summary>
+		[Icon( "shield" )] Safe
+	}
+
+	/// <summary>
+	/// Everything that controls a slicing pass.
+	/// </summary>
+	public class SliceSettings
+	{
+		/// <summary>
+		/// How to find the slices.
+		/// </summary>
+		[Property, EnumDropdown]
+		public SliceType Type { get; set; } = SliceType.Automatic;
+
+		/// <summary>True for the grid types, which share most of their settings.</summary>
+		[Hide, JsonIgnore]
+		public bool IsGrid => Type != SliceType.Automatic;
+
+		/// <summary>
+		/// Cell size in pixels.
+		/// </summary>
+		[Property, Title( "Pixel Size" ), ShowIf( nameof( Type ), SliceType.GridByCellSize )]
+		public Vector2Int CellSize { get; set; } = new Vector2Int( 64, 64 );
+
+		/// <summary>
+		/// Columns and rows. The cell size is worked out from whatever is left of the image.
+		/// </summary>
+		[Property, Title( "Column & Row" ), ShowIf( nameof( Type ), SliceType.GridByCellCount )]
+		public Vector2Int CellCount { get; set; } = new Vector2Int( 8, 8 );
+
+		/// <summary>
+		/// Where the grid starts, in pixels from the top-left.
+		/// </summary>
+		[Property, ShowIf( nameof( IsGrid ), true )]
+		public Vector2Int Offset { get; set; }
+
+		/// <summary>
+		/// Gap between cells, in pixels.
+		/// </summary>
+		[Property, ShowIf( nameof( IsGrid ), true )]
+		public Vector2Int Padding { get; set; }
+
+		/// <summary>
+		/// Keep cells that turned out to be entirely transparent. Off by default, because a sheet is
+		/// rarely completely full.
+		/// </summary>
+		[Property, ShowIf( nameof( IsGrid ), true )]
+		public bool KeepEmptyRects { get; set; }
+
+		/// <summary>
+		/// Alpha at or below this counts as transparent. Leave at 0 for clean artwork; raise it for
+		/// scans, soft brushes, or anything with grubby edges.
+		/// </summary>
+		[Property, Range( 0, 254 ), Step( 1 )]
+		public byte AlphaTolerance { get; set; }
+
+		/// <summary>
+		/// What counts as empty space. Set from the sheet, not edited here.
+		/// </summary>
+		[Hide, JsonIgnore]
+		public BackgroundKey Background { get; set; }
+
+		/// <summary>
+		/// Where to put the pivot on every slice this pass produces.
+		/// </summary>
+		[Property, Header( "Pivot" ), EnumDropdown]
+		public PivotAlignment Alignment { get; set; } = PivotAlignment.Center;
+
+		/// <summary>
+		/// The pivot, normalized within each slice, when <see cref="Alignment"/> is Custom.
+		/// </summary>
+		[Property, Title( "Custom Pivot" ), Range( 0, 1 ), ShowIf( nameof( Alignment ), PivotAlignment.Custom )]
+		public Vector2 CustomPivot { get; set; } = new Vector2( 0.5f, 0.5f );
+
+		/// <summary>
+		/// What happens to slices that are already there.
+		/// </summary>
+		[Property, Header( "Method" ), EnumDropdown]
+		public SliceMethod Method { get; set; } = SliceMethod.DeleteExisting;
+
+		internal Vector2 ResolvePivot()
+			=> Alignment == PivotAlignment.Custom ? CustomPivot : Slice.GetPivot( Alignment );
+	}
+
+	/// <summary>
+	/// The smallest run of pixels automatic slicing will treat as artwork rather than noise.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately not a setting. Unity exposed this once and took it back out, on the grounds that
+	/// hunting for the right number is worse than slicing roughly and fixing the few rects that came
+	/// out wrong. Their note: "4 seems to be a pretty nice min size for a automatic sprite slicing.
+	/// It used to be exposed to the slicing dialog, but it is actually better workflow to slice &amp;
+	/// crop manually than find a suitable size number".
+	/// </remarks>
+	public const int MinimumAutomaticSliceSize = 4;
+
+	// How near a perfect fit an existing slice has to be before Smart will reshape it rather than
+	// treat the incoming rect as something new. 0 is exact containment; beyond this they are
+	// different things that happen to touch.
+	const float BestFitTolerance = 0.5f;
+
+	// Two candidates this close in fit are a tie, broken by preferring the smaller existing slice.
+	const float OverlapTolerance = 0.00001f;
+
+	/// <summary>
+	/// Cut a sheet up and fold the result into whatever is already there.
+	/// </summary>
+	/// <param name="pixels">The source image, row-major from the top-left</param>
+	/// <param name="width">Source image width in pixels</param>
+	/// <param name="height">Source image height in pixels</param>
+	/// <param name="settings">How to cut</param>
+	/// <param name="existing">Slices already on the sheet. Not modified; the result is a new list.</param>
+	/// <param name="namePrefix">Stem for generated names, usually the asset's name</param>
+	public static List<Slice> CreateSlices( Color32[] pixels, int width, int height, SliceSettings settings, IEnumerable<Slice> existing = null, string namePrefix = "slice" )
+	{
+		ArgumentNullException.ThrowIfNull( settings );
+
+		var found = settings.Type switch
+		{
+			SliceType.GridByCellSize => SliceGridByCellSize( pixels, width, height, settings ),
+			SliceType.GridByCellCount => SliceGridByCellCount( pixels, width, height, settings ),
+			_ => SliceAutomatic( pixels, width, height, settings ),
+		};
+
+		return Merge( existing, found, settings, namePrefix );
+	}
+
+	/// <summary>
+	/// A regular grid from an explicit cell size.
+	/// </summary>
+	public static List<Rect> SliceGridByCellSize( Color32[] pixels, int width, int height, SliceSettings settings )
+	{
+		var cell = new Vector2Int(
+			Math.Clamp( settings.CellSize.x, 1, Math.Max( 1, width ) ),
+			Math.Clamp( settings.CellSize.y, 1, Math.Max( 1, height ) ) );
+
+		return BuildGrid( pixels, width, height, cell, settings );
+	}
+
+	/// <summary>
+	/// A regular grid from a column and row count, working the cell size out from what is left of the
+	/// image once the offset and the gaps between cells are taken off.
+	/// </summary>
+	public static List<Rect> SliceGridByCellCount( Color32[] pixels, int width, int height, SliceSettings settings )
+	{
+		var columns = Math.Max( 1, settings.CellCount.x );
+		var rows = Math.Max( 1, settings.CellCount.y );
+
+		var cell = new Vector2Int(
+			(width - settings.Offset.x - (settings.Padding.x * Math.Max( 0, columns - 1 ))) / columns,
+			(height - settings.Offset.y - (settings.Padding.y * Math.Max( 0, rows - 1 ))) / rows );
+
+		cell = new Vector2Int(
+			Math.Clamp( cell.x, 1, Math.Max( 1, width ) ),
+			Math.Clamp( cell.y, 1, Math.Max( 1, height ) ) );
+
+		return BuildGrid( pixels, width, height, cell, settings, columns, rows );
+	}
+
+	static List<Rect> BuildGrid( Color32[] pixels, int width, int height, Vector2Int cell, SliceSettings settings, int? columnLimit = null, int? rowLimit = null )
+	{
+		var rects = new List<Rect>();
+
+		var stepX = cell.x + settings.Padding.x;
+		var stepY = cell.y + settings.Padding.y;
+
+		int column = 0;
+		for ( int x = settings.Offset.x; x + cell.x <= width; x += stepX )
+		{
+			if ( columnLimit.HasValue && column >= columnLimit.Value ) break;
+
+			int row = 0;
+			for ( int y = settings.Offset.y; y + cell.y <= height; y += stepY )
+			{
+				if ( rowLimit.HasValue && row >= rowLimit.Value ) break;
+
+				var rect = new Rect( x, y, cell.x, cell.y );
+
+				if ( settings.KeepEmptyRects || !IsEmpty( pixels, width, height, rect, settings.AlphaTolerance, settings.Background ) )
+				{
+					rects.Add( rect );
+				}
+
+				row++;
+			}
+
+			column++;
+		}
+
+		// Row-major, so frames come out in the order they read on the sheet rather than column-first.
+		return rects.OrderBy( r => r.Top ).ThenBy( r => r.Left ).ToList();
+	}
+
+	/// <summary>
+	/// Find the artwork by looking for connected islands of opaque pixels, and take the bounding box
+	/// of each.
+	/// </summary>
+	public static List<Rect> SliceAutomatic( Color32[] pixels, int width, int height, SliceSettings settings )
+	{
+		var rects = FindIslands( pixels, width, height, settings?.AlphaTolerance ?? 0, settings?.Background ?? default );
+
+		// Two islands whose boxes overlap are almost always one thing that happens to be drawn in
+		// separate pieces - a highlight sitting over a limb, a dotted outline. Fold them together
+		// until nothing overlaps any more.
+		MergeOverlapping( rects );
+
+		rects.RemoveAll( r => r.Width < MinimumAutomaticSliceSize || r.Height < MinimumAutomaticSliceSize );
+
+		return SortReadingOrder( rects );
+	}
+
+	/// <summary>
+	/// Bounding boxes of every 8-connected island of non-transparent pixels.
+	/// </summary>
+	static List<Rect> FindIslands( Color32[] pixels, int width, int height, byte alphaTolerance, BackgroundKey background )
+	{
+		var rects = new List<Rect>();
+		if ( pixels is null || width <= 0 || height <= 0 ) return rects;
+
+		var count = Math.Min( pixels.Length, width * height );
+		var visited = new bool[count];
+
+		// Explicit stack rather than recursion - a 4096x4096 sheet is 16 million pixels and one
+		// island can span all of them, which would blow the call stack instantly.
+		var stack = new Stack<int>();
+
+		for ( int start = 0; start < count; start++ )
+		{
+			if ( visited[start] ) continue;
+			visited[start] = true;
+
+			if ( background.IsEmpty( pixels[start], alphaTolerance ) ) continue;
+
+			int minX = start % width, maxX = minX;
+			int minY = start / width, maxY = minY;
+
+			stack.Push( start );
+
+			while ( stack.Count > 0 )
+			{
+				var index = stack.Pop();
+				var x = index % width;
+				var y = index / width;
+
+				if ( x < minX ) minX = x;
+				if ( x > maxX ) maxX = x;
+				if ( y < minY ) minY = y;
+				if ( y > maxY ) maxY = y;
+
+				for ( int dy = -1; dy <= 1; dy++ )
+				{
+					var ny = y + dy;
+					if ( ny < 0 || ny >= height ) continue;
+
+					for ( int dx = -1; dx <= 1; dx++ )
+					{
+						if ( dx == 0 && dy == 0 ) continue;
+
+						var nx = x + dx;
+						if ( nx < 0 || nx >= width ) continue;
+
+						var neighbour = (ny * width) + nx;
+						if ( neighbour >= count || visited[neighbour] ) continue;
+
+						visited[neighbour] = true;
+						if ( background.IsEmpty( pixels[neighbour], alphaTolerance ) ) continue;
+
+						stack.Push( neighbour );
+					}
+				}
+			}
+
+			rects.Add( new Rect( minX, minY, maxX - minX + 1, maxY - minY + 1 ) );
+		}
+
+		return rects;
+	}
+
+	static void MergeOverlapping( List<Rect> rects )
+	{
+		bool merged = true;
+
+		while ( merged )
+		{
+			merged = false;
+
+			for ( int i = 0; i < rects.Count && !merged; i++ )
+			{
+				for ( int j = i + 1; j < rects.Count; j++ )
+				{
+					if ( !Overlaps( rects[i], rects[j] ) ) continue;
+
+					rects[i] = Union( rects[i], rects[j] );
+					rects.RemoveAt( j );
+					merged = true;
+					break;
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Put rects in the order someone would read them off the sheet: banded into rows by vertical
+	/// overlap, then left to right within each row.
+	/// </summary>
+	/// <remarks>
+	/// Sorting on Top alone looks right until automatic slicing returns rects trimmed to their
+	/// artwork, at which point two frames on the same row differ by a few pixels and interleave with
+	/// the row below. Frame order decides animation order, so that matters.
+	/// </remarks>
+	static List<Rect> SortReadingOrder( List<Rect> rects )
+	{
+		var sorted = rects.OrderBy( r => r.Top ).ToList();
+		var result = new List<Rect>( sorted.Count );
+
+		int index = 0;
+		while ( index < sorted.Count )
+		{
+			var band = new List<Rect> { sorted[index] };
+			var bandBottom = sorted[index].Top + sorted[index].Height;
+			index++;
+
+			// Anything starting before the band ends shares a row with it.
+			while ( index < sorted.Count && sorted[index].Top < bandBottom )
+			{
+				bandBottom = Math.Max( bandBottom, sorted[index].Top + sorted[index].Height );
+				band.Add( sorted[index] );
+				index++;
+			}
+
+			result.AddRange( band.OrderBy( r => r.Left ) );
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Shrink a rect until it just contains the artwork inside it. Returns an empty rect if there is
+	/// nothing there.
+	/// </summary>
+	/// <param name="pixels">The source image, row-major from the top-left</param>
+	/// <param name="width">Source image width in pixels</param>
+	/// <param name="height">Source image height in pixels</param>
+	/// <param name="rect">The rect to tighten</param>
+	/// <param name="alphaTolerance">Alpha at or below this counts as transparent</param>
+	/// <param name="background">A solid colour to treat as empty, for artwork with no alpha</param>
+	public static Rect Trim( Color32[] pixels, int width, int height, Rect rect, byte alphaTolerance = 0, BackgroundKey background = default )
+	{
+		if ( pixels is null || width <= 0 || height <= 0 ) return default;
+
+		var left = Math.Max( 0, (int)rect.Left );
+		var top = Math.Max( 0, (int)rect.Top );
+		var right = Math.Min( width, (int)(rect.Left + rect.Width) );
+		var bottom = Math.Min( height, (int)(rect.Top + rect.Height) );
+
+		int minX = int.MaxValue, minY = int.MaxValue, maxX = int.MinValue, maxY = int.MinValue;
+
+		for ( int y = top; y < bottom; y++ )
+		{
+			for ( int x = left; x < right; x++ )
+			{
+				var index = (y * width) + x;
+				if ( index >= pixels.Length ) continue;
+				if ( background.IsEmpty( pixels[index], alphaTolerance ) ) continue;
+
+				if ( x < minX ) minX = x;
+				if ( x > maxX ) maxX = x;
+				if ( y < minY ) minY = y;
+				if ( y > maxY ) maxY = y;
+			}
+		}
+
+		if ( minX > maxX || minY > maxY ) return default;
+
+		return new Rect( minX, minY, maxX - minX + 1, maxY - minY + 1 );
+	}
+
+	/// <summary>
+	/// Whether a rect contains no artwork at all.
+	/// </summary>
+	public static bool IsEmpty( Color32[] pixels, int width, int height, Rect rect, byte alphaTolerance = 0, BackgroundKey background = default )
+	{
+		if ( pixels is null || width <= 0 || height <= 0 ) return true;
+
+		var left = Math.Max( 0, (int)rect.Left );
+		var top = Math.Max( 0, (int)rect.Top );
+		var right = Math.Min( width, (int)(rect.Left + rect.Width) );
+		var bottom = Math.Min( height, (int)(rect.Top + rect.Height) );
+
+		for ( int y = top; y < bottom; y++ )
+		{
+			for ( int x = left; x < right; x++ )
+			{
+				var index = (y * width) + x;
+				if ( index >= pixels.Length ) continue;
+				if ( !background.IsEmpty( pixels[index], alphaTolerance ) ) return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Fold a freshly cut set of rects into the slices already on a sheet.
+	/// </summary>
+	static List<Slice> Merge( IEnumerable<Slice> existing, List<Rect> found, SliceSettings settings, string namePrefix )
+	{
+		var result = existing?.ToList() ?? new List<Slice>();
+
+		if ( settings.Method == SliceMethod.DeleteExisting )
+		{
+			result.Clear();
+		}
+
+		// Lets us reuse the sheet's own uniqueness check while the list is still being built.
+		var scratch = new SpriteSheet { Slices = result };
+		var nextIndex = 0;
+
+		string NextFreeName()
+		{
+			while ( true )
+			{
+				var candidate = $"{namePrefix}_{nextIndex++}";
+				if ( scratch.GetSliceIndex( candidate ) == -1 ) return candidate;
+			}
+		}
+
+		foreach ( var rect in found )
+		{
+			if ( settings.Method == SliceMethod.Smart )
+			{
+				var match = FindBestFit( result, rect );
+				if ( match is not null )
+				{
+					// Reshape in place. The name and the id are what references hang off, so they
+					// have to survive a re-slice - that is the entire point of this method.
+					//
+					// The pivot is left alone too, which is a deliberate difference from Unity: it
+					// reapplies the dialog's alignment here. Placing pivots on joints is the slow,
+					// careful part of rigging a character, and re-slicing to pick up a few missed
+					// limbs should not throw that away.
+					match.Rect = rect;
+					continue;
+				}
+			}
+			else if ( settings.Method == SliceMethod.Safe )
+			{
+				if ( result.Any( s => Overlaps( s.Rect, rect ) ) ) continue;
+			}
+
+			var slice = new Slice
+			{
+				Rect = rect,
+				Alignment = settings.Alignment,
+				Pivot = settings.ResolvePivot()
+			};
+
+			slice.Name = NextFreeName();
+			result.Add( slice );
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// The existing slice an incoming rect most likely *is*, or null if it is something new.
+	/// </summary>
+	static Slice FindBestFit( List<Slice> slices, Rect rect )
+	{
+		var area = rect.Width * rect.Height;
+		if ( area <= 0 ) return null;
+
+		Slice best = null;
+		var bestRatio = float.MaxValue;
+
+		foreach ( var slice in slices )
+		{
+			if ( !Overlaps( slice.Rect, rect ) ) continue;
+
+			var overlap = Intersection( slice.Rect, rect );
+			// 0 means the incoming rect sits entirely inside the existing one.
+			var ratio = MathF.Abs( ((overlap.Width * overlap.Height) / area) - 1f );
+
+			if ( ratio < bestRatio - OverlapTolerance )
+			{
+				best = slice;
+				bestRatio = ratio;
+				continue;
+			}
+
+			// Equally good fits: prefer the tighter existing slice.
+			if ( MathF.Abs( ratio - bestRatio ) <= OverlapTolerance && best is not null )
+			{
+				if ( (slice.Rect.Width * slice.Rect.Height) < (best.Rect.Width * best.Rect.Height) )
+				{
+					best = slice;
+					bestRatio = ratio;
+				}
+			}
+		}
+
+		return bestRatio > BestFitTolerance ? null : best;
+	}
+
+	static bool Overlaps( Rect a, Rect b )
+		=> a.Left < b.Left + b.Width && b.Left < a.Left + a.Width
+		&& a.Top < b.Top + b.Height && b.Top < a.Top + a.Height;
+
+	static Rect Intersection( Rect a, Rect b )
+	{
+		var left = Math.Max( a.Left, b.Left );
+		var top = Math.Max( a.Top, b.Top );
+		var right = Math.Min( a.Left + a.Width, b.Left + b.Width );
+		var bottom = Math.Min( a.Top + a.Height, b.Top + b.Height );
+
+		if ( right <= left || bottom <= top ) return default;
+
+		return new Rect( left, top, right - left, bottom - top );
+	}
+
+	static Rect Union( Rect a, Rect b )
+	{
+		var left = Math.Min( a.Left, b.Left );
+		var top = Math.Min( a.Top, b.Top );
+		var right = Math.Max( a.Left + a.Width, b.Left + b.Width );
+		var bottom = Math.Max( a.Top + a.Height, b.Top + b.Height );
+
+		return new Rect( left, top, right - left, bottom - top );
+	}
+}

--- a/engine/Sandbox.Engine/Resources/SpriteSheet/SpriteSheet.cs
+++ b/engine/Sandbox.Engine/Resources/SpriteSheet/SpriteSheet.cs
@@ -1,0 +1,301 @@
+using Sandbox.UI;
+
+namespace Sandbox;
+
+/// <summary>
+/// A source image plus the named rectangles it has been cut into. Each slice carries its own pivot,
+/// which is what lets a sheet of body parts become a rig - a thigh pivots at the hip, a calf at the
+/// knee.
+/// <para>
+/// The sheet is the editable record of how an image was cut. It does not render directly: slices
+/// reach the renderer as ordinary textures through <c>SpriteSheetSliceGenerator</c>, so re-slicing
+/// updates everything already using it.
+/// </para>
+/// </summary>
+// "sheet" rather than "spritesheet": resource extensions have to be at most 8 letters, and the
+// native asset compiler quietly produces nothing for one that is longer.
+[AssetType( Name = "Sprite Sheet", Extension = "sheet", Category = "Rendering" )]
+public sealed partial class SpriteSheet : GameResource
+{
+	/// <summary>
+	/// The image being cut up, relative to the project's assets.
+	/// </summary>
+	[Property, TextureImagePath]
+	public string ImagePath { get; set; }
+
+	/// <summary>
+	/// Treat a solid background colour as empty space.
+	/// </summary>
+	/// <remarks>
+	/// Artwork does not always arrive with an alpha channel - a JPEG never has one, and scans and
+	/// exports from paint packages are routinely flat white behind the drawing. Without this, every
+	/// pixel counts as artwork, automatic slicing finds one island covering the whole image, and every
+	/// part renders as a rectangle of background.
+	/// </remarks>
+	[Property, ToggleGroup( "KeyBackground", Label = "Background Colour" )]
+	public bool KeyBackground { get; set; }
+
+	/// <summary>
+	/// The colour to treat as empty. <see cref="DetectBackgroundColor"/> can guess it.
+	/// </summary>
+	[Property, Group( "KeyBackground" ), Title( "Colour" )]
+	public Color BackgroundColor { get; set; } = Color.White;
+
+	/// <summary>
+	/// How far a pixel may stray from the background colour and still count as background. Needs to
+	/// be above zero for anything that has been through JPEG, which smears colours near edges.
+	/// </summary>
+	[Property, Group( "KeyBackground" ), Title( "Tolerance" ), Range( 0, 1 )]
+	public float BackgroundTolerance { get; set; } = 0.08f;
+
+	/// <summary>
+	/// Every rectangle this sheet has been cut into.
+	/// </summary>
+	[Property, InlineEditor, WideMode]
+	public List<Slice> Slices { get; set; } = new();
+
+	/// <summary>
+	/// How to tell artwork from empty space on this sheet, in a form the slicing and texture code can
+	/// use without knowing about the resource.
+	/// </summary>
+	[Hide, System.Text.Json.Serialization.JsonIgnore]
+	public BackgroundKey Background => new()
+	{
+		Enabled = KeyBackground,
+		Color = new Color32(
+			(byte)(BackgroundColor.r * 255f),
+			(byte)(BackgroundColor.g * 255f),
+			(byte)(BackgroundColor.b * 255f),
+			255 ),
+		Tolerance = (byte)(BackgroundTolerance.Clamp( 0f, 1f ) * 255f)
+	};
+
+	/// <summary>
+	/// Which pixels count as empty space rather than artwork.
+	/// </summary>
+	public readonly struct BackgroundKey
+	{
+		public bool Enabled { get; init; }
+		public Color32 Color { get; init; }
+		public byte Tolerance { get; init; }
+
+		/// <summary>
+		/// Whether a pixel is background - either see-through, or near enough the keyed colour.
+		/// </summary>
+		/// <param name="pixel">The pixel to test</param>
+		/// <param name="alphaTolerance">Alpha at or below this is see-through regardless of colour</param>
+		public bool IsEmpty( Color32 pixel, byte alphaTolerance )
+		{
+			if ( pixel.a <= alphaTolerance ) return true;
+			if ( !Enabled ) return false;
+
+			// Per-channel rather than euclidean: cheap, and it behaves predictably when someone drags
+			// the tolerance slider looking for the point where the drawing stops disappearing.
+			return Math.Abs( pixel.r - Color.r ) <= Tolerance
+				&& Math.Abs( pixel.g - Color.g ) <= Tolerance
+				&& Math.Abs( pixel.b - Color.b ) <= Tolerance;
+		}
+	}
+
+	/// <summary>
+	/// Guess the background colour by looking at the corners, which is where artwork almost never is.
+	/// Returns null if the corners disagree, rather than guessing wrongly.
+	/// </summary>
+	/// <param name="pixels">The source image, row-major from the top-left</param>
+	/// <param name="width">Source image width in pixels</param>
+	/// <param name="height">Source image height in pixels</param>
+	public static Color? DetectBackgroundColor( Color32[] pixels, int width, int height )
+	{
+		if ( pixels is null || width < 2 || height < 2 ) return null;
+
+		// Inset a little - a stray dark edge pixel from a scan or a border would otherwise decide it.
+		var inset = Math.Max( 1, Math.Min( width, height ) / 64 );
+
+		var corners = new[]
+		{
+			Sample( inset, inset ),
+			Sample( width - 1 - inset, inset ),
+			Sample( inset, height - 1 - inset ),
+			Sample( width - 1 - inset, height - 1 - inset )
+		};
+
+		Color32 Sample( int x, int y )
+		{
+			var index = (Math.Clamp( y, 0, height - 1 ) * width) + Math.Clamp( x, 0, width - 1 );
+			return index >= 0 && index < pixels.Length ? pixels[index] : default;
+		}
+
+		var first = corners[0];
+
+		foreach ( var corner in corners )
+		{
+			// Generous, because JPEG will not give four identical corners even on flat white.
+			if ( Math.Abs( corner.r - first.r ) > 12 ) return null;
+			if ( Math.Abs( corner.g - first.g ) > 12 ) return null;
+			if ( Math.Abs( corner.b - first.b ) > 12 ) return null;
+		}
+
+		// Already see-through: there is nothing to key, alpha is doing the job.
+		if ( first.a == 0 ) return null;
+
+		return new Color( first.r / 255f, first.g / 255f, first.b / 255f );
+	}
+
+	/// <summary>
+	/// Get a slice by its stable id. This is how anything holding a reference to a slice should look
+	/// it up - names change, ids do not. Returns null if not found.
+	/// </summary>
+	/// <param name="id">The id of the slice</param>
+	public Slice GetSlice( Guid id )
+	{
+		if ( id == Guid.Empty ) return null;
+
+		foreach ( var slice in Slices )
+		{
+			if ( slice.Id == id ) return slice;
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Get the index of a slice by name. Returns -1 if not found.
+	/// </summary>
+	/// <param name="name">The name of the slice</param>
+	public int GetSliceIndex( string name )
+	{
+		for ( int i = 0; i < Slices.Count; i++ )
+		{
+			if ( string.Equals( Slices[i].Name, name, StringComparison.OrdinalIgnoreCase ) )
+			{
+				return i;
+			}
+		}
+		return -1; // Not found
+	}
+
+	/// <summary>
+	/// Get a slice by name. Returns null if not found.
+	/// </summary>
+	/// <param name="name">The name of the slice</param>
+	public Slice GetSlice( string name )
+	{
+		int index = GetSliceIndex( name );
+		if ( index == -1 )
+		{
+			return null;
+		}
+		return Slices[index];
+	}
+
+	/// <summary>
+	/// Makes <paramref name="name"/> unique among the existing slices by appending a number, leaving
+	/// it alone if nothing else is using it. Slices are addressed by name, so two sharing one would
+	/// make the second unreachable.
+	/// </summary>
+	/// <param name="name">The desired name</param>
+	/// <param name="ignore">A slice allowed to keep the name - pass the one being renamed</param>
+	public string GetUniqueName( string name, Slice ignore = null )
+	{
+		if ( string.IsNullOrWhiteSpace( name ) ) name = "slice";
+
+		bool Taken( string candidate )
+		{
+			foreach ( var slice in Slices )
+			{
+				if ( slice == ignore ) continue;
+				if ( string.Equals( slice.Name, candidate, StringComparison.OrdinalIgnoreCase ) ) return true;
+			}
+			return false;
+		}
+
+		if ( !Taken( name ) ) return name;
+
+		for ( int i = 1; ; i++ )
+		{
+			var candidate = $"{name}_{i}";
+			if ( !Taken( candidate ) ) return candidate;
+		}
+	}
+
+	/// <summary>
+	/// The slices hanging directly off <paramref name="parentId"/>, in sheet order.
+	/// Pass <see cref="Guid.Empty"/> for the roots.
+	/// </summary>
+	/// <param name="parentId">The parent to list the children of</param>
+	public IEnumerable<Slice> GetChildren( Guid parentId )
+		=> Slices.Where( s => s.ParentId == parentId );
+
+	/// <summary>
+	/// Point one slice at another as its parent, refusing anything that would make a loop.
+	/// </summary>
+	/// <remarks>
+	/// A loop is not a hypothetical: the parent list is a set of independent dropdowns, so making a
+	/// thigh the child of its own calf takes two ordinary-looking clicks. Building that would recurse
+	/// until the stack ran out.
+	/// </remarks>
+	/// <param name="slice">The slice to reparent</param>
+	/// <param name="parentId">The proposed parent, or <see cref="Guid.Empty"/> for none</param>
+	/// <returns>True if the parent was set</returns>
+	public bool TrySetParent( Slice slice, Guid parentId )
+	{
+		if ( slice is null ) return false;
+
+		if ( parentId == Guid.Empty )
+		{
+			slice.ParentId = Guid.Empty;
+			return true;
+		}
+
+		if ( parentId == slice.Id ) return false;
+
+		// Walk up from the proposed parent; if we meet this slice, the link would close a loop.
+		var seen = 0;
+		var walk = GetSlice( parentId );
+
+		while ( walk is not null )
+		{
+			if ( walk == slice ) return false;
+			if ( ++seen > Slices.Count ) return false; // already looped somehow - refuse rather than hang
+
+			walk = walk.ParentId == Guid.Empty ? null : GetSlice( walk.ParentId );
+		}
+
+		slice.ParentId = parentId;
+		return true;
+	}
+
+	/// <summary>
+	/// Slices in the order a rig should be built: parents before their children, so a child always
+	/// has something to attach to.
+	/// </summary>
+	public List<Slice> InHierarchyOrder()
+	{
+		var ordered = new List<Slice>( Slices.Count );
+
+		void Walk( Guid parentId )
+		{
+			foreach ( var slice in GetChildren( parentId ) )
+			{
+				ordered.Add( slice );
+				Walk( slice.Id );
+			}
+		}
+
+		Walk( Guid.Empty );
+
+		// Anything left over pointed at a parent that has since been deleted. Treat it as a root
+		// rather than dropping it silently.
+		foreach ( var slice in Slices )
+		{
+			if ( !ordered.Contains( slice ) ) ordered.Add( slice );
+		}
+
+		return ordered;
+	}
+
+	protected override Bitmap CreateAssetTypeIcon( int width, int height )
+	{
+		var svg = "<svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><g fill=\"none\" stroke=\"#8fe637\" stroke-width=\"1.6\" stroke-linejoin=\"round\"><rect x=\"2.5\" y=\"2.5\" width=\"19\" height=\"19\" rx=\"1.5\"/><path d=\"M8.833 2.5v19M15.167 2.5v19M2.5 8.833h19M2.5 15.167h19\"/></g><rect x=\"9.4\" y=\"9.4\" width=\"5.2\" height=\"5.2\" fill=\"#8fe637\"/></svg>";
+		return Bitmap.CreateFromSvgString( svg, width, height );
+	}
+}

--- a/engine/Sandbox.Engine/Resources/Textures/Generators/SpriteSheetSliceTextureGenerator.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Generators/SpriteSheetSliceTextureGenerator.cs
@@ -1,0 +1,171 @@
+using System.Threading;
+
+namespace Sandbox.Resources;
+
+/// <summary>
+/// Produces the texture for one slice of a <see cref="SpriteSheet"/>, by cropping the sheet's source
+/// image down to that slice's rect.
+/// </summary>
+/// <remarks>
+/// This is what keeps the sheet the single place a cut is recorded. A sprite built from a sheet holds
+/// one of these rather than a baked-out image, so re-slicing reaches everything already using it -
+/// the same way <see cref="ImageFileGenerator"/> frames follow edits to the file they came from.
+/// </remarks>
+[Title( "Sprite Sheet Slice" )]
+[Icon( "crop" )]
+[ClassName( "spritesheetslice" )]
+public sealed class SpriteSheetSliceGenerator : TextureGenerator
+{
+	/// <summary>
+	/// The sheet the slice belongs to.
+	/// </summary>
+	[KeyProperty]
+	public SpriteSheet Sheet { get; set; }
+
+	/// <summary>
+	/// Which slice, by its stable id. Names get changed - labelling parts <c>L_Thigh</c> and
+	/// <c>R_Calf</c> is a required step of rigging - so the id is what the reference hangs off.
+	/// </summary>
+	public Guid SliceId { get; set; }
+
+	/// <summary>
+	/// The slice's name when this reference was made. Only used to find the slice again if its id
+	/// goes missing, and to give the reference something readable to show.
+	/// </summary>
+	public string SliceName { get; set; }
+
+	[Hide]
+	public override bool CacheToDisk => true;
+
+	// Sprites are pixel art as often as not, and block compression would visibly wreck them.
+	[Hide]
+	public override ImageFormat? FormatOverride => ImageFormat.RGBA8888;
+
+	protected override async ValueTask<Texture> CreateTexture( Options options, CancellationToken ct )
+	{
+		if ( Sheet is null )
+			return null;
+
+		// Id first, name only as a repair path for a reference that lost track of its slice.
+		var slice = Sheet.GetSlice( SliceId ) ?? Sheet.GetSlice( SliceName );
+		if ( slice is null )
+			return Texture.Transparent;
+
+		if ( string.IsNullOrWhiteSpace( Sheet.ImagePath ) )
+			return Texture.Transparent;
+
+		//
+		// Both the sheet and the image it cuts up are inputs, so a change to either has to be able to
+		// bring this back around. Without these the compiler has no idea this texture went stale.
+		//
+		if ( options.Compiler is not null )
+		{
+			if ( !string.IsNullOrEmpty( Sheet.ResourcePath ) )
+				options.Compiler.Context.AddCompileReference( Sheet.ResourcePath );
+
+			options.Compiler.Context.AddCompileReference( Sheet.ImagePath );
+		}
+
+		var path = Sheet.ImagePath.NormalizeFilename();
+
+		if ( !EngineFileSystem.Mounted.FileExists( path ) )
+		{
+			Log.Warning( $"SpriteSheetSliceGenerator could not find file: {path}" );
+			return Texture.Invalid;
+		}
+
+		var bytes = await EngineFileSystem.Mounted.ReadAllBytesAsync( path );
+		ct.ThrowIfCancellationRequested();
+
+		var bitmap = Bitmap.CreateFromBytes( bytes );
+		if ( bitmap is null )
+			return Texture.Invalid;
+
+		try
+		{
+			var rect = ClampToBitmap( slice.Rect, bitmap.Width, bitmap.Height );
+
+			// A slice that ended up outside the image entirely - the source was swapped for a smaller
+			// one, most likely. Transparent rather than invalid, so the rest of the sprite still works
+			// and the gap is obvious in the editor.
+			if ( rect.Width < 1 || rect.Height < 1 )
+				return Texture.Transparent;
+
+			// Whole-image slices are common enough (a one-part sheet) to be worth not copying for.
+			if ( rect.Width < bitmap.Width || rect.Height < bitmap.Height )
+			{
+				var cropped = bitmap.Crop( rect.SnapToGrid() );
+				bitmap.Dispose();
+				bitmap = cropped;
+			}
+
+			if ( Sheet.KeyBackground )
+			{
+				KnockOutBackground( bitmap, Sheet.Background );
+			}
+
+			return bitmap?.ToTexture();
+		}
+		finally
+		{
+			bitmap?.Dispose();
+		}
+	}
+
+	/// <summary>
+	/// Make the sheet's background colour see-through, so a part cut from a flat white sheet does not
+	/// render as a white rectangle.
+	/// </summary>
+	/// <remarks>
+	/// Edges are faded rather than cut hard. Artwork keyed this way is usually a JPEG or a scan, where
+	/// the boundary between drawing and background is a gradient several pixels wide - a hard threshold
+	/// leaves a bright fringe around every part, which is very obvious once the parts are laid over
+	/// each other in a rig.
+	/// </remarks>
+	static void KnockOutBackground( Bitmap bitmap, SpriteSheet.BackgroundKey key )
+	{
+		if ( bitmap is null || !key.Enabled ) return;
+
+		var pixels = bitmap.GetPixels32();
+		if ( pixels is null || pixels.Length == 0 ) return;
+
+		var output = new Color[pixels.Length];
+
+		// Beyond this the pixel is left alone; between the two it fades.
+		var feather = Math.Max( 1, key.Tolerance * 2 );
+
+		for ( int i = 0; i < pixels.Length; i++ )
+		{
+			var pixel = pixels[i];
+
+			var distance = Math.Max(
+				Math.Abs( pixel.r - key.Color.r ),
+				Math.Max( Math.Abs( pixel.g - key.Color.g ), Math.Abs( pixel.b - key.Color.b ) ) );
+
+			float alpha = pixel.a / 255f;
+
+			if ( distance <= key.Tolerance )
+			{
+				alpha = 0f;
+			}
+			else if ( distance < feather )
+			{
+				alpha *= (distance - key.Tolerance) / (float)(feather - key.Tolerance);
+			}
+
+			output[i] = new Color( pixel.r / 255f, pixel.g / 255f, pixel.b / 255f, alpha );
+		}
+
+		bitmap.SetPixels( output );
+	}
+
+	static Rect ClampToBitmap( Rect rect, int width, int height )
+	{
+		var left = Math.Clamp( (int)rect.Left, 0, width );
+		var top = Math.Clamp( (int)rect.Top, 0, height );
+		var right = Math.Clamp( (int)(rect.Left + rect.Width), 0, width );
+		var bottom = Math.Clamp( (int)(rect.Top + rect.Height), 0, height );
+
+		return new Rect( left, top, right - left, bottom - top );
+	}
+}

--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.Sorting.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.Sorting.cs
@@ -1,0 +1,106 @@
+namespace Sandbox;
+
+/// <summary>
+/// How sorted sprites are ordered against each other by a camera, once their sort layer and
+/// order in layer have been compared and come out equal.
+/// </summary>
+[Expose]
+public enum TransparencySortMode
+{
+	/// <summary>
+	/// Follow the camera's projection - distance from the camera when perspective, depth along
+	/// the view direction when orthographic.
+	/// </summary>
+	[Icon( "auto_awesome" )]
+	Default,
+
+	/// <summary>
+	/// Always sort by distance from the camera position, even in an orthographic view.
+	/// </summary>
+	[Icon( "videocam" )]
+	Perspective,
+
+	/// <summary>
+	/// Always sort by depth along the camera's view direction, even in a perspective view.
+	/// </summary>
+	[Icon( "crop_free" )]
+	Orthographic,
+
+	/// <summary>
+	/// Sort by position along <see cref="CameraComponent.TransparencySortAxis"/>, ignoring where
+	/// the camera is. This is how top-down and isometric games make characters occlude each other
+	/// by their feet.
+	/// </summary>
+	[Icon( "straighten" )]
+	CustomAxis,
+}
+
+public sealed partial class CameraComponent
+{
+	/// <summary>
+	/// How this camera breaks ties between sprites that share a sort layer and order in layer.
+	/// Only affects sprites with <see cref="SpriteRenderer.IsSorted"/> enabled.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( 300 )]
+	public TransparencySortMode TransparencySort { get; set; } = TransparencySortMode.Default;
+
+	/// <summary>
+	/// The axis sprites are sorted along when <see cref="TransparencySort"/> is
+	/// <see cref="TransparencySortMode.CustomAxis"/>. A sprite further along this axis draws
+	/// behind one that is less far along it - so for a top-down game the default (0,1,0) makes a
+	/// character lower on the screen walk in front of one higher up.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( 301 )]
+	[ShowIf( nameof( TransparencySort ), TransparencySortMode.CustomAxis )]
+	public Vector3 TransparencySortAxis { get; set; } = new( 0, 1, 0 );
+
+	/// <summary>
+	/// The axis handed to the sprite compute shader for a given mode. Only
+	/// <see cref="TransparencySortMode.CustomAxis"/> sorts along an axis at all, so every other
+	/// mode resolves to zero - which the shader reads as "sort by camera depth instead".
+	///
+	/// A zero axis in CustomAxis mode stays zero rather than becoming a NaN, so a half-configured
+	/// camera degrades to the old behaviour instead of corrupting the sort.
+	/// </summary>
+	internal static Vector3 ResolveSortAxis( TransparencySortMode mode, Vector3 axis )
+	{
+		if ( mode != TransparencySortMode.CustomAxis ) return Vector3.Zero;
+
+		// Normal returns the vector untouched when it is near-zero, so this cannot produce NaN.
+		return axis.Normal;
+	}
+
+	/// <summary>
+	/// Pushes the sorting settings onto the camera so the sprite compute shader can read them.
+	/// A camera that never touches these renders exactly as it did before they existed.
+	/// </summary>
+	internal void UpdateSortingAttributes( SceneCamera camera )
+	{
+		camera.Attributes.Set( "SpriteSortMode", (int)TransparencySort );
+		camera.Attributes.Set( "SpriteSortAxis", ResolveSortAxis( TransparencySort, TransparencySortAxis ) );
+	}
+
+	/// <summary>
+	/// Draws the sort axis in front of the camera while it is selected. "Which way is behind?" is
+	/// the question a custom axis immediately raises, and a number in the inspector answers it far
+	/// less well than an arrow does.
+	/// </summary>
+	private void DrawSortAxisGizmo()
+	{
+		var axis = ResolveSortAxis( TransparencySort, TransparencySortAxis );
+		if ( axis.IsNearZeroLength ) return;
+
+		// Out in front of the camera, so the arrow lands somewhere the camera can actually see
+		// rather than on top of the frustum apex.
+		var origin = WorldPosition + WorldRotation.Forward * 128f;
+		var length = 48f;
+
+		Gizmo.Draw.Color = Color.Cyan.WithAlpha( 0.9f );
+		Gizmo.Draw.Arrow( origin - axis * length, origin + axis * length, 12f, 4f );
+
+		// The arrow alone does not say which end wins, and guessing wrong inverts the whole scene.
+		Gizmo.Draw.Color = Color.Cyan.WithAlpha( 0.6f );
+		Gizmo.Draw.ScreenText( "behind", Gizmo.Camera.ToScreen( origin + axis * length ), size: 12 );
+		Gizmo.Draw.ScreenText( "in front", Gizmo.Camera.ToScreen( origin - axis * length ), size: 12 );
+	}
+}

--- a/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Camera/CameraComponent.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Sandbox.Rendering;
 using Sandbox.UI;
 using System.Drawing;
@@ -257,6 +257,8 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 
 		Gizmo.Draw.Color = Color.White.WithAlpha( 0.4f );
 		Gizmo.Draw.LineFrustum( frustum );
+
+		DrawSortAxisGizmo();
 	}
 
 	/// <summary>
@@ -414,6 +416,9 @@ public sealed partial class CameraComponent : Component, Component.ExecuteInEdit
 
 		// Merge our global Scene attributes into the camera
 		Scene.RenderAttributes.MergeTo( camera.Attributes );
+
+		// After the merge, so the camera's own sorting settings win over any scene-wide value
+		UpdateSortingAttributes( camera );
 
 		camera.DebugMode = DebugMode;
 		camera.WireframeMode = WireframeMode;

--- a/engine/Sandbox.Engine/Scene/Components/Render/SortingGroup.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/SortingGroup.cs
@@ -1,0 +1,105 @@
+namespace Sandbox;
+
+/// <summary>
+/// Makes every <see cref="SpriteRenderer"/> beneath this object sort as one unit. The whole group
+/// takes its place in the draw order from this component's own layer and order, and its sprites
+/// sort among themselves by their individual sort orders - so nothing from outside the group can
+/// ever be drawn in between them.
+///
+/// This is what keeps a character built out of separate sprites from being sliced apart by a tree
+/// or another character standing at a similar depth.
+/// </summary>
+[Expose]
+[Title( "Sorting Group" )]
+[Category( "Rendering" )]
+[Icon( "layers" )]
+public sealed class SortingGroup : Component, Component.ExecuteInEditor
+{
+	/// <summary>
+	/// Which sort layer the whole group sits in. The sort layer on the individual sprites beneath
+	/// this group is ignored.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -150 )]
+	[Editor( "sortlayer" )]
+	public SortLayerHandle SortLayer { get; set; }
+
+	/// <summary>
+	/// Draw order of the whole group within its layer. Higher draws on top. The sort order on the
+	/// individual sprites beneath this group orders them against each other, not against the world.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -149 )]
+	public int SortOrder { get; set; }
+
+	/// <summary>
+	/// The number of sprite members, so the inspector can say whether this group is doing anything.
+	/// </summary>
+	public int MemberCount => GetComponentsInChildren<SpriteRenderer>( true ).Count();
+
+	/// <summary>
+	/// The group a sprite actually belongs to: the nearest enabled one at or above it.
+	///
+	/// Nesting is deliberately not supported - the draw order has room for one group's worth of
+	/// ordering, not a tree of it - so an inner group simply wins outright for the sprites beneath
+	/// it and the outer group never sees them.
+	/// </summary>
+	internal static SortingGroup FindFor( SpriteRenderer sprite )
+		=> sprite.GetComponentInParent<SortingGroup>();
+
+	/// <summary>
+	/// True when this group is inside another one. Reported in the editor rather than fixed,
+	/// because silently flattening someone's hierarchy is worse than telling them it won't nest.
+	/// </summary>
+	public bool IsNested => GameObject.Parent?.GetComponentInParent<SortingGroup>() is not null;
+
+	/// <summary>
+	/// The largest rank the draw order can represent. Members past this all share the last rank
+	/// and fall back to sorting against each other by depth.
+	/// </summary>
+	internal const int MaxRank = 255;
+
+	private readonly Dictionary<Guid, int> _ranks = new();
+	private readonly List<SpriteRenderer> _rankScratch = new();
+
+	/// <summary>
+	/// Rebuilds the member ordering. The draw order only has room for a small dense rank per
+	/// member, so the authored sort orders - which may be any integers at all, with gaps - are
+	/// compressed down to 0, 1, 2... in the same relative order.
+	///
+	/// Call this before reading <see cref="GetRank"/> from parallel code; it is not thread safe,
+	/// but it is deterministic, so calling it more than once in a frame is harmless.
+	/// </summary>
+	internal void RefreshRanks()
+	{
+		_ranks.Clear();
+		_rankScratch.Clear();
+
+		foreach ( var sprite in GetComponentsInChildren<SpriteRenderer>( true ) )
+		{
+			// A sprite under a nested group belongs to that group, not to this one.
+			if ( FindFor( sprite ) != this ) continue;
+
+			_rankScratch.Add( sprite );
+		}
+
+		// Id breaks ties so that two members sharing a sort order keep a stable order between
+		// frames. Without it they would swap according to component iteration order and flicker.
+		_rankScratch.Sort( ( a, b ) =>
+		{
+			var byOrder = a.SortOrder.CompareTo( b.SortOrder );
+			return byOrder != 0 ? byOrder : a.Id.CompareTo( b.Id );
+		} );
+
+		for ( var i = 0; i < _rankScratch.Count; i++ )
+		{
+			_ranks[_rankScratch[i].Id] = Math.Min( i, MaxRank );
+		}
+
+		_rankScratch.Clear();
+	}
+
+	/// <summary>
+	/// This sprite's position in the group's internal draw order. Higher draws in front.
+	/// </summary>
+	internal int GetRank( SpriteRenderer sprite )
+		=> _ranks.TryGetValue( sprite.Id, out var rank ) ? rank : 0;
+}

--- a/engine/Sandbox.Engine/Scene/Components/Render/SpriteRenderer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Render/SpriteRenderer.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Rendering;
+using Sandbox.Rendering;
 
 namespace Sandbox;
 
@@ -148,6 +148,43 @@ public sealed partial class SpriteRenderer : Renderer, Component.ExecuteInEditor
 	/// </summary>
 	[Property, Category( "Visuals" ), Order( -200 )]
 	public bool IsSorted { get; set; }
+
+	/// <summary>
+	/// Which sort layer this sprite belongs to. Sprites in a later layer always draw in front of
+	/// sprites in an earlier one. Layers are defined in the project's sorting settings.
+	/// Requires <see cref="IsSorted"/> to have any effect.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -150 )]
+	[Editor( "sortlayer" )]
+	public SortLayerHandle SortLayer { get; set; }
+
+	/// <summary>
+	/// Draw order within the sort layer. Higher values draw on top. Sprites with an equal order
+	/// fall back to sorting by depth. Requires <see cref="IsSorted"/> to have any effect.
+	/// </summary>
+	[Property, Category( "Sorting" ), Order( -149 )]
+	public int SortOrder { get; set; }
+
+	/// <summary>
+	/// The <see cref="SortingGroup"/> this sprite belongs to, if any. While it has one, the
+	/// group's layer and order decide where it sits against the rest of the world, and this
+	/// sprite's own <see cref="SortOrder"/> only orders it against the group's other members.
+	/// </summary>
+	public SortingGroup SortingGroup => SortingGroup.FindFor( this );
+
+	/// <summary>
+	/// Where this sprite actually lands in the draw order, once its sorting group has had its say.
+	/// This is what gets uploaded, and what the editor reports.
+	/// </summary>
+	internal (SortLayerHandle Layer, int Order, Vector3 Origin, int Rank) ResolveSorting( SortingGroup group )
+	{
+		// The group's origin, not the sprite's, is what the whole group sorts at - that is what
+		// stops anything outside the group from being drawn in between its members.
+		if ( group is not null )
+			return (group.SortLayer, group.SortOrder, group.WorldPosition, group.GetRank( this ));
+
+		return (SortLayer, SortOrder, WorldPosition, 0);
+	}
 
 	/// <summary>
 	/// This action is invoked when an animation starts playing. The string parameter is the name of the animation that started.

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/SceneSpriteSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/SceneSpriteSystem.cs
@@ -15,7 +15,9 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 	/// <summary>Carries the data needed to configure a new <see cref="SpriteBatchSceneObject"/> from the original component state.</summary>
 	private readonly record struct RenderGroupConfig( InstanceGroupFlags Flags, RenderOptions RenderOptions, IReadOnlySet<uint> Tags );
 
-	Dictionary<ulong, SpriteBatchSceneObject> RenderGroups = [];
+	// Internal rather than private so tests can check how sprites got divided into batches - which
+	// batch a sprite lands in is what decides whether its sort layer can be honoured at all.
+	internal Dictionary<ulong, SpriteBatchSceneObject> RenderGroups = [];
 
 	public SceneSpriteSystem( Scene scene ) : base( scene )
 	{
@@ -126,7 +128,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 			var particleSystemID = particleRenderer.Id;
 			_activeParticleEmitters[i] = particleSystemID;
 
-			var rendergroup = GetRenderGroupKey( systemInfo.System, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions );
+			var rendergroup = GetRenderGroupKey( systemInfo.System, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions, allowBlendMerge: false );
 
 			// This is a very hot codepath, beware!
 			// Create span from the managed array starting at the correct offset with the correct length
@@ -168,7 +170,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 			if ( !RenderGroups.ContainsKey( rendergroup ) )
 			{
 				var particleRenderer = (ParticleRenderer)system;
-				CreateRenderGroup( rendergroup, BuildConfig( system, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions ) );
+				CreateRenderGroup( rendergroup, BuildConfig( system, (GameTags)particleRenderer.Tags, particleRenderer.RenderOptions, allowBlendMerge: false ) );
 			}
 
 			// Register in correct render group using shared block with offset and precomputed splot count
@@ -261,7 +263,22 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		}
 	}
 
-	private static ulong GetRenderGroupKey( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions )
+	/// <summary>
+	/// Whether this sprite can share a batch with sprites of a different blend state.
+	///
+	/// It has to, for sort layers to mean anything: the engine offers no way to order one scene
+	/// object against another, so two sprites in separate batches have no defined order however
+	/// their layers are set. Sprites that share a batch are ordered by the GPU sort, which leads
+	/// with the layer - so merging is what makes the layer win.
+	///
+	/// Only within the translucent pass. Opaque sprites belong to a different render pass
+	/// entirely, and a shadow caster carries a scene-object flag that additive sprites never set,
+	/// so neither can be folded in without changing what it does.
+	/// </summary>
+	private static bool CanMergeBlendModes( ISpriteRenderGroup component, bool castsShadow )
+		=> component.IsSorted && !component.Opaque && !castsShadow;
+
+	internal static ulong GetRenderGroupKey( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions, bool allowBlendMerge )
 	{
 		var flags = InstanceGroupFlags.None;
 
@@ -272,14 +289,25 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		}
 
 		// Shadows
-		if ( component.Shadows && !component.Additive )
+		var castsShadow = component.Shadows && !component.Additive;
+		if ( castsShadow )
 		{
 			flags |= InstanceGroupFlags.CastShadow;
 		}
 
-		if ( component.Additive )
+		// Leaving Additive out of the key is what lets additive and ordinary sprites land in the
+		// same batch, and so be ordered against each other by their sort layers. The batch then
+		// draws each blend state as its own run - see SpriteDrawPlan.
+		var merged = allowBlendMerge && CanMergeBlendModes( component, castsShadow );
+
+		if ( component.Additive && !merged )
 		{
 			flags |= InstanceGroupFlags.Additive;
+		}
+
+		if ( merged )
+		{
+			flags |= InstanceGroupFlags.MixedBlend;
 		}
 
 		if ( component.Opaque )
@@ -307,12 +335,20 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		return XxHash3.HashToUInt64( buf );
 	}
 
-	private static RenderGroupConfig BuildConfig( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions )
+	private static RenderGroupConfig BuildConfig( ISpriteRenderGroup component, GameTags tags, RenderOptions renderOptions, bool allowBlendMerge )
 	{
 		var flags = InstanceGroupFlags.None;
 		if ( !component.Opaque && component.IsSorted ) flags |= InstanceGroupFlags.Transparent;
-		if ( component.Shadows && !component.Additive ) flags |= InstanceGroupFlags.CastShadow;
-		if ( component.Additive ) flags |= InstanceGroupFlags.Additive;
+
+		var castsShadow = component.Shadows && !component.Additive;
+		if ( castsShadow ) flags |= InstanceGroupFlags.CastShadow;
+
+		// Must stay in step with GetRenderGroupKey, or a batch gets configured for flags its key
+		// was never built from.
+		var merged = allowBlendMerge && CanMergeBlendModes( component, castsShadow );
+		if ( component.Additive && !merged ) flags |= InstanceGroupFlags.Additive;
+		if ( merged ) flags |= InstanceGroupFlags.MixedBlend;
+
 		if ( component.Opaque ) flags |= InstanceGroupFlags.Opaque;
 
 		return new RenderGroupConfig( flags, renderOptions.Clone(), tags.GetTokens().ToFrozenSet() );
@@ -360,6 +396,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		renderGroupObject.Sorted = (config.Flags & InstanceGroupFlags.Transparent) != 0;
 		renderGroupObject.Additive = (config.Flags & InstanceGroupFlags.Additive) != 0;
 		renderGroupObject.Opaque = (config.Flags & InstanceGroupFlags.Opaque) != 0;
+		renderGroupObject.MixedBlend = (config.Flags & InstanceGroupFlags.MixedBlend) != 0;
 		renderGroupObject.Tags.SetFrom( new TagSet( config.Tags.Select( StringToken.GetValue ) ) );
 		config.RenderOptions.Apply( renderGroupObject );
 
@@ -369,9 +406,9 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 
 	internal void RegisterSprite( Guid componentId, SpriteRenderer component )
 	{
-		var key = GetRenderGroupKey( component, component.Tags as GameTags, component.RenderOptions );
+		var key = GetRenderGroupKey( component, component.Tags as GameTags, component.RenderOptions, allowBlendMerge: true );
 		if ( !RenderGroups.ContainsKey( key ) )
-			CreateRenderGroup( key, BuildConfig( component, component.Tags as GameTags, component.RenderOptions ) );
+			CreateRenderGroup( key, BuildConfig( component, component.Tags as GameTags, component.RenderOptions, allowBlendMerge: true ) );
 
 		InsertInRenderGroup( componentId, component, key );
 	}
@@ -381,7 +418,7 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		// If found in old renderGroup, we unregister it and register it in the new one
 		if ( FindCurrentRenderGroup( componentId ) is ulong oldRenderGroup )
 		{
-			var newRenderGroup = GetRenderGroupKey( component, (GameTags)component.Tags, component.RenderOptions );
+			var newRenderGroup = GetRenderGroupKey( component, (GameTags)component.Tags, component.RenderOptions, allowBlendMerge: true );
 			if ( !oldRenderGroup.Equals( newRenderGroup ) )
 			{
 				RemoveFromRenderGroup( componentId, oldRenderGroup );
@@ -416,6 +453,9 @@ public sealed class SceneSpriteSystem : GameObjectSystem<SceneSpriteSystem>
 		CastOnlyShadow = 1 << 1,
 		Transparent = 1 << 2,
 		Additive = 1 << 3,
-		Opaque = 1 << 4
+		Opaque = 1 << 4,
+
+		/// <summary>Holds more than one blend state, drawn as one run per state in layer order.</summary>
+		MixedBlend = 1 << 5
 	}
 }

--- a/engine/Sandbox.Engine/Systems/Project/ProjectSettings/ProjectSettings.cs
+++ b/engine/Sandbox.Engine/Systems/Project/ProjectSettings/ProjectSettings.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Audio;
+using Sandbox.Audio;
 
 namespace Sandbox;
 
@@ -59,6 +59,11 @@ public class ProjectSettings
 	/// and it will return the same object. The cache is cleared automatically when the project changes, 
 	/// or when it's hotloaded.
 	/// </summary>
+	/// <summary>
+	/// Get the <see cref="SortingSettings"/> from the active project settings.
+	/// </summary>
+	public static SortingSettings Sorting => Get<SortingSettings>( "Sorting.config" );
+
 	public static T Get<T>( string filename ) where T : ConfigData, new()
 	{
 		if ( _cache.TryGetValue( filename, out var result ) && result is T t )

--- a/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortLayerHandle.cs
+++ b/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortLayerHandle.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Serialization;
+
+namespace Sandbox;
+
+/// <summary>
+/// A reference to one of the project's sprite sort layers. Stores the layer's id rather than its
+/// name or position, so renaming or reordering layers never changes what a sprite points at.
+/// </summary>
+public struct SortLayerHandle : IEquatable<SortLayerHandle>
+{
+	/// <summary>
+	/// Id of the referenced layer. Empty means the default layer.
+	/// </summary>
+	public Guid Id { get; set; }
+
+	/// <summary>
+	/// Initializes a handle pointing at the layer with the given id.
+	/// </summary>
+	public SortLayerHandle( Guid id ) => Id = id;
+
+	/// <summary>
+	/// Initializes a handle pointing at a layer.
+	/// </summary>
+	public SortLayerHandle( SortingSettings.SortLayer layer ) => Id = layer?.Id ?? Guid.Empty;
+
+	/// <summary>
+	/// The layer this handle refers to, falling back to the default layer when the referenced
+	/// layer has been deleted.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public readonly SortingSettings.SortLayer Layer
+	{
+		get
+		{
+			var settings = ProjectSettings.Sorting;
+			return settings.GetLayer( Id ) ?? settings.DefaultLayer;
+		}
+	}
+
+	/// <summary>
+	/// Position of this layer in the draw order. Higher draws in front.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public readonly int Index => ProjectSettings.Sorting.GetLayerIndex( Id );
+
+	/// <summary>
+	/// Display name of this layer.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public readonly string Name => Layer.Name;
+
+	/// <summary>
+	/// Finds a layer by name. Returns a handle to the default layer if there is no match.
+	/// </summary>
+	public static SortLayerHandle FromName( string name )
+	{
+		return new SortLayerHandle( ProjectSettings.Sorting.GetLayer( name ) );
+	}
+
+	/// <inheritdoc />
+	public readonly bool Equals( SortLayerHandle other ) => Id == other.Id;
+
+	/// <inheritdoc />
+	public readonly override bool Equals( object obj ) => obj is SortLayerHandle other && Equals( other );
+
+	/// <inheritdoc />
+	public readonly override int GetHashCode() => Id.GetHashCode();
+
+	/// <inheritdoc />
+	public readonly override string ToString() => Name;
+
+	public static bool operator ==( SortLayerHandle a, SortLayerHandle b ) => a.Equals( b );
+	public static bool operator !=( SortLayerHandle a, SortLayerHandle b ) => !a.Equals( b );
+}

--- a/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortingSettings.cs
+++ b/engine/Sandbox.Engine/Systems/Project/ProjectSettings/SortingSettings.cs
@@ -1,0 +1,184 @@
+using System.Text.Json.Serialization;
+
+namespace Sandbox;
+
+/// <summary>
+/// Project wide draw order settings for sprites. Sort layers are an ordered list - a sprite in a
+/// later layer always draws in front of a sprite in an earlier one, whatever their positions.
+/// </summary>
+[Expose]
+public class SortingSettings : ConfigData
+{
+	/// <summary>
+	/// Name given to the layer that every sprite starts in.
+	/// </summary>
+	public const string DefaultLayerName = "Default";
+
+	/// <summary>
+	/// A named position in the draw order. Sprites reference layers by <see cref="Id"/>, so a layer
+	/// can be freely renamed or moved without silently re-sorting anything that points at it.
+	/// </summary>
+	public class SortLayer
+	{
+		/// <summary>
+		/// Display name, expected to be unique within the list.
+		/// </summary>
+		[KeyProperty]
+		public string Name { get; set; } = "New Layer";
+
+		/// <summary>
+		/// Stable identity, preserved across reordering and renaming.
+		/// </summary>
+		[Hide]
+		public Guid Id { get; set; } = Guid.NewGuid();
+	}
+
+	/// <summary>
+	/// Every sort layer, back to front. The first entry draws first and so appears behind the rest.
+	/// </summary>
+	public List<SortLayer> Layers { get; set; }
+
+	private Dictionary<Guid, int> _indexById;
+
+	public SortingSettings()
+	{
+		OnValidate();
+	}
+
+	/// <summary>
+	/// The layer that sprites fall back to when they have no layer assigned, or when the layer they
+	/// reference no longer exists. Always the first layer in the list.
+	/// </summary>
+	[JsonIgnore, Hide]
+	public SortLayer DefaultLayer => Layers[0];
+
+	/// <summary>
+	/// Finds the position of a layer in the draw order. Returns 0 - the default layer - if the id is
+	/// empty or refers to a layer that has since been deleted.
+	/// </summary>
+	public int GetLayerIndex( Guid id )
+	{
+		if ( id == Guid.Empty ) return 0;
+
+		return _indexById.TryGetValue( id, out var index ) ? index : 0;
+	}
+
+	/// <summary>
+	/// Finds a layer by its id, or null if no such layer exists.
+	/// </summary>
+	public SortLayer GetLayer( Guid id )
+	{
+		if ( id == Guid.Empty ) return null;
+
+		return _indexById.TryGetValue( id, out var index ) ? Layers[index] : null;
+	}
+
+	/// <summary>
+	/// Finds a layer by name, case insensitively, or null if no such layer exists.
+	/// </summary>
+	public SortLayer GetLayer( string name )
+	{
+		foreach ( var layer in Layers )
+		{
+			if ( string.Equals( layer.Name, name, StringComparison.OrdinalIgnoreCase ) )
+				return layer;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Adds a layer at the front of the draw order, so it draws on top of everything already there.
+	/// </summary>
+	public SortLayer AddLayer( string name )
+	{
+		var layer = new SortLayer { Name = name };
+
+		Layers.Add( layer );
+		Refresh();
+
+		return layer;
+	}
+
+	/// <summary>
+	/// Removes a layer. Sprites still pointing at it resolve back to <see cref="DefaultLayer"/> on
+	/// their own, so there is nothing to fix up afterwards.
+	///
+	/// Refuses to remove the last layer, since everything falls back to it.
+	/// </summary>
+	public bool RemoveLayer( SortLayer layer )
+	{
+		if ( Layers.Count <= 1 ) return false;
+		if ( !Layers.Remove( layer ) ) return false;
+
+		Refresh();
+		return true;
+	}
+
+	/// <summary>
+	/// Moves a layer to a new position in the draw order.
+	/// </summary>
+	public void MoveLayer( int fromIndex, int toIndex )
+	{
+		if ( fromIndex < 0 || fromIndex >= Layers.Count ) return;
+		if ( toIndex < 0 || toIndex >= Layers.Count ) return;
+		if ( fromIndex == toIndex ) return;
+
+		var layer = Layers[fromIndex];
+
+		Layers.RemoveAt( fromIndex );
+		Layers.Insert( toIndex, layer );
+
+		Refresh();
+	}
+
+	/// <summary>
+	/// Rebuilds the id lookup after the layer list has been changed.
+	///
+	/// Every lookup from a layer id to its position in the draw order goes through that map, so
+	/// leaving it stale does not throw - it quietly resolves layers to the wrong position, or to
+	/// the default. Prefer <see cref="AddLayer"/>, <see cref="RemoveLayer"/> and
+	/// <see cref="MoveLayer"/>, which cannot forget to call this.
+	/// </summary>
+	public void Refresh() => OnValidate();
+
+	protected override void OnValidate()
+	{
+		Layers ??= [new SortLayer { Name = DefaultLayerName }];
+
+		// A project with no layers at all has nothing to fall back to, so keep one alive.
+		if ( Layers.Count == 0 )
+		{
+			Layers.Add( new SortLayer { Name = DefaultLayerName } );
+		}
+
+		_indexById = new Dictionary<Guid, int>( Layers.Count );
+
+		for ( int i = 0; i < Layers.Count; i++ )
+		{
+			var layer = Layers[i];
+
+			// Layers authored by hand, or duplicated in the editor, can arrive without an id.
+			if ( layer.Id == Guid.Empty )
+			{
+				layer.Id = Guid.NewGuid();
+			}
+
+			// First one wins, so a duplicated id can never make a layer unreachable.
+			_indexById.TryAdd( layer.Id, i );
+		}
+	}
+
+	public override int GetHashCode()
+	{
+		HashCode hc = default;
+
+		foreach ( var layer in Layers )
+		{
+			hc.Add( layer.Id );
+			hc.Add( layer.Name );
+		}
+
+		return hc.ToHashCode();
+	}
+}

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
@@ -1,4 +1,4 @@
-﻿namespace Sandbox.Rendering;
+namespace Sandbox.Rendering;
 
 using NativeEngine;
 using System.Buffers;
@@ -33,6 +33,21 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		AddressModeU = TextureAddressMode.Clamp,
 		AddressModeV = TextureAddressMode.Clamp,
 	};
+
+	/// <summary>
+	/// A sprite's place in the draw order, compared lexicographically on the GPU. Splitting this
+	/// across two integers keeps the comparison exact - a single float could not hold the full
+	/// layer/order range alongside a distance without silently losing precision.
+	/// </summary>
+	[StructLayout( LayoutKind.Sequential, Pack = 4 )]
+	internal struct SpriteSortKey
+	{
+		/// <summary>Sort layer and order in layer, inverted on the GPU so higher draws in front.</summary>
+		public uint Coarse;
+
+		/// <summary>Distance along the transparency sort axis, made unsigned-comparable.</summary>
+		public uint Fine;
+	}
 
 	/// <summary>
 	/// Flags for sprite rendering, must match SpriteFlags in sprite_ps.shader
@@ -71,6 +86,30 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		public Vector3 Velocity = Vector3.Zero;
 		public Vector4 BlendSheetUV;
 		public Vector2 Offset;
+
+		/// <summary>
+		/// Coarse draw order, packed by <see cref="PackSortKey"/>. Compared before the sort axis
+		/// distance, so it wins over any positional ordering.
+		/// </summary>
+		public uint SortKey = 0;
+
+		/// <summary>
+		/// Moves the point this sprite sorts at, relative to <see cref="Position"/>. Set to a
+		/// sorting group's origin so every member of the group resolves to one depth and nothing
+		/// outside it can be drawn in between them.
+		///
+		/// Deliberately an offset rather than an absolute position: zero means "sort where I am",
+		/// so every sprite built without knowing about sorting groups - particles especially -
+		/// keeps sorting exactly as it did.
+		/// </summary>
+		public Vector3 SortOriginOffset = Vector3.Zero;
+
+		/// <summary>
+		/// Order within the sorting group, densely ranked from 0. Occupies the low bits of the
+		/// sort key's distance term, so it only ever decides between sprites at the same depth.
+		/// </summary>
+		public uint SortRank = 0;
+
 		public SpriteData()
 		{
 
@@ -84,6 +123,29 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			byte b = (byte)(color.b * 255f);
 			byte a = (byte)(color.a * 255f);
 			return (uint)(r | (g << 8) | (b << 16) | (a << 24));
+		}
+
+		/// <summary>Bits of the sort key given over to the layer index. 16k layers is far past useful.</summary>
+		internal const int SortKeyLayerBits = 14;
+
+		/// <summary>
+		/// Packs a sprite's layer, blend state and order within the layer into a single value that
+		/// orders correctly under plain unsigned comparison.
+		///
+		/// Layer is the most significant term, so it beats everything. Blend comes next, above
+		/// order: sprites needing different blend states cannot share a draw call, so grouping
+		/// them is what lets a layer be drawn as a small run of draws instead of being broken up.
+		/// The cost is that order-in-layer only ranks a sprite against others of the same blend
+		/// state - which is the same trade the renderer is already forced into.
+		/// </summary>
+		internal static uint PackSortKey( int layerIndex, SpriteBlendMode blend, int sortOrder )
+		{
+			var layer = (uint)Math.Clamp( layerIndex, 0, (1 << SortKeyLayerBits) - 1 );
+
+			// Bias the signed order so that negative orders still compare below positive ones.
+			var order = (uint)(Math.Clamp( sortOrder, short.MinValue, short.MaxValue ) - short.MinValue);
+
+			return (layer << 18) | ((uint)blend << 16) | order;
 		}
 
 		// Pack fog strength and alpha cutout into a single uint
@@ -175,7 +237,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 	GpuBuffer<SpriteVertex> VertexBuffer;
 	GpuBuffer<int> IndexBuffer;
 	GpuBuffer<uint> GPUSortingBuffer;
-	GpuBuffer<float> GPUDistanceBuffer;
+	GpuBuffer<SpriteSortKey> GPUSortKeyBuffer;
 
 	SpriteData[] SpriteDataBuffer = null!;
 	bool SpriteDataBufferRented = false;
@@ -195,7 +257,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		SpriteBuffer = new( CurrentBufferSize );
 		SpriteBufferOut = new( CurrentBufferSize );
 		GPUSortingBuffer = new( CurrentBufferSize );
-		GPUDistanceBuffer = new( CurrentBufferSize );
+		GPUSortKeyBuffer = new( CurrentBufferSize );
 		SpriteAtomicCounter = new( 1 );
 	}
 
@@ -255,18 +317,111 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		SpriteBuffer?.Dispose();
 		SpriteBufferOut?.Dispose();
 		GPUSortingBuffer?.Dispose();
-		GPUDistanceBuffer?.Dispose();
+		GPUSortKeyBuffer?.Dispose();
 
 		SpriteBuffer = new( CurrentBufferSize );
 		SpriteBufferOut = new( CurrentBufferSize );
 		GPUSortingBuffer = new( CurrentBufferSize );
-		GPUDistanceBuffer = new( CurrentBufferSize );
+		GPUSortKeyBuffer = new( CurrentBufferSize );
 	}
 
 	private readonly Dictionary<Guid, int> _precomputedSplotCounts = [];
 
 	// Pre-allocated buffer to avoid GC allocations in hot path
 	private SpriteRenderer[] _componentBuffer = new SpriteRenderer[16];
+	private SortingGroup[] _spriteGroupBuffer = new SortingGroup[16];
+	private int[] _bucketLayers = new int[16];
+	private SpriteBlendMode[] _bucketBlends = new SpriteBlendMode[16];
+	private int[] _bucketCounts = [];
+	private readonly HashSet<SortingGroup> _rankedGroups = new();
+
+	/// <summary>
+	/// The runs being built by the current upload, on the main thread.
+	///
+	/// Double buffered against <see cref="_renderBuckets"/> because RenderSceneObject runs on the
+	/// render thread: handing it the list being rebuilt lets it walk half-written offsets and draw
+	/// sprites from the wrong part of the buffer. Same reason the counts below are snapshotted.
+	/// </summary>
+	private List<SpriteDrawBucket> _drawBuckets = new();
+
+	/// <summary>
+	/// The finished runs, swapped in at the end of an upload and only read by the render thread.
+	/// Empty when this batch holds a single blend state, which draws in one call as before.
+	/// </summary>
+	private List<SpriteDrawBucket> _renderBuckets = new();
+
+	/// <summary>
+	/// True when this batch mixes blend states so that sort layers can order across them. Set from
+	/// the render group's flags - see <see cref="SceneSpriteSystem"/>.
+	/// </summary>
+	public bool MixedBlend { get; set; } = false;
+
+	/// <summary>
+	/// Works out the runs this batch has to draw, when it holds more than one blend state.
+	///
+	/// The GPU sort orders by layer first and blend second, so sprites sharing a layer and a blend
+	/// state end up next to each other - which means a run's position is just how many sprites
+	/// sort ahead of it. Counting that on the CPU is what avoids reading the sort result back.
+	///
+	/// Leaves the list empty for every other case, and the batch then draws in one call as before.
+	/// </summary>
+	private void BuildDrawBuckets( int componentCount, int spriteCount, int splotCount, bool sorted )
+	{
+		_drawBuckets.Clear();
+
+		// Unsorted batches have no meaningful order to divide up, and the runs are only in step
+		// with the buffer if every sprite in it came through the component path - particles set no
+		// sort key, and motion blur adds instances the count above never saw.
+		if ( !MixedBlend || !sorted ) return;
+		if ( spriteCount != componentCount || splotCount != 0 ) return;
+
+		var layerCount = ProjectSettings.Sorting.Layers.Count;
+		var requiredCounts = Math.Max( layerCount, 1 ) * SpriteDrawPlan.BlendModeCount;
+
+		if ( _bucketCounts.Length < requiredCounts )
+		{
+			_bucketCounts = new int[requiredCounts];
+		}
+
+		SpriteDrawPlan.BuildBuckets(
+			_bucketLayers.AsSpan( 0, componentCount ),
+			_bucketBlends.AsSpan( 0, componentCount ),
+			layerCount,
+			_drawBuckets,
+			_bucketCounts );
+	}
+
+	/// <summary>
+	/// Works out which sorting group each sprite belongs to and gets every one of those groups to
+	/// rebuild its member ordering.
+	///
+	/// This has to happen before the parallel upload pass rather than inside it: ranking reads a
+	/// whole group's members at once, and walking a sprite's ancestors is not safe to do from
+	/// several threads at the same time. Scenes with no sorting groups pay a single null check
+	/// per sprite for it.
+	/// </summary>
+	private void ResolveSortingGroups( int componentCount )
+	{
+		if ( _spriteGroupBuffer.Length < componentCount )
+		{
+			_spriteGroupBuffer = new SortingGroup[componentCount * 2];
+		}
+
+		_rankedGroups.Clear();
+
+		for ( var i = 0; i < componentCount; i++ )
+		{
+			var group = SortingGroup.FindFor( _componentBuffer[i] );
+
+			_spriteGroupBuffer[i] = group;
+
+			// Rebuild each group once, however many of its members are in this batch.
+			if ( group is not null && _rankedGroups.Add( group ) )
+			{
+				group.RefreshRanks();
+			}
+		}
+	}
 	private readonly object _boundsLock = new();
 
 	public void RegisterSprite( Guid ownerId, SpriteData[] sharedSprites, int offset, int count, int splotCount, BBox bounds )
@@ -366,6 +521,8 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			if ( _componentBuffer.Length < componentCount )
 			{
 				_componentBuffer = new SpriteRenderer[componentCount * 2];
+				_bucketLayers = new int[componentCount * 2];
+				_bucketBlends = new SpriteBlendMode[componentCount * 2];
 			}
 
 			int index = 0;
@@ -373,6 +530,12 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			{
 				_componentBuffer[index++] = component;
 			}
+
+			// Hoisted out of the loop - resolving a layer id to its position in the draw order is a
+			// lookup into this, and it must not change underneath the parallel pass.
+			var sorting = ProjectSettings.Sorting;
+
+			ResolveSortingGroups( componentCount );
 
 			object boundsLock = _boundsLock;
 			Parallel.For<(Vector3 mins, Vector3 maxs)>(
@@ -425,6 +588,14 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 
 					uint packedFogAndAlpha = SpriteData.PackFogAndAlphaCutout( c.FogStrength, c.AlphaCutoff );
 
+					// Ranks were built in the sequential pass above, so this only reads them.
+					var (sortLayer, sortOrder, sortOrigin, sortRank) = c.ResolveSorting( _spriteGroupBuffer[i] );
+
+					// Recorded per sprite so the draw runs can be counted once the loop is done.
+					// Each iteration owns its own slot, so this is safe to write from here.
+					_bucketLayers[i] = sorting.GetLayerIndex( sortLayer.Id );
+					_bucketBlends[i] = SpriteDrawPlan.GetBlendMode( c.Opaque, c.Additive );
+
 					var spritePos = transform.Position;
 					var spriteScale = new Vector2( transform.Scale.x, transform.Scale.z );
 
@@ -442,7 +613,10 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 						Lighting = packedExponent,
 						DepthFeather = c.DepthFeather,
 						SamplerIndex = SamplerState.GetBindlessIndex( sampler with { Filter = c.TextureFilter } ),
-						Offset = c.Pivot
+						Offset = c.Pivot,
+						SortKey = SpriteData.PackSortKey( sorting.GetLayerIndex( sortLayer.Id ), SpriteDrawPlan.GetBlendMode( c.Opaque, c.Additive ), sortOrder ),
+						SortOriginOffset = sortOrigin - spritePos,
+						SortRank = (uint)sortRank
 					};
 
 					var pivot = c.Pivot;
@@ -508,6 +682,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		}
 
 		bool sorted = Sorted;
+		BuildDrawBuckets( componentCount, SpriteCount, SplotCount, sorted );
 		bool filtered = Filtered;
 		bool additive = Additive;
 		bool opaque = Opaque;
@@ -519,25 +694,25 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		if ( sorted && totalInstances >= 2 )
 		{
 			_commandList.Attributes.Set( "SortBuffer", (GpuBuffer)GPUSortingBuffer );
-			_commandList.Attributes.Set( "DistanceBuffer", (GpuBuffer)GPUDistanceBuffer );
+			_commandList.Attributes.Set( "SortKeyBuffer", (GpuBuffer)GPUSortKeyBuffer );
 			_commandList.Attributes.Set( "Count", bufferSize );
 			_commandList.Attributes.SetCombo( "D_CLEAR", 1 );
 			_commandList.DispatchCompute( SortComputeShader, bufferSize, 1, 1 );
 
 			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortingBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
-			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
+			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
 		}
 
 		_commandList.ResourceBarrierTransition( SpriteAtomicCounter, ResourceState.Common );
 		_commandList.ResourceBarrierTransition( (GpuBuffer)SpriteBuffer, ResourceState.Common );
 		_commandList.ResourceBarrierTransition( (GpuBuffer)SpriteBufferOut, ResourceState.Common );
-		_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.Common );
+		_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.Common );
 
 		_commandList.Attributes.Set( "Sprites", (GpuBuffer)SpriteBuffer );
 		_commandList.Attributes.Set( "SpriteBufferOut", (GpuBuffer)SpriteBufferOut );
 		_commandList.Attributes.Set( "SpriteCount", spriteCount );
 		_commandList.Attributes.Set( "AtomicCounter", SpriteAtomicCounter );
-		_commandList.Attributes.Set( "DistanceBuffer", (GpuBuffer)GPUDistanceBuffer );
+		_commandList.Attributes.Set( "SortKeyBuffer", (GpuBuffer)GPUSortKeyBuffer );
 		_commandList.DispatchCompute( SpriteComputeShader, spriteCount, 1, 1 );
 
 		_commandList.ResourceBarrierTransition( SpriteAtomicCounter, ResourceState.Common );
@@ -545,7 +720,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 
 		if ( sorted && totalInstances >= 2 )
 		{
-			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.Common );
+			_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.Common );
 			_commandList.Attributes.SetCombo( "D_CLEAR", 0 );
 
 			var x = Math.Min( bufferSize, MaxDimThreads );
@@ -561,7 +736,7 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 					_commandList.DispatchCompute( SortComputeShader, x, y, 1 );
 
 					_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortingBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
-					_commandList.ResourceBarrierTransition( (GpuBuffer)GPUDistanceBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
+					_commandList.ResourceBarrierTransition( (GpuBuffer)GPUSortKeyBuffer, ResourceState.UnorderedAccess, ResourceState.UnorderedAccess );
 				}
 			}
 		}
@@ -573,6 +748,11 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		_renderFiltered = filtered;
 		_renderAdditive = additive;
 		_renderOpaque = opaque;
+
+		// Publish the runs alongside the counts they were built against. Swapping the reference
+		// hands the render thread a finished list, and gives us the old one back to build into
+		// next frame without allocating.
+		(_renderBuckets, _drawBuckets) = (_drawBuckets, _renderBuckets);
 	}
 
 	public override void RenderSceneObject()
@@ -588,7 +768,6 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		var attributes = RenderAttributes.Pool.Get();
 		try
 		{
-			attributes.SetCombo( "D_BLEND", _renderAdditive ? 1 : 0 );
 			attributes.SetCombo( "D_OPAQUE", _renderOpaque ? 1 : 0 );
 			attributes.Set( "IsSorted", _renderIsSorted ? 1 : 0 );
 			attributes.Set( "SpriteCount", _renderInstanceCount );
@@ -598,7 +777,32 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 			attributes.Set( "Vertices", (GpuBuffer)VertexBuffer );
 			attributes.Set( "g_bNonDirectionalDiffuseLighting", true );
 
-			Graphics.DrawIndexedInstanced( (GpuBuffer)IndexBuffer, SpriteMaterial, _renderInstanceCount, attributes );
+			// Read once - the main thread may swap this reference between uploads.
+			var buckets = _renderBuckets;
+
+			if ( buckets.Count == 0 )
+			{
+				attributes.SetCombo( "D_BLEND", _renderAdditive ? 1 : 0 );
+				attributes.Set( "SortLUTOffset", 0 );
+
+				Graphics.DrawIndexedInstanced( (GpuBuffer)IndexBuffer, SpriteMaterial, _renderInstanceCount, attributes );
+			}
+			else
+			{
+				// One draw per run, walked in order, so a lower sort layer is finished before a
+				// higher one starts. This is the whole reason the batch holds mixed blend states:
+				// ordering between scene objects is not ours to control, ordering within one is.
+				foreach ( var bucket in buckets )
+				{
+					attributes.SetCombo( "D_BLEND", bucket.Blend == SpriteBlendMode.Additive ? 1 : 0 );
+
+					// The shader walks the sort table backwards from the end, so a run starting
+					// this far into the draw order starts this far back from the end.
+					attributes.Set( "SortLUTOffset", bucket.Offset );
+
+					Graphics.DrawIndexedInstanced( (GpuBuffer)IndexBuffer, SpriteMaterial, bucket.Count, attributes );
+				}
+			}
 		}
 		finally
 		{

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteBatchSceneObject.cs
@@ -711,6 +711,11 @@ internal sealed class SpriteBatchSceneObject : SceneCustomObject
 		_commandList.Attributes.Set( "Sprites", (GpuBuffer)SpriteBuffer );
 		_commandList.Attributes.Set( "SpriteBufferOut", (GpuBuffer)SpriteBufferOut );
 		_commandList.Attributes.Set( "SpriteCount", spriteCount );
+
+		// The motion blur trails are placed by an atomic counter rather than by thread index, so the
+		// shader has no other way to tell where the buffers end.
+		_commandList.Attributes.Set( "BufferCapacity", bufferSize );
+
 		_commandList.Attributes.Set( "AtomicCounter", SpriteAtomicCounter );
 		_commandList.Attributes.Set( "SortKeyBuffer", (GpuBuffer)GPUSortKeyBuffer );
 		_commandList.DispatchCompute( SpriteComputeShader, spriteCount, 1, 1 );

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SpriteDrawPlan.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SpriteDrawPlan.cs
@@ -1,0 +1,128 @@
+namespace Sandbox.Rendering;
+
+/// <summary>
+/// The blend state a sprite has to be drawn with. Sprites needing different states cannot share a
+/// draw call, so this is the second axis - after the sort layer - that the draw order is cut along.
+/// </summary>
+internal enum SpriteBlendMode
+{
+	/// <summary>Writes depth and occludes. Drawn before the see-through work in the same layer.</summary>
+	Opaque = 0,
+
+	/// <summary>Ordinary alpha blending.</summary>
+	Transparent = 1,
+
+	/// <summary>Additive blending, which has no meaningful order against itself.</summary>
+	Additive = 2,
+}
+
+/// <summary>
+/// One run of sprites sharing a sort layer and a blend state, drawn as a single instanced call.
+/// </summary>
+internal readonly record struct SpriteDrawBucket( int LayerIndex, SpriteBlendMode Blend, int Offset, int Count );
+
+/// <summary>
+/// Works out the order sprites have to be drawn in, and where each run of them lives in the buffer.
+///
+/// The problem this solves: a sort layer is meant to beat everything, but sprites needing different
+/// blend states cannot be drawn together, and the engine gives no way to order one scene object
+/// against another. So the ordering has to happen *inside* a single scene object, by laying the
+/// sprites out grouped by layer and blend and then issuing one draw per group, layer by layer.
+///
+/// Grouping on the CPU is what keeps this verifiable: the run boundaries are known before anything
+/// reaches the GPU, so no read-back or indirect draw is needed, and the draw order is a pure
+/// function of the sprites - which is what <c>SpriteDrawPlanTest</c> pins down.
+/// </summary>
+internal static class SpriteDrawPlan
+{
+	/// <summary>Number of distinct blend states, and so the number of buckets a layer can hold.</summary>
+	internal const int BlendModeCount = 3;
+
+	/// <summary>
+	/// The blend state a sprite's flags call for. Opaque wins over additive, because an opaque
+	/// sprite is never blended whatever else it asks for.
+	/// </summary>
+	internal static SpriteBlendMode GetBlendMode( bool opaque, bool additive )
+	{
+		if ( opaque ) return SpriteBlendMode.Opaque;
+
+		return additive ? SpriteBlendMode.Additive : SpriteBlendMode.Transparent;
+	}
+
+	/// <summary>
+	/// The position of a sprite's bucket in the draw order. Layer is the more significant term, so
+	/// every bucket of a lower layer is drawn before any bucket of a higher one - which is exactly
+	/// the guarantee sort layers are supposed to make.
+	/// </summary>
+	internal static int GetBucketIndex( int layerIndex, SpriteBlendMode blend )
+		=> layerIndex * BlendModeCount + (int)blend;
+
+	/// <summary>
+	/// Works out where each run of sprites will land in the sorted draw order.
+	///
+	/// Nothing is rearranged here. The GPU sort already puts sprites in key order, and the key
+	/// leads with layer then blend - so a run's *position* is simply how many sprites sort ahead
+	/// of it, which is a matter of counting. That is what removes any need to read the sort result
+	/// back or to permute the buffer on the CPU.
+	///
+	/// Linear time, because this is on the per-frame upload path.
+	/// </summary>
+	/// <param name="layerIndices">Each sprite's resolved sort layer index.</param>
+	/// <param name="blendModes">Each sprite's blend state, parallel to <paramref name="layerIndices"/>.</param>
+	/// <param name="layerCount">Number of layers in the project, sizing the counting pass.</param>
+	/// <param name="buckets">Receives the non-empty runs in draw order, cleared first.</param>
+	/// <param name="counts">Scratch of at least <paramref name="layerCount"/> * <see cref="BlendModeCount"/> entries.</param>
+	internal static void BuildBuckets(
+		ReadOnlySpan<int> layerIndices,
+		ReadOnlySpan<SpriteBlendMode> blendModes,
+		int layerCount,
+		List<SpriteDrawBucket> buckets,
+		Span<int> counts )
+	{
+		buckets.Clear();
+
+		var spriteCount = layerIndices.Length;
+		var bucketCount = Math.Max( layerCount, 1 ) * BlendModeCount;
+
+		counts = counts[..bucketCount];
+		counts.Clear();
+
+		for ( var i = 0; i < spriteCount; i++ )
+		{
+			counts[BucketOf( layerIndices[i], blendModes[i], layerCount )]++;
+		}
+
+		// Turn the counts into start offsets. Empty buckets are skipped rather than emitted as
+		// zero-length draws - layers are project-wide, so most scenes leave most of them unused.
+		var running = 0;
+
+		for ( var bucket = 0; bucket < counts.Length; bucket++ )
+		{
+			if ( counts[bucket] > 0 )
+			{
+				buckets.Add( new SpriteDrawBucket(
+					LayerIndex: bucket / BlendModeCount,
+					Blend: (SpriteBlendMode)(bucket % BlendModeCount),
+					Offset: running,
+					Count: counts[bucket] ) );
+			}
+
+			running += counts[bucket];
+		}
+	}
+
+	/// <summary>
+	/// A sprite's bucket, with an out-of-range layer sent back to the default one.
+	///
+	/// A layer index can outlive the layer it referred to, if one is deleted while sprites still
+	/// point at it. Falling back to layer 0 matches how <see cref="SortingSettings.GetLayerIndex"/>
+	/// already resolves an unknown id - and it fails in the quieter direction, leaving the orphan
+	/// at the back rather than promoting it in front of everything.
+	/// </summary>
+	private static int BucketOf( int layerIndex, SpriteBlendMode blend, int layerCount )
+	{
+		var resolved = layerIndex >= 0 && layerIndex < layerCount ? layerIndex : 0;
+
+		return GetBucketIndex( resolved, blend );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
@@ -1,0 +1,122 @@
+using Sandbox.Resources;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace SceneTests.Components;
+
+/// <summary>
+/// Multi-editing sprites whose Sprite is an *embedded* resource, which is what dragging an image
+/// into the scene actually produces.
+///
+/// An earlier test used a plain <c>new Sprite()</c> and found nothing wrong. That was the wrong
+/// shape: <c>TextureDropObject.CreateSpriteFromTexture</c> stamps
+/// <c>EmbeddedResource { ResourceCompiler = "embed" }</c>, and embedded resources take a completely
+/// different path through serialization - they are written inline and rebuilt by
+/// <c>Activator.CreateInstance</c> on the way back, rather than being referenced by path.
+/// </summary>
+[TestClass]
+public class EmbeddedSpriteMultiEditTest
+{
+	/// <summary>Builds a sprite the same way the editor's drop handler does.</summary>
+	static Sprite CreateEmbeddedSprite( string name )
+	{
+		var sprite = new Sprite
+		{
+			Animations =
+			[
+				new Sprite.Animation
+				{
+					Name = name,
+					Frames = [new Sprite.Frame { Texture = Texture.White }]
+				}
+			]
+		};
+
+		sprite.EmbeddedResource = new EmbeddedResource
+		{
+			ResourceCompiler = "embed",
+			Data = new JsonObject()
+		};
+
+		return sprite;
+	}
+
+	static (SpriteRenderer A, SpriteRenderer B, Sprite SpriteA, Sprite SpriteB) TwoEmbedded( Scene scene )
+	{
+		var a = scene.CreateObject().Components.Create<SpriteRenderer>();
+		var b = scene.CreateObject().Components.Create<SpriteRenderer>();
+
+		var sa = CreateEmbeddedSprite( "first" );
+		var sb = CreateEmbeddedSprite( "second" );
+
+		a.Sprite = sa;
+		b.Sprite = sb;
+
+		return (a, b, sa, sb);
+	}
+
+	[TestMethod]
+	public void TwoEmbeddedSpritesStartDistinct()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, sb) = TwoEmbedded( scene );
+
+		Assert.AreNotSame( sa, sb );
+		Assert.AreSame( sa, a.Sprite );
+		Assert.AreSame( sb, b.Sprite );
+		Assert.AreNotEqual( a.Sprite.Animations[0].Name, b.Sprite.Animations[0].Name );
+	}
+
+	/// <summary>
+	/// Multi-selecting builds a MultiSerializedObject over both, exactly as the inspector does.
+	/// Reading every property must not disturb either sprite.
+	/// </summary>
+	[TestMethod]
+	public void MultiSelectingEmbeddedSpritesDoesNotMergeThem()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, sb) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		foreach ( var property in mso )
+		{
+			_ = property.GetValue<object>();
+		}
+
+		var sb2 = new StringBuilder();
+		sb2.Append( $"A={a.Sprite?.Animations?[0]?.Name} B={b.Sprite?.Animations?[0]?.Name} " );
+		sb2.Append( $"same={ReferenceEquals( a.Sprite, b.Sprite )}" );
+
+		Assert.AreSame( sa, a.Sprite, sb2.ToString() );
+		Assert.AreSame( sb, b.Sprite, sb2.ToString() );
+	}
+
+	/// <summary>
+	/// The undo system serializes whole components when an edit starts. Round-tripping both through
+	/// that is where two embedded resources could collapse into one, since neither has a path to
+	/// tell them apart.
+	/// </summary>
+	[TestMethod]
+	public void SerializingBothEmbeddedSpritesKeepsThemDistinct()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, _, _) = TwoEmbedded( scene );
+
+		var jsonA = Json.Serialize( a.Sprite );
+		var jsonB = Json.Serialize( b.Sprite );
+
+		Assert.AreNotEqual( jsonA, jsonB,
+			$"two embedded sprites serialized identically, so nothing can tell them apart: {jsonA}" );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/EmbeddedSpriteMultiEditTest.cs
@@ -119,4 +119,95 @@ public class EmbeddedSpriteMultiEditTest
 		Assert.AreNotEqual( jsonA, jsonB,
 			$"two embedded sprites serialized identically, so nothing can tell them apart: {jsonA}" );
 	}
+
+	/// <summary>
+	/// Control widgets reach each selected object's own property through <c>MultipleProperties</c>.
+	/// Pin that it enumerates every target, and collapses to just itself for a single selection -
+	/// widgets use one loop for both cases.
+	/// </summary>
+	[TestMethod]
+	public void MultiplePropertiesEnumeratesEveryTarget()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, _, _) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		var multi = mso.GetProperty( nameof( SpriteRenderer.Sprite ) );
+		Assert.AreEqual( 2, multi.MultipleProperties.Count() );
+
+		var single = a.GetSerialized().GetProperty( nameof( SpriteRenderer.Sprite ) );
+		Assert.AreEqual( 1, single.MultipleProperties.Count() );
+		Assert.AreSame( single, single.MultipleProperties.Single() );
+	}
+
+	/// <summary>
+	/// The trap behind the multi-select merge: GetValue returns only the first selection, while
+	/// SetValue writes that one instance to every selected object. So a control widget that reads a
+	/// value and writes it back - even completely unchanged - permanently aliases the whole selection
+	/// on to the first object's sprite. This pins the engine behaviour widgets have to work around.
+	/// </summary>
+	[TestMethod]
+	public void SetValueOnAMultiSelectionAliasesEveryTarget()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, _) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		var property = mso.GetProperty( nameof( SpriteRenderer.Sprite ) );
+
+		Assert.AreSame( sa, property.GetValue<Sprite>( null ), "GetValue should return the first selection" );
+
+		property.SetValue( property.GetValue<Sprite>( null ) );
+
+		Assert.AreSame( sa, a.Sprite );
+		Assert.AreSame( sa, b.Sprite,
+			"SetValue is expected to fan out - this is why widgets must write to each target instead" );
+	}
+
+	/// <summary>
+	/// What <c>EmbeddedSpriteControlWidget</c>'s Texture setter does now: update each selected
+	/// object's own sprite instead of broadcasting one instance. Both keep their own Sprite, and both
+	/// receive the new texture.
+	/// </summary>
+	[TestMethod]
+	public void PerTargetWriteKeepsSpritesDistinct()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (a, b, sa, sb) = TwoEmbedded( scene );
+
+		var mso = new MultiSerializedObject();
+		mso.Add( a.GetSerialized() );
+		mso.Add( b.GetSerialized() );
+		mso.Rebuild();
+
+		var property = mso.GetProperty( nameof( SpriteRenderer.Sprite ) );
+		var newTexture = Texture.Transparent;
+
+		foreach ( var target in property.MultipleProperties )
+		{
+			var sprite = target.GetValue<Sprite>( null ) ?? new Sprite();
+			sprite.Animations[0].Frames[0].Texture = newTexture;
+			target.SetValue( sprite );
+		}
+
+		Assert.AreSame( sa, a.Sprite );
+		Assert.AreSame( sb, b.Sprite );
+		Assert.AreNotSame( a.Sprite, b.Sprite );
+		Assert.AreSame( newTexture, a.Sprite.Animations[0].Frames[0].Texture );
+		Assert.AreSame( newTexture, b.Sprite.Animations[0].Frames[0].Texture );
+	}
 }

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
@@ -138,4 +138,103 @@ public class SpriteMultiEditTests
 		Assert.AreEqual( Color.Red, first.Tint );
 		Assert.AreEqual( Color.Blue, second.Tint );
 	}
+
+	/// <summary>
+	/// Sort layers have to survive a multi-selection like anything else. This is what
+	/// <c>SortLayerControlWidget</c> reads to decide between showing a layer and showing
+	/// "Multiple Values" - showing the first sprite's layer while the others disagree would claim
+	/// they all share it.
+	/// </summary>
+	[TestMethod]
+	public void SortLayersThatDifferAreReportedAsMultipleValues()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		var background = settings.AddLayer( "MultiEditBackground" );
+		var foreground = settings.AddLayer( "MultiEditForeground" );
+
+		var (first, second, _, _) = TwoDistinctSprites( scene );
+
+		first.SortLayer = new SortLayerHandle( background );
+		second.SortLayer = new SortLayerHandle( foreground );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.SortLayer ), out var property ) );
+		Assert.IsTrue( property.IsMultipleDifferentValues );
+
+		// Selecting them must not have merged the layers.
+		Assert.AreEqual( background.Id, first.SortLayer.Id );
+		Assert.AreEqual( foreground.Id, second.SortLayer.Id );
+	}
+
+	/// <summary>
+	/// Picking a layer with several sprites selected applies it to all of them. Unlike the sprite
+	/// texture, fanning out here is the whole point - the value written is the one that was picked,
+	/// not one read back off the first selection.
+	/// </summary>
+	[TestMethod]
+	public void PickingASortLayerAppliesItToEverySelectedSprite()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		var target = settings.AddLayer( "MultiEditTarget" );
+
+		var (first, second, firstSprite, secondSprite) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.SortLayer ), out var property ) );
+
+		property.SetValue( new SortLayerHandle( target ) );
+
+		Assert.AreEqual( target.Id, first.SortLayer.Id );
+		Assert.AreEqual( target.Id, second.SortLayer.Id );
+
+		// The two features have to coexist: setting a sort layer across the selection must leave
+		// each sprite holding its own Sprite, which is exactly what the embedded sprite widget was
+		// getting wrong.
+		Assert.AreSame( firstSprite, first.Sprite );
+		Assert.AreSame( secondSprite, second.Sprite );
+		Assert.AreNotSame( first.Sprite, second.Sprite );
+	}
+
+	/// <summary>
+	/// The other direction of the same requirement: editing the sprites must not flatten sorting
+	/// state that was deliberately different between them.
+	/// </summary>
+	[TestMethod]
+	public void EditingSpritesLeavesDifferingSortOrdersAlone()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, _, _) = TwoDistinctSprites( scene );
+
+		first.SortOrder = 3;
+		second.SortOrder = 9;
+
+		var mso = SelectBoth( first, second );
+
+		// Whatever the inspector reads while building rows must not disturb anything.
+		foreach ( var property in mso )
+		{
+			_ = property.GetValue<object>();
+		}
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.Sprite ), out var spriteProperty ) );
+
+		// Write each sprite through its own property, the way the fixed widget does.
+		foreach ( var target in spriteProperty.MultipleProperties )
+		{
+			target.SetValue( target.GetValue<Sprite>( null ) ?? new Sprite() );
+		}
+
+		Assert.AreEqual( 3, first.SortOrder );
+		Assert.AreEqual( 9, second.SortOrder );
+	}
 }

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteMultiEditTests.cs
@@ -1,0 +1,141 @@
+namespace SceneTests.Components;
+
+/// <summary>
+/// Reproduces what the inspector does when several sprites are selected at once, to settle whether
+/// selecting them changes their values or merely displays one of them.
+///
+/// Built the same way <c>ComponentListWidget</c> builds it: a <see cref="MultiSerializedObject"/>
+/// holding each component's serialized form, rebuilt into shared properties.
+/// </summary>
+[TestClass]
+public class SpriteMultiEditTests
+{
+	static MultiSerializedObject SelectBoth( params Component[] components )
+	{
+		var mso = new MultiSerializedObject();
+
+		foreach ( var component in components )
+		{
+			mso.Add( component.GetSerialized() );
+		}
+
+		mso.Rebuild();
+
+		return mso;
+	}
+
+	static (SpriteRenderer First, SpriteRenderer Second, Sprite FirstSprite, Sprite SecondSprite) TwoDistinctSprites( Scene scene )
+	{
+		var firstSprite = new Sprite();
+		var secondSprite = new Sprite();
+
+		var first = scene.CreateObject().Components.Create<SpriteRenderer>();
+		var second = scene.CreateObject().Components.Create<SpriteRenderer>();
+
+		first.Sprite = firstSprite;
+		second.Sprite = secondSprite;
+
+		return (first, second, firstSprite, secondSprite);
+	}
+
+	/// <summary>
+	/// The question that matters: does selecting two sprites overwrite one with the other?
+	///
+	/// Displaying a shared value is survivable. Silently reassigning artwork because someone
+	/// clicked two objects is not, so this is worth pinning down on its own.
+	/// </summary>
+	[TestMethod]
+	public void SelectingTwoSpritesDoesNotChangeEither()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, firstSprite, secondSprite) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		// Read every property, the way an inspector populating its widgets would.
+		foreach ( var property in mso )
+		{
+			_ = property.GetValue<object>();
+		}
+
+		Assert.AreSame( firstSprite, first.Sprite, "the first sprite must be left alone" );
+		Assert.AreSame( secondSprite, second.Sprite, "the second sprite must be left alone" );
+	}
+
+	/// <summary>
+	/// What a multi-selection reports for a property the two sprites disagree on. This is display
+	/// behaviour, not corruption - but it is why both rows appear to show the same artwork.
+	/// </summary>
+	[TestMethod]
+	public void MultiSelectionReportsTheFirstValueForDifferingProperties()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, firstSprite, secondSprite) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.Sprite ), out var property ) );
+
+		Assert.IsTrue( property.IsMultipleDifferentValues,
+			"the two sprites differ, and the property knows it - nothing acts on that yet" );
+
+		Assert.AreSame( firstSprite, property.GetValue<Sprite>(),
+			"GetValue reports the first selected object, which is why both rows look identical" );
+
+		Assert.AreNotSame( secondSprite, property.GetValue<Sprite>() );
+	}
+
+	/// <summary>
+	/// Editing through a multi-selection writes to every selected object. Expected, and the reason
+	/// one edit appears to set the other.
+	/// </summary>
+	[TestMethod]
+	public void EditingThroughAMultiSelectionWritesToEverySelectedSprite()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var (first, second, _, _) = TwoDistinctSprites( scene );
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( SpriteRenderer.SortOrder ), out var property ) );
+
+		property.SetValue( 7 );
+
+		Assert.AreEqual( 7, first.SortOrder );
+		Assert.AreEqual( 7, second.SortOrder );
+	}
+
+	/// <summary>
+	/// The same reporting behaviour on a component that has nothing to do with sprites, which is
+	/// what makes this a property of the inspector rather than of sprite sorting.
+	/// </summary>
+	[TestMethod]
+	public void TheSameHappensForAnyComponent()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var first = scene.CreateObject().Components.Create<ModelRenderer>();
+		var second = scene.CreateObject().Components.Create<ModelRenderer>();
+
+		first.Tint = Color.Red;
+		second.Tint = Color.Blue;
+
+		var mso = SelectBoth( first, second );
+
+		Assert.IsTrue( mso.TryGetProperty( nameof( ModelRenderer.Tint ), out var property ) );
+
+		Assert.IsTrue( property.IsMultipleDifferentValues );
+		Assert.AreEqual( Color.Red, property.GetValue<Color>(), "the first selected object again" );
+
+		// And the values themselves are untouched by having been selected.
+		Assert.AreEqual( Color.Red, first.Tint );
+		Assert.AreEqual( Color.Blue, second.Tint );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteSortingTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/SpriteSortingTests.cs
@@ -1,0 +1,310 @@
+using Sandbox.Rendering;
+
+namespace SceneTests.Components;
+
+/// <summary>
+/// Sprite sorting against a real scene and a real engine.
+///
+/// The unit tests cover the arithmetic - key packing, draw runs, index math. What they cannot
+/// reach is the thing the arithmetic depends on: which batch a sprite is actually put in. Sprites
+/// in different batches have no defined order however their layers are set, because nothing orders
+/// one scene object against another. So "did these two sprites end up in the same batch" is the
+/// question that decides whether sort layers work at all, and it needs a live scene to answer.
+/// </summary>
+[TestClass]
+public class SpriteSortingTests
+{
+	static SpriteRenderer CreateSprite( Scene scene, bool sorted = true, bool additive = false, bool opaque = false, bool shadows = false )
+	{
+		var go = scene.CreateObject();
+		var sprite = go.Components.Create<SpriteRenderer>();
+
+		sprite.IsSorted = sorted;
+		sprite.Additive = additive;
+		sprite.Opaque = opaque;
+		sprite.Shadows = shadows;
+
+		return sprite;
+	}
+
+	/// <summary>
+	/// The batch a sprite would be put in.
+	///
+	/// Asking the system to actually build its batches is not possible here - a batch allocates GPU
+	/// buffers in its constructor and these tests run without a graphics device. But the batch a
+	/// sprite lands in is decided entirely by this key, so comparing keys answers the same question
+	/// without needing one.
+	/// </summary>
+	static ulong BatchKey( SpriteRenderer sprite )
+		=> SceneSpriteSystem.GetRenderGroupKey( sprite, sprite.Tags as GameTags, sprite.RenderOptions, allowBlendMerge: true );
+
+	/// <summary>
+	/// The fix this whole change exists for. An additive sprite and an ordinary one used to be put
+	/// in separate scene objects, and no sort layer could order them against each other. They have
+	/// to share a batch now.
+	/// </summary>
+	[TestMethod]
+	public void AdditiveAndTransparentSpritesShareOneBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var transparent = CreateSprite( scene, additive: false );
+		var additive = CreateSprite( scene, additive: true );
+
+		Assert.AreEqual( BatchKey( transparent ), BatchKey( additive ),
+			"additive and transparent sprites must batch together, or their sort layers cannot be honoured" );
+	}
+
+	/// <summary>
+	/// Opaque sprites belong to a different render pass, so folding them in would change when they
+	/// draw. They stay separate on purpose.
+	/// </summary>
+	[TestMethod]
+	public void OpaqueSpritesStayInTheirOwnBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		Assert.AreNotEqual( BatchKey( CreateSprite( scene, opaque: false ) ), BatchKey( CreateSprite( scene, opaque: true ) ) );
+	}
+
+	/// <summary>
+	/// A shadow caster carries a scene object flag that additive sprites never set, so it cannot be
+	/// merged without silently changing whether it casts a shadow.
+	/// </summary>
+	[TestMethod]
+	public void ShadowCastingSpritesStayInTheirOwnBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		Assert.AreNotEqual( BatchKey( CreateSprite( scene, shadows: false ) ), BatchKey( CreateSprite( scene, shadows: true ) ) );
+	}
+
+	/// <summary>
+	/// Unsorted sprites opted out of ordering entirely, so there is nothing to gain by merging them
+	/// and the old batching is left exactly as it was.
+	/// </summary>
+	[TestMethod]
+	public void UnsortedSpritesAreNotMerged()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var plain = CreateSprite( scene, sorted: false, additive: false );
+		var additive = CreateSprite( scene, sorted: false, additive: true );
+
+		Assert.AreNotEqual( BatchKey( plain ), BatchKey( additive ) );
+	}
+
+	/// <summary>
+	/// Sprites differing only in sort layer must stay together - splitting by layer would put each
+	/// layer in a scene object whose draw order against the others is undefined, which is worse
+	/// than not having layers at all.
+	/// </summary>
+	[TestMethod]
+	public void SortLayerDoesNotSplitTheBatch()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		settings.AddLayer( "Foreground" );
+
+		var back = CreateSprite( scene );
+		var front = CreateSprite( scene );
+		front.SortLayer = new SortLayerHandle( settings.Layers[^1] );
+
+		Assert.AreEqual( BatchKey( back ), BatchKey( front ) );
+		Assert.AreNotEqual( back.SortLayer.Index, front.SortLayer.Index );
+	}
+
+	// ---- sorting groups, against a real hierarchy --------------------------------------------
+
+	/// <summary>
+	/// Authored sort orders can be any integers with gaps. The draw order only has room for a small
+	/// dense rank, so they have to be compressed while keeping their relative order.
+	/// </summary>
+	[TestMethod]
+	public void GroupRanksCompressArbitraryOrders()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var root = scene.CreateObject();
+		var group = root.Components.Create<SortingGroup>();
+
+		var legs = CreateSprite( scene );
+		var body = CreateSprite( scene );
+		var head = CreateSprite( scene );
+
+		legs.GameObject.SetParent( root );
+		body.GameObject.SetParent( root );
+		head.GameObject.SetParent( root );
+
+		legs.SortOrder = -500;
+		body.SortOrder = 0;
+		head.SortOrder = 9000;
+
+		group.RefreshRanks();
+
+		Assert.AreEqual( 0, group.GetRank( legs ) );
+		Assert.AreEqual( 1, group.GetRank( body ) );
+		Assert.AreEqual( 2, group.GetRank( head ) );
+	}
+
+	/// <summary>
+	/// A grouped sprite takes its place in the world from the group, and keeps its own order only
+	/// for ranking against the group's other members.
+	/// </summary>
+	[TestMethod]
+	public void GroupedSpriteResolvesToTheGroupsPlaceInTheOrder()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var settings = ProjectSettings.Sorting;
+		settings.AddLayer( "Characters" );
+
+		var root = scene.CreateObject();
+		root.WorldPosition = new Vector3( 100, 200, 300 );
+
+		var group = root.Components.Create<SortingGroup>();
+		group.SortLayer = new SortLayerHandle( settings.Layers[^1] );
+		group.SortOrder = 42;
+
+		var sprite = CreateSprite( scene );
+		sprite.GameObject.SetParent( root );
+		sprite.GameObject.WorldPosition = new Vector3( 0, 0, 0 );
+		sprite.SortOrder = 7;
+
+		group.RefreshRanks();
+
+		var (layer, order, origin, rank) = sprite.ResolveSorting( group );
+
+		Assert.AreEqual( group.SortLayer.Id, layer.Id, "the group decides the layer" );
+		Assert.AreEqual( 42, order, "the group decides the order against the rest of the world" );
+		Assert.AreEqual( root.WorldPosition, origin, "every member sorts at the group's origin" );
+		Assert.AreEqual( 0, rank, "the sprite's own order only ranks it inside the group" );
+	}
+
+	/// <summary>
+	/// Groups do not nest. A sprite belongs to the nearest one above it, and the outer group never
+	/// sees it - reported rather than silently flattened.
+	/// </summary>
+	[TestMethod]
+	public void NestedGroupsResolveToTheNearestOne()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var outer = scene.CreateObject();
+		var outerGroup = outer.Components.Create<SortingGroup>();
+
+		var inner = scene.CreateObject();
+		inner.SetParent( outer );
+		var innerGroup = inner.Components.Create<SortingGroup>();
+
+		var sprite = CreateSprite( scene );
+		sprite.GameObject.SetParent( inner );
+
+		Assert.AreEqual( innerGroup, SortingGroup.FindFor( sprite ) );
+		Assert.IsTrue( innerGroup.IsNested, "the inner group has to know it is nested so it can say so" );
+		Assert.IsFalse( outerGroup.IsNested );
+
+		// The outer group must not claim the sprite, or it would be ranked in two places at once.
+		outerGroup.RefreshRanks();
+		Assert.AreEqual( 0, outerGroup.GetRank( sprite ) );
+	}
+
+	/// <summary>
+	/// An ungrouped sprite keeps its own layer, order and position.
+	/// </summary>
+	[TestMethod]
+	public void UngroupedSpriteKeepsItsOwnSorting()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var sprite = CreateSprite( scene );
+		sprite.GameObject.WorldPosition = new Vector3( 10, 20, 30 );
+		sprite.SortOrder = 5;
+
+		Assert.IsNull( sprite.SortingGroup );
+
+		var (layer, order, origin, rank) = sprite.ResolveSorting( null );
+
+		Assert.AreEqual( sprite.SortLayer.Id, layer.Id );
+		Assert.AreEqual( 5, order );
+		Assert.AreEqual( sprite.WorldPosition, origin );
+		Assert.AreEqual( 0, rank );
+	}
+
+	// ---- the layer list is mutable at runtime, and the id lookup must keep up ----------------
+
+	/// <summary>
+	/// A layer added through the editor has to be usable straight away. Adding it to the list
+	/// without rebuilding the id lookup does not throw - the new layer simply resolves to the
+	/// default, so sprites assigned to it quietly render in the wrong place.
+	/// </summary>
+	[TestMethod]
+	public void NewlyAddedLayerResolvesImmediately()
+	{
+		var settings = new SortingSettings();
+		var added = settings.AddLayer( "Foreground" );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( added.Id ) );
+		Assert.AreEqual( added, settings.GetLayer( added.Id ) );
+	}
+
+	/// <summary>
+	/// Reordering is the whole point of the layer editor, and it changes what every id maps to. A
+	/// stale lookup here would draw every sprite in the scene in the wrong layer.
+	/// </summary>
+	[TestMethod]
+	public void ReorderingLayersUpdatesEveryIndex()
+	{
+		var settings = new SortingSettings();
+		var first = settings.AddLayer( "First" );
+		var second = settings.AddLayer( "Second" );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( first.Id ) );
+		Assert.AreEqual( 2, settings.GetLayerIndex( second.Id ) );
+
+		settings.MoveLayer( 2, 1 );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( second.Id ), "the moved layer has to report its new position" );
+		Assert.AreEqual( 2, settings.GetLayerIndex( first.Id ), "and the one it displaced has to report its new one" );
+	}
+
+	/// <summary>
+	/// Deleting a layer shifts everything after it, and orphaned sprites must land on the default
+	/// rather than on whichever layer happens to have inherited the index.
+	/// </summary>
+	[TestMethod]
+	public void DeletingALayerReindexesAndOrphansFallBack()
+	{
+		var settings = new SortingSettings();
+		var doomed = settings.AddLayer( "Doomed" );
+		var after = settings.AddLayer( "After" );
+
+		Assert.IsTrue( settings.RemoveLayer( doomed ) );
+
+		Assert.AreEqual( 1, settings.GetLayerIndex( after.Id ), "later layers move down" );
+		Assert.AreEqual( 0, settings.GetLayerIndex( doomed.Id ), "the deleted layer falls back to the default" );
+		Assert.IsNull( settings.GetLayer( doomed.Id ) );
+	}
+
+	/// <summary>
+	/// Everything falls back to the first layer, so it cannot be removed.
+	/// </summary>
+	[TestMethod]
+	public void TheLastLayerCannotBeRemoved()
+	{
+		var settings = new SortingSettings();
+
+		Assert.IsFalse( settings.RemoveLayer( settings.DefaultLayer ) );
+		Assert.AreEqual( 1, settings.Layers.Count );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/TextureGeneratorIdentityTest.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/TextureGeneratorIdentityTest.cs
@@ -1,0 +1,40 @@
+using Sandbox.Resources;
+
+namespace SceneTests.Components;
+
+/// <summary>
+/// Where a dragged-in image gets its identity from.
+///
+/// Dropping an image builds an <see cref="ImageFileGenerator"/> and generates a texture from it.
+/// That texture is looked up later through a process-wide cache keyed by
+/// <see cref="ResourceGenerator.GetHash"/>, which is a CRC64 of the generator serialized to JSON.
+/// If two different images hash the same, both resolve to one texture - which is what "the sprites
+/// swap to a single image" would look like.
+/// </summary>
+[TestClass]
+public class TextureGeneratorIdentityTest
+{
+	static ImageFileGenerator ForFile( string path ) => new() { FilePath = path };
+
+	/// <summary>
+	/// The property that has to hold: two different files must never share an identity.
+	/// </summary>
+	[TestMethod]
+	public void DifferentFilesMustHashDifferently()
+	{
+		var a = ForFile( "textures/one.png" );
+		var b = ForFile( "textures/two.png" );
+
+		Assert.AreNotEqual( a.GetHash(), b.GetHash(),
+			"two different image files resolved to the same generated-texture identity" );
+	}
+
+	/// <summary>
+	/// And the same file must hash stably, or the cache never hits and every load regenerates.
+	/// </summary>
+	[TestMethod]
+	public void SameFileHashesStably()
+	{
+		Assert.AreEqual( ForFile( "textures/one.png" ).GetHash(), ForFile( "textures/one.png" ).GetHash() );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawIndexingTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawIndexingTest.cs
@@ -1,0 +1,293 @@
+using Sandbox.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace SceneTests;
+
+/// <summary>
+/// The one part of sprite sorting that no other test reaches: whether the index arithmetic on the
+/// GPU actually lines up.
+///
+/// Three separate pieces have to agree - the bitonic sort in <c>sort_cs.shader</c>, the draw runs
+/// worked out by <see cref="SpriteDrawPlan"/>, and the backwards walk of the sort table in
+/// <c>sprite_ps.shader</c>. Each is defensible on its own and the combination is easy to get off
+/// by one, which would draw sprites with the wrong blend state or read past the real entries into
+/// the padding. Neither shows up as a failure anywhere - just as a wrong picture.
+///
+/// So the shader code is transcribed here and run over real keys. This proves the arithmetic, not
+/// the HLSL: it cannot tell us the shaders compile to this or that the attributes arrive. But the
+/// arithmetic is the part that was only ever argued for.
+/// </summary>
+[TestClass]
+public class SpriteDrawIndexingTest
+{
+	record struct Sprite( int Layer, SpriteBlendMode Blend, int Order, float Depth );
+
+	// ---- transcribed from the shaders -------------------------------------------------------
+
+	/// <summary>SORTKEY_MAX in sort_cs.shader. Sorts after every real sprite.</summary>
+	static readonly (uint X, uint Y) SortKeyMax = (0xFFFFFFFFu, 0xFFFFFFFFu);
+
+	/// <summary>FloatToSortableUint in sprite_cs.shader.</summary>
+	static uint FloatToSortableUint( float value )
+	{
+		var bits = BitConverter.SingleToUInt32Bits( value );
+		return (bits & 0x80000000u) != 0 ? ~bits : bits | 0x80000000u;
+	}
+
+	/// <summary>CalculateSortKey in sprite_cs.shader, for a sprite with no sorting group.</summary>
+	static (uint X, uint Y) CalculateSortKey( Sprite sprite )
+	{
+		var packed = SpriteBatchSceneObject.SpriteData.PackSortKey( sprite.Layer, sprite.Blend, sprite.Order );
+		var quantized = FloatToSortableUint( sprite.Depth ) & ~0xFFu;
+
+		return (~packed, quantized | 0xFFu);
+	}
+
+	/// <summary>The lexicographic comparison in sort_cs.shader.</summary>
+	static bool Greater( (uint X, uint Y) a, (uint X, uint Y) b )
+		=> a.X != b.X ? a.X > b.X : a.Y > b.Y;
+
+	static bool Less( (uint X, uint Y) a, (uint X, uint Y) b )
+		=> a.X != b.X ? a.X < b.X : a.Y < b.Y;
+
+	/// <summary>
+	/// MainCs in sort_cs.shader, both the D_CLEAR pass and the sort passes, driven by the dispatch
+	/// loop in SpriteBatchSceneObject.UploadOnHost.
+	///
+	/// Running the threads of a stage in sequence matches the GPU here: a stage only ever swaps
+	/// disjoint pairs, and the shader's own <c>compareIndex &lt; currentIndex</c> guard means just
+	/// one thread of each pair does the work.
+	/// </summary>
+	static uint[] RunBitonicSort( IReadOnlyList<Sprite> sprites )
+	{
+		var bufferSize = (int)BitOperations.RoundUpToPowerOf2( (uint)Math.Max( sprites.Count, 1 ) );
+
+		// D_CLEAR: every slot is seeded, so the padding carries SORTKEY_MAX and sorts to the end.
+		var sortBuffer = new uint[bufferSize];
+		var keys = new (uint X, uint Y)[bufferSize];
+
+		for ( var i = 0; i < bufferSize; i++ )
+		{
+			sortBuffer[i] = (uint)i;
+			keys[i] = SortKeyMax;
+		}
+
+		// sprite_cs writes a real key for each live sprite; the rest keep SORTKEY_MAX.
+		for ( var i = 0; i < sprites.Count; i++ )
+		{
+			keys[i] = CalculateSortKey( sprites[i] );
+		}
+
+		for ( var dim = 2; dim <= bufferSize; dim <<= 1 )
+		{
+			for ( var block = dim >> 1; block > 0; block >>= 1 )
+			{
+				for ( var currentIndex = 0; currentIndex < bufferSize; currentIndex++ )
+				{
+					var compareIndex = currentIndex ^ block;
+
+					if ( compareIndex >= bufferSize || compareIndex < currentIndex ) continue;
+
+					var indexA = sortBuffer[currentIndex];
+					var indexB = sortBuffer[compareIndex];
+
+					var keyA = keys[indexA];
+					var keyB = keys[indexB];
+
+					var ascending = (currentIndex & dim) == 0;
+
+					if ( ascending ? Greater( keyA, keyB ) : Less( keyA, keyB ) )
+					{
+						sortBuffer[currentIndex] = indexB;
+						sortBuffer[compareIndex] = indexA;
+					}
+				}
+			}
+		}
+
+		return sortBuffer;
+	}
+
+	/// <summary>
+	/// GetSprite in sprite_ps.shader. <paramref name="instanceId"/> is relative to the draw, which
+	/// is why the run's offset comes into it.
+	/// </summary>
+	static int GetSpriteIndex( uint[] sortLut, int instanceCount, int sortLutOffset, int instanceId )
+		=> (int)sortLut[instanceCount - 1 - instanceId - sortLutOffset];
+
+	// ---- the actual pipeline ----------------------------------------------------------------
+
+	/// <summary>
+	/// Everything the renderer would do, end to end: build the runs, sort, then walk each run the
+	/// way the shader does. Returns each drawn sprite paired with the blend state its draw call
+	/// was configured for.
+	/// </summary>
+	static List<(Sprite Sprite, SpriteBlendMode DrawnAs)> Draw( IReadOnlyList<Sprite> sprites, int layerCount )
+	{
+		var buckets = new List<SpriteDrawBucket>();
+
+		SpriteDrawPlan.BuildBuckets(
+			sprites.Select( s => s.Layer ).ToArray(),
+			sprites.Select( s => s.Blend ).ToArray(),
+			layerCount,
+			buckets,
+			new int[layerCount * SpriteDrawPlan.BlendModeCount] );
+
+		var sortLut = RunBitonicSort( sprites );
+		var drawn = new List<(Sprite, SpriteBlendMode)>();
+
+		foreach ( var bucket in buckets )
+		{
+			for ( var instanceId = 0; instanceId < bucket.Count; instanceId++ )
+			{
+				var index = GetSpriteIndex( sortLut, sprites.Count, bucket.Offset, instanceId );
+
+				Assert.IsTrue( index >= 0 && index < sprites.Count,
+					$"read index {index} outside the {sprites.Count} live sprites - the walk ran into the padding" );
+
+				drawn.Add( (sprites[index], bucket.Blend) );
+			}
+		}
+
+		return drawn;
+	}
+
+	// ---- tests ------------------------------------------------------------------------------
+
+	[TestMethod]
+	public void EverySpriteIsDrawnUnderItsOwnBlendState()
+	{
+		// The failure this exists for. If a run's offset is off by even one, sprites are handed to
+		// a draw call set up for someone else's blend state - additive artwork rendered opaque, or
+		// the reverse. Nothing errors; the picture is just wrong.
+		var sprites = new List<Sprite>();
+		var random = new Random( 4242 );
+
+		for ( var i = 0; i < 120; i++ )
+		{
+			sprites.Add( new Sprite(
+				random.Next( 0, 5 ),
+				(SpriteBlendMode)random.Next( 0, SpriteDrawPlan.BlendModeCount ),
+				random.Next( -50, 50 ),
+				random.NextSingle() * 2000f - 1000f ) );
+		}
+
+		foreach ( var (sprite, drawnAs) in Draw( sprites, layerCount: 5 ) )
+		{
+			Assert.AreEqual( sprite.Blend, drawnAs );
+		}
+	}
+
+	[TestMethod]
+	public void EverySpriteIsDrawnExactlyOnce()
+	{
+		// Catches the walk overlapping itself or skipping a slot between runs.
+		var sprites = Enumerable.Range( 0, 64 )
+			.Select( i => new Sprite( i % 3, (SpriteBlendMode)(i % 3), i, i * 10f ) )
+			.ToList();
+
+		var drawn = Draw( sprites, layerCount: 3 );
+
+		Assert.AreEqual( sprites.Count, drawn.Count );
+		CollectionAssert.AreEquivalent( sprites, drawn.Select( d => d.Sprite ).ToList() );
+	}
+
+	[TestMethod]
+	public void DrawOrderIsBackToFront()
+	{
+		// The order the whole feature is for: layer, then blend, then order in layer, then depth
+		// with the furthest away drawn first.
+		var sprites = new List<Sprite>
+		{
+			new( 1, SpriteBlendMode.Transparent, 0, 100f ),
+			new( 0, SpriteBlendMode.Additive, 5, 50f ),
+			new( 0, SpriteBlendMode.Transparent, 5, 10f ),
+			new( 0, SpriteBlendMode.Transparent, 5, 900f ),
+			new( 0, SpriteBlendMode.Transparent, -3, 20f ),
+			new( 2, SpriteBlendMode.Opaque, 0, 30f ),
+		};
+
+		var expected = sprites
+			.OrderBy( s => s.Layer )
+			.ThenBy( s => (int)s.Blend )
+			.ThenBy( s => s.Order )
+			.ThenByDescending( s => s.Depth )
+			.ToList();
+
+		CollectionAssert.AreEqual( expected, Draw( sprites, layerCount: 3 ).Select( d => d.Sprite ).ToList() );
+	}
+
+	[TestMethod]
+	public void PaddingIsNeverDrawn()
+	{
+		// A sprite count just past a power of two leaves the buffer mostly padding. If the walk
+		// started from the padded size instead of the live count, this is where it would show.
+		foreach ( var count in new[] { 1, 2, 3, 5, 9, 17, 33, 65 } )
+		{
+			var sprites = Enumerable.Range( 0, count )
+				.Select( i => new Sprite( i % 2, SpriteBlendMode.Transparent, i, i ) )
+				.ToList();
+
+			var drawn = Draw( sprites, layerCount: 2 );
+
+			Assert.AreEqual( count, drawn.Count, $"{count} sprites" );
+			CollectionAssert.AreEquivalent( sprites, drawn.Select( d => d.Sprite ).ToList(), $"{count} sprites" );
+		}
+	}
+
+	[TestMethod]
+	public void SingleDrawPathMatchesTheBucketedPath()
+	{
+		// A batch with one blend state takes the old single-draw path with offset 0. It has to
+		// produce the same order as the bucketed path, or enabling the merge would change how
+		// existing scenes look.
+		var sprites = Enumerable.Range( 0, 40 )
+			.Select( i => new Sprite( i % 3, SpriteBlendMode.Transparent, i % 7, (i * 37) % 500 ) )
+			.ToList();
+
+		var sortLut = RunBitonicSort( sprites );
+
+		var singleDraw = Enumerable.Range( 0, sprites.Count )
+			.Select( i => sprites[GetSpriteIndex( sortLut, sprites.Count, 0, i )] )
+			.ToList();
+
+		CollectionAssert.AreEqual( singleDraw, Draw( sprites, layerCount: 3 ).Select( d => d.Sprite ).ToList() );
+	}
+
+	[TestMethod]
+	public void ArbitraryScenesKeepEveryGuarantee()
+	{
+		var random = new Random( 20260719 );
+
+		for ( var iteration = 0; iteration < 300; iteration++ )
+		{
+			var layerCount = random.Next( 1, 6 );
+			var count = random.Next( 1, 130 );
+
+			var sprites = Enumerable.Range( 0, count )
+				.Select( _ => new Sprite(
+					random.Next( 0, layerCount ),
+					(SpriteBlendMode)random.Next( 0, SpriteDrawPlan.BlendModeCount ),
+					random.Next( -20, 20 ),
+					random.NextSingle() * 400f - 200f ) )
+				.ToList();
+
+			var drawn = Draw( sprites, layerCount );
+			var context = $"iteration {iteration}, {count} sprites over {layerCount} layers";
+
+			Assert.AreEqual( count, drawn.Count, context );
+
+			foreach ( var (sprite, drawnAs) in drawn )
+			{
+				Assert.AreEqual( sprite.Blend, drawnAs, context );
+			}
+
+			// Layers must come out non-decreasing however the blend states are mixed in.
+			var layers = drawn.Select( d => d.Sprite.Layer ).ToArray();
+			CollectionAssert.AreEqual( layers.OrderBy( l => l ).ToArray(), layers, context );
+		}
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawPlanTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Scene/SpriteDrawPlanTest.cs
@@ -1,0 +1,194 @@
+using Sandbox.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SceneTests;
+
+// Sort layers are supposed to beat everything, and until now they did not: sprites needing
+// different blend states ended up in different scene objects, and nothing in the engine orders one
+// scene object against another. They now share a batch and are drawn as one run per
+// (layer, blend) - so the layer wins, at the price of a few extra draw calls.
+//
+// This pins down where those runs land. The other half - that the GPU sort actually puts each
+// sprite in the run these offsets claim - is what the key packing in SpriteSortKeyTest guarantees.
+[TestClass]
+public class SpriteDrawPlanTest
+{
+	record struct Sprite( int Layer, SpriteBlendMode Blend );
+
+	// layerCount defaults to "every layer these sprites mention exists". Pass it explicitly to
+	// model a project with fewer layers than the sprites are asking for.
+	static List<SpriteDrawBucket> BuildPlan( Sprite[] sprites, int? layerCountOverride = null )
+	{
+		var layerCount = layerCountOverride
+			?? (sprites.Length == 0 ? 1 : sprites.Max( s => s.Layer ) + 1);
+
+		var buckets = new List<SpriteDrawBucket>();
+
+		SpriteDrawPlan.BuildBuckets(
+			sprites.Select( s => s.Layer ).ToArray(),
+			sprites.Select( s => s.Blend ).ToArray(),
+			layerCount,
+			buckets,
+			new int[layerCount * SpriteDrawPlan.BlendModeCount] );
+
+		return buckets;
+	}
+
+	// The whole point of the change. Before it, these two lived in separate scene objects and the
+	// additive one could be drawn either side of the other, whatever the layers said.
+	[TestMethod]
+	public void LayerBeatsBlendMode()
+	{
+		var plan = BuildPlan( [
+			new Sprite( 1, SpriteBlendMode.Additive ),
+			new Sprite( 0, SpriteBlendMode.Transparent )] );
+
+		Assert.AreEqual( 0, plan[0].LayerIndex, "the lower layer has to be drawn first, at the back" );
+		Assert.AreEqual( 1, plan[1].LayerIndex );
+	}
+
+	[TestMethod]
+	public void EveryLowerLayerIsFullyDrawnBeforeAnyHigherOne()
+	{
+		var plan = BuildPlan( [
+			new Sprite( 2, SpriteBlendMode.Transparent ),
+			new Sprite( 0, SpriteBlendMode.Additive ),
+			new Sprite( 1, SpriteBlendMode.Opaque ),
+			new Sprite( 2, SpriteBlendMode.Additive ),
+			new Sprite( 0, SpriteBlendMode.Transparent ),
+			new Sprite( 1, SpriteBlendMode.Additive )] );
+
+		var layers = plan.Select( b => b.LayerIndex ).ToArray();
+
+		CollectionAssert.AreEqual( layers.OrderBy( l => l ).ToArray(), layers,
+			"runs must come out in layer order, whatever blend states are mixed in" );
+	}
+
+	[TestMethod]
+	public void OpaqueIsDrawnBeforeBlendedWorkInTheSameLayer()
+	{
+		// Opaque sprites occlude, so drawing them first lets the depth test reject what is behind
+		// them instead of blending over it.
+		var plan = BuildPlan( [
+			new Sprite( 0, SpriteBlendMode.Additive ),
+			new Sprite( 0, SpriteBlendMode.Transparent ),
+			new Sprite( 0, SpriteBlendMode.Opaque )] );
+
+		CollectionAssert.AreEqual(
+			new[] { SpriteBlendMode.Opaque, SpriteBlendMode.Transparent, SpriteBlendMode.Additive },
+			plan.Select( b => b.Blend ).ToArray() );
+	}
+
+	[TestMethod]
+	public void EverySpriteIsAccountedForExactlyOnce()
+	{
+		// A miscount here would leave sprites outside every run, so they would simply never draw.
+		var sprites = Enumerable.Range( 0, 50 )
+			.Select( i => new Sprite( i % 4, (SpriteBlendMode)(i % 3) ) )
+			.ToArray();
+
+		Assert.AreEqual( sprites.Length, BuildPlan( sprites ).Sum( b => b.Count ) );
+	}
+
+	[TestMethod]
+	public void RunsAreContiguousAndInDrawOrder()
+	{
+		// Each run becomes one instanced draw over [Offset, Offset+Count), so a gap or an overlap
+		// between them would silently skip or repeat sprites.
+		var sprites = Enumerable.Range( 0, 30 )
+			.Select( i => new Sprite( i % 3, (SpriteBlendMode)(i % 3) ) )
+			.ToArray();
+
+		var expectedOffset = 0;
+
+		foreach ( var bucket in BuildPlan( sprites ) )
+		{
+			Assert.AreEqual( expectedOffset, bucket.Offset, "runs must tile the buffer with no holes" );
+			expectedOffset += bucket.Count;
+		}
+
+		Assert.AreEqual( sprites.Length, expectedOffset );
+	}
+
+	[TestMethod]
+	public void EmptyRunsAreNotDrawn()
+	{
+		// Layers are project-wide, so most scenes leave most of them unused. A draw call per empty
+		// layer would cost more than the ordering is worth.
+		var plan = BuildPlan( [new Sprite( 3, SpriteBlendMode.Transparent )] );
+
+		Assert.AreEqual( 1, plan.Count );
+		Assert.AreEqual( 3, plan[0].LayerIndex );
+		Assert.AreEqual( 1, plan[0].Count );
+	}
+
+	[TestMethod]
+	public void LayersPastTheEndFallBackToTheFirst()
+	{
+		// A sprite can outlive the layer it pointed at - delete a layer and its sprites keep the
+		// old index. It must still be drawn; dropping it would make deleting a layer look like
+		// deleting the artwork.
+		var plan = BuildPlan( [new Sprite( 99, SpriteBlendMode.Transparent )], layerCountOverride: 2 );
+
+		Assert.AreEqual( 1, plan.Sum( b => b.Count ) );
+		Assert.AreEqual( 0, plan[0].LayerIndex );
+	}
+
+	[TestMethod]
+	public void OpaqueWinsOverAdditive()
+	{
+		// An opaque sprite is never blended, whatever else it asks for.
+		Assert.AreEqual( SpriteBlendMode.Opaque, SpriteDrawPlan.GetBlendMode( opaque: true, additive: true ) );
+		Assert.AreEqual( SpriteBlendMode.Additive, SpriteDrawPlan.GetBlendMode( opaque: false, additive: true ) );
+		Assert.AreEqual( SpriteBlendMode.Transparent, SpriteDrawPlan.GetBlendMode( opaque: false, additive: false ) );
+	}
+
+	[TestMethod]
+	public void NoSpritesProducesNoDraws()
+	{
+		Assert.AreEqual( 0, BuildPlan( [] ).Count );
+	}
+
+	// The cases above are the ones worth reading. This is the one worth trusting: arbitrary mixes,
+	// re-checking the invariants that must hold for every scene rather than the shapes someone
+	// thought to write down. Seeded, so a failure reproduces.
+	[TestMethod]
+	public void InvariantsHoldAcrossArbitraryScenes()
+	{
+		var random = new Random( 20260719 );
+
+		for ( var iteration = 0; iteration < 500; iteration++ )
+		{
+			var layerCount = random.Next( 1, 9 );
+			var spriteCount = random.Next( 0, 200 );
+
+			var sprites = Enumerable.Range( 0, spriteCount )
+				.Select( _ => new Sprite(
+					random.Next( 0, layerCount ),
+					(SpriteBlendMode)random.Next( 0, SpriteDrawPlan.BlendModeCount ) ) )
+				.ToArray();
+
+			var plan = BuildPlan( sprites, layerCount );
+			var context = $"iteration {iteration}, {spriteCount} sprites over {layerCount} layers";
+
+			// Nothing left outside a run.
+			Assert.AreEqual( spriteCount, plan.Sum( b => b.Count ), context );
+
+			// The runs tile the buffer exactly, since each becomes a draw over its own range.
+			var expectedOffset = 0;
+			foreach ( var bucket in plan )
+			{
+				Assert.AreEqual( expectedOffset, bucket.Offset, context );
+				Assert.IsTrue( bucket.Count > 0, context );
+				expectedOffset += bucket.Count;
+			}
+
+			// The guarantee the whole feature rests on: a lower layer is never drawn after a
+			// higher one, whatever blend states are mixed into either.
+			var keys = plan.Select( b => SpriteDrawPlan.GetBucketIndex( b.LayerIndex, b.Blend ) ).ToArray();
+			CollectionAssert.AreEqual( keys.OrderBy( k => k ).ToArray(), keys, context );
+		}
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Scene/SpriteSheetSlicingTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Scene/SpriteSheetSlicingTest.cs
@@ -1,0 +1,669 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SceneTests;
+
+/// <summary>
+/// Slicing turns an image into the named, individually-pivoted parts a cutout rig is built from.
+/// It is worth testing hard because every mistake here is silent: a rect a few pixels out still
+/// renders, an island missed by automatic detection just looks like the artist forgot to draw it,
+/// and a re-slice that loses ids breaks sprites that were fine a moment ago.
+/// </summary>
+[TestClass]
+public class SpriteSheetSlicingTest
+{
+	static Color32 Opaque => new Color32( 255, 255, 255, 255 );
+
+	static Color32[] Blank( int width, int height ) => new Color32[width * height];
+
+	/// <summary>Fill a pixel run, in the same top-left-origin space slices use.</summary>
+	static void Fill( Color32[] pixels, int width, int x, int y, int w, int h )
+	{
+		for ( int py = y; py < y + h; py++ )
+		{
+			for ( int px = x; px < x + w; px++ )
+			{
+				pixels[(py * width) + px] = Opaque;
+			}
+		}
+	}
+
+	static void AssertRect( Rect rect, float x, float y, float w, float h, string because = null )
+	{
+		Assert.AreEqual( x, rect.Left, $"left {because}" );
+		Assert.AreEqual( y, rect.Top, $"top {because}" );
+		Assert.AreEqual( w, rect.Width, $"width {because}" );
+		Assert.AreEqual( h, rect.Height, $"height {because}" );
+	}
+
+	//
+	// Grids
+	//
+
+	[TestMethod]
+	public void GridByCellCountDividesTheImageEvenly()
+	{
+		var settings = new SpriteSheet.SliceSettings
+		{
+			Type = SpriteSheet.SliceType.GridByCellCount,
+			CellCount = new Vector2Int( 4, 2 ),
+			KeepEmptyRects = true
+		};
+
+		var rects = SpriteSheet.SliceGridByCellCount( Blank( 64, 32 ), 64, 32, settings );
+
+		Assert.AreEqual( 8, rects.Count );
+		foreach ( var rect in rects )
+		{
+			Assert.AreEqual( 16, rect.Width );
+			Assert.AreEqual( 16, rect.Height );
+		}
+
+		// Reading order: across the top row first, then down.
+		AssertRect( rects[0], 0, 0, 16, 16, "first cell" );
+		AssertRect( rects[3], 48, 0, 16, 16, "end of the top row" );
+		AssertRect( rects[4], 0, 16, 16, 16, "start of the second row" );
+	}
+
+	[TestMethod]
+	public void GridByCellCountTakesOffsetAndPaddingBeforeDividing()
+	{
+		// 64 wide, 4 across, starting 4px in, with 2px between cells:
+		//   (64 - 4 - 2*3) / 4 = 13.5 -> 13
+		var settings = new SpriteSheet.SliceSettings
+		{
+			Type = SpriteSheet.SliceType.GridByCellCount,
+			CellCount = new Vector2Int( 4, 1 ),
+			Offset = new Vector2Int( 4, 0 ),
+			Padding = new Vector2Int( 2, 0 ),
+			KeepEmptyRects = true
+		};
+
+		var rects = SpriteSheet.SliceGridByCellCount( Blank( 64, 16 ), 64, 16, settings );
+
+		Assert.AreEqual( 4, rects.Count );
+		AssertRect( rects[0], 4, 0, 13, 16 );
+		AssertRect( rects[1], 19, 0, 13, 16, "one cell plus the gap along" );
+	}
+
+	[TestMethod]
+	public void GridByCellSizeOnlyEmitsWholeCells()
+	{
+		// 70px of image at 16px cells leaves 6px over, which is not a cell.
+		var settings = new SpriteSheet.SliceSettings
+		{
+			Type = SpriteSheet.SliceType.GridByCellSize,
+			CellSize = new Vector2Int( 16, 16 ),
+			KeepEmptyRects = true
+		};
+
+		var rects = SpriteSheet.SliceGridByCellSize( Blank( 70, 16 ), 70, 16, settings );
+
+		Assert.AreEqual( 4, rects.Count, "the leftover strip is not a cell and must not be emitted" );
+	}
+
+	[TestMethod]
+	public void EmptyGridCellsAreDroppedUnlessAskedFor()
+	{
+		var pixels = Blank( 32, 16 );
+		Fill( pixels, 32, 0, 0, 16, 16 ); // only the left cell has anything in it
+
+		var settings = new SpriteSheet.SliceSettings
+		{
+			Type = SpriteSheet.SliceType.GridByCellSize,
+			CellSize = new Vector2Int( 16, 16 )
+		};
+
+		var dropped = SpriteSheet.SliceGridByCellSize( pixels, 32, 16, settings );
+		Assert.AreEqual( 1, dropped.Count, "a sheet is rarely full, so blank cells go by default" );
+
+		settings.KeepEmptyRects = true;
+		var kept = SpriteSheet.SliceGridByCellSize( pixels, 32, 16, settings );
+		Assert.AreEqual( 2, kept.Count );
+	}
+
+	//
+	// Automatic
+	//
+
+	[TestMethod]
+	public void AutomaticFindsEachIslandSeparately()
+	{
+		// Two blobs with a gap between them - a sheet of loose parts, which is what the modular
+		// character workflow produces.
+		var pixels = Blank( 64, 32 );
+		Fill( pixels, 64, 2, 2, 10, 10 );
+		Fill( pixels, 64, 40, 6, 12, 8 );
+
+		var rects = SpriteSheet.SliceAutomatic( pixels, 64, 32, new SpriteSheet.SliceSettings() );
+
+		Assert.AreEqual( 2, rects.Count );
+		AssertRect( rects[0], 2, 2, 10, 10, "first blob, tight to its pixels" );
+		AssertRect( rects[1], 40, 6, 12, 8, "second blob" );
+	}
+
+	[TestMethod]
+	public void AutomaticIgnoresSpecksBelowTheMinimumSize()
+	{
+		var pixels = Blank( 32, 32 );
+		Fill( pixels, 32, 1, 1, 8, 8 );  // real artwork
+		Fill( pixels, 32, 20, 20, 2, 2 ); // a stray couple of pixels
+
+		var rects = SpriteSheet.SliceAutomatic( pixels, 32, 32, new SpriteSheet.SliceSettings() );
+
+		Assert.AreEqual( 1, rects.Count, $"anything under {SpriteSheet.MinimumAutomaticSliceSize}px is noise" );
+		AssertRect( rects[0], 1, 1, 8, 8 );
+	}
+
+	[TestMethod]
+	public void AutomaticFoldsTogetherIslandsWhoseBoxesOverlap()
+	{
+		// A hollow ring with a separate dot floating inside it. The two never touch, so they are
+		// two islands, but they are plainly one piece of artwork - the dot's box sits entirely
+		// inside the ring's.
+		var pixels = Blank( 32, 32 );
+		Fill( pixels, 32, 0, 0, 10, 1 );  // ring: top
+		Fill( pixels, 32, 0, 9, 10, 1 );  //       bottom
+		Fill( pixels, 32, 0, 0, 1, 10 );  //       left
+		Fill( pixels, 32, 9, 0, 1, 10 );  //       right
+		Fill( pixels, 32, 3, 3, 4, 4 );   // the dot inside
+
+		var rects = SpriteSheet.SliceAutomatic( pixels, 32, 32, new SpriteSheet.SliceSettings() );
+
+		Assert.AreEqual( 1, rects.Count, "overlapping boxes are one thing drawn in pieces" );
+		AssertRect( rects[0], 0, 0, 10, 10 );
+	}
+
+	[TestMethod]
+	public void AutomaticOrdersRowsLeftToRightEvenWhenTopsDiffer()
+	{
+		// Automatic slicing trims to the artwork, so two parts on the same row almost never share a
+		// top edge. Ordering on top alone would interleave them with the row below, and frame order
+		// is animation order.
+		var pixels = Blank( 64, 64 );
+		Fill( pixels, 64, 30, 2, 8, 8 );  // right-hand part, sits higher
+		Fill( pixels, 64, 4, 5, 8, 8 );   // left-hand part, sits lower but shares the row
+		Fill( pixels, 64, 4, 40, 8, 8 );  // clearly a row below
+
+		var rects = SpriteSheet.SliceAutomatic( pixels, 64, 64, new SpriteSheet.SliceSettings() );
+
+		Assert.AreEqual( 3, rects.Count );
+		AssertRect( rects[0], 4, 5, 8, 8, "leftmost of the top row comes first despite its lower top" );
+		AssertRect( rects[1], 30, 2, 8, 8, "then its neighbour" );
+		AssertRect( rects[2], 4, 40, 8, 8, "then the next row down" );
+	}
+
+	[TestMethod]
+	public void AlphaToleranceDecidesWhatCountsAsArtwork()
+	{
+		var pixels = Blank( 32, 32 );
+		Fill( pixels, 32, 1, 1, 8, 8 );
+
+		// A faint patch of nearly-transparent pixels, the sort of thing a soft brush or a bad export
+		// leaves behind. Deliberately bigger than the minimum slice size, so that what decides its
+		// fate is the alpha tolerance and not the noise filter.
+		for ( int y = 20; y < 28; y++ )
+		{
+			for ( int x = 20; x < 28; x++ ) pixels[(y * 32) + x] = new Color32( 255, 255, 255, 6 );
+		}
+
+		var strict = SpriteSheet.SliceAutomatic( pixels, 32, 32, new SpriteSheet.SliceSettings() );
+		Assert.AreEqual( 2, strict.Count, "by default anything above zero alpha is artwork" );
+
+		var tolerant = SpriteSheet.SliceAutomatic( pixels, 32, 32,
+			new SpriteSheet.SliceSettings { AlphaTolerance = 10 } );
+		Assert.AreEqual( 1, tolerant.Count, "raising the tolerance discards the halo" );
+	}
+
+	//
+	// Artwork on a solid background, which is what a JPEG or a scan actually looks like
+	//
+
+	/// <summary>Fill the whole image with a colour, the way a white-background export arrives.</summary>
+	static Color32[] Filled( int width, int height, Color32 colour )
+	{
+		var pixels = new Color32[width * height];
+		for ( int i = 0; i < pixels.Length; i++ ) pixels[i] = colour;
+		return pixels;
+	}
+
+	static void FillWith( Color32[] pixels, int width, int x, int y, int w, int h, Color32 colour )
+	{
+		for ( int py = y; py < y + h; py++ )
+		{
+			for ( int px = x; px < x + w; px++ ) pixels[(py * width) + px] = colour;
+		}
+	}
+
+	static Color32 White => new Color32( 255, 255, 255, 255 );
+	static Color32 Ink => new Color32( 20, 30, 40, 255 );
+
+	[TestMethod]
+	public void OpaqueArtworkWithNoBackgroundKeyFindsOneBigRectangle()
+	{
+		// The failure this was reported as. A JPEG has no alpha channel at all, so every pixel is
+		// artwork, every pixel is connected, and the whole image comes back as a single island.
+		var pixels = Filled( 64, 32, White );
+		FillWith( pixels, 64, 4, 4, 10, 10, Ink );
+		FillWith( pixels, 64, 40, 4, 10, 10, Ink );
+
+		var rects = SpriteSheet.SliceAutomatic( pixels, 64, 32, new SpriteSheet.SliceSettings() );
+
+		Assert.AreEqual( 1, rects.Count );
+		AssertRect( rects[0], 0, 0, 64, 32, "the entire sheet, which is the symptom to look out for" );
+	}
+
+	[TestMethod]
+	public void KeyingTheBackgroundColourFindsTheArtwork()
+	{
+		var pixels = Filled( 64, 32, White );
+		FillWith( pixels, 64, 4, 4, 10, 10, Ink );
+		FillWith( pixels, 64, 40, 6, 12, 8, Ink );
+
+		var settings = new SpriteSheet.SliceSettings
+		{
+			Background = new SpriteSheet.BackgroundKey { Enabled = true, Color = White, Tolerance = 8 }
+		};
+
+		var rects = SpriteSheet.SliceAutomatic( pixels, 64, 32, settings );
+
+		Assert.AreEqual( 2, rects.Count, "with white understood as empty, the two shapes separate" );
+		AssertRect( rects[0], 4, 4, 10, 10 );
+		AssertRect( rects[1], 40, 6, 12, 8 );
+	}
+
+	[TestMethod]
+	public void ToleranceCopesWithABackgroundThatIsNotQuiteFlat()
+	{
+		// JPEG never gives back the white it was handed.
+		var pixels = Filled( 64, 32, new Color32( 250, 252, 249, 255 ) );
+		FillWith( pixels, 64, 4, 4, 10, 10, Ink );
+
+		var tight = new SpriteSheet.SliceSettings
+		{
+			Background = new SpriteSheet.BackgroundKey { Enabled = true, Color = White, Tolerance = 1 }
+		};
+		Assert.AreEqual( 1, SpriteSheet.SliceAutomatic( pixels, 64, 32, tight ).Count );
+		AssertRect( SpriteSheet.SliceAutomatic( pixels, 64, 32, tight )[0], 0, 0, 64, 32,
+			"too tight a tolerance and the off-white still reads as artwork" );
+
+		var forgiving = new SpriteSheet.SliceSettings
+		{
+			Background = new SpriteSheet.BackgroundKey { Enabled = true, Color = White, Tolerance = 12 }
+		};
+		var rects = SpriteSheet.SliceAutomatic( pixels, 64, 32, forgiving );
+		Assert.AreEqual( 1, rects.Count );
+		AssertRect( rects[0], 4, 4, 10, 10, "a little slack and the drawing separates cleanly" );
+	}
+
+	[TestMethod]
+	public void BackgroundColourIsGuessedFromTheCorners()
+	{
+		var pixels = Filled( 64, 32, White );
+		FillWith( pixels, 64, 20, 10, 20, 12, Ink );
+
+		var detected = SpriteSheet.DetectBackgroundColor( pixels, 64, 32 );
+
+		Assert.IsNotNull( detected );
+		Assert.AreEqual( 1f, detected.Value.r, 0.01f );
+		Assert.AreEqual( 1f, detected.Value.g, 0.01f );
+		Assert.AreEqual( 1f, detected.Value.b, 0.01f );
+	}
+
+	[TestMethod]
+	public void NoGuessIsMadeWhenTheCornersDisagree()
+	{
+		// Artwork running into a corner, or a gradient. Guessing here would key away part of the
+		// drawing, which is worse than leaving it to be set by hand.
+		var pixels = Filled( 64, 32, White );
+		FillWith( pixels, 64, 0, 0, 20, 20, Ink );
+
+		Assert.IsNull( SpriteSheet.DetectBackgroundColor( pixels, 64, 32 ) );
+	}
+
+	[TestMethod]
+	public void NoGuessIsMadeWhenTheImageIsAlreadyTransparent()
+	{
+		var pixels = Blank( 64, 32 );
+		Fill( pixels, 64, 20, 10, 20, 12 );
+
+		Assert.IsNull( SpriteSheet.DetectBackgroundColor( pixels, 64, 32 ),
+			"alpha is already doing the job; keying a colour on top would only cause trouble" );
+	}
+
+	[TestMethod]
+	public void TrimUsesTheBackgroundKeyToo()
+	{
+		// Otherwise trimming a slice on a white sheet does nothing at all, because every pixel in it
+		// counts as content.
+		var pixels = Filled( 64, 32, White );
+		FillWith( pixels, 64, 10, 12, 5, 6, Ink );
+
+		var key = new SpriteSheet.BackgroundKey { Enabled = true, Color = White, Tolerance = 8 };
+		var trimmed = SpriteSheet.Trim( pixels, 64, 32, new Rect( 0, 0, 64, 32 ), 0, key );
+
+		AssertRect( trimmed, 10, 12, 5, 6 );
+	}
+
+	//
+	// Trim
+	//
+
+	[TestMethod]
+	public void TrimTightensToTheArtwork()
+	{
+		var pixels = Blank( 32, 32 );
+		Fill( pixels, 32, 10, 12, 5, 6 );
+
+		var trimmed = SpriteSheet.Trim( pixels, 32, 32, new Rect( 0, 0, 32, 32 ) );
+
+		AssertRect( trimmed, 10, 12, 5, 6 );
+	}
+
+	[TestMethod]
+	public void TrimmingNothingGivesNothing()
+	{
+		var trimmed = SpriteSheet.Trim( Blank( 32, 32 ), 32, 32, new Rect( 0, 0, 32, 32 ) );
+
+		Assert.AreEqual( 0, trimmed.Width, "an empty rect is the signal there was nothing to keep" );
+		Assert.AreEqual( 0, trimmed.Height );
+	}
+
+	//
+	// Re-slicing
+	//
+
+	static SpriteSheet.SliceSettings GridOf( int columns, int rows ) => new()
+	{
+		Type = SpriteSheet.SliceType.GridByCellCount,
+		CellCount = new Vector2Int( columns, rows ),
+		KeepEmptyRects = true
+	};
+
+	[TestMethod]
+	public void EveryNewSliceGetsItsOwnIdentity()
+	{
+		var slices = SpriteSheet.CreateSlices( Blank( 64, 16 ), 64, 16, GridOf( 4, 1 ) );
+
+		Assert.AreEqual( 4, slices.Count );
+		Assert.AreEqual( 4, slices.Select( s => s.Id ).Distinct().Count(), "ids must be unique" );
+		Assert.AreEqual( 4, slices.Select( s => s.Name ).Distinct().Count(), "names must be unique" );
+		Assert.IsFalse( slices.Any( s => s.Id == System.Guid.Empty ) );
+	}
+
+	[TestMethod]
+	public void DeleteExistingStartsOver()
+	{
+		var original = new SpriteSheet.Slice { Name = "L_Thigh", Rect = new Rect( 0, 0, 16, 16 ) };
+
+		var settings = GridOf( 2, 1 );
+		settings.Method = SpriteSheet.SliceMethod.DeleteExisting;
+
+		var slices = SpriteSheet.CreateSlices( Blank( 32, 16 ), 32, 16, settings, new[] { original } );
+
+		Assert.AreEqual( 2, slices.Count );
+		Assert.IsFalse( slices.Any( s => s.Id == original.Id ), "nothing survives this method" );
+	}
+
+	[TestMethod]
+	public void SmartReshapesTheSliceThatWasAlreadyThere()
+	{
+		// The case that matters: parts have been cut, renamed and had their pivots placed on joints,
+		// and now the sheet is sliced again to pick up something missed. Losing the name or the id
+		// would break every sprite already built from it.
+		var original = new SpriteSheet.Slice
+		{
+			Name = "L_Thigh",
+			Rect = new Rect( 0, 0, 14, 16 ),
+			Pivot = new Vector2( 0.5f, 0.05f ),
+			Alignment = SpriteSheet.PivotAlignment.Custom
+		};
+		var id = original.Id;
+
+		var settings = GridOf( 2, 1 );
+		settings.Method = SpriteSheet.SliceMethod.Smart;
+
+		var slices = SpriteSheet.CreateSlices( Blank( 32, 16 ), 32, 16, settings, new[] { original } );
+
+		Assert.AreEqual( 2, slices.Count, "the second cell is new, the first is the one we had" );
+
+		var kept = slices.Single( s => s.Id == id );
+		Assert.AreEqual( "L_Thigh", kept.Name, "the name has to survive" );
+		AssertRect( kept.Rect, 0, 0, 16, 16, "but the shape follows the new cut" );
+
+		// Deliberately unlike Unity, which reapplies the dialog's pivot here. Putting pivots on
+		// joints is the slow part of rigging; re-slicing must not undo it.
+		Assert.AreEqual( 0.05f, kept.Pivot.y, "the hand-placed pivot has to survive too" );
+		Assert.AreEqual( SpriteSheet.PivotAlignment.Custom, kept.Alignment );
+	}
+
+	[TestMethod]
+	public void SmartTreatsSomethingSomewhereElseAsNew()
+	{
+		var original = new SpriteSheet.Slice { Name = "Head", Rect = new Rect( 0, 0, 16, 16 ) };
+
+		var settings = GridOf( 2, 1 );
+		settings.Method = SpriteSheet.SliceMethod.Smart;
+
+		var slices = SpriteSheet.CreateSlices( Blank( 32, 16 ), 32, 16, settings, new[] { original } );
+
+		Assert.AreEqual( 2, slices.Count );
+		Assert.IsTrue( slices.Any( s => s.Id == original.Id ) );
+		Assert.AreEqual( 1, slices.Count( s => s.Id != original.Id ), "the far cell is a new slice" );
+	}
+
+	[TestMethod]
+	public void SafeOnlyFillsEmptySpace()
+	{
+		var original = new SpriteSheet.Slice { Name = "Head", Rect = new Rect( 0, 0, 16, 16 ) };
+
+		var settings = GridOf( 2, 1 );
+		settings.Method = SpriteSheet.SliceMethod.Safe;
+
+		var slices = SpriteSheet.CreateSlices( Blank( 32, 16 ), 32, 16, settings, new[] { original } );
+
+		Assert.AreEqual( 2, slices.Count, "one kept, one added where nothing was" );
+
+		var kept = slices.Single( s => s.Id == original.Id );
+		AssertRect( kept.Rect, 0, 0, 16, 16, "the existing slice is untouched" );
+	}
+
+	[TestMethod]
+	public void ReslicingDoesNotReuseNamesAlreadyTaken()
+	{
+		var original = new SpriteSheet.Slice { Name = "sheet_0", Rect = new Rect( 0, 0, 16, 16 ) };
+
+		var settings = GridOf( 2, 1 );
+		settings.Method = SpriteSheet.SliceMethod.Safe;
+
+		var slices = SpriteSheet.CreateSlices( Blank( 32, 16 ), 32, 16, settings, new[] { original }, "sheet" );
+
+		Assert.AreEqual( 2, slices.Select( s => s.Name ).Distinct().Count(),
+			"the generated name has to step over the one already in use" );
+	}
+
+	//
+	// Pivots
+	//
+
+	[TestMethod]
+	public void PivotPresetsUseTheSameUpIsUpConventionAsSpriteOrigin()
+	{
+		// This is copied straight into Sprite.Animation.Origin, which a default (billboarded)
+		// SpriteRenderer reads as Y-up. Getting it upside down would put every pivot on the wrong
+		// end of every limb.
+		Assert.AreEqual( new Vector2( 0f, 0f ), SpriteSheet.Slice.GetPivot( SpriteSheet.PivotAlignment.BottomLeft ) );
+		Assert.AreEqual( new Vector2( 1f, 1f ), SpriteSheet.Slice.GetPivot( SpriteSheet.PivotAlignment.TopRight ) );
+		Assert.AreEqual( new Vector2( 0.5f, 0.5f ), SpriteSheet.Slice.GetPivot( SpriteSheet.PivotAlignment.Center ) );
+		Assert.AreEqual( new Vector2( 0.5f, 0f ), SpriteSheet.Slice.GetPivot( SpriteSheet.PivotAlignment.Bottom ) );
+	}
+
+	[TestMethod]
+	public void PivotConvertsIntoImageSpaceTheOtherWayUp()
+	{
+		var slice = new SpriteSheet.Slice { Rect = new Rect( 10, 20, 100, 50 ) };
+
+		slice.SetAlignment( SpriteSheet.PivotAlignment.BottomLeft );
+		Assert.AreEqual( new Vector2( 10, 70 ), slice.PivotToImagePixels,
+			"the bottom of the slice is the far edge in image space" );
+
+		slice.SetAlignment( SpriteSheet.PivotAlignment.TopLeft );
+		Assert.AreEqual( new Vector2( 10, 20 ), slice.PivotToImagePixels );
+
+		slice.SetAlignment( SpriteSheet.PivotAlignment.Center );
+		Assert.AreEqual( new Vector2( 60, 45 ), slice.PivotToImagePixels );
+	}
+
+	[TestMethod]
+	public void PlacingAPivotByHandRoundTripsAndMarksItCustom()
+	{
+		var slice = new SpriteSheet.Slice { Rect = new Rect( 10, 20, 100, 50 ) };
+
+		// Somewhere a joint might plausibly be - near the top edge, slightly off centre.
+		slice.SetPivotFromImagePixels( new Vector2( 35, 25 ) );
+
+		Assert.AreEqual( SpriteSheet.PivotAlignment.Custom, slice.Alignment );
+		Assert.AreEqual( new Vector2( 35, 25 ), slice.PivotToImagePixels );
+	}
+
+	[TestMethod]
+	public void SnappingToAPresetForgetsAHandPlacedPivot()
+	{
+		var slice = new SpriteSheet.Slice { Rect = new Rect( 0, 0, 10, 10 ) };
+		slice.SetPivotFromImagePixels( new Vector2( 3, 7 ) );
+
+		slice.SetAlignment( SpriteSheet.PivotAlignment.Center );
+
+		Assert.AreEqual( new Vector2( 0.5f, 0.5f ), slice.Pivot );
+		Assert.AreEqual( SpriteSheet.PivotAlignment.Center, slice.Alignment );
+	}
+
+	//
+	// Rig hierarchy
+	//
+
+	static (SpriteSheet Sheet, SpriteSheet.Slice Hips, SpriteSheet.Slice Thigh, SpriteSheet.Slice Calf) Leg()
+	{
+		var hips = new SpriteSheet.Slice { Name = "Hips" };
+		var thigh = new SpriteSheet.Slice { Name = "L_Thigh" };
+		var calf = new SpriteSheet.Slice { Name = "L_Calf" };
+
+		var sheet = new SpriteSheet
+		{
+			Slices = new List<SpriteSheet.Slice> { hips, thigh, calf }
+		};
+
+		Assert.IsTrue( sheet.TrySetParent( thigh, hips.Id ) );
+		Assert.IsTrue( sheet.TrySetParent( calf, thigh.Id ) );
+
+		return (sheet, hips, thigh, calf);
+	}
+
+	[TestMethod]
+	public void PartsHangOffTheirParents()
+	{
+		var (sheet, hips, thigh, calf) = Leg();
+
+		Assert.AreEqual( hips.Id, thigh.ParentId );
+		Assert.AreEqual( calf.Id, sheet.GetChildren( thigh.Id ).Single().Id );
+		Assert.AreEqual( hips.Id, sheet.GetChildren( System.Guid.Empty ).Single().Id, "only the hips are a root" );
+	}
+
+	[TestMethod]
+	public void APartCannotBeItsOwnParent()
+	{
+		var (sheet, hips, _, _) = Leg();
+
+		Assert.IsFalse( sheet.TrySetParent( hips, hips.Id ) );
+		Assert.AreEqual( System.Guid.Empty, hips.ParentId );
+	}
+
+	[TestMethod]
+	public void ParentingCannotBeMadeToLoop()
+	{
+		// Two clicks in the build dialog get you here: the thigh already owns the calf, so making the
+		// thigh a child of the calf closes a ring. Building that would recurse until the stack ran out.
+		var (sheet, hips, thigh, calf) = Leg();
+
+		Assert.IsFalse( sheet.TrySetParent( hips, calf.Id ), "hips -> calf -> thigh -> hips" );
+		Assert.AreEqual( System.Guid.Empty, hips.ParentId, "and the attempt must leave things as they were" );
+
+		Assert.IsFalse( sheet.TrySetParent( thigh, calf.Id ) );
+		Assert.AreEqual( hips.Id, thigh.ParentId );
+	}
+
+	[TestMethod]
+	public void DetachingToRootIsAlwaysAllowed()
+	{
+		var (sheet, _, thigh, _) = Leg();
+
+		Assert.IsTrue( sheet.TrySetParent( thigh, System.Guid.Empty ) );
+		Assert.AreEqual( System.Guid.Empty, thigh.ParentId );
+	}
+
+	[TestMethod]
+	public void BuildOrderPutsParentsFirst()
+	{
+		// A child has to have something to attach to by the time it is created.
+		var (sheet, hips, thigh, calf) = Leg();
+
+		var order = sheet.InHierarchyOrder();
+
+		Assert.AreEqual( 3, order.Count );
+		Assert.IsTrue( order.IndexOf( hips ) < order.IndexOf( thigh ) );
+		Assert.IsTrue( order.IndexOf( thigh ) < order.IndexOf( calf ) );
+	}
+
+	[TestMethod]
+	public void APartWhoseParentWentAwayIsStillBuilt()
+	{
+		// Delete a part that others hang off - by re-slicing, or from the canvas - and the orphans
+		// must still turn up in the rig rather than quietly vanishing.
+		var (sheet, hips, thigh, calf) = Leg();
+
+		sheet.Slices.Remove( thigh );
+
+		var order = sheet.InHierarchyOrder();
+
+		Assert.AreEqual( 2, order.Count );
+		CollectionAssert.Contains( order, calf, "the calf still points at a thigh that is gone" );
+		CollectionAssert.Contains( order, hips );
+	}
+
+	//
+	// Naming
+	//
+
+	[TestMethod]
+	public void UniqueNamesStepAroundWhatIsAlreadyThere()
+	{
+		var sheet = new SpriteSheet
+		{
+			Slices = new List<SpriteSheet.Slice>
+			{
+				new() { Name = "Head" },
+				new() { Name = "Head_1" }
+			}
+		};
+
+		Assert.AreEqual( "Torso", sheet.GetUniqueName( "Torso" ) );
+		Assert.AreEqual( "Head_2", sheet.GetUniqueName( "Head" ) );
+
+		// Renaming a slice to what it is already called must not push it to Head_2.
+		Assert.AreEqual( "Head", sheet.GetUniqueName( "Head", sheet.Slices[0] ) );
+	}
+
+	[TestMethod]
+	public void SlicesAreFoundByIdRatherThanName()
+	{
+		var slice = new SpriteSheet.Slice { Name = "Thigh" };
+		var sheet = new SpriteSheet { Slices = new List<SpriteSheet.Slice> { slice } };
+
+		Assert.AreSame( slice, sheet.GetSlice( slice.Id ) );
+
+		// The rename that makes a sheet usable must not lose the reference.
+		slice.Name = "L_Thigh";
+		Assert.AreSame( slice, sheet.GetSlice( slice.Id ) );
+		Assert.IsNull( sheet.GetSlice( "Thigh" ) );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Scene/SpriteSortKeyTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Scene/SpriteSortKeyTest.cs
@@ -1,0 +1,313 @@
+using Sandbox.Rendering;
+using System;
+using System.Collections.Generic;
+
+namespace SceneTests;
+
+// The sprite draw order is a lexicographic comparison of a packed layer/blend/order key and a
+// distance, resolved on the GPU. These tests pin down the CPU half of that key: the packing has to
+// be monotonic, because a non-monotonic key sorts wrongly with no visible error anywhere.
+[TestClass]
+public class SpriteSortKeyTest
+{
+	// Blend sits between layer and order in the key. Most of these cases only care about layer and
+	// order, so they hold blend fixed at Transparent - what an ordinary 2D sprite is.
+	static uint Pack( int layer, int order, SpriteBlendMode blend = SpriteBlendMode.Transparent )
+		=> SpriteBatchSceneObject.SpriteData.PackSortKey( layer, blend, order );
+
+	[TestMethod]
+	public void SpritesWithNoSortingSetUpCompareEqual()
+	{
+		// Existing content has no layer or order, so every such sprite has to pack identically and
+		// leave the distance term to decide - exactly the behaviour before sorting existed.
+		Assert.AreEqual( Pack( 0, 0 ), Pack( 0, 0 ) );
+
+		// And it must sit at the bottom of its blend state's range, so anything explicitly ordered
+		// rises above it.
+		Assert.AreEqual( Pack( 0, short.MinValue ), Pack( 0, 0 ) & 0xFFFF0000u );
+	}
+
+	[TestMethod]
+	public void LayerOutranksOrder()
+	{
+		// A higher layer beats any order within a lower layer, however extreme.
+		Assert.IsTrue( Pack( 1, short.MinValue ) > Pack( 0, short.MaxValue ) );
+	}
+
+	[TestMethod]
+	public void OrderIsMonotonicWithinLayer()
+	{
+		int[] orders = [short.MinValue, -1000, -1, 0, 1, 1000, short.MaxValue];
+
+		for ( int i = 1; i < orders.Length; i++ )
+		{
+			Assert.IsTrue( Pack( 5, orders[i - 1] ) < Pack( 5, orders[i] ),
+				$"order {orders[i - 1]} should pack below {orders[i]}" );
+		}
+	}
+
+	[TestMethod]
+	public void NegativeOrderSortsBelowZero()
+	{
+		// The signed-to-unsigned bias exists for this case, so test it on its own.
+		Assert.IsTrue( Pack( 3, -1 ) < Pack( 3, 0 ) );
+	}
+
+	[TestMethod]
+	public void LayerIsMonotonic()
+	{
+		int[] layers = [0, 1, 2, 255, 256, 1000, ushort.MaxValue];
+
+		for ( int i = 1; i < layers.Length; i++ )
+		{
+			Assert.IsTrue( Pack( layers[i - 1], 0 ) < Pack( layers[i], 0 ),
+				$"layer {layers[i - 1]} should pack below {layers[i]}" );
+		}
+	}
+
+	[TestMethod]
+	public void OutOfRangeValuesClamp()
+	{
+		// Clamping rather than wrapping - a wrapped key would sort an extreme value to the
+		// opposite end of the scene, which is the worst possible failure.
+		Assert.AreEqual( Pack( 0, short.MinValue ), Pack( 0, int.MinValue ) );
+		Assert.AreEqual( Pack( 0, short.MaxValue ), Pack( 0, int.MaxValue ) );
+		Assert.AreEqual( Pack( 0, 0 ), Pack( int.MinValue, 0 ) );
+	}
+
+	[TestMethod]
+	public void PackingIsUniqueAcrossTheGrid()
+	{
+		var seen = new HashSet<uint>();
+
+		for ( int layer = 0; layer < 40; layer++ )
+		{
+			for ( int order = -20; order <= 20; order++ )
+			{
+				Assert.IsTrue( seen.Add( Pack( layer, order ) ),
+					$"layer {layer} order {order} collided with another key" );
+			}
+		}
+	}
+
+	[TestMethod]
+	public void LayerOutranksBlendMode()
+	{
+		// Blend state groups sprites into drawable runs, but it must never override a layer -
+		// otherwise every additive sprite in the scene would jump in front of every ordinary one.
+		Assert.IsTrue( Pack( 1, 0, SpriteBlendMode.Opaque ) > Pack( 0, 0, SpriteBlendMode.Additive ) );
+	}
+
+	[TestMethod]
+	public void BlendModeOutranksOrderWithinALayer()
+	{
+		// The trade the renderer forces: sprites needing different blend states cannot share a
+		// draw call, so within one layer they are grouped by blend before order is considered.
+		Assert.IsTrue( Pack( 2, short.MinValue, SpriteBlendMode.Additive ) > Pack( 2, short.MaxValue, SpriteBlendMode.Transparent ) );
+	}
+
+	[TestMethod]
+	public void BlendModesGroupIntoContiguousRuns()
+	{
+		// Each blend state has to occupy one unbroken run of the key space, or a run could not be
+		// drawn as a single call over a contiguous range.
+		//
+		// int, not var: var would infer short here, and short arithmetic wraps silently at 32767
+		// rather than throwing - which turns this into an infinite loop.
+		for ( int order = short.MinValue; order < short.MaxValue; order += 4096 )
+		{
+			Assert.IsTrue( Pack( 7, order, SpriteBlendMode.Opaque ) < Pack( 7, short.MinValue, SpriteBlendMode.Transparent ) );
+			Assert.IsTrue( Pack( 7, order, SpriteBlendMode.Transparent ) < Pack( 7, short.MinValue, SpriteBlendMode.Additive ) );
+		}
+	}
+
+	// The compute shader inverts the packed key, because the pixel shader walks the sort LUT
+	// backwards. Getting this backwards would put the front layer at the back.
+	static uint Coarse( int layer, int order, SpriteBlendMode blend = SpriteBlendMode.Transparent ) => ~Pack( layer, order, blend );
+
+	[TestMethod]
+	public void InvertedKeyPutsHigherLayersInFront()
+	{
+		// Drawn back to front, so "in front" means a smaller sorted key.
+		Assert.IsTrue( Coarse( 2, 0 ) < Coarse( 1, 0 ) );
+		Assert.IsTrue( Coarse( 1, 10 ) < Coarse( 1, 9 ) );
+	}
+
+	// Mirror of FloatToSortableUint in sprite_cs.shader. The GPU compares distances as unsigned
+	// integers so they can share a comparison with the packed key, and that mapping has to
+	// preserve float ordering across the sign boundary.
+	static uint FloatToSortableUint( float value )
+	{
+		var bits = BitConverter.SingleToUInt32Bits( value );
+		return (bits & 0x80000000u) != 0 ? ~bits : bits | 0x80000000u;
+	}
+
+	[TestMethod]
+	public void FloatMappingPreservesOrder()
+	{
+		float[] values = [-1e30f, -1000f, -1f, -0.001f, 0f, 0.001f, 1f, 1000f, 1e30f];
+
+		for ( int i = 1; i < values.Length; i++ )
+		{
+			Assert.IsTrue( FloatToSortableUint( values[i - 1] ) < FloatToSortableUint( values[i] ),
+				$"{values[i - 1]} should map below {values[i]}" );
+		}
+	}
+
+	// Only CustomAxis sorts along an axis. Every other mode has to resolve to zero, because the
+	// shader reads a zero axis as "use camera depth" - that fallback is what keeps existing
+	// cameras rendering unchanged.
+	[TestMethod]
+	public void OnlyCustomAxisModeResolvesAnAxis()
+	{
+		var axis = new Vector3( 0, 1, 0 );
+
+		Assert.AreEqual( Vector3.Zero, CameraComponent.ResolveSortAxis( TransparencySortMode.Default, axis ) );
+		Assert.AreEqual( Vector3.Zero, CameraComponent.ResolveSortAxis( TransparencySortMode.Perspective, axis ) );
+		Assert.AreEqual( Vector3.Zero, CameraComponent.ResolveSortAxis( TransparencySortMode.Orthographic, axis ) );
+		Assert.AreEqual( axis, CameraComponent.ResolveSortAxis( TransparencySortMode.CustomAxis, axis ) );
+	}
+
+	[TestMethod]
+	public void SortAxisIsNormalized()
+	{
+		// Length would otherwise scale every distance, which changes nothing about the ordering
+		// but makes the numbers meaningless to anyone reading them back.
+		var resolved = CameraComponent.ResolveSortAxis( TransparencySortMode.CustomAxis, new Vector3( 0, 12, 0 ) );
+
+		Assert.AreEqual( 1f, resolved.Length, 0.0001f );
+	}
+
+	[TestMethod]
+	public void ZeroSortAxisStaysZeroRatherThanBecomingNaN()
+	{
+		// A camera switched to CustomAxis before an axis is typed in. Degrading to camera depth is
+		// survivable; a NaN axis would poison every key in the batch.
+		var resolved = CameraComponent.ResolveSortAxis( TransparencySortMode.CustomAxis, Vector3.Zero );
+
+		Assert.AreEqual( Vector3.Zero, resolved );
+		Assert.IsFalse( float.IsNaN( resolved.x ) );
+	}
+
+	// Mirror of the fine key in sprite_cs.shader: the depth with its low bits traded away for a
+	// sorting group member's rank.
+	const uint RankMask = 0xFFu;
+
+	static uint Fine( float depth, int rank )
+	{
+		var quantized = FloatToSortableUint( depth ) & ~RankMask;
+		var inverted = RankMask - Math.Min( (uint)rank, RankMask );
+
+		return quantized | inverted;
+	}
+
+	// The full key as the GPU compares it: coarse first, axis distance only as a tiebreak.
+	static (uint Coarse, uint Fine) Key( int layer, int order, float axisDistance, int rank = 0 )
+		=> (Coarse( layer, order ), Fine( axisDistance, rank ));
+
+	static bool DrawsInFrontOf( (uint Coarse, uint Fine) a, (uint Coarse, uint Fine) b )
+		=> a.Coarse != b.Coarse ? a.Coarse < b.Coarse : a.Fine < b.Fine;
+
+	[TestMethod]
+	public void HigherAlongSortAxisDrawsBehind()
+	{
+		// The whole point of Y-sorting: a character lower on the screen walks in front of one
+		// higher up. Same layer, same order, so only the axis distance decides.
+		var nearer = Key( 0, 0, axisDistance: 10f );
+		var further = Key( 0, 0, axisDistance: 90f );
+
+		Assert.IsTrue( DrawsInFrontOf( nearer, further ) );
+	}
+
+	[TestMethod]
+	public void SortAxisWorksAcrossTheOrigin()
+	{
+		// Unlike camera distance, an axis dot product is signed - sprites on the far side of the
+		// world origin produce negative distances and still have to order correctly.
+		var below = Key( 0, 0, axisDistance: -500f );
+		var above = Key( 0, 0, axisDistance: 500f );
+
+		Assert.IsTrue( DrawsInFrontOf( below, above ) );
+	}
+
+	[TestMethod]
+	public void SortLayerBeatsSortAxis()
+	{
+		// A sprite explicitly placed in a higher layer must draw in front no matter how far along
+		// the sort axis it sits. If the axis could ever win, layers would be advisory.
+		var highLayerFarBack = Key( 3, 0, axisDistance: 1e6f );
+		var lowLayerFarFront = Key( 0, 0, axisDistance: -1e6f );
+
+		Assert.IsTrue( DrawsInFrontOf( highLayerFarBack, lowLayerFarFront ) );
+	}
+
+	[TestMethod]
+	public void HigherRankDrawsInFrontWithinAGroup()
+	{
+		// Every member of a group resolves to the group's own depth, so rank is the only thing
+		// separating them.
+		var back = Key( 0, 0, axisDistance: 100f, rank: 0 );
+		var front = Key( 0, 0, axisDistance: 100f, rank: 5 );
+
+		Assert.IsTrue( DrawsInFrontOf( front, back ) );
+	}
+
+	// The property sorting groups exist for: nothing from outside a group may be drawn in between
+	// its members. This is the test that would catch the rank bits being too few, or the depth
+	// quantization being finer than the rank field.
+	[TestMethod]
+	public void OutsideSpriteCannotLandBetweenGroupMembers()
+	{
+		const float groupDepth = 500f;
+
+		var first = Key( 0, 0, groupDepth, rank: 0 );
+		var last = Key( 0, 0, groupDepth, rank: 20 );
+
+		// Depths within the group's own quantization bucket are the dangerous ones - anything
+		// further away is separated by the depth term and was never a risk.
+		float[] nearbyDepths = [groupDepth, groupDepth + 0.001f, groupDepth - 0.001f, groupDepth + 0.01f];
+
+		foreach ( var depth in nearbyDepths )
+		{
+			var outsider = Key( 0, 0, depth, rank: 0 );
+
+			var isBetween = DrawsInFrontOf( outsider, first ) && DrawsInFrontOf( last, outsider );
+
+			Assert.IsFalse( isBetween, $"a sprite at depth {depth} sliced the group apart" );
+		}
+	}
+
+	[TestMethod]
+	public void QuantizationNeverReordersSeparatedDepths()
+	{
+		// Trading the low bits away may make two near-equal depths tie, but it must never swap
+		// them. Anything coarser than the quantization step has to survive intact.
+		float[] depths = [-1e5f, -1f, 0f, 1f, 100f, 1e5f];
+
+		for ( var i = 1; i < depths.Length; i++ )
+		{
+			Assert.IsTrue( Fine( depths[i - 1], 0 ) <= Fine( depths[i], 0 ),
+				$"depth {depths[i - 1]} must not quantize above {depths[i]}" );
+		}
+	}
+
+	[TestMethod]
+	public void RanksBeyondTheLastRungShareIt()
+	{
+		// Groups larger than the rank field degrade to a tie rather than wrapping around, which
+		// would otherwise send the 256th member to the very back of the group.
+		var last = Key( 0, 0, 10f, rank: SortingGroup.MaxRank );
+		var overflow = Key( 0, 0, 10f, rank: SortingGroup.MaxRank + 50 );
+
+		Assert.AreEqual( last.Fine, overflow.Fine );
+		Assert.IsFalse( DrawsInFrontOf( overflow, last ) );
+	}
+
+	[TestMethod]
+	public void UngroupedSpritesAllShareTheBottomRung()
+	{
+		// Rank 0 is what every ungrouped sprite gets, so the rank bits must be a constant for
+		// them and leave the depth entirely in charge.
+		Assert.AreEqual( Fine( 42f, 0 ) & RankMask, Fine( 99f, 0 ) & RankMask );
+	}
+}

--- a/game/addons/base/Assets/shaders/sort_cs.shader
+++ b/game/addons/base/Assets/shaders/sort_cs.shader
@@ -23,10 +23,14 @@ CS
 	#define GROUP_SIZE 256
 	#define MAX_DIM_GROUPS 1024
 	#define MAX_DIM_THREADS ( GROUP_SIZE * MAX_DIM_GROUPS )
-	#define FLT_MAX 3.402823466e+38f;
+	// Sorts after every real sprite, so padding entries end up outside the drawn range.
+	#define SORTKEY_MAX uint2( 0xFFFFFFFFu, 0xFFFFFFFFu )
 
 	RWStructuredBuffer<uint> SortBuffer < Attribute( "SortBuffer" ); >;
-	RWStructuredBuffer<float> DistanceBuffer < Attribute( "DistanceBuffer" ); >;
+
+	// Sort keys are compared lexicographically: .x is the coarse key (sort layer and order in
+	// layer, packed and inverted), .y is the fine key (sort axis distance, made unsigned-comparable).
+	RWStructuredBuffer<uint2> SortKeyBuffer < Attribute( "SortKeyBuffer" ); >;
 	int Count < Attribute( "Count" ); >;
 	int Block < Attribute( "Block" ); >;
 	int Dim < Attribute( "Dim" ); >;
@@ -44,7 +48,7 @@ CS
 				return;
 
 			SortBuffer[currentIndex] = currentIndex;
-			DistanceBuffer[currentIndex] = FLT_MAX;
+			SortKeyBuffer[currentIndex] = SORTKEY_MAX;
 		}
 		#else
 		{
@@ -55,13 +59,17 @@ CS
 			uint indexA = SortBuffer[currentIndex];
 			uint indexB = SortBuffer[compareIndex];
 
-			float distanceA = DistanceBuffer[indexA];
-			float distanceB = DistanceBuffer[indexB];
+			uint2 keyA = SortKeyBuffer[indexA];
+			uint2 keyB = SortKeyBuffer[indexB];
+
+			// Lexicographic: the fine key only breaks ties in the coarse key.
+			// Equal keys must not swap, so compare both directions explicitly.
+			bool greater = ( keyA.x != keyB.x ) ? ( keyA.x > keyB.x ) : ( keyA.y > keyB.y );
+			bool less = ( keyA.x != keyB.x ) ? ( keyA.x < keyB.x ) : ( keyA.y < keyB.y );
 
 			bool ascending = ( currentIndex & Dim ) == 0;
-			float comparison = ( distanceA - distanceB ) * ( ascending ? 1 : -1 );
 
-			if ( comparison > 0 )
+			if ( ascending ? greater : less )
 			{
 				SortBuffer[currentIndex] = indexB;
 				SortBuffer[compareIndex] = indexA;

--- a/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
@@ -88,6 +88,13 @@ CS
 	#define SPRITE_SORT_CUSTOM_AXIS 3
 
 	int SpriteCount < Attribute( "SpriteCount"); >;
+
+	// How many entries SpriteBufferOut and SortKeyBuffer actually hold. Larger than SpriteCount -
+	// the batch is sized for the motion blur trails too, and rounded up to a power of two. Needed
+	// because the splot writes below are placed by a running atomic counter rather than by thread
+	// index, so nothing else bounds them.
+	int BufferCapacity < Attribute( "BufferCapacity" ); >;
+
 	RWStructuredBuffer<int> AtomicCounter < Attribute( "AtomicCounter" ); >;
 
 	// Motion blur
@@ -251,10 +258,15 @@ CS
 			SortKeyBuffer[i] = CalculateSortKey(sprite.SortKey, sprite.Position, sprite.SortOriginOffset, sprite.SortRank);
 			SpriteBufferOut[i] = sprite;
 		}
-		else
-		{
-			SortKeyBuffer[i] = SORTKEY_MAX;
-		}
+
+		// Nothing is written for the idle threads. The dispatch is rounded up to a whole group, so
+		// a scene with two sprites still starts 64 threads, while the key buffer only holds as many
+		// entries as the batch was sized for - 16 at the smallest. Padding the tail from here ran
+		// off the end of the buffer, and the stray writes landed on whatever followed it.
+		//
+		// The padding still happens, just where the buffer's size is actually known: sort_cs fills
+		// the whole thing with SORTKEY_MAX in its D_CLEAR pass, which is dispatched just before this
+		// shader and under the same condition that makes these keys get read at all.
 
 		int writeSize = 0;
 		int splotCount = 0;
@@ -327,9 +339,16 @@ CS
 					pos += moveStep;
 
 					b.Position = pos;
-					// We fill the sort key buffer for sorting
-					SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
-					SpriteBufferOut[writeLocation] = b;
+
+					// Placed by the atomic counter, so the only thing keeping this inside the
+					// buffer is the counter agreeing with how the batch was sized. Checked rather
+					// than assumed - overrunning a UAV here hangs the GPU rather than failing.
+					if ( writeLocation < (uint)BufferCapacity )
+					{
+						// We fill the sort key buffer for sorting
+						SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
+						SpriteBufferOut[writeLocation] = b;
+					}
 
 					index++;
 				}
@@ -338,11 +357,14 @@ CS
 				spritePosition -= moveStep;
 				b.Position = spritePosition;
 
-				// Fill the sort key buffer for sorting
 				writeLocation = writeOffset + index;
-				SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
 
-				SpriteBufferOut[writeLocation] = b;
+				if ( writeLocation < (uint)BufferCapacity )
+				{
+					// Fill the sort key buffer for sorting
+					SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
+					SpriteBufferOut[writeLocation] = b;
+				}
 
 				index++;
 			}

--- a/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_cs.shader
@@ -63,13 +63,29 @@ CS
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
+		uint SortKey;
+		float3 SortOriginOffset;
+		uint SortRank;
 	};
 	StructuredBuffer<SpriteData> SpriteBuffer < Attribute( "Sprites" ); >;
 	RWStructuredBuffer<SpriteData> SpriteBufferOut < Attribute( "SpriteBufferOut" ); >;
 
 	// Sorting related
-	RWStructuredBuffer<float> DistanceBuffer < Attribute( "DistanceBuffer" ); >;
+	RWStructuredBuffer<uint2> SortKeyBuffer < Attribute( "SortKeyBuffer" ); >;
 	float3 CameraPosition < Attribute ("CameraPosition"); >;
+
+	// How the fine half of the sort key is measured. Matches TransparencySortMode on the camera.
+	// Defaults to 0 (Default) when unset, which is the behaviour from before sort modes existed.
+	int SpriteSortMode < Attribute( "SpriteSortMode" ); >;
+
+	// Only set in CustomAxis mode, and always normalized. Left at zero otherwise, which every
+	// path below treats as "no axis given, sort by camera depth".
+	float3 SpriteSortAxis < Attribute( "SpriteSortAxis" ); >;
+
+	#define SPRITE_SORT_DEFAULT 0
+	#define SPRITE_SORT_PERSPECTIVE 1
+	#define SPRITE_SORT_ORTHOGRAPHIC 2
+	#define SPRITE_SORT_CUSTOM_AXIS 3
 
 	int SpriteCount < Attribute( "SpriteCount"); >;
 	RWStructuredBuffer<int> AtomicCounter < Attribute( "AtomicCounter" ); >;
@@ -130,6 +146,7 @@ CS
 	}
 
 	#define FLT_MAX 3.402823466e+38f
+	#define SORTKEY_MAX uint2( 0xFFFFFFFFu, 0xFFFFFFFFu )
 
 	groupshared int groupWriteSize[64];
     groupshared int groupWriteOffset[64];
@@ -141,13 +158,71 @@ CS
 	{
 		float3 delta = (worldPosition - CameraPosition);
 
-		// Check if orthographic
-		if ( g_matViewToProjection[3].w != 0.0f )
+		bool isOrthographic = g_matViewToProjection[3].w != 0.0f;
+
+		// The projection decides only in Default mode; the other two modes name a measure outright.
+		bool useViewDepth = ( SpriteSortMode == SPRITE_SORT_ORTHOGRAPHIC ) ||
+			( SpriteSortMode == SPRITE_SORT_DEFAULT && isOrthographic );
+
+		if ( useViewDepth )
 		{
 			return dot( delta, g_vCameraDirWs.xyz );
 		}
 
 		return dot(delta, delta);
+	}
+
+	// The value the fine half of the sort key is built from. Larger means further back.
+	float CalculateSortDepth(float3 worldPosition)
+	{
+		// A zero axis means the mode never supplied one, so there is nothing to sort along and
+		// camera depth is the only sensible answer. This is also what keeps a camera that has
+		// never been told about sort modes rendering exactly as it always did.
+		if ( SpriteSortMode == SPRITE_SORT_CUSTOM_AXIS && any( SpriteSortAxis != 0.0f ) )
+		{
+			// Position along the axis, with no reference to the camera at all - that is the whole
+			// point. Further along the axis sorts larger, so it draws first and ends up behind.
+			return dot( worldPosition, SpriteSortAxis );
+		}
+
+		return CalculateDistance( worldPosition );
+	}
+
+	// Maps a float onto a uint whose unsigned ordering matches the float's signed ordering,
+	// so distances can be compared alongside the integer part of the key.
+	uint FloatToSortableUint( float value )
+	{
+		uint bits = asuint( value );
+
+		// Negative floats compare in reverse as raw bits, so flip them entirely.
+		// Positive floats only need their sign bit set to sort above every negative.
+		return ( bits & 0x80000000u ) ? ~bits : ( bits | 0x80000000u );
+	}
+
+	// The bottom of the fine key is given over to a sorting group member's rank. 8 bits leaves
+	// 15 bits of float mantissa for the depth, which is finer than a sprite's own size at any
+	// sane world scale. Must match SortingGroup.MaxRank on the CPU.
+	#define SPRITE_SORT_RANK_MASK 0xFFu
+
+	// Sprites are drawn back-to-front - the pixel shader walks the sort LUT in reverse - so a
+	// LARGER key is drawn EARLIER, further back. The coarse key is therefore inverted: a higher
+	// sort layer or order has to draw LATER, which means it has to sort SMALLER.
+	uint2 CalculateSortKey( uint packedSortKey, float3 worldPosition, float3 sortOriginOffset, uint sortRank )
+	{
+		// Zero offset means the sprite sorts where it is; a sorting group moves every one of its
+		// members onto the group's own origin so they resolve to a single depth.
+		float depth = CalculateSortDepth( worldPosition + sortOriginOffset );
+
+		// Trading the low bits of the depth away for the rank is a monotonic quantization: it can
+		// only make two near-equal depths tie, never reorder them. And a tie is precisely where
+		// the group's own ordering should be taking over anyway.
+		uint quantized = FloatToSortableUint( depth ) & ~SPRITE_SORT_RANK_MASK;
+
+		// Inverted for the same reason as the coarse key - a higher rank draws later, so it has
+		// to sort smaller. Ungrouped sprites are rank 0 and all land on the same bottom rung.
+		uint rank = SPRITE_SORT_RANK_MASK - min( sortRank, SPRITE_SORT_RANK_MASK );
+
+		return uint2( ~packedSortKey, quantized | rank );
 	}
 
 	[numthreads( 64, 1, 1 ) ]
@@ -173,12 +248,12 @@ CS
 			}
 
 
-			DistanceBuffer[i] = CalculateDistance(sprite.Position);
+			SortKeyBuffer[i] = CalculateSortKey(sprite.SortKey, sprite.Position, sprite.SortOriginOffset, sprite.SortRank);
 			SpriteBufferOut[i] = sprite;
 		}
 		else
 		{
-			DistanceBuffer[i] = FLT_MAX;
+			SortKeyBuffer[i] = SORTKEY_MAX;
 		}
 
 		int writeSize = 0;
@@ -252,8 +327,8 @@ CS
 					pos += moveStep;
 
 					b.Position = pos;
-					// We fill distance buffer for sorting
-					DistanceBuffer[writeLocation] = CalculateDistance(b.Position);
+					// We fill the sort key buffer for sorting
+					SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
 					SpriteBufferOut[writeLocation] = b;
 
 					index++;
@@ -263,9 +338,9 @@ CS
 				spritePosition -= moveStep;
 				b.Position = spritePosition;
 
-				// Fil distance buffer for sorting
+				// Fill the sort key buffer for sorting
 				writeLocation = writeOffset + index;
-				DistanceBuffer[writeLocation] = CalculateDistance(b.Position);
+				SortKeyBuffer[writeLocation] = CalculateSortKey(b.SortKey, b.Position, b.SortOriginOffset, b.SortRank);
 
 				SpriteBufferOut[writeLocation] = b;
 

--- a/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
+++ b/game/addons/base/Assets/shaders/sprite/sprite_ps.shader
@@ -54,6 +54,9 @@ COMMON
 		float3 Velocity;
 		float4 BlendSheetUV;
 		float2 Offset;
+		uint SortKey;
+		float3 SortOriginOffset;
+		uint SortRank;
 	};
 
 	StructuredBuffer<SpriteData> Sprites < Attribute( "Sprites" ); >;
@@ -61,12 +64,19 @@ COMMON
 	int IsSorted < Attribute( "IsSorted" ); >;
 	int CurrentBufferSize < Attribute( "SpriteCount" ); >;
 
+	// Where in the draw order this call starts. A batch holding more than one blend state is drawn
+	// as several calls, each covering one run of the sorted order, so the instance id is relative
+	// to the run rather than to the whole batch.
+	int SortLUTOffset < Attribute( "SortLUTOffset" ); >;
+
 	SpriteData GetSprite( uint index )
 	{
 		int spriteIndex = index;
 		if ( IsSorted == 1 )
 		{
-			spriteIndex = SortLUT[CurrentBufferSize - 1 - index];
+			// The table is walked from the end because sprites are drawn back to front, and the
+			// furthest away sorts largest.
+			spriteIndex = SortLUT[CurrentBufferSize - 1 - index - SortLUTOffset];
 		}
 		return Sprites[spriteIndex];
 	}

--- a/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
+++ b/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Linq;
+
+namespace Editor;
+
+/// <summary>
+/// Picks one of the project's sprite sort layers. Offers a way through to the layer editor
+/// inline, so needing a new layer doesn't mean going hunting through project settings.
+/// </summary>
+[CustomEditor( typeof( SortLayerHandle ), NamedEditor = "sortlayer" )]
+public class SortLayerControlWidget : ControlWidget
+{
+	public SortLayerControlWidget( SerializedProperty property ) : base( property )
+	{
+		Layout = Layout.Column();
+		Layout.Spacing = 2;
+		AcceptDrops = false;
+
+		Rebuild();
+	}
+
+	void Rebuild()
+	{
+		Layout.Clear( true );
+
+		var settings = ProjectSettings.Sorting;
+		var current = SerializedProperty.GetValue<SortLayerHandle>();
+
+		var comboBox = new ComboBox( this );
+
+		foreach ( var layer in settings.Layers )
+		{
+			// Captured per iteration so each entry writes back its own id.
+			var id = layer.Id;
+
+			comboBox.AddItem( layer.Name,
+				onSelected: () => SerializedProperty.SetValue( new SortLayerHandle( id ) ),
+				selected: current.Id == id || (current.Id == Guid.Empty && layer == settings.DefaultLayer) );
+		}
+
+		comboBox.AddItem( "Edit Layers…", "tune", onSelected: OpenLayerEditor );
+
+		Layout.Add( comboBox );
+
+		AddUnsortedWarning();
+		AddGroupWarnings();
+	}
+
+	/// <summary>
+	/// The two ways a sorting group silently does nothing: it is nested inside another one, or its
+	/// sprites never opted into sorting. Both look identical from the viewport - the group is
+	/// simply ignored - so neither is discoverable without being told.
+	/// </summary>
+	void AddGroupWarnings()
+	{
+		if ( SerializedProperty.Parent?.Targets.FirstOrDefault() is not SortingGroup group ) return;
+
+		if ( group.IsNested )
+		{
+			Layout.Add( new Label( "Inside another Sorting Group - the inner group wins, and this one will not see these sprites." )
+			{
+				Color = Theme.Yellow,
+				WordWrap = true
+			} );
+		}
+
+		if ( group.MemberCount == 0 )
+		{
+			Layout.Add( new Label( "No Sprite Renderers beneath this object, so this group has nothing to order." )
+			{
+				Color = Theme.Yellow,
+				WordWrap = true
+			} );
+		}
+	}
+
+	/// <summary>
+	/// Sorting does nothing at all while Is Sorted is off, and it is off by default. Without this,
+	/// the most likely first experience of the feature is picking a layer and seeing no change.
+	/// </summary>
+	void AddUnsortedWarning()
+	{
+		if ( !TryGetIsSorted( out var isSorted ) || isSorted ) return;
+
+		var fix = new Button.Primary( "Enable sorting on this sprite", "sort" );
+		fix.ToolTip = "Sort layers and sort order are ignored until Is Sorted is enabled.";
+		fix.Clicked = EnableSorting;
+
+		Layout.Add( new Label( "Is Sorted is off - this layer is being ignored." )
+		{
+			Color = Theme.Yellow
+		} );
+
+		Layout.Add( fix );
+	}
+
+	bool TryGetIsSorted( out bool value )
+	{
+		value = false;
+
+		if ( SerializedProperty.Parent is not { } parent ) return false;
+		if ( !parent.TryGetProperty( "IsSorted", out var property ) ) return false;
+
+		// With several sprites selected, GetValue only reports the first one. The warning is about
+		// sorting silently doing nothing, so it has to appear if *any* of them has it switched off.
+		if ( property.IsMultipleValues )
+		{
+			value = property.MultipleProperties.All( p => p.GetValue<bool>() );
+			return true;
+		}
+
+		value = property.GetValue<bool>();
+		return true;
+	}
+
+	void EnableSorting()
+	{
+		if ( SerializedProperty.Parent is not { } parent ) return;
+		if ( !parent.TryGetProperty( "IsSorted", out var property ) ) return;
+
+		property.SetValue( true );
+
+		Rebuild();
+	}
+
+	static void OpenLayerEditor()
+	{
+		var project = Project.Current;
+		if ( project is null ) return;
+
+		ProjectSettingsWindow.OpenForProject( project );
+	}
+
+	protected override int ValueHash
+	{
+		get
+		{
+			var hc = new HashCode();
+			hc.Add( base.ValueHash );
+
+			// Rebuild when layers are added, removed, renamed or reordered.
+			hc.Add( ProjectSettings.Sorting.GetHashCode() );
+
+			// Rebuild when Is Sorted is toggled, so the warning appears and clears with it.
+			hc.Add( TryGetIsSorted( out var isSorted ) && isSorted );
+
+			return hc.ToHashCode();
+		}
+	}
+
+	protected override void OnValueChanged()
+	{
+		Rebuild();
+	}
+
+	protected override void OnPaint()
+	{
+		// Combo box paints itself
+	}
+}

--- a/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
+++ b/game/addons/tools/Code/Editor/ControlWidgets/SortLayerControlWidget.cs
@@ -10,6 +10,22 @@ namespace Editor;
 [CustomEditor( typeof( SortLayerHandle ), NamedEditor = "sortlayer" )]
 public class SortLayerControlWidget : ControlWidget
 {
+	/// <summary>
+	/// Picking a layer writes that one layer to every selected object, which is what multi-editing
+	/// this should mean. Without this the whole row is replaced by "Multi Edit Not Supported" and a
+	/// selection cannot be given a layer at all.
+	/// </summary>
+	public override bool SupportsMultiEdit => true;
+
+	/// <summary>
+	/// Set while the combo box is being filled in. Adding an entry with <c>selected</c> assigns
+	/// CurrentIndex, and that reaches the item's action whether or not anybody picked it - so
+	/// without this a rebuild can write a layer to the whole selection on its own. On a
+	/// multi-selection that would quietly copy the first object's layer over all the others, which
+	/// is the same way the sprite texture used to get aliased.
+	/// </summary>
+	bool _building;
+
 	public SortLayerControlWidget( SerializedProperty property ) : base( property )
 	{
 		Layout = Layout.Column();
@@ -21,12 +37,37 @@ public class SortLayerControlWidget : ControlWidget
 
 	void Rebuild()
 	{
+		_building = true;
+
+		try
+		{
+			RebuildLayout();
+		}
+		finally
+		{
+			_building = false;
+		}
+	}
+
+	void RebuildLayout()
+	{
 		Layout.Clear( true );
 
 		var settings = ProjectSettings.Sorting;
+
+		// GetValue only reports the first selected object, so it only describes the selection when
+		// they all agree.
+		var mixed = SerializedProperty.IsMultipleDifferentValues;
 		var current = SerializedProperty.GetValue<SortLayerHandle>();
 
 		var comboBox = new ComboBox( this );
+
+		if ( mixed )
+		{
+			// Nothing else is pre-selected in this case, and an empty selection makes the combo
+			// settle on the first layer - which would read as though everything already shared it.
+			comboBox.AddItem( "Multiple Values", onSelected: () => { }, selected: true );
+		}
 
 		foreach ( var layer in settings.Layers )
 		{
@@ -34,8 +75,8 @@ public class SortLayerControlWidget : ControlWidget
 			var id = layer.Id;
 
 			comboBox.AddItem( layer.Name,
-				onSelected: () => SerializedProperty.SetValue( new SortLayerHandle( id ) ),
-				selected: current.Id == id || (current.Id == Guid.Empty && layer == settings.DefaultLayer) );
+				onSelected: () => SetLayer( id ),
+				selected: !mixed && (current.Id == id || (current.Id == Guid.Empty && layer == settings.DefaultLayer)) );
 		}
 
 		comboBox.AddItem( "Edit Layers…", "tune", onSelected: OpenLayerEditor );
@@ -46,6 +87,13 @@ public class SortLayerControlWidget : ControlWidget
 		AddGroupWarnings();
 	}
 
+	void SetLayer( Guid id )
+	{
+		if ( _building ) return;
+
+		SerializedProperty.SetValue( new SortLayerHandle( id ) );
+	}
+
 	/// <summary>
 	/// The two ways a sorting group silently does nothing: it is nested inside another one, or its
 	/// sprites never opted into sorting. Both look identical from the viewport - the group is
@@ -53,26 +101,43 @@ public class SortLayerControlWidget : ControlWidget
 	/// </summary>
 	void AddGroupWarnings()
 	{
-		if ( SerializedProperty.Parent?.Targets.FirstOrDefault() is not SortingGroup group ) return;
+		// Every selected group, not just the first. These warn about a group silently doing nothing,
+		// so one bad group in a selection is still worth saying out loud.
+		var groups = SerializedProperty.Parent?.Targets.OfType<SortingGroup>().ToList();
+		if ( groups is not { Count: > 0 } ) return;
 
-		if ( group.IsNested )
+		var nested = groups.Count( x => x.IsNested );
+		var empty = groups.Count( x => x.MemberCount == 0 );
+
+		if ( nested > 0 )
 		{
-			Layout.Add( new Label( "Inside another Sorting Group - the inner group wins, and this one will not see these sprites." )
+			Layout.Add( new Label( groups.Count > 1
+				? $"{Describe( nested, groups.Count )} are inside another Sorting Group - the inner group wins, and the outer one will not see those sprites."
+				: "Inside another Sorting Group - the inner group wins, and this one will not see these sprites." )
 			{
 				Color = Theme.Yellow,
 				WordWrap = true
 			} );
 		}
 
-		if ( group.MemberCount == 0 )
+		if ( empty > 0 )
 		{
-			Layout.Add( new Label( "No Sprite Renderers beneath this object, so this group has nothing to order." )
+			Layout.Add( new Label( groups.Count > 1
+				? $"{Describe( empty, groups.Count )} have no Sprite Renderers beneath them, so they have nothing to order."
+				: "No Sprite Renderers beneath this object, so this group has nothing to order." )
 			{
 				Color = Theme.Yellow,
 				WordWrap = true
 			} );
 		}
 	}
+
+	/// <summary>
+	/// Names how much of a selection a warning applies to, so it is clear whether it is about all of
+	/// them or only some.
+	/// </summary>
+	static string Describe( int matching, int total )
+		=> matching == total ? $"All {total} selected groups" : $"{matching} of {total} selected groups";
 
 	/// <summary>
 	/// Sorting does nothing at all while Is Sorted is off, and it is off by default. Without this,
@@ -82,13 +147,21 @@ public class SortLayerControlWidget : ControlWidget
 	{
 		if ( !TryGetIsSorted( out var isSorted ) || isSorted ) return;
 
-		var fix = new Button.Primary( "Enable sorting on this sprite", "sort" );
+		// EnableSorting writes to every selected object, so the button has to say that rather than
+		// claim it only touches one of them.
+		var total = SerializedProperty.MultipleProperties.Count();
+		var many = total > 1;
+
+		var fix = new Button.Primary( many ? $"Enable sorting on all {total} sprites" : "Enable sorting on this sprite", "sort" );
 		fix.ToolTip = "Sort layers and sort order are ignored until Is Sorted is enabled.";
 		fix.Clicked = EnableSorting;
 
-		Layout.Add( new Label( "Is Sorted is off - this layer is being ignored." )
+		Layout.Add( new Label( many
+			? "Is Sorted is off on at least one of these - the layer is being ignored there."
+			: "Is Sorted is off - this layer is being ignored." )
 		{
-			Color = Theme.Yellow
+			Color = Theme.Yellow,
+			WordWrap = true
 		} );
 
 		Layout.Add( fix );

--- a/game/addons/tools/Code/Editor/ProjectSettings/ProjectSettingsWindow.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/ProjectSettingsWindow.cs
@@ -175,6 +175,8 @@ internal sealed class ProjectSettingsWindow : Window
 
 			AddCategoryToList( typeof( PhysicsCategory ), "Physics" );
 
+			AddCategoryToList( typeof( SortingCategory ), "Rendering" );
+
 			AddCategoryToList( typeof( InputCategory ), "Input" );
 
 			AddCategoryToList( typeof( MultiplayerCategory ), "Networking" );

--- a/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerListWidget.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerListWidget.cs
@@ -1,0 +1,125 @@
+namespace Editor.ProjectSettingPages;
+
+/// <summary>
+/// The ordered list of sprite sort layers, back to front.
+/// </summary>
+internal sealed class SortLayerListWidget : Widget
+{
+	public SortingSettings Settings { get; }
+
+	/// <summary>
+	/// Raised whenever a layer is added, removed, renamed or moved.
+	/// </summary>
+	public Action ValueChanged { get; set; }
+
+	private Layout _rows;
+
+	public SortLayerListWidget( SortingSettings settings ) : base( null )
+	{
+		Settings = settings;
+
+		Layout = Layout.Column();
+		Layout.Spacing = 2;
+
+		_rows = Layout.AddColumn();
+		_rows.Spacing = 1;
+
+		var addButton = new Button( "Add Layer", "add" );
+		addButton.Clicked = AddLayer;
+		Layout.AddSpacingCell( 4 );
+		Layout.Add( addButton );
+
+		// Which end of the list is the front is the single most common point of confusion with
+		// layer lists anywhere, so say it outright rather than leaving it to be discovered.
+		Layout.AddSpacingCell( 4 );
+		Layout.Add( new Label( "Drawn first, at the back  →  drawn last, in front" )
+		{
+			Color = Theme.Text.WithAlpha( 0.5f )
+		} );
+
+		Rebuild();
+	}
+
+	public void Rebuild()
+	{
+		_rows.Clear( true );
+
+		foreach ( var layer in Settings.Layers )
+		{
+			_rows.Add( new SortLayerRow( this, layer ) );
+		}
+	}
+
+	public void NotifyChanged()
+	{
+		ValueChanged?.Invoke();
+	}
+
+	private void AddLayer()
+	{
+		// Through the settings rather than the list, so the id lookup is rebuilt with it.
+		Settings.AddLayer( UniqueName( "New Layer" ) );
+
+		NotifyChanged();
+		Rebuild();
+	}
+
+	/// <summary>
+	/// Removes a layer, warning first if any sprite in the open scene still points at it.
+	/// </summary>
+	public void RemoveLayer( SortingSettings.SortLayer layer )
+	{
+		var users = CountUsers( layer );
+
+		if ( users > 0 )
+		{
+			var confirm = new PopupWindow(
+				$"Delete \"{layer.Name}\"?",
+				$"{users} sprite{(users == 1 ? "" : "s")} in the open scene {(users == 1 ? "is" : "are")} using this layer. " +
+				$"They will fall back to \"{Settings.DefaultLayer.Name}\".",
+				"Cancel",
+				new Dictionary<string, Action> { { "Delete", () => DoRemoveLayer( layer ) } } );
+
+			confirm.Show();
+			return;
+		}
+
+		DoRemoveLayer( layer );
+	}
+
+	private void DoRemoveLayer( SortingSettings.SortLayer layer )
+	{
+		// Sprites referencing this id resolve back to the default layer on their own, so there is
+		// nothing to fix up - GetLayerIndex already treats an unknown id as the default.
+		Settings.RemoveLayer( layer );
+
+		NotifyChanged();
+		Rebuild();
+	}
+
+	private static int CountUsers( SortingSettings.SortLayer layer )
+	{
+		var scene = SceneEditorSession.Active?.Scene;
+		if ( scene is null ) return 0;
+
+		var count = 0;
+
+		foreach ( var sprite in scene.GetAllComponents<SpriteRenderer>() )
+		{
+			if ( sprite.SortLayer.Id == layer.Id ) count++;
+		}
+
+		return count;
+	}
+
+	private string UniqueName( string baseName )
+	{
+		if ( Settings.GetLayer( baseName ) is null ) return baseName;
+
+		for ( var i = 2; ; i++ )
+		{
+			var candidate = $"{baseName} {i}";
+			if ( Settings.GetLayer( candidate ) is null ) return candidate;
+		}
+	}
+}

--- a/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerRow.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortLayerRow.cs
@@ -1,0 +1,159 @@
+namespace Editor.ProjectSettingPages;
+
+/// <summary>
+/// One layer in the sort layer list. Draggable, because reordering is the whole point of the list -
+/// the position of a layer is what decides draw order.
+/// </summary>
+internal sealed class SortLayerRow : Widget
+{
+	private readonly SortLayerListWidget _list;
+
+	public SortingSettings.SortLayer Layer { get; }
+
+	private Drag _dragData;
+	private bool _draggingAbove;
+	private bool _draggingBelow;
+
+	public SortLayerRow( SortLayerListWidget list, SortingSettings.SortLayer layer ) : base( null )
+	{
+		_list = list;
+		Layer = layer;
+
+		FixedHeight = 30;
+		Cursor = CursorShape.Finger;
+
+		Layout = Layout.Row();
+		Layout.Margin = new Sandbox.UI.Margin( 24, 3, 4, 3 );
+		Layout.Spacing = 4;
+
+		var nameEntry = new LineEdit( layer.Name );
+		nameEntry.PlaceholderText = "Layer name";
+		nameEntry.TextEdited += OnNameEdited;
+		Layout.Add( nameEntry, 1 );
+
+		// The first layer is what everything falls back to, so it must always exist.
+		if ( !IsDefaultLayer )
+		{
+			var deleteButton = new IconButton( "close" );
+			deleteButton.ToolTip = "Delete";
+			deleteButton.StatusTip = $"Delete sort layer \"{layer.Name}\"";
+			deleteButton.OnClick += () => _list.RemoveLayer( Layer );
+			Layout.Add( deleteButton );
+		}
+		else
+		{
+			Layout.AddSpacingCell( 24 );
+		}
+
+		IsDraggable = true;
+		AcceptDrops = true;
+	}
+
+	private bool IsDefaultLayer => _list.Settings.Layers.IndexOf( Layer ) == 0;
+
+	private void OnNameEdited( string value )
+	{
+		// Renaming is free - sprites reference layers by id, so nothing needs fixing up.
+		Layer.Name = value;
+		_list.NotifyChanged();
+	}
+
+	protected override void OnPaint()
+	{
+		if ( IsUnderMouse )
+		{
+			Paint.SetBrushAndPen( Theme.Highlight.WithAlpha( 0.1f ) );
+			Paint.DrawRect( LocalRect, 3 );
+		}
+
+		if ( _dragData?.IsValid ?? false )
+		{
+			Paint.SetBrushAndPen( Theme.WindowBackground.WithAlpha( 0.5f ) );
+			Paint.DrawRect( LocalRect, 3 );
+		}
+
+		// Drag handle, hinting that the row can be moved without needing a tooltip to say so.
+		Paint.SetPen( Theme.Text.WithAlpha( IsUnderMouse ? 0.6f : 0.3f ) );
+		Paint.DrawIcon( new Rect( 4, 0, 20, LocalRect.Height ), "drag_indicator", 16, TextFlag.Center );
+
+		base.OnPaint();
+
+		if ( _draggingAbove )
+		{
+			Paint.SetPen( Theme.Primary, 2f, PenStyle.Dot );
+			Paint.DrawLine( LocalRect.TopLeft, LocalRect.TopRight );
+			_draggingAbove = false;
+		}
+		else if ( _draggingBelow )
+		{
+			Paint.SetPen( Theme.Primary, 2f, PenStyle.Dot );
+			Paint.DrawLine( LocalRect.BottomLeft, LocalRect.BottomRight );
+			_draggingBelow = false;
+		}
+	}
+
+	protected override void OnDragStart()
+	{
+		base.OnDragStart();
+
+		_dragData = new Drag( this );
+		_dragData.Data.Object = Layer;
+		_dragData.Execute();
+	}
+
+	public override void OnDragHover( DragEvent ev )
+	{
+		base.OnDragHover( ev );
+
+		if ( !TryDragOperation( ev, out var delta ) )
+		{
+			_draggingAbove = false;
+			_draggingBelow = false;
+			return;
+		}
+
+		_draggingAbove = delta > 0;
+		_draggingBelow = delta < 0;
+	}
+
+	public override void OnDragDrop( DragEvent ev )
+	{
+		base.OnDragDrop( ev );
+
+		if ( !TryDragOperation( ev, out var delta ) ) return;
+
+		var index = _list.Settings.Layers.IndexOf( Layer );
+
+		// Through the settings rather than the list: reordering changes what every layer id maps
+		// to, and a stale lookup would silently draw every sprite in the wrong layer.
+		_list.Settings.MoveLayer( index + delta, index );
+
+		_list.NotifyChanged();
+		_list.Rebuild();
+	}
+
+	public override void OnDragLeave()
+	{
+		base.OnDragLeave();
+
+		_draggingAbove = false;
+		_draggingBelow = false;
+	}
+
+	private bool TryDragOperation( DragEvent ev, out int delta )
+	{
+		delta = 0;
+
+		var other = ev.Data.OfType<SortingSettings.SortLayer>().FirstOrDefault();
+		if ( other is null || other == Layer ) return false;
+
+		var layers = _list.Settings.Layers;
+		var myIndex = layers.IndexOf( Layer );
+		var otherIndex = layers.IndexOf( other );
+
+		if ( myIndex < 0 || otherIndex < 0 || myIndex == otherIndex ) return false;
+
+		delta = otherIndex - myIndex;
+		return true;
+	}
+}

--- a/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortingCategory.cs
+++ b/game/addons/tools/Code/Editor/ProjectSettings/Sorting/SortingCategory.cs
@@ -1,0 +1,39 @@
+namespace Editor.ProjectSettingPages;
+
+[Title( "Sorting" ), Icon( "layers" )]
+internal sealed class SortingCategory : ProjectSettingsWindow.Category
+{
+	public override void OnInit( Project project )
+	{
+		var col = BodyLayout.AddColumn();
+		col.Spacing = 8;
+
+		{
+			col.Add( new Label.Header( "Sort Layers" ) );
+
+			var list = col.Add( new SortLayerListWidget( ProjectSettings.Sorting ) );
+			list.ValueChanged = () => StateHasChanged();
+		}
+
+		{
+			col.Add( new InformationBox(
+				"""
+				<p>Sort layers control which sprites draw in front of which, regardless of where they are in the world.</p>
+				<ul style="-qt-list-indent: 0; margin-left: 10px;" >
+					<li>A sprite in a later layer always draws in front of a sprite in an earlier one
+					<li>Within a layer, <b>Sort Order</b> on the Sprite Renderer decides - higher draws on top
+					<li>Sprites with the same layer and order fall back to sorting by depth
+					<li>Sprites only sort at all when <b>Is Sorted</b> is enabled on the renderer
+				</ul>
+				<p>Layers are referenced by identity, so renaming or reordering them will not re-sort anything unexpectedly.</p>
+				""" ) );
+		}
+	}
+
+	public override void OnSave()
+	{
+		EditorUtility.SaveProjectSettings( ProjectSettings.Sorting, "Sorting.config" );
+
+		base.OnSave();
+	}
+}

--- a/game/addons/tools/Code/Editor/SpriteSheetEditor/RigBuilder.cs
+++ b/game/addons/tools/Code/Editor/SpriteSheetEditor/RigBuilder.cs
@@ -1,0 +1,496 @@
+using Sandbox.Resources;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Editor.SpriteSheetEditor;
+
+/// <summary>
+/// Turns a sliced sheet into a character: a sprite asset per part, and a parented hierarchy of
+/// GameObjects in the open scene.
+/// <para>
+/// It cannot assemble the character for you. A sheet has the limbs spread out with space between
+/// them, so it records what the parts are but not how they fit together - the parts land laid out as
+/// they are on the sheet and get dragged into place. What it does do is the work that is tedious to
+/// do by hand and easy to get wrong: parenting, per-part size, sort order, and pivots that are
+/// already on the joints.
+/// </para>
+/// </summary>
+public class RigBuilder : Dialog
+{
+	readonly Window _editor;
+
+	/// <summary>
+	/// How many source pixels make one world unit. Only relative sizes matter for a rig, so this is
+	/// really a "how big is the character" dial.
+	/// </summary>
+	int _pixelsPerUnit = 100;
+
+	string _sortLayerName;
+	bool _rebuildSprites = true;
+
+	ScrollArea _list;
+	Label _status;
+
+	// Combo boxes assign CurrentIndex while being filled, and that reaches the item's action whether
+	// or not anybody picked anything. Without this, building the list rewrites every parent.
+	bool _building;
+
+	public RigBuilder( Window editor ) : base( editor, false )
+	{
+		_editor = editor;
+
+		Window.Title = "Build Rig";
+		Window.WindowTitle = "Build Rig";
+		Window.Size = new Vector2( 520, 620 );
+		Window.SetModal( true );
+
+		_sortLayerName = editor.Asset?.Name ?? "Sprites";
+		_pixelsPerUnit = EditorCookie.Get( "SpriteSheetEditor.PixelsPerUnit", 100 );
+
+		BuildLayout();
+	}
+
+	void BuildLayout()
+	{
+		Layout = Layout.Column();
+		Layout.Margin = 12;
+		Layout.Spacing = 8;
+
+		Layout.Add( new Label(
+			"Each part becomes a sprite and a GameObject. Set what hangs off what - a calf's parent is " +
+			"a thigh - then build, and drag the parts together in the scene." )
+		{
+			WordWrap = true,
+			Color = Theme.TextControl.WithAlpha( 0.7f )
+		} );
+
+		//
+		// Parents
+		//
+
+		var header = Layout.AddRow();
+		header.Spacing = 6;
+		header.Add( new Label( "Hierarchy" ) );
+		header.AddStretchCell();
+
+		var guess = new Button( "Guess from names", "auto_fix_high" );
+		guess.ToolTip = "Work the hierarchy out from part names like L_Thigh and R_Calf";
+		guess.Clicked = GuessHierarchy;
+		header.Add( guess );
+
+		var clear = new Button( "Clear", "clear" );
+		clear.Clicked = () =>
+		{
+			foreach ( var slice in _editor.Sheet.Slices ) slice.ParentId = Guid.Empty;
+			_editor.SetModified();
+			RebuildList();
+		};
+		header.Add( clear );
+
+		_list = new ScrollArea( this );
+		_list.Canvas = new Widget();
+		_list.Canvas.Layout = Layout.Column();
+		_list.Canvas.Layout.Spacing = 2;
+		_list.Canvas.VerticalSizeMode = SizeMode.CanGrow;
+		_list.Canvas.HorizontalSizeMode = SizeMode.Flexible;
+		Layout.Add( _list, 1 );
+
+		//
+		// Options
+		//
+
+		var options = new ControlSheet();
+		options.AddRow( this.GetSerialized().GetProperty( nameof( PixelsPerUnit ) ) );
+		options.AddRow( this.GetSerialized().GetProperty( nameof( SortLayer ) ) );
+		options.AddRow( this.GetSerialized().GetProperty( nameof( RebuildSprites ) ) );
+		Layout.Add( options );
+
+		_status = new Label( "" ) { WordWrap = true, Color = Theme.Yellow };
+		Layout.Add( _status );
+
+		var buttons = Layout.AddRow();
+		buttons.Spacing = 6;
+		buttons.AddStretchCell();
+
+		var cancel = new Button( "Cancel" );
+		cancel.Clicked = Close;
+		buttons.Add( cancel );
+
+		var build = new Button.Primary( "Build Rig", "accessibility_new" );
+		build.Clicked = Build;
+		buttons.Add( build );
+
+		RebuildList();
+	}
+
+	//
+	// Bound options - properties so a ControlSheet can edit them
+	//
+
+	[Property, Title( "Pixels Per Unit" ), Range( 1, 512, true, false ), Step( 1 )]
+	public int PixelsPerUnit
+	{
+		get => _pixelsPerUnit;
+		set { _pixelsPerUnit = Math.Max( 1, value ); EditorCookie.Set( "SpriteSheetEditor.PixelsPerUnit", _pixelsPerUnit ); }
+	}
+
+	/// <summary>
+	/// The sorting layer every part is put on. Created if it does not exist.
+	/// </summary>
+	[Property, Title( "Sort Layer" )]
+	public string SortLayer
+	{
+		get => _sortLayerName;
+		set => _sortLayerName = value;
+	}
+
+	/// <summary>
+	/// Write the per-part sprite assets again. Turn off to keep sprites you have since edited by hand.
+	/// </summary>
+	[Property, Title( "Rewrite Sprites" )]
+	public bool RebuildSprites
+	{
+		get => _rebuildSprites;
+		set => _rebuildSprites = value;
+	}
+
+	//
+	// The parent list
+	//
+
+	void RebuildList()
+	{
+		_building = true;
+
+		try
+		{
+			var layout = _list.Canvas.Layout;
+			layout.Clear( true );
+
+			var sheet = _editor.Sheet;
+			if ( sheet is null ) return;
+
+			foreach ( var slice in sheet.Slices )
+			{
+				layout.Add( BuildRow( sheet, slice ) );
+			}
+
+			layout.AddStretchCell();
+		}
+		finally
+		{
+			_building = false;
+		}
+	}
+
+	Widget BuildRow( SpriteSheet sheet, SpriteSheet.Slice slice )
+	{
+		var row = new Widget();
+		row.Layout = Layout.Row();
+		row.Layout.Spacing = 6;
+		row.Layout.Margin = new Sandbox.UI.Margin( 4, 2, 4, 2 );
+		row.FixedHeight = 28;
+
+		var name = new Label( slice.Name );
+		name.MinimumWidth = 150;
+		row.Layout.Add( name );
+
+		var combo = new ComboBox( row );
+
+		combo.AddItem( "(root)",
+			onSelected: () => SetParent( sheet, slice, Guid.Empty ),
+			selected: slice.ParentId == Guid.Empty );
+
+		foreach ( var candidate in sheet.Slices )
+		{
+			if ( candidate == slice ) continue;
+
+			var id = candidate.Id;
+			combo.AddItem( candidate.Name,
+				onSelected: () => SetParent( sheet, slice, id ),
+				selected: slice.ParentId == id );
+		}
+
+		row.Layout.Add( combo, 1 );
+
+		return row;
+	}
+
+	void SetParent( SpriteSheet sheet, SpriteSheet.Slice slice, Guid parentId )
+	{
+		if ( _building ) return;
+
+		if ( !sheet.TrySetParent( slice, parentId ) )
+		{
+			_status.Text = $"{slice.Name} cannot be a child of that - it would make a loop.";
+			RebuildList();
+			return;
+		}
+
+		_status.Text = "";
+		_editor.SetModified();
+	}
+
+	//
+	// Guessing
+	//
+
+	// Part name -> the part it hangs off. Ordered longest-first when matched, so "upperarm" is not
+	// mistaken for "arm".
+	static readonly (string Part, string Parent)[] CommonHierarchy =
+	{
+		("torso", "hips"), ("chest", "hips"), ("body", "hips"), ("spine", "hips"),
+		("head", "torso"), ("neck", "torso"), ("hair", "head"),
+		("upperarm", "torso"), ("shoulder", "torso"), ("arm", "torso"),
+		("forearm", "arm"), ("lowerarm", "arm"), ("elbow", "arm"),
+		("hand", "forearm"),
+		("thigh", "hips"), ("upperleg", "hips"), ("leg", "hips"),
+		("calf", "thigh"), ("shin", "thigh"), ("lowerleg", "thigh"), ("knee", "thigh"),
+		("foot", "calf"), ("shoe", "calf"),
+	};
+
+	/// <summary>
+	/// Fill the hierarchy in from the part names, matching left to left and right to right.
+	/// </summary>
+	void GuessHierarchy()
+	{
+		var sheet = _editor.Sheet;
+		if ( sheet is null ) return;
+
+		var matched = 0;
+
+		foreach ( var slice in sheet.Slices )
+		{
+			var (side, bare) = SplitSide( slice.Name );
+
+			// Longest match first, so "lowerarm" beats "arm".
+			var rule = CommonHierarchy
+				.Where( r => bare.Contains( r.Part, StringComparison.OrdinalIgnoreCase ) )
+				.OrderByDescending( r => r.Part.Length )
+				.FirstOrDefault();
+
+			if ( rule.Parent is null ) continue;
+
+			// Prefer a parent on the same side, then one with no side at all - a left calf belongs to
+			// the left thigh, but both legs hang off the one set of hips.
+			var parent = FindPart( sheet, rule.Parent, side ) ?? FindPart( sheet, rule.Parent, "" );
+			if ( parent is null || parent == slice ) continue;
+
+			if ( sheet.TrySetParent( slice, parent.Id ) ) matched++;
+		}
+
+		_editor.SetModified();
+		RebuildList();
+
+		_status.Text = matched > 0
+			? $"Matched {matched} of {sheet.Slices.Count} parts. Check the rest by hand."
+			: "Nothing matched. Names like Hips, Torso, L_Thigh, L_Calf are what this looks for.";
+	}
+
+	/// <summary>Split a leading or trailing side marker off a part name.</summary>
+	static (string Side, string Bare) SplitSide( string name )
+	{
+		var lower = name.ToLowerInvariant();
+
+		foreach ( var (marker, side) in new[]
+		{
+			("l_", "l"), ("r_", "r"), ("left_", "l"), ("right_", "r"),
+			("left", "l"), ("right", "r")
+		} )
+		{
+			if ( lower.StartsWith( marker, StringComparison.Ordinal ) )
+				return (side, lower[marker.Length..]);
+
+			if ( lower.EndsWith( "_" + marker.TrimEnd( '_' ), StringComparison.Ordinal ) )
+				return (side, lower[..^(marker.TrimEnd( '_' ).Length + 1)]);
+		}
+
+		return ("", lower);
+	}
+
+	static SpriteSheet.Slice FindPart( SpriteSheet sheet, string part, string side )
+	{
+		foreach ( var slice in sheet.Slices )
+		{
+			var (sliceSide, bare) = SplitSide( slice.Name );
+			if ( sliceSide != side ) continue;
+			if ( bare.Contains( part, StringComparison.OrdinalIgnoreCase ) ) return slice;
+		}
+
+		return null;
+	}
+
+	//
+	// Building
+	//
+
+	void Build()
+	{
+		var sheet = _editor.Sheet;
+
+		if ( sheet is null || sheet.Slices.Count == 0 )
+		{
+			_status.Text = "Nothing to build - slice the sheet first.";
+			return;
+		}
+
+		if ( _editor.Asset is null )
+		{
+			_status.Text = "Save the sheet before building, so the part sprites have somewhere to live.";
+			return;
+		}
+
+		if ( SceneEditorSession.Active is null )
+		{
+			_status.Text = "No scene open to build into.";
+			return;
+		}
+
+		var sprites = CreatePartSprites( sheet );
+		if ( sprites is null ) return;
+
+		BuildHierarchy( sheet, sprites );
+
+		Close();
+	}
+
+	/// <summary>
+	/// One sprite asset per part, in a folder beside the sheet.
+	/// </summary>
+	/// <remarks>
+	/// A part gets a whole sprite rather than being one animation inside a shared one, so that its
+	/// Animations list stays free for actual animation - a head that blinks, a torch that flickers -
+	/// on top of whatever the rig does by rotating it.
+	/// </remarks>
+	Dictionary<Guid, Sprite> CreatePartSprites( SpriteSheet sheet )
+	{
+		var sheetFile = _editor.Asset.GetSourceFile( true );
+		var directory = Path.GetDirectoryName( sheetFile );
+
+		if ( string.IsNullOrEmpty( directory ) )
+		{
+			_status.Text = "Could not work out where to put the part sprites.";
+			return null;
+		}
+
+		var folder = Path.Combine( directory, $"{Path.GetFileNameWithoutExtension( sheetFile )}_parts" );
+		Directory.CreateDirectory( folder );
+
+		var result = new Dictionary<Guid, Sprite>();
+
+		foreach ( var slice in sheet.Slices )
+		{
+			var path = Path.Combine( folder, $"{SanitiseFileName( slice.Name )}.sprite" );
+			var existing = AssetSystem.FindByPath( path );
+
+			if ( existing is not null && !_rebuildSprites )
+			{
+				var loaded = existing.LoadResource<Sprite>();
+				if ( loaded is not null ) { result[slice.Id] = loaded; continue; }
+			}
+
+			// The texture is a live reference to the slice, not a baked copy - re-slicing or nudging
+			// a rect reaches this sprite without anything being rebuilt.
+			var generator = new SpriteSheetSliceGenerator
+			{
+				Sheet = sheet,
+				SliceId = slice.Id,
+				SliceName = slice.Name
+			};
+
+			var texture = generator.Create( ResourceGenerator.Options.Default );
+			if ( texture is null )
+			{
+				_status.Text = $"Could not build a texture for {slice.Name}.";
+				return null;
+			}
+
+			var sprite = new Sprite
+			{
+				Animations = new List<Sprite.Animation>
+				{
+					new()
+					{
+						Name = "Default",
+						// The joint. This is what makes the part turn about the right point once the
+						// hierarchy is assembled.
+						Origin = slice.Pivot,
+						Frames = new List<Sprite.Frame> { new() { Texture = texture } }
+					}
+				}
+			};
+
+			var asset = existing ?? AssetSystem.CreateResource( "sprite", path );
+			asset.SaveToDisk( sprite );
+
+			result[slice.Id] = asset.LoadResource<Sprite>() ?? sprite;
+		}
+
+		return result;
+	}
+
+	static string SanitiseFileName( string name )
+	{
+		foreach ( var c in Path.GetInvalidFileNameChars() ) name = name.Replace( c, '_' );
+		return name;
+	}
+
+	void BuildHierarchy( SpriteSheet sheet, Dictionary<Guid, Sprite> sprites )
+	{
+		var sorting = ProjectSettings.Sorting;
+		var layer = sorting.GetLayer( _sortLayerName ) ?? sorting.AddLayer( _sortLayerName );
+
+		var centre = new Vector2( _editor.SourceWidth, _editor.SourceHeight ) * 0.5f;
+
+		using var scope = SceneEditorSession.Scope();
+
+		using ( SceneEditorSession.Active.UndoScope( "Build Sprite Rig" ).WithGameObjectCreations().Push() )
+		{
+			var root = new GameObject( true, _editor.Asset?.Name ?? "Rig" );
+			var objects = new Dictionary<Guid, GameObject>();
+
+			var order = 0;
+
+			foreach ( var slice in sheet.InHierarchyOrder() )
+			{
+				var go = new GameObject( true, slice.Name );
+
+				go.Parent = slice.ParentId != Guid.Empty && objects.TryGetValue( slice.ParentId, out var parent )
+					? parent
+					: root;
+
+				var renderer = go.Components.GetOrCreate<SpriteRenderer>();
+
+				if ( sprites.TryGetValue( slice.Id, out var sprite ) )
+					renderer.Sprite = sprite;
+
+				// Size sets the longer side; the shorter one follows the texture's aspect. So feeding
+				// it the larger pixel dimension is what keeps a hand a hand and a torso a torso.
+				var longest = MathF.Max( slice.Rect.Width, slice.Rect.Height );
+				renderer.Size = new Vector2( longest, longest ) / _pixelsPerUnit;
+
+				// Sorting is ignored entirely while this is off, so a rig built without it would come
+				// out in an arbitrary order and look broken for no visible reason.
+				renderer.IsSorted = true;
+				renderer.SortLayer = new SortLayerHandle( layer.Id );
+				renderer.SortOrder = order++;
+
+				// Laid out as they sit on the sheet. Parented first, so this resolves to the right
+				// local offset. Positioning by the pivot rather than the rect corner reproduces the
+				// sheet exactly, because the pivot is where the object's origin actually is.
+				var pivot = slice.PivotToImagePixels;
+				go.WorldPosition = new Vector3(
+					0,
+					(pivot.x - centre.x) / _pixelsPerUnit,
+					-(pivot.y - centre.y) / _pixelsPerUnit );
+
+				objects[slice.Id] = go;
+			}
+
+			EditorScene.Selection.Clear();
+			EditorScene.Selection.Add( root );
+		}
+	}
+}

--- a/game/addons/tools/Code/Editor/SpriteSheetEditor/SheetCanvas.cs
+++ b/game/addons/tools/Code/Editor/SpriteSheetEditor/SheetCanvas.cs
@@ -1,0 +1,425 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Editor.SpriteSheetEditor;
+
+/// <summary>
+/// The sheet, and the slice rectangles laid over it.
+/// <para>
+/// Scene space is image space: one scene unit is one source pixel, with the image's top-left at the
+/// origin. Slice rects then need no conversion at all, which removes an entire category of
+/// off-by-a-pixel bug from everything that draws or drags them.
+/// </para>
+/// </summary>
+public class SheetCanvas : GraphicsView
+{
+	readonly Window _editor;
+
+	SheetImageItem _image;
+	readonly List<SliceItem> _sliceItems = new();
+
+	RectPreviewItem _preview;
+	bool _creating;
+	Vector2 _createStart;
+
+	bool _panning;
+	Vector2 _panStart;
+
+	public SheetCanvas( Window editor )
+	{
+		_editor = editor;
+
+		Name = "Sheet";
+		WindowTitle = "Sheet";
+		SetWindowIcon( "grid_view" );
+
+		Antialiasing = true;
+		TextAntialiasing = true;
+
+		// Pixel art is most of what gets sliced, and smoothing it while zoomed in makes it
+		// impossible to see where the artwork actually ends.
+		BilinearFiltering = false;
+
+		MinZoom = 0.02f;
+		MaxZoom = 50f;
+
+		HorizontalScrollbar = ScrollbarMode.Auto;
+		VerticalScrollbar = ScrollbarMode.Auto;
+
+		SetBackgroundImage( BuildCheckerboard() );
+
+		FocusMode = FocusMode.Click;
+
+		_editor.OnSheetLoaded += Rebuild;
+		_editor.OnSheetModified += Rebuild;
+		_editor.OnSelectionChanged += SyncSelection;
+
+		Rebuild();
+	}
+
+	public override void OnDestroyed()
+	{
+		base.OnDestroyed();
+
+		_editor.OnSheetLoaded -= Rebuild;
+		_editor.OnSheetModified -= Rebuild;
+		_editor.OnSelectionChanged -= SyncSelection;
+	}
+
+	/// <summary>
+	/// The usual grey chequer that means "nothing here". Tiled by the view, so it stays the same
+	/// size on screen however far in you zoom.
+	/// </summary>
+	static Pixmap BuildCheckerboard()
+	{
+		const int cell = 8;
+		using var bitmap = new Bitmap( cell * 2, cell * 2 );
+
+		var dark = new Color( 0.16f, 0.16f, 0.16f );
+		var light = new Color( 0.22f, 0.22f, 0.22f );
+
+		for ( int y = 0; y < cell * 2; y++ )
+		{
+			for ( int x = 0; x < cell * 2; x++ )
+			{
+				var odd = ((x / cell) + (y / cell)) % 2 == 1;
+				bitmap.SetPixel( x, y, odd ? light : dark );
+			}
+		}
+
+		return Pixmap.FromBitmap( bitmap );
+	}
+
+	//
+	// Building
+	//
+
+	public void Rebuild()
+	{
+		DeleteAllItems();
+		_sliceItems.Clear();
+		_image = null;
+		_preview = null;
+
+		var pixmap = _editor.SourcePixmap;
+		var width = _editor.SourceWidth;
+		var height = _editor.SourceHeight;
+
+		if ( pixmap is null || width <= 0 || height <= 0 )
+		{
+			SceneRect = new Rect( -100, -100, 200, 200 );
+			Update();
+			return;
+		}
+
+		_image = new SheetImageItem( pixmap, new Vector2( width, height ) );
+		Add( _image );
+
+		foreach ( var slice in _editor.Sheet?.Slices ?? new List<SpriteSheet.Slice>() )
+		{
+			var item = new SliceItem( _editor, slice );
+			Add( item );
+			_sliceItems.Add( item );
+		}
+
+		// Room to pan the sheet's edges away from the window frame, so a slice tight to one corner
+		// is still reachable.
+		var margin = new Vector2( width, height ) * 0.5f;
+		SceneRect = new Rect( -margin.x, -margin.y, width + (margin.x * 2), height + (margin.y * 2) );
+
+		SyncSelection();
+		Update();
+	}
+
+	void SyncSelection()
+	{
+		foreach ( var item in _sliceItems )
+		{
+			item.IsSelected = _editor.Selection.Contains( item.SliceId );
+		}
+	}
+
+	//
+	// Navigation
+	//
+
+	/// <summary>
+	/// Scale the sheet to fit, keeping it the shape it actually is.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately not <c>FitInView</c>. Qt's <c>fitInView</c> defaults to <c>IgnoreAspectRatio</c>
+	/// and the binding takes no aspect argument, so it stretches the sheet to fill the window. It also
+	/// writes the view transform directly, which leaves <c>GraphicsView.Scale</c> holding a stale
+	/// value - and the slice handles size themselves from that, so they would come out wrong too.
+	/// </remarks>
+	public void FitToWindow()
+	{
+		var width = _editor.SourceWidth;
+		var height = _editor.SourceHeight;
+		if ( width <= 0 || height <= 0 ) return;
+
+		var view = Size;
+		if ( view.x <= 1 || view.y <= 1 ) return;
+
+		// One scale for both axes - that is the whole point.
+		const float padding = 1.06f;
+		var scale = MathF.Min( view.x / (width * padding), view.y / (height * padding) );
+
+		Scale = new Vector2( scale, scale ).Clamp( MinZoom, MaxZoom );
+		CenterOn( new Vector2( width, height ) * 0.5f );
+	}
+
+	public void ZoomToActualSize()
+	{
+		var centre = ToScene( Size * 0.5f );
+		Scale = 1f;
+		CenterOn( centre );
+	}
+
+	protected override void OnMouseWheel( WheelEvent e )
+	{
+		// Anchored on the cursor: the pixel under the pointer stays put, which is the difference
+		// between zooming feeling like a magnifier and feeling like a slider.
+		Zoom( e.Delta > 0 ? 1.1f : 1f / 1.1f, e.Position );
+		e.Accepted = true;
+	}
+
+	//
+	// Mouse
+	//
+
+	protected override void OnMousePress( MouseEvent e )
+	{
+		// Alt is navigation, everywhere, always. Holding it must never edit anything.
+		if ( e.MiddleMouseButton || (e.LeftMouseButton && e.HasAlt) )
+		{
+			_panning = true;
+			_panStart = e.LocalPosition;
+			Cursor = CursorShape.ClosedHand;
+			e.Accepted = true;
+			return;
+		}
+
+		base.OnMousePress( e );
+
+		if ( !e.LeftMouseButton ) return;
+
+		var scenePosition = ToScene( e.LocalPosition );
+
+		// Something under the cursor deals with its own dragging.
+		if ( GetItemAt( scenePosition ) is not null ) return;
+
+		if ( !e.HasCtrl && !e.HasShift ) _editor.ClearSelection();
+
+		// Dragging empty space draws out a new slice.
+		if ( _editor.SourceWidth > 0 )
+		{
+			_creating = true;
+			_createStart = Snap( scenePosition );
+
+			_preview = new RectPreviewItem();
+			Add( _preview );
+		}
+	}
+
+	protected override void OnMouseMove( MouseEvent e )
+	{
+		if ( _panning )
+		{
+			Translate( e.LocalPosition - _panStart );
+			_panStart = e.LocalPosition;
+			e.Accepted = true;
+			return;
+		}
+
+		if ( _creating && _preview is not null )
+		{
+			_preview.SetRect( BuildRect( _createStart, Snap( ToScene( e.LocalPosition ) ) ) );
+			e.Accepted = true;
+			return;
+		}
+
+		base.OnMouseMove( e );
+	}
+
+	protected override void OnMouseReleased( MouseEvent e )
+	{
+		if ( _panning )
+		{
+			_panning = false;
+			Cursor = CursorShape.None;
+			e.Accepted = true;
+			return;
+		}
+
+		if ( _creating )
+		{
+			_creating = false;
+
+			var rect = _preview?.Rect ?? default;
+			_preview?.Destroy();
+			_preview = null;
+
+			// A click rather than a drag - the user was deselecting, not drawing.
+			if ( rect.Width >= 1 && rect.Height >= 1 )
+			{
+				_editor.AddSlice( ClampToSheet( rect ) );
+			}
+
+			e.Accepted = true;
+			return;
+		}
+
+		base.OnMouseReleased( e );
+	}
+
+	//
+	// Keys
+	//
+	// These live on the canvas rather than on the window so they cannot fire while someone is
+	// renaming a slice in the list below - "T" is a letter long before it is a shortcut.
+	//
+
+	protected override void OnKeyPress( KeyEvent e )
+	{
+		switch ( e.Key )
+		{
+			case KeyCode.F:
+				if ( e.HasShift ) ZoomToActualSize();
+				else FitToWindow();
+				e.Accepted = true;
+				return;
+
+			case KeyCode.T:
+				_editor.TrimSelected();
+				e.Accepted = true;
+				return;
+
+			case KeyCode.Delete:
+			case KeyCode.Backspace:
+				_editor.DeleteSelected();
+				e.Accepted = true;
+				return;
+
+			case KeyCode.D:
+				if ( e.HasCtrl )
+				{
+					_editor.DuplicateSelected();
+					e.Accepted = true;
+					return;
+				}
+				break;
+
+			case KeyCode.A:
+				if ( e.HasCtrl )
+				{
+					_editor.SelectAll();
+					e.Accepted = true;
+					return;
+				}
+				break;
+
+			case KeyCode.Escape:
+				_editor.ClearSelection();
+				e.Accepted = true;
+				return;
+		}
+
+		base.OnKeyPress( e );
+	}
+
+	//
+	// Helpers
+	//
+
+	/// <summary>Slices are whole pixels, always. A rect that lands on a half pixel is a bug later.</summary>
+	static Vector2 Snap( Vector2 scenePosition )
+		=> new( MathF.Round( scenePosition.x ), MathF.Round( scenePosition.y ) );
+
+	static Rect BuildRect( Vector2 a, Vector2 b )
+	{
+		// Built from corners rather than a direction, so dragging up or left works as well as down
+		// and right.
+		var left = MathF.Min( a.x, b.x );
+		var top = MathF.Min( a.y, b.y );
+
+		return new Rect( left, top, MathF.Abs( a.x - b.x ), MathF.Abs( a.y - b.y ) );
+	}
+
+	Rect ClampToSheet( Rect rect )
+	{
+		var left = Math.Clamp( rect.Left, 0, _editor.SourceWidth );
+		var top = Math.Clamp( rect.Top, 0, _editor.SourceHeight );
+		var right = Math.Clamp( rect.Left + rect.Width, 0, _editor.SourceWidth );
+		var bottom = Math.Clamp( rect.Top + rect.Height, 0, _editor.SourceHeight );
+
+		return new Rect( left, top, right - left, bottom - top );
+	}
+}
+
+/// <summary>
+/// The sheet image itself. Sits under everything and never takes a click, so dragging across it
+/// draws a new slice rather than shoving the picture around.
+/// </summary>
+internal class SheetImageItem : GraphicsItem
+{
+	readonly Pixmap _pixmap;
+
+	public SheetImageItem( Pixmap pixmap, Vector2 size )
+	{
+		_pixmap = pixmap;
+
+		Size = size;
+		HandlePosition = new Vector2( 0, 0 );
+		Position = Vector2.Zero;
+		ZIndex = -100;
+
+		Movable = false;
+		Selectable = false;
+		HoverEvents = false;
+	}
+
+	public override bool Contains( Vector2 localPos ) => false;
+
+	protected override void OnPaint()
+	{
+		Paint.Draw( new Rect( Vector2.Zero, Size ), _pixmap );
+	}
+}
+
+/// <summary>
+/// The dashed outline shown while a new slice is being dragged out.
+/// </summary>
+internal class RectPreviewItem : GraphicsItem
+{
+	public Rect Rect { get; private set; }
+
+	public RectPreviewItem()
+	{
+		HandlePosition = new Vector2( 0, 0 );
+		ZIndex = 500;
+		Movable = false;
+		Selectable = false;
+		HoverEvents = false;
+	}
+
+	public void SetRect( Rect rect )
+	{
+		PrepareGeometryChange();
+
+		Rect = rect;
+		Position = rect.Position;
+		Size = rect.Size;
+
+		Update();
+	}
+
+	public override bool Contains( Vector2 localPos ) => false;
+
+	protected override void OnPaint()
+	{
+		Paint.SetBrushAndPen( Theme.Primary.WithAlpha( 0.15f ), Theme.Primary, 1f );
+		Paint.DrawRect( new Rect( Vector2.Zero, Size ) );
+	}
+}

--- a/game/addons/tools/Code/Editor/SpriteSheetEditor/SliceInspector.cs
+++ b/game/addons/tools/Code/Editor/SpriteSheetEditor/SliceInspector.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace Editor.SpriteSheetEditor;
+
+/// <summary>
+/// Properties of whatever is selected, plus a quick way to drop the pivot on one of the nine usual
+/// spots.
+/// </summary>
+public class SliceInspector : Widget
+{
+	readonly Window _editor;
+
+	ScrollArea _scroller;
+	JsonObject _stateBeforeEdit;
+
+	public SliceInspector( Window editor ) : base( null )
+	{
+		_editor = editor;
+
+		Name = "Slice";
+		WindowTitle = "Slice";
+		SetWindowIcon( "edit" );
+
+		MinimumWidth = 280;
+
+		Layout = Layout.Column();
+
+		_scroller = new ScrollArea( this );
+		_scroller.Canvas = new Widget();
+		_scroller.Canvas.Layout = Layout.Column();
+		_scroller.Canvas.Layout.Margin = 8;
+		_scroller.Canvas.Layout.Spacing = 8;
+		_scroller.Canvas.VerticalSizeMode = SizeMode.CanGrow;
+		_scroller.Canvas.HorizontalSizeMode = SizeMode.Flexible;
+
+		Layout.Add( _scroller );
+
+		_editor.OnSelectionChanged += Rebuild;
+		_editor.OnSheetLoaded += Rebuild;
+
+		Rebuild();
+	}
+
+	public override void OnDestroyed()
+	{
+		base.OnDestroyed();
+
+		_editor.OnSelectionChanged -= Rebuild;
+		_editor.OnSheetLoaded -= Rebuild;
+	}
+
+	void Rebuild()
+	{
+		var layout = _scroller.Canvas.Layout;
+		layout.Clear( true );
+
+		layout.Add( BuildSheetSection() );
+
+		var selected = _editor.SelectedSlices.ToList();
+
+		if ( selected.Count == 0 )
+		{
+			var hint = new Label(
+				_editor.SourceWidth > 0
+					? "Nothing selected.\n\nDrag on the sheet to draw a slice, or use Slice to cut the whole thing at once."
+					: "No image yet.\n\nPick one with the Image button to start slicing." )
+			{
+				WordWrap = true,
+				Color = Theme.TextControl.WithAlpha( 0.6f )
+			};
+
+			layout.Add( hint );
+			layout.AddStretchCell();
+			return;
+		}
+
+		layout.Add( BuildPivotPresets( selected ) );
+
+		var controlSheet = new ControlSheet();
+
+		if ( selected.Count == 1 )
+		{
+			var serialized = selected[0].GetSerialized();
+			controlSheet.AddObject( serialized );
+			HookUndo( serialized, "Edit Slice" );
+		}
+		else
+		{
+			// Several at once. MultiSerializedObject writes every edit to all of them, which is what
+			// is wanted here - setting a border or an alignment across a selection.
+			var multi = new MultiSerializedObject();
+			foreach ( var slice in selected ) multi.Add( slice.GetSerialized() );
+			multi.Rebuild();
+
+			// Name is per-slice identity; offering one box to rename several at once would just
+			// collapse them onto a single name and then de-duplicate it.
+			controlSheet.AddObject( multi, prop => prop.Name != nameof( SpriteSheet.Slice.Name ) );
+			HookUndo( multi, $"Edit {selected.Count} Slices" );
+		}
+
+		layout.Add( controlSheet );
+		layout.AddStretchCell();
+	}
+
+	/// <summary>
+	/// The sheet itself: which image it cuts up, and what counts as empty space on it.
+	/// </summary>
+	Widget BuildSheetSection()
+	{
+		var holder = new Widget();
+		holder.Layout = Layout.Column();
+		holder.Layout.Spacing = 4;
+
+		holder.Layout.Add( new Label( "Sheet" ) { Color = Theme.TextControl.WithAlpha( 0.7f ) } );
+
+		if ( _editor.Sheet is null ) return holder;
+
+		var serialized = _editor.Sheet.GetSerialized();
+
+		// Slices have their own panel and their own list; showing them again as a raw array here would
+		// be unusable at any real slice count.
+		var sheetControls = new ControlSheet();
+		sheetControls.AddObject( serialized, prop => prop.Name != nameof( SpriteSheet.Slices ) );
+		holder.Layout.Add( sheetControls );
+
+		if ( _editor.SourceWidth > 0 )
+		{
+			var detect = new Button( "Detect Background", "colorize" );
+			detect.ToolTip = "Look at the corners of the image and treat that colour as empty space";
+			detect.Clicked = () => { _editor.DetectBackground(); Rebuild(); };
+			holder.Layout.Add( detect );
+
+			// The state that makes automatic slicing look broken, called out where it can be fixed.
+			if ( !_editor.Sheet.KeyBackground && !HasAnyTransparency() )
+			{
+				holder.Layout.Add( new Label(
+					"This image has no transparency, so everything on it counts as artwork and slicing " +
+					"will find one big rectangle. Set a background colour to say what is empty." )
+				{
+					WordWrap = true,
+					Color = Theme.Yellow
+				} );
+			}
+		}
+
+		HookUndo( serialized, "Edit Sheet" );
+
+		return holder;
+	}
+
+	/// <summary>
+	/// Whether the image has any see-through pixels at all. Sampled rather than exhaustive - this only
+	/// decides whether to show a hint, and walking 16 million pixels to draw a label would be absurd.
+	/// </summary>
+	bool HasAnyTransparency()
+	{
+		var pixels = _editor.SourcePixels;
+		if ( pixels is null || pixels.Length == 0 ) return true;
+
+		var step = Math.Max( 1, pixels.Length / 4096 );
+
+		for ( int i = 0; i < pixels.Length; i += step )
+		{
+			if ( pixels[i].a < 255 ) return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// The nine standard pivot spots as a 3x3 pad. Faster than a dropdown when the answer is
+	/// "bottom-centre", and it leaves the dragging for the joints that are not on a standard spot.
+	/// </summary>
+	Widget BuildPivotPresets( List<SpriteSheet.Slice> selected )
+	{
+		var holder = new Widget();
+		holder.Layout = Layout.Column();
+		holder.Layout.Spacing = 4;
+
+		holder.Layout.Add( new Label( "Pivot" ) { Color = Theme.TextControl.WithAlpha( 0.7f ) } );
+
+		var grid = Layout.Grid();
+		grid.Spacing = 2;
+
+		var rows = new[]
+		{
+			new[] { SpriteSheet.PivotAlignment.TopLeft, SpriteSheet.PivotAlignment.Top, SpriteSheet.PivotAlignment.TopRight },
+			new[] { SpriteSheet.PivotAlignment.Left, SpriteSheet.PivotAlignment.Center, SpriteSheet.PivotAlignment.Right },
+			new[] { SpriteSheet.PivotAlignment.BottomLeft, SpriteSheet.PivotAlignment.Bottom, SpriteSheet.PivotAlignment.BottomRight }
+		};
+
+		var shared = selected.Select( s => s.Alignment ).Distinct().ToList();
+		var common = shared.Count == 1 ? shared[0] : (SpriteSheet.PivotAlignment?)null;
+
+		for ( int y = 0; y < rows.Length; y++ )
+		{
+			for ( int x = 0; x < rows[y].Length; x++ )
+			{
+				var alignment = rows[y][x];
+
+				// The active spot is filled in so the current pivot is readable at a glance.
+				Button button = common == alignment
+					? new Button.Primary( "", IconFor( alignment ) )
+					: new Button.Clear( "", IconFor( alignment ) );
+
+				button.FixedWidth = 30;
+				button.FixedHeight = 26;
+				button.ToolTip = alignment.ToString();
+				button.Clicked = () => ApplyAlignment( selected, alignment );
+
+				grid.AddCell( x, y, button );
+			}
+		}
+
+		holder.Layout.Add( grid );
+
+		if ( common == SpriteSheet.PivotAlignment.Custom )
+		{
+			holder.Layout.Add( new Label( "Placed by hand. Drag the pivot on the sheet, or pick a spot above." )
+			{
+				WordWrap = true,
+				Color = Theme.TextControl.WithAlpha( 0.5f )
+			} );
+		}
+
+		return holder;
+	}
+
+	static string IconFor( SpriteSheet.PivotAlignment alignment ) => alignment switch
+	{
+		SpriteSheet.PivotAlignment.TopLeft => "north_west",
+		SpriteSheet.PivotAlignment.Top => "north",
+		SpriteSheet.PivotAlignment.TopRight => "north_east",
+		SpriteSheet.PivotAlignment.Left => "west",
+		SpriteSheet.PivotAlignment.Right => "east",
+		SpriteSheet.PivotAlignment.BottomLeft => "south_west",
+		SpriteSheet.PivotAlignment.Bottom => "south",
+		SpriteSheet.PivotAlignment.BottomRight => "south_east",
+		_ => "filter_center_focus"
+	};
+
+	void ApplyAlignment( List<SpriteSheet.Slice> selected, SpriteSheet.PivotAlignment alignment )
+	{
+		_editor.ExecuteUndoableAction( "Set Pivot", () =>
+		{
+			foreach ( var slice in selected ) slice.SetAlignment( alignment );
+		} );
+
+		Rebuild();
+	}
+
+	/// <summary>
+	/// Turn control-sheet edits into undo entries. The whole resource is snapshotted, which is what
+	/// the sprite editor does too - slices are small and it avoids having to describe every possible
+	/// edit as its own operation.
+	/// </summary>
+	void HookUndo( SerializedObject serialized, string title )
+	{
+		_stateBeforeEdit = _editor.Sheet.Serialize();
+
+		serialized.OnPropertyChanged += prop =>
+		{
+			if ( prop is null ) return;
+
+			// Renaming has to keep names unique, or two slices become indistinguishable in the list
+			// and one of them stops being findable by name.
+			if ( prop.Name == nameof( SpriteSheet.Slice.Name ) )
+			{
+				var slice = _editor.SelectedSlices.FirstOrDefault();
+				if ( slice is not null )
+				{
+					var unique = _editor.Sheet.GetUniqueName( slice.Name, slice );
+					if ( unique != slice.Name ) slice.Name = unique;
+				}
+			}
+
+			var before = _stateBeforeEdit;
+			var after = _editor.Sheet.Serialize();
+
+			_editor.UndoStack.Insert( $"{title} ({prop.Name})",
+				() => { _editor.Sheet.Deserialize( before ); _editor.OnSheetModified?.Invoke(); },
+				() => { _editor.Sheet.Deserialize( after ); _editor.OnSheetModified?.Invoke(); } );
+
+			_stateBeforeEdit = after;
+
+			_editor.SetModified();
+			_editor.OnSheetModified?.Invoke();
+		};
+	}
+}

--- a/game/addons/tools/Code/Editor/SpriteSheetEditor/SliceItem.cs
+++ b/game/addons/tools/Code/Editor/SpriteSheetEditor/SliceItem.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace Editor.SpriteSheetEditor;
+
+/// <summary>
+/// One slice on the canvas: an outline you can move and resize, and a pivot you can drag onto a
+/// joint.
+/// <para>
+/// What the mouse does is decided by which part of the slice it is nearest - pivot, then corner,
+/// then edge, then body - rather than by a mode picked from a toolbar. Borrowed from Unity's sprite
+/// editor, where it means resizing never needs a different tool to moving.
+/// </para>
+/// </summary>
+public class SliceItem : GraphicsItem
+{
+	/// <summary>How near a handle counts as grabbing it, in screen pixels.</summary>
+	const float PickRadius = 5f;
+
+	readonly Window _editor;
+
+	public Guid SliceId { get; }
+
+	bool _isSelected;
+	public bool IsSelected
+	{
+		get => _isSelected;
+		set { if ( _isSelected == value ) return; _isSelected = value; Update(); }
+	}
+
+	enum Zone { None, Body, Pivot, Left, Right, Top, Bottom, TopLeft, TopRight, BottomLeft, BottomRight }
+
+	Zone _hoverZone = Zone.None;
+	Zone _dragZone = Zone.None;
+	Vector2 _dragStart;
+	Rect _dragOriginalRect;
+	JsonObject _dragUndoState;
+
+	public SliceItem( Window editor, SpriteSheet.Slice slice )
+	{
+		_editor = editor;
+		SliceId = slice.Id;
+
+		HandlePosition = new Vector2( 0, 0 );
+		Movable = false;      // dragging is handled here, so Qt must not also move the item
+		Selectable = false;   // selection lives on the editor, so it survives an undo
+		HoverEvents = true;
+		ZIndex = 10;
+
+		SyncFromSlice();
+	}
+
+	SpriteSheet.Slice Slice => _editor.Sheet?.GetSlice( SliceId );
+
+	/// <summary>Scene units per screen pixel, so handles stay the same size however far you zoom.</summary>
+	float SceneScale
+	{
+		get
+		{
+			var zoom = (GraphicsView as SheetCanvas)?.Scale.x ?? 1f;
+			return zoom <= 0.0001f ? 1f : 1f / zoom;
+		}
+	}
+
+	public void SyncFromSlice()
+	{
+		var slice = Slice;
+		if ( slice is null ) return;
+
+		PrepareGeometryChange();
+		Position = slice.Rect.Position;
+		Size = slice.Rect.Size;
+		Update();
+	}
+
+	// Handles sit outside the outline, so the item has to claim a little more room than its rect or
+	// they get clipped away.
+	public override Rect BoundingRect
+	{
+		get
+		{
+			var pad = PickRadius * SceneScale * 2f;
+			return new Rect( -pad, -pad, Size.x + (pad * 2), Size.y + (pad * 2) );
+		}
+	}
+
+	public override bool Contains( Vector2 localPos ) => HitTest( localPos ) != Zone.None;
+
+	Zone HitTest( Vector2 local )
+	{
+		var slice = Slice;
+		if ( slice is null ) return Zone.None;
+
+		var pick = PickRadius * SceneScale;
+
+		if ( _isSelected )
+		{
+			// Pivot first: it sits inside the body, and moving it is the finer operation.
+			if ( local.Distance( PivotLocal( slice ) ) <= pick * 1.6f ) return Zone.Pivot;
+
+			var left = MathF.Abs( local.x ) <= pick;
+			var right = MathF.Abs( local.x - Size.x ) <= pick;
+			var top = MathF.Abs( local.y ) <= pick;
+			var bottom = MathF.Abs( local.y - Size.y ) <= pick;
+
+			var withinX = local.x >= -pick && local.x <= Size.x + pick;
+			var withinY = local.y >= -pick && local.y <= Size.y + pick;
+
+			// Corners beat edges - they are the smaller target and the more specific intent.
+			if ( left && top ) return Zone.TopLeft;
+			if ( right && top ) return Zone.TopRight;
+			if ( left && bottom ) return Zone.BottomLeft;
+			if ( right && bottom ) return Zone.BottomRight;
+
+			if ( left && withinY ) return Zone.Left;
+			if ( right && withinY ) return Zone.Right;
+			if ( top && withinX ) return Zone.Top;
+			if ( bottom && withinX ) return Zone.Bottom;
+		}
+
+		if ( local.x >= 0 && local.y >= 0 && local.x <= Size.x && local.y <= Size.y ) return Zone.Body;
+
+		return Zone.None;
+	}
+
+	static Vector2 PivotLocal( SpriteSheet.Slice slice )
+	{
+		// Pivot is normalized and Y-up; the canvas is Y-down image space.
+		return new Vector2(
+			slice.Pivot.x * slice.Rect.Width,
+			(1f - slice.Pivot.y) * slice.Rect.Height );
+	}
+
+	static CursorShape CursorFor( Zone zone ) => zone switch
+	{
+		Zone.Pivot => CursorShape.SizeAll,
+		Zone.Left or Zone.Right => CursorShape.SizeH,
+		Zone.Top or Zone.Bottom => CursorShape.SizeV,
+		Zone.TopLeft or Zone.BottomRight => CursorShape.SizeFDiag,
+		Zone.TopRight or Zone.BottomLeft => CursorShape.SizeBDiag,
+		Zone.Body => CursorShape.SizeAll,
+		_ => CursorShape.None
+	};
+
+	//
+	// Mouse
+	//
+
+	protected override void OnHoverMove( GraphicsHoverEvent e )
+	{
+		base.OnHoverMove( e );
+
+		var zone = HitTest( e.LocalPosition );
+		if ( zone == _hoverZone ) return;
+
+		_hoverZone = zone;
+		Cursor = CursorFor( zone );
+		Update();
+	}
+
+	protected override void OnHoverLeave( GraphicsHoverEvent e )
+	{
+		base.OnHoverLeave( e );
+
+		_hoverZone = Zone.None;
+		Cursor = CursorShape.None;
+		Update();
+	}
+
+	protected override void OnMousePressed( GraphicsMouseEvent e )
+	{
+		// Alt means navigate. The view is panning; this must stay out of the way.
+		if ( e.HasAlt ) return;
+		if ( !e.LeftMouseButton ) return;
+
+		var slice = Slice;
+		if ( slice is null ) return;
+
+		if ( !_isSelected || e.HasCtrl || e.HasShift )
+		{
+			_editor.Select( slice, add: e.HasCtrl || e.HasShift );
+		}
+
+		_dragZone = HitTest( e.LocalPosition );
+		if ( _dragZone == Zone.None ) return;
+
+		_dragStart = e.ScenePosition;
+		_dragOriginalRect = slice.Rect;
+
+		// One undo entry for the whole drag, not one per mouse-move.
+		_dragUndoState = _editor.Sheet.Serialize();
+
+		e.Accepted = true;
+	}
+
+	protected override void OnMouseMove( GraphicsMouseEvent e )
+	{
+		if ( _dragZone == Zone.None ) return;
+
+		var slice = Slice;
+		if ( slice is null ) return;
+
+		var delta = e.ScenePosition - _dragStart;
+
+		if ( _dragZone == Zone.Pivot )
+		{
+			var target = e.ScenePosition;
+
+			// Whole pixels unless asked otherwise - joints land on pixels in the art.
+			if ( !e.HasAlt ) target = new Vector2( MathF.Round( target.x ), MathF.Round( target.y ) );
+
+			slice.SetPivotFromImagePixels( target );
+
+			// Ctrl gives up precision for certainty, snapping to the nine usual spots.
+			if ( e.HasCtrl ) SnapPivotToNearestPreset( slice );
+		}
+		else
+		{
+			slice.Rect = _dragZone == Zone.Body
+				? MoveRect( _dragOriginalRect, delta )
+				: ResizeRect( _dragOriginalRect, _dragZone, delta );
+
+			SyncFromSlice();
+		}
+
+		Update();
+		e.Accepted = true;
+	}
+
+	protected override void OnMouseReleased( GraphicsMouseEvent e )
+	{
+		if ( _dragZone == Zone.None ) return;
+
+		var zone = _dragZone;
+		_dragZone = Zone.None;
+
+		if ( _dragUndoState is not null )
+		{
+			_editor.CommitDrag( zone == Zone.Pivot ? "Move Pivot" : zone == Zone.Body ? "Move Slice" : "Resize Slice",
+				_dragUndoState );
+
+			_dragUndoState = null;
+		}
+
+		e.Accepted = true;
+	}
+
+	//
+	// Geometry
+	//
+
+	Rect MoveRect( Rect rect, Vector2 delta )
+	{
+		var left = MathF.Round( rect.Left + delta.x );
+		var top = MathF.Round( rect.Top + delta.y );
+
+		// Slide along the sheet edge rather than shrinking against it - a rect dragged into the
+		// corner should keep its size.
+		left = Math.Clamp( left, 0, MathF.Max( 0, _editor.SourceWidth - rect.Width ) );
+		top = Math.Clamp( top, 0, MathF.Max( 0, _editor.SourceHeight - rect.Height ) );
+
+		return new Rect( left, top, rect.Width, rect.Height );
+	}
+
+	Rect ResizeRect( Rect rect, Zone zone, Vector2 delta )
+	{
+		var left = rect.Left;
+		var top = rect.Top;
+		var right = rect.Left + rect.Width;
+		var bottom = rect.Top + rect.Height;
+
+		if ( zone is Zone.Left or Zone.TopLeft or Zone.BottomLeft ) left += delta.x;
+		if ( zone is Zone.Right or Zone.TopRight or Zone.BottomRight ) right += delta.x;
+		if ( zone is Zone.Top or Zone.TopLeft or Zone.TopRight ) top += delta.y;
+		if ( zone is Zone.Bottom or Zone.BottomLeft or Zone.BottomRight ) bottom += delta.y;
+
+		left = MathF.Round( left );
+		top = MathF.Round( top );
+		right = MathF.Round( right );
+		bottom = MathF.Round( bottom );
+
+		// Dragging an edge past its opposite flips the rect rather than producing a negative one.
+		if ( right < left ) (left, right) = (right, left);
+		if ( bottom < top ) (top, bottom) = (bottom, top);
+
+		left = Math.Clamp( left, 0, _editor.SourceWidth );
+		top = Math.Clamp( top, 0, _editor.SourceHeight );
+		right = Math.Clamp( right, 0, _editor.SourceWidth );
+		bottom = Math.Clamp( bottom, 0, _editor.SourceHeight );
+
+		// Never let a slice vanish - a zero-sized rect cannot be grabbed again.
+		return new Rect( left, top, MathF.Max( 1, right - left ), MathF.Max( 1, bottom - top ) );
+	}
+
+	static void SnapPivotToNearestPreset( SpriteSheet.Slice slice )
+	{
+		var best = SpriteSheet.PivotAlignment.Center;
+		var bestDistance = float.MaxValue;
+
+		foreach ( SpriteSheet.PivotAlignment alignment in Enum.GetValues<SpriteSheet.PivotAlignment>() )
+		{
+			if ( alignment == SpriteSheet.PivotAlignment.Custom ) continue;
+
+			var distance = slice.Pivot.Distance( SpriteSheet.Slice.GetPivot( alignment ) );
+			if ( distance >= bestDistance ) continue;
+
+			bestDistance = distance;
+			best = alignment;
+		}
+
+		slice.SetAlignment( best );
+	}
+
+	//
+	// Paint
+	//
+
+	protected override void OnPaint()
+	{
+		var slice = Slice;
+		if ( slice is null ) return;
+
+		var scale = SceneScale;
+		var rect = new Rect( Vector2.Zero, Size );
+
+		var colour = _isSelected ? Theme.Primary : Color.White.WithAlpha( 0.55f );
+
+		if ( _isSelected )
+		{
+			Paint.SetBrush( Theme.Primary.WithAlpha( 0.08f ) );
+			Paint.SetPen( colour, 1.5f * scale );
+		}
+		else
+		{
+			Paint.SetBrushAndPen( Color.Transparent, colour, 1f * scale );
+		}
+
+		Paint.DrawRect( rect );
+
+		DrawName( slice, scale );
+
+		if ( !_isSelected ) return;
+
+		DrawResizeHandles( scale );
+		DrawPivot( slice, scale );
+	}
+
+	void DrawName( SpriteSheet.Slice slice, float scale )
+	{
+		// Counter-scaled so the label reads at a constant size however far in the view is zoomed.
+		var fontSize = 9f * scale;
+
+		// Below about this size the text is unreadable anyway and just muddies the outlines.
+		if ( fontSize > Size.y * 0.6f ) return;
+
+		Paint.SetPen( _isSelected ? Theme.Primary : Color.White.WithAlpha( 0.7f ) );
+		Paint.SetFont( "Poppins", fontSize );
+		Paint.DrawText( new Rect( 2 * scale, 1 * scale, Size.x, fontSize * 1.4f ), slice.Name,
+			TextFlag.LeftTop | TextFlag.SingleLine );
+	}
+
+	void DrawResizeHandles( float scale )
+	{
+		var size = 3.5f * scale;
+
+		Paint.SetBrushAndPen( Theme.Primary, Color.Black.WithAlpha( 0.8f ), 1f * scale );
+
+		foreach ( var corner in new[]
+		{
+			new Vector2( 0, 0 ), new Vector2( Size.x, 0 ),
+			new Vector2( 0, Size.y ), new Vector2( Size.x, Size.y )
+		} )
+		{
+			Paint.DrawRect( new Rect( corner.x - size, corner.y - size, size * 2, size * 2 ) );
+		}
+
+		// Edge handles are smaller, so the corners stay the easier target.
+		var edge = size * 0.75f;
+
+		foreach ( var mid in new[]
+		{
+			new Vector2( Size.x * 0.5f, 0 ), new Vector2( Size.x * 0.5f, Size.y ),
+			new Vector2( 0, Size.y * 0.5f ), new Vector2( Size.x, Size.y * 0.5f )
+		} )
+		{
+			Paint.DrawRect( new Rect( mid.x - edge, mid.y - edge, edge * 2, edge * 2 ) );
+		}
+	}
+
+	void DrawPivot( SpriteSheet.Slice slice, float scale )
+	{
+		var pivot = PivotLocal( slice );
+		var radius = 4f * scale;
+
+		// Crosshair through the circle, so the exact point is readable even over busy artwork.
+		Paint.SetPen( Color.Black.WithAlpha( 0.7f ), 2.5f * scale );
+		Paint.DrawLine( new Vector2( pivot.x - radius * 1.8f, pivot.y ), new Vector2( pivot.x + radius * 1.8f, pivot.y ) );
+		Paint.DrawLine( new Vector2( pivot.x, pivot.y - radius * 1.8f ), new Vector2( pivot.x, pivot.y + radius * 1.8f ) );
+
+		Paint.SetPen( Theme.Yellow, 1.25f * scale );
+		Paint.DrawLine( new Vector2( pivot.x - radius * 1.8f, pivot.y ), new Vector2( pivot.x + radius * 1.8f, pivot.y ) );
+		Paint.DrawLine( new Vector2( pivot.x, pivot.y - radius * 1.8f ), new Vector2( pivot.x, pivot.y + radius * 1.8f ) );
+
+		Paint.SetBrushAndPen( Theme.Yellow.WithAlpha( _hoverZone == Zone.Pivot ? 0.9f : 0.35f ), Theme.Yellow, 1f * scale );
+		Paint.DrawCircle( pivot, radius * 2 );
+	}
+}

--- a/game/addons/tools/Code/Editor/SpriteSheetEditor/SliceListPanel.cs
+++ b/game/addons/tools/Code/Editor/SpriteSheetEditor/SliceListPanel.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Editor.SpriteSheetEditor;
+
+/// <summary>
+/// Every slice on the sheet, and somewhere to rename them.
+/// <para>
+/// Renaming is not a tidying-up job here - a modular rig is assembled by name, so the parts have to
+/// become <c>L_Thigh</c> and <c>R_Calf</c> before any of it is useful. Enter commits and drops into
+/// the next one, so a whole character can be labelled without touching the mouse.
+/// </para>
+/// </summary>
+public class SliceListPanel : Widget
+{
+	readonly Window _editor;
+
+	LineEdit _filter;
+	ScrollArea _scroller;
+	Label _summary;
+
+	readonly List<SliceRow> _rows = new();
+
+	public SliceListPanel( Window editor ) : base( null )
+	{
+		_editor = editor;
+
+		Name = "Slices";
+		WindowTitle = "Slices";
+		SetWindowIcon( "list" );
+
+		Layout = Layout.Column();
+		Layout.Margin = 4;
+		Layout.Spacing = 4;
+
+		var header = Layout.AddRow();
+		header.Spacing = 4;
+
+		_filter = new LineEdit( this ) { PlaceholderText = "Filter" };
+		_filter.TextChanged += _ => Rebuild();
+		header.Add( _filter );
+
+		_summary = new Label( "" ) { Color = Theme.TextControl.WithAlpha( 0.6f ) };
+		header.Add( _summary );
+
+		_scroller = new ScrollArea( this );
+		_scroller.Canvas = new Widget();
+		_scroller.Canvas.Layout = Layout.Column();
+		_scroller.Canvas.Layout.Spacing = 1;
+		_scroller.Canvas.VerticalSizeMode = SizeMode.CanGrow;
+		_scroller.Canvas.HorizontalSizeMode = SizeMode.Flexible;
+
+		Layout.Add( _scroller, 1 );
+
+		_editor.OnSheetLoaded += Rebuild;
+		_editor.OnSheetModified += Rebuild;
+		_editor.OnSelectionChanged += SyncSelection;
+
+		Rebuild();
+	}
+
+	public override void OnDestroyed()
+	{
+		base.OnDestroyed();
+
+		_editor.OnSheetLoaded -= Rebuild;
+		_editor.OnSheetModified -= Rebuild;
+		_editor.OnSelectionChanged -= SyncSelection;
+	}
+
+	void Rebuild()
+	{
+		// Rebuilding while someone is mid-rename would yank the box out from under them.
+		if ( _rows.Any( r => r.IsEditing ) ) return;
+
+		var layout = _scroller.Canvas.Layout;
+		layout.Clear( true );
+		_rows.Clear();
+
+		var slices = _editor.Sheet?.Slices ?? new List<SpriteSheet.Slice>();
+		var filter = _filter?.Text ?? "";
+
+		var visible = string.IsNullOrWhiteSpace( filter )
+			? slices
+			: slices.Where( s => s.Name.Contains( filter, StringComparison.OrdinalIgnoreCase ) ).ToList();
+
+		foreach ( var slice in visible )
+		{
+			var row = new SliceRow( _editor, this, slice );
+			layout.Add( row );
+			_rows.Add( row );
+		}
+
+		layout.AddStretchCell();
+
+		_summary.Text = visible.Count == slices.Count
+			? $"{slices.Count}"
+			: $"{visible.Count} of {slices.Count}";
+
+		SyncSelection();
+	}
+
+	void SyncSelection()
+	{
+		foreach ( var row in _rows ) row.UpdateSelected();
+	}
+
+	/// <summary>
+	/// Move editing to the row after this one, so a sheet can be labelled straight down the list.
+	/// </summary>
+	public void EditNextAfter( SliceRow row )
+	{
+		var index = _rows.IndexOf( row );
+		if ( index < 0 || index + 1 >= _rows.Count ) return;
+
+		_rows[index + 1].BeginEditing();
+	}
+}
+
+/// <summary>
+/// One row: a name you can edit in place, and its size.
+/// </summary>
+public class SliceRow : Widget
+{
+	readonly Window _editor;
+	readonly SliceListPanel _panel;
+	readonly Guid _sliceId;
+
+	LineEdit _name;
+	Label _size;
+	bool _selected;
+
+	public bool IsEditing { get; private set; }
+
+	public SliceRow( Window editor, SliceListPanel panel, SpriteSheet.Slice slice ) : base( null )
+	{
+		_editor = editor;
+		_panel = panel;
+		_sliceId = slice.Id;
+
+		FixedHeight = 24;
+
+		Layout = Layout.Row();
+		Layout.Margin = new Sandbox.UI.Margin( 6, 0, 6, 0 );
+		Layout.Spacing = 6;
+
+		_name = new LineEdit( slice.Name, this );
+		_name.MinimumWidth = 120;
+		_name.EditingFinished += CommitName;
+		_name.ReturnPressed += () => { CommitName(); _panel.EditNextAfter( this ); };
+		Layout.Add( _name, 1 );
+
+		_size = new Label( $"{(int)slice.Rect.Width} x {(int)slice.Rect.Height}" )
+		{
+			Color = Theme.TextControl.WithAlpha( 0.5f )
+		};
+		Layout.Add( _size );
+
+		UpdateSelected();
+	}
+
+	SpriteSheet.Slice Slice => _editor.Sheet?.GetSlice( _sliceId );
+
+	public void BeginEditing()
+	{
+		_editor.Select( Slice );
+
+		IsEditing = true;
+		_name.Focus();
+		_name.SelectAll();
+	}
+
+	void CommitName()
+	{
+		IsEditing = false;
+
+		var slice = Slice;
+		if ( slice is null ) return;
+
+		var wanted = _name.Text?.Trim();
+		if ( string.IsNullOrWhiteSpace( wanted ) || wanted == slice.Name )
+		{
+			_name.Text = slice.Name;
+			return;
+		}
+
+		var unique = _editor.Sheet.GetUniqueName( wanted, slice );
+
+		_editor.ExecuteUndoableAction( "Rename Slice", () => slice.Name = unique );
+
+		_name.Text = unique;
+	}
+
+	public void UpdateSelected()
+	{
+		_selected = _editor.Selection.Contains( _sliceId );
+		Update();
+	}
+
+	protected override void OnMousePress( MouseEvent e )
+	{
+		base.OnMousePress( e );
+
+		if ( !e.LeftMouseButton ) return;
+
+		_editor.Select( Slice, add: e.HasCtrl || e.HasShift );
+	}
+
+	protected override void OnPaint()
+	{
+		if ( _selected )
+		{
+			Paint.SetBrushAndPen( Theme.Primary.WithAlpha( 0.25f ) );
+			Paint.DrawRect( LocalRect );
+		}
+		else if ( Paint.HasMouseOver )
+		{
+			Paint.SetBrushAndPen( Color.White.WithAlpha( 0.05f ) );
+			Paint.DrawRect( LocalRect );
+		}
+	}
+}

--- a/game/addons/tools/Code/Editor/SpriteSheetEditor/SlicePopup.cs
+++ b/game/addons/tools/Code/Editor/SpriteSheetEditor/SlicePopup.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Editor.SpriteSheetEditor;
+
+/// <summary>
+/// The slicing controls: how to cut, where the pivots go, and what happens to what is already there.
+/// </summary>
+public class SlicePopup : PopupWidget
+{
+	readonly Window _editor;
+
+	ControlSheet _sheet;
+	Label _methodExplanation;
+	Label _warning;
+	Button _sliceButton;
+
+	public SlicePopup( Window editor ) : base( editor )
+	{
+		_editor = editor;
+
+		IsPopup = true;
+		WindowTitle = "Slice";
+
+		Layout = Layout.Column();
+		Layout.Margin = 16;
+		Layout.Spacing = 8;
+
+		MinimumWidth = 320;
+		MaximumWidth = 320;
+
+		Rebuild();
+		Show();
+		ConstrainToScreen();
+	}
+
+	void Rebuild()
+	{
+		Layout.Clear( true );
+
+		var serialized = _editor.SliceSettings.GetSerialized();
+
+		_sheet = new ControlSheet();
+		_sheet.AddObject( serialized );
+		Layout.Add( _sheet );
+
+		// Explaining what each method does, where the choice is made, rather than leaving three
+		// similar-sounding words to be guessed at.
+		_methodExplanation = new Label( "" ) { WordWrap = true };
+		_methodExplanation.SetStyles( "color: #999; font-size: 11px;" );
+		Layout.Add( _methodExplanation );
+
+		_warning = new Label( "" ) { WordWrap = true, Color = Theme.Yellow };
+		Layout.Add( _warning );
+
+		_sliceButton = new Button.Primary( "Slice", "grid_view" );
+		_sliceButton.Clicked = ApplySlicing;
+		Layout.Add( _sliceButton );
+
+		serialized.OnPropertyChanged += prop =>
+		{
+			// Unity resets the method whenever the type changes, on the grounds that a fresh cut is
+			// the common case. Keeping the user's choice is the less surprising behaviour, so we
+			// just re-describe it.
+			UpdateExplanation();
+			Rebuild();
+		};
+
+		UpdateExplanation();
+	}
+
+	void UpdateExplanation()
+	{
+		if ( _methodExplanation is null ) return;
+
+		_methodExplanation.Text = _editor.SliceSettings.Method switch
+		{
+			SpriteSheet.SliceMethod.Smart =>
+				"Smart reshapes slices that clearly match the new cut and adds the rest. Names and " +
+				"references survive, and pivots you placed by hand are left alone.",
+
+			SpriteSheet.SliceMethod.Safe =>
+				"Safe only adds slices where nothing already sits. Nothing existing is changed or removed.",
+
+			_ =>
+				"Delete Existing throws away every slice and starts over. Names, pivots and any " +
+				"sprites built from them are lost."
+		};
+
+		var destructive = _editor.SliceSettings.Method == SpriteSheet.SliceMethod.DeleteExisting;
+
+		_warning.Text = destructive && _editor.HasNamedSlices()
+			? "This sheet has renamed slices. Use Smart to keep them."
+			: "";
+		_warning.Visible = !string.IsNullOrEmpty( _warning.Text );
+
+		if ( _sliceButton is not null )
+		{
+			_sliceButton.Text = _editor.SliceSettings.Type == SpriteSheet.SliceType.Automatic
+				? "Slice Automatically"
+				: "Slice";
+		}
+	}
+
+	void ApplySlicing()
+	{
+		// Only nag when there is actually something to lose. A sheet nobody has named yet can be
+		// re-cut freely, and asking every time trains people to click through the dialog.
+		if ( _editor.SliceSettings.Method == SpriteSheet.SliceMethod.DeleteExisting && _editor.HasNamedSlices() )
+		{
+			var confirm = new PopupWindow(
+				"Potential loss of slice data",
+				"Delete Existing recreates every slice with a default name. Renamed slices will lose " +
+				"their names and pivots, and anything referencing them will break.\n\n" +
+				"Slice with Smart instead to keep them.",
+				"Cancel",
+				new Dictionary<string, Action>
+				{
+					{ "Use Smart", () => { _editor.SliceSettings.Method = SpriteSheet.SliceMethod.Smart; DoSlice(); } },
+					{ "Delete Existing", DoSlice }
+				} );
+
+			confirm.Show();
+			return;
+		}
+
+		DoSlice();
+	}
+
+	void DoSlice()
+	{
+		_editor.ApplySlicing();
+		Close();
+	}
+}

--- a/game/addons/tools/Code/Editor/SpriteSheetEditor/Window.cs
+++ b/game/addons/tools/Code/Editor/SpriteSheetEditor/Window.cs
@@ -1,0 +1,732 @@
+using Sandbox.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace Editor.SpriteSheetEditor;
+
+/// <summary>
+/// Cuts a sheet of artwork into named, individually-pivoted slices.
+/// <para>
+/// The pivot is the part that matters beyond just chopping an image up: putting a thigh's pivot on
+/// the hip and a calf's on the knee is what lets those parts be parented together into a character
+/// that bends in the right places.
+/// </para>
+/// </summary>
+[EditorForAssetType( "sheet" )]
+[EditorApp( "Sprite Sheet Editor", "grid_view", "Slice sprite sheets into parts" )]
+public class Window : DockWindow, IAssetEditor
+{
+	public bool CanOpenMultipleAssets => true;
+
+	public SpriteSheet Sheet { get; private set; }
+
+	/// <summary>The asset being edited, or null if it has never been saved.</summary>
+	public Asset Asset => _asset;
+
+	/// <summary>
+	/// What is selected, held by id rather than by reference. Undo swaps the whole resource out from
+	/// under us, so anything holding <see cref="SpriteSheet.Slice"/> objects would be pointing at
+	/// detached copies the moment someone hit ctrl-Z.
+	/// </summary>
+	public List<Guid> Selection { get; } = new();
+
+	public IEnumerable<SpriteSheet.Slice> SelectedSlices
+		=> Selection.Select( id => Sheet?.GetSlice( id ) ).Where( x => x is not null );
+
+	public SpriteSheet.SliceSettings SliceSettings { get; set; } = new();
+
+	public Action OnSheetLoaded { get; set; }
+	public Action OnSheetModified { get; set; }
+	public Action OnSelectionChanged { get; set; }
+
+	public UndoSystem UndoStack;
+
+	Asset _asset;
+	bool _isModified;
+
+	Pixmap _sourcePixmap;
+	Color32[] _sourcePixels;
+	int _sourceWidth;
+	int _sourceHeight;
+	string _loadedImagePath;
+
+	ToolBar _toolBar;
+	SheetCanvas _canvas;
+	Option _undoMenuOption;
+	Option _redoMenuOption;
+	Option _undoOption;
+	Option _redoOption;
+
+	public Window()
+	{
+		DeleteOnClose = true;
+		Size = new Vector2( 1280, 800 );
+
+		Sheet = new SpriteSheet();
+
+		var saved = EditorCookie.Get<SpriteSheet.SliceSettings>( "SpriteSheetEditor.SliceSettings", null );
+		if ( saved is not null ) SliceSettings = saved;
+
+		UndoStack = new UndoSystem();
+		UndoStack.Initialize();
+		UndoStack.OnUndo += _ => AfterUndoRedo();
+		UndoStack.OnRedo += _ => AfterUndoRedo();
+
+		SetWindowIcon( "grid_view" );
+
+		CreateDocks();
+		RebuildUI();
+		Show();
+		StateCookie = "SpriteSheetEditor";
+	}
+
+	public void AssetOpen( Asset asset )
+	{
+		Raise();
+		Open( null, asset );
+	}
+
+	public void SelectMember( string memberName ) { }
+
+	void CreateDocks()
+	{
+		_canvas = new SheetCanvas( this );
+
+		DockManager.AddDock( "Sheet", "grid_view", _canvas, DockArea.Center );
+		DockManager.AddDock( "Slice", "edit", new SliceInspector( this ), DockArea.Right );
+		DockManager.AddDock( "Slices", "list", new SliceListPanel( this ), DockArea.Bottom );
+	}
+
+	protected override void BuildDefaultLayout()
+	{
+		var sheet = DockManager.OpenDock( "Sheet", DockArea.Center );
+		var inspector = DockManager.OpenDock( "Slice", DockArea.Right );
+		var list = DockManager.OpenDock( "Slices", DockArea.Bottom );
+
+		DockManager.SetSplitterProportions( sheet, 0.78f, 0.22f );
+		DockManager.SetSplitterProportions( list, 0.75f, 0.25f );
+	}
+
+	//
+	// The source image
+	//
+
+	/// <summary>The sheet's image ready to paint onto the canvas.</summary>
+	public Pixmap SourcePixmap { get { EnsureImageLoaded(); return _sourcePixmap; } }
+
+	/// <summary>
+	/// The image's pixels, for slicing and trimming. Held onto because a 4096x4096 sheet is 67MB of
+	/// Color32 and re-reading it per interaction would make trimming feel broken.
+	/// </summary>
+	public Color32[] SourcePixels { get { EnsureImageLoaded(); return _sourcePixels; } }
+
+	public int SourceWidth { get { EnsureImageLoaded(); return _sourceWidth; } }
+	public int SourceHeight { get { EnsureImageLoaded(); return _sourceHeight; } }
+
+	/// <summary>
+	/// Load the sheet's image, taking the size, the picture and the pixels from one decode of the
+	/// source file.
+	/// </summary>
+	/// <remarks>
+	/// All three have to come from the same place. A <see cref="Texture"/> is not necessarily the size
+	/// of the file it came from - it can be resized or padded on the way in - so measuring the canvas
+	/// from a texture while slicing pixels from the file puts the rects in a different space to the
+	/// picture they are drawn over. The bitmap is the file, so it is the one to trust.
+	/// </remarks>
+	void EnsureImageLoaded()
+	{
+		var path = Sheet?.ImagePath;
+
+		if ( string.IsNullOrWhiteSpace( path ) )
+		{
+			ClearImage();
+			_loadedImagePath = null;
+			return;
+		}
+
+		if ( path == _loadedImagePath ) return;
+
+		_loadedImagePath = path;
+		ClearImage();
+
+		try
+		{
+			var bytes = FileSystem.Mounted.ReadAllBytes( path ).ToArray();
+			using var bitmap = Bitmap.CreateFromBytes( bytes );
+
+			if ( bitmap is null )
+			{
+				Log.Warning( $"Sprite Sheet Editor could not read image: {path}" );
+				return;
+			}
+
+			_sourceWidth = bitmap.Width;
+			_sourceHeight = bitmap.Height;
+			_sourcePixels = bitmap.GetPixels32();
+			_sourcePixmap = Pixmap.FromBitmap( bitmap );
+		}
+		catch ( Exception e )
+		{
+			Log.Warning( $"Sprite Sheet Editor could not read image {path}: {e.Message}" );
+			ClearImage();
+		}
+	}
+
+	void ClearImage()
+	{
+		_sourcePixmap = null;
+		_sourcePixels = null;
+		_sourceWidth = 0;
+		_sourceHeight = 0;
+	}
+
+	/// <summary>Forget the cached image, so the next use picks up a changed file or path.</summary>
+	public void InvalidateImage()
+	{
+		_loadedImagePath = null;
+		EnsureImageLoaded();
+	}
+
+	public void PickSourceImage()
+	{
+		var picker = AssetPicker.Create( this, AssetType.ImageFile, new()
+		{
+			EnableMultiselect = false,
+			EnableCloud = false
+		} );
+
+		picker.Window.StateCookie = "SpriteSheetEditor.PickImage";
+		picker.Window.RestoreFromStateCookie();
+		picker.Window.Title = "Pick a sheet image";
+
+		picker.OnAssetPicked = assets =>
+		{
+			var asset = assets.FirstOrDefault();
+			if ( asset is null ) return;
+
+			SetSourceImage( asset.RelativePath );
+		};
+
+		picker.Window.Show();
+	}
+
+	void SetSourceImage( string path )
+	{
+		if ( string.IsNullOrWhiteSpace( path ) ) return;
+		if ( Sheet is null ) return;
+		if ( Sheet.ImagePath == path ) return;
+
+		ExecuteUndoableAction( "Set Sheet Image", () => Sheet.ImagePath = path );
+		InvalidateImage();
+
+		DetectBackground();
+
+		OnSheetLoaded?.Invoke();
+	}
+
+	/// <summary>
+	/// Work out whether this sheet has a solid background colour behind the artwork, and set it up to
+	/// be treated as empty space if so.
+	/// </summary>
+	/// <remarks>
+	/// Done on the way in rather than left as a setting to find. Artwork very often arrives as a JPEG
+	/// or a scan with flat white behind it, and with no alpha to go on the whole image reads as one
+	/// solid lump - automatic slicing returns a single rect covering everything, which looks like the
+	/// feature is broken rather than like the image needs configuring.
+	/// </remarks>
+	public void DetectBackground()
+	{
+		var pixels = SourcePixels;
+		if ( pixels is null || Sheet is null ) return;
+
+		var detected = SpriteSheet.DetectBackgroundColor( pixels, SourceWidth, SourceHeight );
+		if ( detected is null ) return;
+
+		ExecuteUndoableAction( "Detect Background", () =>
+		{
+			Sheet.KeyBackground = true;
+			Sheet.BackgroundColor = detected.Value;
+		} );
+	}
+
+	//
+	// Selection
+	//
+
+	public void Select( SpriteSheet.Slice slice, bool add = false )
+	{
+		if ( !add ) Selection.Clear();
+
+		if ( slice is not null )
+		{
+			if ( add && Selection.Contains( slice.Id ) ) Selection.Remove( slice.Id );
+			else if ( !Selection.Contains( slice.Id ) ) Selection.Add( slice.Id );
+		}
+
+		OnSelectionChanged?.Invoke();
+	}
+
+	public void SelectAll()
+	{
+		Selection.Clear();
+		if ( Sheet?.Slices is not null )
+		{
+			Selection.AddRange( Sheet.Slices.Select( s => s.Id ) );
+		}
+		OnSelectionChanged?.Invoke();
+	}
+
+	public void ClearSelection()
+	{
+		if ( Selection.Count == 0 ) return;
+		Selection.Clear();
+		OnSelectionChanged?.Invoke();
+	}
+
+	//
+	// Editing slices
+	//
+
+	public void AddSlice( Rect rect )
+	{
+		if ( Sheet is null ) return;
+
+		SpriteSheet.Slice created = null;
+
+		ExecuteUndoableAction( "Add Slice", () =>
+		{
+			created = new SpriteSheet.Slice
+			{
+				Rect = rect,
+				Alignment = SliceSettings.Alignment,
+				Pivot = SliceSettings.Alignment == SpriteSheet.PivotAlignment.Custom
+					? SliceSettings.CustomPivot
+					: SpriteSheet.Slice.GetPivot( SliceSettings.Alignment )
+			};
+
+			created.Name = Sheet.GetUniqueName( $"{_asset?.Name ?? "slice"}_{Sheet.Slices.Count}" );
+			Sheet.Slices.Add( created );
+		} );
+
+		if ( created is not null ) Select( created );
+	}
+
+	public void DeleteSelected()
+	{
+		var doomed = SelectedSlices.Select( s => s.Id ).ToList();
+		if ( doomed.Count == 0 ) return;
+
+		ExecuteUndoableAction( doomed.Count == 1 ? "Delete Slice" : $"Delete {doomed.Count} Slices",
+			() => Sheet.Slices.RemoveAll( s => doomed.Contains( s.Id ) ) );
+
+		ClearSelection();
+	}
+
+	public void DuplicateSelected()
+	{
+		var source = SelectedSlices.ToList();
+		if ( source.Count == 0 ) return;
+
+		var created = new List<Guid>();
+
+		ExecuteUndoableAction( source.Count == 1 ? "Duplicate Slice" : $"Duplicate {source.Count} Slices", () =>
+		{
+			foreach ( var slice in source )
+			{
+				// Offset a little so the copy is visibly its own thing rather than hidden underneath.
+				var copy = new SpriteSheet.Slice
+				{
+					Rect = new Rect( slice.Rect.Left + 8, slice.Rect.Top + 8, slice.Rect.Width, slice.Rect.Height ),
+					Pivot = slice.Pivot,
+					Alignment = slice.Alignment,
+					Border = slice.Border
+				};
+
+				copy.Name = Sheet.GetUniqueName( slice.Name );
+				Sheet.Slices.Add( copy );
+				created.Add( copy.Id );
+			}
+		} );
+
+		Selection.Clear();
+		Selection.AddRange( created );
+		OnSelectionChanged?.Invoke();
+	}
+
+	/// <summary>
+	/// Shrink the selected slices to the artwork inside them. A slice with nothing in it is removed,
+	/// because an empty rect is not something anyone meant to keep.
+	/// </summary>
+	public void TrimSelected()
+	{
+		var pixels = SourcePixels;
+		if ( pixels is null ) return;
+
+		var slices = SelectedSlices.ToList();
+		if ( slices.Count == 0 ) return;
+
+		ExecuteUndoableAction( slices.Count == 1 ? "Trim Slice" : $"Trim {slices.Count} Slices", () =>
+		{
+			foreach ( var slice in slices )
+			{
+				var trimmed = SpriteSheet.Trim( pixels, SourceWidth, SourceHeight, slice.Rect,
+					SliceSettings.AlphaTolerance, Sheet.Background );
+
+				if ( trimmed.Width < 1 || trimmed.Height < 1 )
+				{
+					Sheet.Slices.Remove( slice );
+					continue;
+				}
+
+				slice.Rect = trimmed;
+			}
+		} );
+
+		Selection.RemoveAll( id => Sheet.GetSlice( id ) is null );
+		OnSelectionChanged?.Invoke();
+	}
+
+	/// <summary>
+	/// Run a slicing pass with the current settings.
+	/// </summary>
+	public void ApplySlicing()
+	{
+		var pixels = SourcePixels;
+		if ( pixels is null )
+		{
+			Log.Warning( "Sprite Sheet Editor: no image to slice." );
+			return;
+		}
+
+		var prefix = _asset?.Name ?? "slice";
+
+		// The sheet owns what counts as empty space; the settings just carry it into the algorithms.
+		SliceSettings.Background = Sheet.Background;
+
+		ExecuteUndoableAction( $"Slice ({SliceSettings.Type})", () =>
+		{
+			Sheet.Slices = SpriteSheet.CreateSlices( pixels, SourceWidth, SourceHeight,
+				SliceSettings, Sheet.Slices, prefix );
+		} );
+
+		EditorCookie.Set( "SpriteSheetEditor.SliceSettings", SliceSettings );
+
+		Selection.RemoveAll( id => Sheet.GetSlice( id ) is null );
+		OnSelectionChanged?.Invoke();
+	}
+
+	/// <summary>
+	/// Whether re-slicing would throw away work. Used to decide if the destructive method needs
+	/// confirming - there is no point nagging about a sheet nobody has touched yet.
+	/// </summary>
+	public bool HasNamedSlices()
+	{
+		if ( Sheet?.Slices is null ) return false;
+
+		var prefix = _asset?.Name ?? "slice";
+		return Sheet.Slices.Any( s => !s.Name.StartsWith( prefix, StringComparison.OrdinalIgnoreCase ) );
+	}
+
+	//
+	// Asset plumbing
+	//
+
+	void RebuildUI()
+	{
+		MenuBar.Clear();
+
+		{
+			var file = MenuBar.AddMenu( "File" );
+			file.AddOption( "New", "common/new.png", () => New(), "editor.new" ).StatusTip = "New Sprite Sheet";
+			file.AddOption( "Open", "common/open.png", () => Open(), "editor.open" ).StatusTip = "Open Sprite Sheet";
+			file.AddOption( "Save", "common/save.png", () => Save(), "editor.save" ).StatusTip = "Save Sprite Sheet";
+			file.AddOption( "Save As...", "common/save.png", () => Save( true ), "editor.save-as" );
+			file.AddSeparator();
+			file.AddOption( new Option( "Exit" ) { Triggered = Close } );
+		}
+
+		{
+			var edit = MenuBar.AddMenu( "Edit" );
+			_undoMenuOption = edit.AddOption( "Undo", "undo", () => Undo(), "editor.undo" );
+			_redoMenuOption = edit.AddOption( "Redo", "redo", () => Redo(), "editor.redo" );
+			edit.AddSeparator();
+			edit.AddOption( "Select All", "select_all", SelectAll );
+			edit.AddOption( "Duplicate", "content_copy", DuplicateSelected );
+			edit.AddOption( "Delete", "delete", DeleteSelected );
+		}
+
+		{
+			var view = MenuBar.AddMenu( "View" );
+			view.AddOption( "Fit to Window", "fit_screen", () => _canvas?.FitToWindow() );
+			view.AddOption( "Actual Size", "crop_original", () => _canvas?.ZoomToActualSize() );
+			view.AddSeparator();
+			view.AboutToShow += () => { };
+		}
+
+		CreateToolBar();
+		UpdateUndoRedoOptions();
+	}
+
+	void CreateToolBar()
+	{
+		_toolBar?.Destroy();
+		_toolBar = new ToolBar( this, "SpriteSheetEditor.Toolbar" );
+		AddToolBar( _toolBar, ToolbarPosition.Top );
+
+		_toolBar.AddOption( "New", "common/new.png", () => New() ).StatusTip = "New Sprite Sheet";
+		_toolBar.AddOption( "Open", "common/open.png", () => Open() ).StatusTip = "Open Sprite Sheet";
+		_toolBar.AddOption( "Save", "common/save.png", () => Save() ).StatusTip = "Save Sprite Sheet";
+
+		_toolBar.AddSeparator();
+
+		_undoOption = _toolBar.AddOption( "Undo", "undo", () => Undo() );
+		_redoOption = _toolBar.AddOption( "Redo", "redo", () => Redo() );
+
+		_toolBar.AddSeparator();
+
+		_toolBar.AddOption( "Image", "image", PickSourceImage ).StatusTip = "Choose the image this sheet cuts up";
+
+		var slice = _toolBar.AddOption( "Slice", "grid_view", OpenSlicePopup );
+		slice.StatusTip = "Cut the sheet into slices";
+
+		var trim = _toolBar.AddOption( "Trim", "crop_free", TrimSelected );
+		trim.StatusTip = "Shrink the selected slices to their artwork (T)";
+
+		_toolBar.AddSeparator();
+
+		var rig = _toolBar.AddOption( "Build Rig", "accessibility_new", OpenRigBuilder );
+		rig.StatusTip = "Turn the slices into sprites and a parented character in the open scene";
+
+		_toolBar.AddSeparator();
+
+		_toolBar.AddOption( "Fit", "fit_screen", () => _canvas?.FitToWindow() ).StatusTip = "Fit the sheet to the window (F)";
+	}
+
+	void OpenRigBuilder()
+	{
+		if ( Sheet is null || Sheet.Slices.Count == 0 )
+		{
+			Log.Warning( "Sprite Sheet Editor: slice the sheet before building a rig." );
+			return;
+		}
+
+		new RigBuilder( this ).Show();
+	}
+
+	void OpenSlicePopup()
+	{
+		if ( SourcePixels is null )
+		{
+			Log.Warning( "Sprite Sheet Editor: pick an image before slicing." );
+			return;
+		}
+
+		var popup = new SlicePopup( this );
+		popup.Position = Editor.Application.CursorPosition;
+		popup.Visible = true;
+	}
+
+	void New()
+	{
+		var savePath = GetSavePath( "New Sprite Sheet" );
+		if ( string.IsNullOrWhiteSpace( savePath ) ) return;
+
+		_asset = AssetSystem.CreateResource( "sheet", savePath );
+		Sheet = _asset.LoadResource<SpriteSheet>();
+		_isModified = false;
+
+		Selection.Clear();
+		UndoStack.Initialize();
+		InvalidateImage();
+
+		OnSheetLoaded?.Invoke();
+		OnSelectionChanged?.Invoke();
+		UpdateWindowTitle();
+	}
+
+	[Shortcut( "editor.open", "CTRL+O", ShortcutType.Window )]
+	void Open()
+	{
+		var fd = new FileDialog( null )
+		{
+			Title = "Open Sprite Sheet",
+			DefaultSuffix = ".sheet"
+		};
+
+		fd.SetNameFilter( "Sprite Sheet (*.sheet)" );
+		fd.SetFindFile();
+		if ( !fd.Execute() ) return;
+
+		Open( fd.SelectedFile );
+	}
+
+	void Open( string path, Asset asset = null )
+	{
+		if ( !string.IsNullOrEmpty( path ) ) asset ??= AssetSystem.FindByPath( path );
+		if ( asset is null ) return;
+
+		if ( asset == _asset )
+		{
+			Focus();
+			return;
+		}
+
+		var sheet = asset.LoadResource<SpriteSheet>();
+		if ( sheet is null )
+		{
+			Log.Warning( $"Failed to load sprite sheet from asset {asset.Name}" );
+			return;
+		}
+
+		Sheet = sheet;
+		_asset = asset;
+		_isModified = false;
+
+		Selection.Clear();
+		UndoStack.Initialize();
+		InvalidateImage();
+
+		OnSheetLoaded?.Invoke();
+		OnSelectionChanged?.Invoke();
+		UpdateWindowTitle();
+
+		_canvas?.FitToWindow();
+	}
+
+	[Shortcut( "editor.save", "CTRL+S", ShortcutType.Window )]
+	bool Save( bool saveAs = false )
+	{
+		if ( saveAs || _asset is null )
+		{
+			var savePath = GetSavePath();
+			if ( string.IsNullOrWhiteSpace( savePath ) ) return false;
+
+			_asset = AssetSystem.CreateResource( "sheet", savePath );
+		}
+
+		_asset.SaveToDisk( Sheet );
+		_isModified = false;
+		UpdateWindowTitle();
+		return true;
+	}
+
+	static string GetSavePath( string title = "Save Sprite Sheet" )
+	{
+		var fd = new FileDialog( null )
+		{
+			Title = title,
+			DefaultSuffix = ".sheet"
+		};
+
+		fd.SelectFile( "untitled.sheet" );
+		fd.SetFindFile();
+		fd.SetModeSave();
+		fd.SetNameFilter( "Sprite Sheet (*.sheet)" );
+		if ( !fd.Execute() ) return null;
+
+		return fd.SelectedFile;
+	}
+
+	[Shortcut( "editor.undo", "CTRL+Z", ShortcutType.Window )]
+	void Undo() => UndoStack.Undo();
+
+	[Shortcut( "editor.redo", "CTRL+Y", ShortcutType.Window )]
+	void Redo() => UndoStack.Redo();
+
+	void AfterUndoRedo()
+	{
+		// Undo swaps the slices for fresh objects, so anything selected that no longer exists has to
+		// go rather than linger as a dangling id.
+		Selection.RemoveAll( id => Sheet?.GetSlice( id ) is null );
+
+		UpdateUndoRedoOptions();
+		OnSheetModified?.Invoke();
+		OnSelectionChanged?.Invoke();
+	}
+
+	/// <summary>
+	/// Run something that changes the sheet, recording it as one undo step.
+	/// </summary>
+	public void ExecuteUndoableAction( string title, Action action )
+	{
+		var before = Sheet.Serialize();
+		action.Invoke();
+		var after = Sheet.Serialize();
+
+		UndoStack.Insert( title,
+			() => { Sheet.Deserialize( before ); OnSheetModified?.Invoke(); },
+			() => { Sheet.Deserialize( after ); OnSheetModified?.Invoke(); } );
+
+		SetModified();
+		OnSheetModified?.Invoke();
+	}
+
+	/// <summary>
+	/// Close off a drag as a single undo step, given the sheet's state from before it started.
+	/// </summary>
+	/// <remarks>
+	/// Dragging cannot go through <see cref="ExecuteUndoableAction"/>: that fires OnSheetModified,
+	/// which rebuilds the canvas, which would destroy the very item being dragged. So a drag mutates
+	/// the slice directly and settles up here, on release.
+	/// </remarks>
+	/// <param name="title">What to call it in the undo history</param>
+	/// <param name="before">The sheet as it was when the drag began</param>
+	public void CommitDrag( string title, JsonObject before )
+	{
+		var after = Sheet.Serialize();
+
+		UndoStack.Insert( title,
+			() => { Sheet.Deserialize( before ); OnSheetModified?.Invoke(); },
+			() => { Sheet.Deserialize( after ); OnSheetModified?.Invoke(); } );
+
+		SetModified();
+		OnSheetModified?.Invoke();
+	}
+
+	public void SetModified()
+	{
+		_isModified = true;
+		UpdateUndoRedoOptions();
+		UpdateWindowTitle();
+	}
+
+	void UpdateUndoRedoOptions()
+	{
+		if ( _undoMenuOption is null ) return;
+
+		_undoMenuOption.Enabled = UndoStack.Back.Count > 0;
+		_redoMenuOption.Enabled = UndoStack.Forward.Count > 0;
+		_undoMenuOption.Text = $"Undo {(UndoStack.Back.Count > 0 ? $"\"{UndoStack.Back.Peek().Name}\"" : "")}";
+		_redoMenuOption.Text = $"Redo {(UndoStack.Forward.Count > 0 ? $"\"{UndoStack.Forward.Peek().Name}\"" : "")}";
+
+		if ( _undoOption is null ) return;
+
+		_undoOption.Enabled = UndoStack.Back.Count > 0;
+		_redoOption.Enabled = UndoStack.Forward.Count > 0;
+		_undoOption.ToolTip = _undoMenuOption.Text;
+		_redoOption.ToolTip = _redoMenuOption.Text;
+	}
+
+	void UpdateWindowTitle()
+	{
+		Title = $"Sprite Sheet Editor - {(_asset?.Name ?? "untitled")}{(_isModified ? "*" : "")}";
+	}
+
+	protected override bool OnClose()
+	{
+		if ( !_isModified ) return true;
+
+		var confirm = new PopupWindow(
+			"Save Sprite Sheet", "This sprite sheet has unsaved changes. Save now?", "Cancel",
+			new Dictionary<string, Action>()
+			{
+				{ "No", () => { _isModified = false; Close(); } },
+				{ "Yes", () => { if ( Save() ) Close(); } }
+			} );
+
+		confirm.Show();
+		return false;
+	}
+}

--- a/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedResourceControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedResourceControlWidget.cs
@@ -35,16 +35,34 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 		// If we're opening the popup editor, we need to ensure that the resource is valid
 		//
 
-		var resource = Resource;
-		if ( resource is null && !SerializedProperty.PropertyType.IsAbstract )
+		if ( !SerializedProperty.PropertyType.IsAbstract )
 		{
-			resource = EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name );
-			SerializedProperty.SetValue( resource );
+			//
+			// One resource per selected object. SerializedProperty.SetValue writes a single instance
+			// to every selected object, which would both alias them together and wipe out any
+			// selection that already had a resource of its own.
+			//
+			foreach ( var target in SerializedProperty.MultipleProperties )
+			{
+				if ( target.GetValue<Resource>( null ) is not null )
+					continue;
+
+				target.SetValue( EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name ) );
+			}
 		}
 
 		SerializedProperty.OnChanged = OnChanged;
 
-		Reset( resource, SerializedProperty );
+		Reset( Resource, SerializedProperty );
+
+		//
+		// Reset only stamps the first selection's resource - the others hold their own instances
+		//
+		foreach ( var target in SerializedProperty.MultipleProperties )
+		{
+			MarkAsEmbedded( target.GetValue<Resource>( null ), target );
+		}
+
 		InitializeInlineEditor();
 	}
 
@@ -58,25 +76,34 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 		//
 		// This can be null if the resource's type is abstract
 		//
-		if ( resource.IsValid() )
-		{
-			var type = Game.TypeLibrary.GetType( resource.GetType() );
-			string typeName = null;
-
-			if ( !property.PropertyType.Equals( type.TargetType ) )
-			{
-				typeName = type.Name;
-			}
-
-			resource.EmbeddedResource = new()
-			{
-				ResourceCompiler = "embed",
-				TypeName = typeName
-			};
-		}
+		MarkAsEmbedded( resource, property );
 
 		_typeDescription = Game.TypeLibrary.GetType( resource.IsValid() ? resource.GetType() : property.PropertyType );
 		_assetType = AssetType.FromType( _typeDescription?.TargetType ?? property.PropertyType );
+	}
+
+	/// <summary>
+	/// Stamp embed info on to a resource. Every selected object holds its own resource instance, so
+	/// this has to be done for each of them individually.
+	/// </summary>
+	private static void MarkAsEmbedded( Resource resource, SerializedProperty property )
+	{
+		if ( !resource.IsValid() )
+			return;
+
+		var type = Game.TypeLibrary.GetType( resource.GetType() );
+		string typeName = null;
+
+		if ( !property.PropertyType.Equals( type.TargetType ) )
+		{
+			typeName = type.Name;
+		}
+
+		resource.EmbeddedResource = new()
+		{
+			ResourceCompiler = "embed",
+			TypeName = typeName
+		};
 	}
 
 	void OnChanged( SerializedProperty prop )
@@ -124,12 +151,18 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 		PropertyStartEdit();
 
 		//
-		// Clean slate
+		// Clean slate - a fresh resource each, so clearing a multi-selection doesn't leave every
+		// selected object sharing one instance
 		//
-		var newResource = EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name );
-		Reset( newResource, SerializedProperty );
+		foreach ( var property in SerializedProperty.MultipleProperties )
+		{
+			var newResource = EditorTypeLibrary.Create<Resource>( SerializedProperty.PropertyType.Name );
+			MarkAsEmbedded( newResource, property );
 
-		SerializedProperty.SetValue( newResource );
+			property.SetValue( newResource );
+		}
+
+		Reset( Resource, SerializedProperty );
 
 		SignalValuesChanged();
 		PropertyFinishEdit();
@@ -141,9 +174,18 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 	{
 		PropertyStartEdit();
 
-		var resource = EditorTypeLibrary.Create<Resource>( type.Name );
-		Reset( resource, SerializedProperty );
-		SerializedProperty.SetValue( resource );
+		//
+		// One instance per selected object, otherwise they all end up sharing this one
+		//
+		foreach ( var property in SerializedProperty.MultipleProperties )
+		{
+			var resource = EditorTypeLibrary.Create<Resource>( type.Name );
+			MarkAsEmbedded( resource, property );
+
+			property.SetValue( resource );
+		}
+
+		Reset( Resource, SerializedProperty );
 
 		RebuildEditor();
 		SignalValuesChanged();
@@ -277,23 +319,30 @@ public class EmbeddedResourceControlWidget : StickyPopupControlWidget
 	{
 		if ( target.PropertyType.IsAbstract ) return null;
 
-		var data = source.Serialize();
+		GameResource first = null;
 
 		//
-		// Create a fresh resource when switching to embedded
+		// Create a fresh resource when switching to embedded - one per selected object, with its own
+		// copy of the data. Sharing a single instance between them means editing any one of them
+		// silently edits all of the others.
 		//
-		var resource = EditorTypeLibrary.Create<GameResource>( target.PropertyType.Name );
-		resource.CopyFrom( source );
-
-		resource.EmbeddedResource = new()
+		foreach ( var property in target.MultipleProperties )
 		{
-			ResourceCompiler = "embed",
-			Data = data
-		};
+			var resource = EditorTypeLibrary.Create<GameResource>( target.PropertyType.Name );
+			resource.CopyFrom( source );
 
-		target.SetValue( resource );
+			resource.EmbeddedResource = new()
+			{
+				ResourceCompiler = "embed",
+				Data = source.Serialize()
+			};
 
-		return resource;
+			property.SetValue( resource );
+
+			first ??= resource;
+		}
+
+		return first;
 	}
 
 	void OpenInEditor()

--- a/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedSpriteControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/EmbeddedSpriteControlWidget.cs
@@ -8,8 +8,10 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 	/// <summary>
 	/// Whether or not we are displaying an advanced version of the control
 	/// </summary>
-	public bool AdvancedMode => (Sprite?.Animations?.Count ?? 0) > 1
-							 || (Sprite?.Animations?.FirstOrDefault()?.Frames?.Count ?? 0) > 1;
+	public bool AdvancedMode => IsAdvanced( Sprite );
+
+	static bool IsAdvanced( Sprite sprite ) => (sprite?.Animations?.Count ?? 0) > 1
+										   || (sprite?.Animations?.FirstOrDefault()?.Frames?.Count ?? 0) > 1;
 
 	/// <summary>
 	/// An easy accessor for the first texture in the sprite, great for embedded sprites
@@ -18,22 +20,38 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 	{
 		get
 		{
-			var sprite = Sprite;
-			CheckForSpriteTexture( sprite ); // Ensure frame/animation exists
-			return sprite.Animations[0].Frames[0].Texture;
+			//
+			// Never write from here. This is read while the inspector is being built, and again on a
+			// timer for as long as it stays open. On a multi-selection SerializedProperty.SetValue
+			// writes to every selected object, so a write here would copy the first selection's
+			// sprite on to all of the others without anyone touching anything.
+			//
+			return Sprite?.Animations?.FirstOrDefault()?.Frames?.FirstOrDefault()?.Texture;
 		}
 		set
 		{
 			PropertyStartEdit();
-			var sprite = Sprite;
-			if ( sprite == null || AdvancedMode )
+
+			//
+			// Update each selected object's own sprite. SerializedProperty.SetValue would write one
+			// instance to all of them, permanently aliasing every selected SpriteRenderer on to
+			// whichever sprite happened to be first in the selection.
+			//
+			foreach ( var property in SerializedProperty.MultipleProperties )
 			{
-				// Create a new sprite if we don't have one, or if we're in advanced mode to avoid setting texture of pre-existing sprite
-				sprite = new Sprite();
+				var sprite = property.GetValue<Sprite>( null );
+
+				if ( sprite is null || IsAdvanced( sprite ) )
+				{
+					// Create a new sprite if we don't have one, or if we're in advanced mode to avoid setting texture of pre-existing sprite
+					sprite = new Sprite();
+				}
+
+				EnsureFirstFrame( sprite ); // Ensure frame/animation exists
+				sprite.Animations[0].Frames[0].Texture = value;
+				property.SetValue( sprite );
 			}
-			CheckForSpriteTexture( sprite ); // Ensure frame/animation exists
-			sprite.Animations[0].Frames[0].Texture = value;
-			SerializedProperty.SetValue( sprite );
+
 			PropertyFinishEdit();
 		}
 	}
@@ -92,8 +110,6 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 			OpenPopupEditor();
 		};
 		ContentWidget.Layout.Add( btnAdvanced );
-
-		System.HashCode.Combine( Texture, AdvancedMode );
 	}
 
 	public override void OnDragHover( DragEvent ev )
@@ -180,14 +196,12 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 		base.OnMouseReleased( e );
 	}
 
-	private void CheckForSpriteTexture( Sprite sprite )
+	/// <summary>
+	/// Make sure the sprite has an animation and a frame for us to put a texture in. Mutates the
+	/// sprite in place - the caller is responsible for writing it back to its own property.
+	/// </summary>
+	private static void EnsureFirstFrame( Sprite sprite )
 	{
-		if ( sprite is null )
-		{
-			sprite = new();
-			SerializedProperty.SetValue( sprite );
-		}
-
 		// Ensure first animation exists
 		if ( (sprite.Animations?.Count ?? 0) == 0 )
 		{
@@ -198,7 +212,6 @@ public class EmbeddedSpriteControlWidget : EmbeddedResourceControlWidget
 		if ( (anim.Frames?.Count ?? 0) == 0 )
 		{
 			anim.Frames = [new Sprite.Frame()];
-			SerializedProperty.SetValue( sprite );
 		}
 	}
 

--- a/game/addons/tools/Code/Widgets/ControlWidgets/ResourceGeneratorControlWidget.cs
+++ b/game/addons/tools/Code/Widgets/ControlWidgets/ResourceGeneratorControlWidget.cs
@@ -27,7 +27,7 @@ public class ResourceGeneratorControlWidget : ControlWidget
 		var generatorObject = generator.GetSerialized();
 		Generator = generator;
 
-		LoadFromResource( property.GetValue<Resource>() );
+		var loadedFromProperty = LoadFromResource( property.GetValue<Resource>() );
 
 		var prop = EditorTypeLibrary.CreateProperty<ResourceGenerator>( "Generator", generatorObject );
 
@@ -36,7 +36,7 @@ public class ResourceGeneratorControlWidget : ControlWidget
 
 		BuildContent();
 
-		_ = UpdateGenerator();
+		_ = UpdateGenerator( writeBack: !loadedFromProperty );
 	}
 
 	protected virtual void BuildContent()
@@ -51,22 +51,24 @@ public class ResourceGeneratorControlWidget : ControlWidget
 	/// We might want existing data from an embedded resource - in that case, deserialize it
 	/// </summary>
 	/// <param name="resource"></param>
-	void LoadFromResource( Resource resource )
+	/// <returns>True if our config came from the resource the property is already holding.</returns>
+	bool LoadFromResource( Resource resource )
 	{
 		var embeddedResource = resource?.EmbeddedResource;
 
 		if ( embeddedResource is null )
 		{
-			return;
+			return false;
 		}
 
 		// Not a matching compiler
 		if ( embeddedResource.Value.ResourceGenerator != EditorTypeLibrary.GetType( Generator.GetType() ).ClassName )
 		{
-			return;
+			return false;
 		}
 
 		Generator.Deserialize( embeddedResource.Value.Data );
+		return true;
 	}
 
 	void MakeDirty()
@@ -74,14 +76,29 @@ public class ResourceGeneratorControlWidget : ControlWidget
 		_isDirty = true;
 	}
 
-	async Task UpdateGenerator()
+	/// <param name="writeBack">
+	/// Whether the generated resource should be written back to the property. False when we only
+	/// materialised what the property was already describing.
+	/// </param>
+	async Task UpdateGenerator( bool writeBack = true )
 	{
 		_isGenerating = true;
 
 		try
 		{
 			var resource = await Generator.FindOrCreateObjectAsync( ResourceGenerator.Options.Default, default );
-			SerializedProperty.SetValue( resource );
+
+			//
+			// Only write when this is actually a change. On a multi-selection SerializedProperty.SetValue
+			// writes to every selected object, so writing back a resource we just loaded out of the
+			// property would copy the first selection's resource on to all of the others - just from
+			// opening the inspector, with nothing edited.
+			//
+			if ( writeBack )
+			{
+				SerializedProperty.SetValue( resource );
+			}
+
 			OnResourceChanged( resource );
 			Update();
 		}


### PR DESCRIPTION
> **Depends on #11535.** The rig builder sets `IsSorted`, `SortLayer` and `SortOrder` on the parts it creates, so it needs the sorting work first. This branch sits on top of that one, and its commits will drop out of this diff once #11535 merges. Only the last commit here is new.

## What this adds

Tooling to cut a sprite sheet into named, individually pivoted parts, and to assemble those parts into a cutout rig. The target workflow is the usual modular one: draw a character, lasso the limbs onto a sheet, slice, put each part's pivot on its joint, rename, parent into a hierarchy, then rotate to animate.

### The asset

A new `.sheet` `GameResource` records how an image was cut: the source image path, an optional background colour key, and a list of slices. Each slice carries a name, a pixel rect, a normalized pivot with the usual nine alignment presets, a nine slice border, and a stable id.

Slices are addressed by id rather than by name or index, because the workflow renames every part after cutting and re slicing reorders them freely. A name keyed reference would break exactly when the sheet became useful.

### Slicing

Three modes: automatic, grid by cell size, and grid by cell count. Automatic builds an alpha mask, finds islands by 8 connected component labelling over an explicit stack rather than recursion, drops anything below a minimum size, merges contained and overlapping boxes, and orders the result in reading order by banding rects into rows before sorting left to right. Sorting on the top edge alone interleaves rows, because automatic slicing trims to artwork so no two frames share a top edge.

Re slicing an already cut sheet offers three merge behaviours: delete existing, smart, and safe. Smart deliberately preserves hand placed pivots, since putting pivots on joints is the slow part of rigging.

### Artwork with no alpha channel

A JPEG has no alpha at all, and scans and paint exports are routinely flat white behind the drawing. Alpha based detection then finds one island covering the whole image, which reads as automatic slicing being broken.

A sheet can therefore name a background colour and tolerance, which is threaded through island finding, trimming and the empty cell test. The colour is guessed from the image corners on import, and left unset when the corners disagree rather than keying away part of the drawing. The texture generator knocks the same background out, feathering the edge, since keyed artwork is usually JPEG where the boundary is a gradient several pixels wide.

### The editor

An asset editor for `.sheet` files: a zoomable canvas with unfiltered rendering for crisp pixel art and a checkerboard backing, slice rects with eight resize handles, a draggable pivot with snapping, a filterable slice list with inline rename that commits on Enter and moves to the next row, and an inspector that is multi edit safe.

### Rigging

A rig builder that turns slices into a parented GameObject hierarchy. It writes one `.sprite` per part with the slice pivot as the animation origin, so rotating a part rotates it about its joint. Parenting is stored on the sheet rather than in the scene, so it survives re slicing, and cycles are rejected.

Parts are laid out as they sit on the sheet and are dragged together afterwards. The sheet records what the parts are, not how they assemble.

### How slices reach the renderer

Through a new `SpriteSheetSliceGenerator : TextureGenerator`, which crops the sheet and registers compile references for both the sheet and its source image. Nothing in the sprite render path changes, and no new render concept is introduced: it still receives an ordinary texture and a normalized origin.

## What this fixes

**Resource extensions longer than eight characters register fine but never compile.** The limit is enforced in the `GameResourceAttribute` constructor, which `[AssetType( Extension = ... )]` with an object initializer never runs. So the type registers, the asset browser creates the file, the JSON serializes correctly, and the native compiler silently emits no `_c`. The only symptom is "couldn't get compiled file" surfacing from an unrelated part of the code, with nothing pointing at the extension.

The same check now runs at type registration, so it reports the problem instead of failing quietly.

## Tests

`SpriteSheetSlicingTest`, 36 cases covering the grid modes, automatic slicing, the minimum size filter, overlap merging, reading order, alpha tolerance, background keying, trimming, the three merge behaviours, the pivot coordinate conventions, naming, and the rig hierarchy including cycle rejection.

The slicing algorithms live in the engine rather than the editor addon so they are reachable from the test projects, and so game code can slice at runtime.

## Notes

There is no proposal issue behind this. Happy to open one and discuss first if you would rather.

Two things worth knowing before review. The rig builder has had far less live editor time than the slicing side, so treat it as the less settled half. And nine slice borders are authored and stored but not yet consumed anywhere, included now so the format does not need a migration later.
