### PR TITLE
door: use pivot rotation as hinge axis (trapdoor support)

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Map/Door.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/Door.cs
@@ -53,6 +53,8 @@ public sealed class Door : Component, Component.IPressable
 
 	/// <summary>
 	/// Optional pivot point, origin will be used if not specified.
+	/// The pivot's rotation defines the hinge axis - the door rotates around the pivot's up axis.
+	/// Orient the pivot so its up axis points sideways to make a trapdoor.
 	/// </summary>
 	[Property, ShowIf( "Mode", DoorMode.Rotating )] public GameObject Pivot { get; set; }
 
@@ -109,8 +111,15 @@ public sealed class Door : Component, Component.IPressable
 
 	Transform _startTransform;
 	Vector3 _pivotPosition;
+	Rotation _pivotRotation;
 	bool _reverseDirection;
 	GameObject _lastPresser;
+
+	/// <summary>
+	/// Builds the rotation applied to the door when opened by <paramref name="angle"/> degrees,
+	/// hinging around the pivot's up axis (defaults to world up when no pivot is set).
+	/// </summary>
+	Rotation GetOpenRotation( float angle ) => Rotation.FromAxis( _pivotRotation.Up, angle );
 
 	/// <summary>
 	/// Is this door locked?
@@ -166,6 +175,7 @@ public sealed class Door : Component, Component.IPressable
 	{
 		_startTransform = Transform.Local;
 		_pivotPosition = Pivot is not null ? Pivot.WorldPosition : _startTransform.Position;
+		_pivotRotation = Pivot is not null ? Pivot.WorldRotation : Rotation.Identity;
 
 		if ( StartOpen )
 		{
@@ -175,7 +185,7 @@ public sealed class Door : Component, Component.IPressable
 			}
 			else
 			{
-				Transform.Local = _startTransform.RotateAround( _pivotPosition, Rotation.FromYaw( TargetAngle ) );
+				Transform.Local = _startTransform.RotateAround( _pivotPosition, GetOpenRotation( TargetAngle ) );
 			}
 
 			_state = DoorState.Open;
@@ -249,7 +259,8 @@ public sealed class Door : Component, Component.IPressable
 	void DrawAt( float f )
 	{
 		var pivotWorld = Pivot is not null ? Pivot.WorldPosition : WorldTransform.Position;
-		Gizmo.Transform = WorldTransform.RotateAround( pivotWorld, Rotation.FromYaw( TargetAngle * f ) );
+		var pivotAxis = (Pivot is not null ? Pivot.WorldRotation : Rotation.Identity).Up;
+		Gizmo.Transform = WorldTransform.RotateAround( pivotWorld, Rotation.FromAxis( pivotAxis, TargetAngle * f ) );
 
 		var bbox = GameObject.GetLocalBounds();
 
@@ -399,7 +410,7 @@ public sealed class Door : Component, Component.IPressable
 		var targetAngle = TargetAngle;
 		if ( _reverseDirection ) targetAngle *= -1.0f;
 
-		Transform.Local = _startTransform.RotateAround( _pivotPosition, Rotation.FromYaw( curve * targetAngle ) );
+		Transform.Local = _startTransform.RotateAround( _pivotPosition, GetOpenRotation( curve * targetAngle ) );
 
 		if ( time < 1f ) return;
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Adds support for using the `Door` component's pivot object **rotation** to define the
hinge axis, not just its position. This lets a rotating door hinge around any axis =>
enabling trapdoors (and other non-vertical hinged doors) instead of only vertical-axis
swinging doors.

## Motivation & Context

Previously the `Door` component always rotated around the world up axis
(`Rotation.FromYaw`), so the pivot object only contributed its *position*. There was no
way to make a door that hinges horizontally, e.g. a trapdoor or a hatch. By respecting the
pivot's orientation, mappers can build these with the existing component.

Fixes: N/A

## Implementation Details

- The door now hinges around the pivot's **up axis** via a new helper:
  `Rotation GetOpenRotation( float angle ) => Rotation.FromAxis( _pivotRotation.Up, angle );`
- The pivot's world rotation is cached in `OnStart` (`_pivotRotation`), defaulting to
  `Rotation.Identity` when no pivot is assigned.
- Both the `StartOpen` initial state and `UpdateRotating` now use `GetOpenRotation`.
- The `DrawAt` gizmo preview was updated to use the same pivot axis, so the editor preview
  matches runtime behaviour.
- **Backward compatible:** with no pivot (or an unrotated pivot), the up axis is world up,
  so `Rotation.FromAxis( Vector3.Up, angle )` is identical to the previous
  `Rotation.FromYaw( angle )`. Existing doors behave exactly as before.

Chose the pivot's up axis as the hinge so that default/unrotated pivots keep the current
vertical-hinge behaviour.

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/17cc1d11-3d92-4e62-9a0c-713bec3d0120

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂