### PR TITLE
Fetch latest package revision on mount instead of reusing cached version

### DIFF
--- a/engine/Sandbox.Engine/Services/Packages/Package.Download.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Download.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Engine;
+using Sandbox.Engine;
 using Sandbox.Menu;
 using Sentry;
 using System.Collections.Concurrent;
@@ -274,13 +274,30 @@ public partial class Package
 	{
 		SentrySdk.AddBreadcrumb( $"Mounting {this.FullIdent}", "package.mount" );
 
-		int? version = Revision?.VersionId > 0 ? (int)Revision.VersionId : null;
-		var fs = await ServerPackages.DownloadAndMount( FormatIdent( Org.Ident, Ident, version, !IsRemote ) );
+		var packageToMount = this;
+
+		if ( IsRemote )
+		{
+			var versionlessIdent = FormatIdent( Org.Ident, Ident );
+			Log.Info( $"[Package.Mount] Checking server for updates on remote package: {versionlessIdent}..." );
+			var latest = await FetchAsync( versionlessIdent, false, useCache: false );
+			if ( latest != null && latest.Revision != null )
+			{
+				packageToMount = latest;
+			}
+			else
+			{
+				Log.Warning( $"[Package.Mount] Couldn't verify the latest revision for {versionlessIdent}; mounting the current revision." );
+			}
+		}
+
+		int? version = packageToMount.Revision?.VersionId > 0 ? (int)packageToMount.Revision.VersionId : null;
+		var fs = await ServerPackages.DownloadAndMount( FormatIdent( packageToMount.Org.Ident, packageToMount.Ident, version, !packageToMount.IsRemote ) );
 		if ( fs is null ) return default;
 
 		if ( withCode )
 		{
-			await IGameInstanceDll.Current?.LoadPackageAssembliesAsync( this );
+			await IGameInstanceDll.Current?.LoadPackageAssembliesAsync( packageToMount );
 		}
 
 		return fs;

--- a/engine/Sandbox.Engine/Services/Packages/Package.Download.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Download.cs
@@ -279,7 +279,7 @@ public partial class Package
 		if ( IsRemote )
 		{
 			var versionlessIdent = FormatIdent( Org.Ident, Ident );
-			Log.Info( $"[Package.Mount] Checking server for updates on remote package: {versionlessIdent}..." );
+			Log.Info( $"Checking server for updates on remote package: {versionlessIdent}..." );
 			var latest = await FetchAsync( versionlessIdent, false, useCache: false );
 			if ( latest != null && latest.Revision != null )
 			{
@@ -287,7 +287,7 @@ public partial class Package
 			}
 			else
 			{
-				Log.Warning( $"[Package.Mount] Couldn't verify the latest revision for {versionlessIdent}; mounting the current revision." );
+				Log.Warning( $"Couldn't verify the latest revision for {versionlessIdent}; mounting the current revision." );
 			}
 		}
 

--- a/engine/Sandbox.Engine/Services/Packages/Package.Mount.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Mount.cs
@@ -12,7 +12,7 @@ public partial class Package
 		// fully good
 		if ( download != null && download.IsMounted )
 		{
-			if ( IsRemote && download.activePackage != null && Revision != null )
+			if ( IsRemote && download.activePackage != null && download.activePackage.Package != null && Revision != null )
 			{
 				if ( download.activePackage.Package.Revision?.VersionId != Revision.VersionId )
 					return false;

--- a/engine/Sandbox.Engine/Services/Packages/Package.Mount.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Mount.cs
@@ -1,4 +1,4 @@
-﻿namespace Sandbox;
+namespace Sandbox;
 
 public partial class Package
 {
@@ -11,7 +11,14 @@ public partial class Package
 
 		// fully good
 		if ( download != null && download.IsMounted )
+		{
+			if ( IsRemote && download.activePackage != null && Revision != null )
+			{
+				if ( download.activePackage.Package.Revision?.VersionId != Revision.VersionId )
+					return false;
+			}
 			return true;
+		}
 
 		// fully in progress
 		if ( download != null && download.IsDownloading )

--- a/engine/Sandbox.Engine/Services/Packages/Package.Mount.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Mount.cs
@@ -7,16 +7,16 @@ public partial class Package
 	/// </summary>
 	public bool IsMounted()
 	{
+		// A remote package must be resolved again when its owner asks to mount it.
+		// The published revision may have changed since its last mount.
+		if ( IsRemote )
+			return false;
+
 		var download = ServerPackages.Get( FullIdent );
 
 		// fully good
 		if ( download != null && download.IsMounted )
 		{
-			if ( IsRemote && download.activePackage != null && download.activePackage.Package != null && Revision != null )
-			{
-				if ( download.activePackage.Package.Revision?.VersionId != Revision.VersionId )
-					return false;
-			}
 			return true;
 		}
 

--- a/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
@@ -1,4 +1,4 @@
-﻿using Refit;
+using Refit;
 using Sandbox.Internal;
 using Sandbox.Protobuf;
 using System.Collections.Concurrent;
@@ -11,6 +11,7 @@ public partial class Package
 {
 	static ConcurrentDictionary<string, Package> Packages = new( StringComparer.OrdinalIgnoreCase );
 	static ConcurrentDictionary<string, Package> PartialPackages = new( StringComparer.OrdinalIgnoreCase );
+	static ConcurrentDictionary<string, DateTime> LastFetchTimes = new( StringComparer.OrdinalIgnoreCase );
 
 	static Package()
 	{
@@ -21,6 +22,7 @@ public partial class Package
 	{
 		Packages.Clear();
 		PartialPackages.Clear();
+		LastFetchTimes.Clear();
 	}
 
 	/// <summary>
@@ -30,6 +32,7 @@ public partial class Package
 	{
 		Packages.Remove( packageIdent, out _ );
 		PartialPackages.Remove( packageIdent, out _ );
+		LastFetchTimes.Remove( packageIdent, out _ );
 	}
 
 	/// <summary>
@@ -148,7 +151,19 @@ public partial class Package
 		Package package = default;
 
 		if ( useCache && TryGetCached( identString, out package, partial ) )
+		{
+			if ( package.IsRemote && ident.version == null )
+			{
+				var fullIdent = FormatIdent( ident.org, ident.package );
+				if ( !LastFetchTimes.TryGetValue( fullIdent, out var lastFetch ) || (DateTime.UtcNow - lastFetch).TotalSeconds > 5 )
+				{
+					var latest = await FetchAsync( identString, partial, useCache: false );
+					if ( latest != null )
+						return latest;
+				}
+			}
 			return package;
+		}
 
 		// GetCached should have returned the local mock package
 		if ( ident.local || string.Compare( "local", ident.org, StringComparison.OrdinalIgnoreCase ) == 0 )
@@ -168,6 +183,12 @@ public partial class Package
 			if ( ident.version is not null ) packageIdent += $"#{ident.version}";
 			var result = await Backend.Package.Get( packageIdent );
 			if ( result is null ) return null;
+
+			if ( !ident.local && ident.version == null )
+			{
+				var fullIdent = FormatIdent( ident.org, ident.package );
+				LastFetchTimes[fullIdent] = DateTime.UtcNow;
+			}
 
 
 			if ( package is not RemotePackage )

--- a/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
@@ -152,7 +152,7 @@ public partial class Package
 
 		if ( useCache && TryGetCached( identString, out package, partial ) )
 		{
-			if ( package.IsRemote && ident.version == null )
+			if ( package != null && package.IsRemote && ident.version == null )
 			{
 				var fullIdent = FormatIdent( ident.org, ident.package );
 				if ( !LastFetchTimes.TryGetValue( fullIdent, out var lastFetch ) || (DateTime.UtcNow - lastFetch).TotalSeconds > 5 )

--- a/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
+++ b/engine/Sandbox.Engine/Services/Packages/Package.Static.cs
@@ -261,7 +261,7 @@ public partial class Package
 			// if this is a local package we need to say this is it
 			// whether we found it or not. We don't want it to look up
 			// the real package because that gets confusing.
-			return true;
+			return package != null;
 		}
 
 		if ( Packages.TryGetValue( fullIdent, out package ) )

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoader.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Audio;
+using Sandbox.Audio;
 using Sandbox.Engine;
 using Sandbox.Internal;
 using Sentry;
@@ -14,6 +14,9 @@ namespace Sandbox;
 internal sealed partial class PackageLoader : IDisposable
 {
 	bool FastHotloadEnabled => HotloadManager.hotload_fast;
+
+	private static readonly object loadersLock = new();
+	private static List<PackageLoader> ActiveLoaders = new();
 
 	private List<LoadedAssembly> Loaded { get; set; } = new();
 	private LoadContext LoadContext { get; set; }
@@ -55,10 +58,20 @@ internal sealed partial class PackageLoader : IDisposable
 
 		loadedPackages.Clear();
 		changedPackageDlls.Clear();
+
+		lock ( loadersLock )
+		{
+			ActiveLoaders.Add( this );
+		}
 	}
 
 	public void Dispose()
 	{
+		lock ( loadersLock )
+		{
+			ActiveLoaders.Remove( this );
+		}
+
 		foreach ( var dllWatcher in dllWatchers )
 		{
 			dllWatcher.Dispose();
@@ -132,7 +145,7 @@ internal sealed partial class PackageLoader : IDisposable
 		var allChangedDlls = this.changedPackageDlls.ToArray();
 		this.changedPackageDlls.Clear();
 
-		if ( !allChangedDlls.Any() )
+		if ( !allChangedDlls.Any() && !IncomingThisHotload.Any() )
 			return;
 
 		// Entries without a package come from a stream (e.g. assemblies sent by a server)
@@ -151,6 +164,18 @@ internal sealed partial class PackageLoader : IDisposable
 		//
 
 		var hotloadedPackages = new HashSet<PackageManager.ActivePackage>();
+
+		foreach ( var la in IncomingThisHotload )
+		{
+			if ( la.Package != null )
+			{
+				var ap = loadedPackages.FirstOrDefault( x => x.Package == la.Package );
+				if ( ap != null && !la.FastHotload )
+				{
+					hotloadedPackages.Add( ap );
+				}
+			}
+		}
 
 		//
 		// Resolve stream-swapped assemblies back to their loaded package, so packages that
@@ -268,6 +293,21 @@ internal sealed partial class PackageLoader : IDisposable
 		bool isEditorAssembly = filename.EndsWith( ".editor.dll", StringComparison.OrdinalIgnoreCase ) && !ap.Package.IsRemote;
 		bool isToolAssembly = ap.Package.TypeName == "tool" || isEditorAssembly;
 		var assmName = System.IO.Path.GetFileNameWithoutExtension( filename );
+
+		if ( ap.Package.IsRemote )
+		{
+			var existing = Loaded.FirstOrDefault( x => x.Name == assmName );
+			if ( existing != null && existing.Assembly != null && existing.Package != null )
+			{
+				if ( existing.Package.Revision?.VersionId == ap.Package.Revision?.VersionId )
+				{
+					log.Info( $"[PackageLoader] Assembly {assmName} is already loaded with the same version ({ap.Package.Revision?.VersionId}) - Reusing memory assembly." );
+					return existing;
+				}
+			}
+		}
+
+		log.Info( $"[PackageLoader] Loading assembly {assmName} from package {ap.Package.FullIdent} (version: {ap.Package.Revision?.VersionId})..." );
 
 		// if this is an editor dll, it shouldn't have loaded anywhere but the tools!
 		Assert.False( isToolAssembly && !ToolsMode );
@@ -837,4 +877,24 @@ internal sealed partial class PackageLoader : IDisposable
 	}
 
 	public Action OnAfterHotload { get; set; }
+
+	internal static void OnPackageUnmounted( PackageManager.ActivePackage ap )
+	{
+		PackageLoader[] loaders;
+		lock ( loadersLock )
+		{
+			loaders = ActiveLoaders.ToArray();
+		}
+		foreach ( var loader in loaders )
+		{
+			loader.UnloadPackage( ap );
+		}
+	}
+
+	internal void UnloadPackage( PackageManager.ActivePackage ap )
+	{
+		if ( ap == null ) return;
+
+		loadedPackages.Remove( ap );
+	}
 }

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoader.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageLoader.cs
@@ -301,13 +301,13 @@ internal sealed partial class PackageLoader : IDisposable
 			{
 				if ( existing.Package.Revision?.VersionId == ap.Package.Revision?.VersionId )
 				{
-					log.Info( $"[PackageLoader] Assembly {assmName} is already loaded with the same version ({ap.Package.Revision?.VersionId}) - Reusing memory assembly." );
+					log.Info( $"Assembly {assmName} is already loaded with the same version ({ap.Package.Revision?.VersionId}) - Reusing memory assembly." );
 					return existing;
 				}
 			}
 		}
 
-		log.Info( $"[PackageLoader] Loading assembly {assmName} from package {ap.Package.FullIdent} (version: {ap.Package.Revision?.VersionId})..." );
+		log.Info( $"Loading assembly {assmName} from package {ap.Package.FullIdent} (version: {ap.Package.Revision?.VersionId})..." );
 
 		// if this is an editor dll, it shouldn't have loaded anywhere but the tools!
 		Assert.False( isToolAssembly && !ToolsMode );

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.ActivePackage.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.ActivePackage.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Net;
 using System.Threading;
 
@@ -333,6 +333,8 @@ internal static partial class PackageManager
 		/// </summary>
 		public void Delete()
 		{
+			PackageLoader.OnPackageUnmounted( this );
+
 			MountedFileSystem.UnMount( FileSystem );
 
 			FileSystem.Dispose();

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
@@ -65,7 +65,7 @@ internal static partial class PackageManager
 		var existingPackage = Find( options.PackageIdent, options.AllowLocalPackages );
 		if ( existingPackage != null )
 		{
-			if ( existingPackage.Package.IsRemote && Package.TryParseIdent( options.PackageIdent, out var parsedIdent ) )
+			if ( existingPackage.Package != null && existingPackage.Package.IsRemote && Package.TryParseIdent( options.PackageIdent, out var parsedIdent ) )
 			{
 				if ( parsedIdent.version != null )
 				{

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Menu;
+using Sandbox.Menu;
 using System.IO;
 using System.Threading;
 
@@ -63,6 +63,52 @@ internal static partial class PackageManager
 		// If this package exists then mark it with our tag and move on
 		//
 		var existingPackage = Find( options.PackageIdent, options.AllowLocalPackages );
+		if ( existingPackage != null )
+		{
+			if ( existingPackage.Package.IsRemote && Package.TryParseIdent( options.PackageIdent, out var parsedIdent ) )
+			{
+				if ( parsedIdent.version != null )
+				{
+					if ( parsedIdent.version != existingPackage.Package.Revision?.VersionId )
+					{
+						log.Info( $"Replacing mounted package {options.PackageIdent} (mounted version: {existingPackage.Package.Revision?.VersionId}, requested version: {parsedIdent.version})" );
+						
+						existingPackage.Delete();
+						ActivePackages.Remove( existingPackage );
+						ServerPackages.Remove( options.PackageIdent );
+						
+						int? currentVersion = existingPackage.Package.Revision != null ? (int)existingPackage.Package.Revision.VersionId : null;
+						var oldVersionIdent = Package.FormatIdent( existingPackage.Package.Org.Ident, existingPackage.Package.Ident, currentVersion );
+						ServerPackages.Remove( oldVersionIdent );
+						
+						existingPackage = null;
+					}
+				}
+				else
+				{
+					// If no specific version was requested, check the server for updates
+					var latestPackage = await Package.FetchAsync( options.PackageIdent, false, useCache: false );
+					if ( latestPackage != null && latestPackage.Revision != null && existingPackage.Package.Revision != null )
+					{
+						if ( latestPackage.Revision.VersionId > existingPackage.Package.Revision.VersionId )
+						{
+							log.Info( $"Replacing mounted package {options.PackageIdent} with newer version (mounted version: {existingPackage.Package.Revision.VersionId}, latest version: {latestPackage.Revision.VersionId})" );
+							
+							existingPackage.Delete();
+							ActivePackages.Remove( existingPackage );
+							ServerPackages.Remove( options.PackageIdent );
+							
+							int? currentVersion = existingPackage.Package.Revision != null ? (int)existingPackage.Package.Revision.VersionId : null;
+							var oldVersionIdent = Package.FormatIdent( existingPackage.Package.Org.Ident, existingPackage.Package.Ident, currentVersion );
+							ServerPackages.Remove( oldVersionIdent );
+							
+							existingPackage = null;
+						}
+					}
+				}
+			}
+		}
+
 		if ( existingPackage != null )
 		{
 			existingPackage.AddContextTag( options.ContextTag );

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
@@ -1,4 +1,4 @@
-using Sandbox.Menu;
+﻿using Sandbox.Menu;
 using System.IO;
 using System.Threading;
 
@@ -63,52 +63,6 @@ internal static partial class PackageManager
 		// If this package exists then mark it with our tag and move on
 		//
 		var existingPackage = Find( options.PackageIdent, options.AllowLocalPackages );
-		if ( existingPackage != null )
-		{
-			if ( existingPackage.Package != null && existingPackage.Package.IsRemote && Package.TryParseIdent( options.PackageIdent, out var parsedIdent ) )
-			{
-				if ( parsedIdent.version != null )
-				{
-					if ( parsedIdent.version != existingPackage.Package.Revision?.VersionId )
-					{
-						log.Info( $"Replacing mounted package {options.PackageIdent} (mounted version: {existingPackage.Package.Revision?.VersionId}, requested version: {parsedIdent.version})" );
-						
-						existingPackage.Delete();
-						ActivePackages.Remove( existingPackage );
-						ServerPackages.Remove( options.PackageIdent );
-						
-						int? currentVersion = existingPackage.Package.Revision != null ? (int)existingPackage.Package.Revision.VersionId : null;
-						var oldVersionIdent = Package.FormatIdent( existingPackage.Package.Org.Ident, existingPackage.Package.Ident, currentVersion );
-						ServerPackages.Remove( oldVersionIdent );
-						
-						existingPackage = null;
-					}
-				}
-				else
-				{
-					// If no specific version was requested, check the server for updates
-					var latestPackage = await Package.FetchAsync( options.PackageIdent, false, useCache: false );
-					if ( latestPackage != null && latestPackage.Revision != null && existingPackage.Package.Revision != null )
-					{
-						if ( latestPackage.Revision.VersionId > existingPackage.Package.Revision.VersionId )
-						{
-							log.Info( $"Replacing mounted package {options.PackageIdent} with newer version (mounted version: {existingPackage.Package.Revision.VersionId}, latest version: {latestPackage.Revision.VersionId})" );
-							
-							existingPackage.Delete();
-							ActivePackages.Remove( existingPackage );
-							ServerPackages.Remove( options.PackageIdent );
-							
-							int? currentVersion = existingPackage.Package.Revision != null ? (int)existingPackage.Package.Revision.VersionId : null;
-							var oldVersionIdent = Package.FormatIdent( existingPackage.Package.Org.Ident, existingPackage.Package.Ident, currentVersion );
-							ServerPackages.Remove( oldVersionIdent );
-							
-							existingPackage = null;
-						}
-					}
-				}
-			}
-		}
-
 		if ( existingPackage != null )
 		{
 			existingPackage.AddContextTag( options.ContextTag );

--- a/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
+++ b/engine/Sandbox.Engine/Services/Packages/PackageManager/PackageManager.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Menu;
+using Sandbox.Menu;
 using System.IO;
 using System.Threading;
 
@@ -63,6 +63,25 @@ internal static partial class PackageManager
 		// If this package exists then mark it with our tag and move on
 		//
 		var existingPackage = Find( options.PackageIdent, options.AllowLocalPackages );
+		if ( existingPackage != null )
+		{
+			if ( existingPackage.Package != null && existingPackage.Package.IsRemote && Package.TryParseIdent( options.PackageIdent, out var parsedIdent ) )
+			{
+				if ( parsedIdent.version != null && parsedIdent.version != existingPackage.Package.Revision?.VersionId )
+				{
+					log.Info( $"Version mismatch: replacing mounted package {existingPackage.Package.FullIdent} (version {existingPackage.Package.Revision?.VersionId}) with requested version {parsedIdent.version}." );
+
+					var mountedIdent = Package.FormatIdent( existingPackage.Package.Org.Ident, existingPackage.Package.Ident, (int?)existingPackage.Package.Revision?.VersionId );
+					existingPackage.Delete();
+					ActivePackages.Remove( existingPackage );
+					ServerPackages.Remove( options.PackageIdent );
+					ServerPackages.Remove( mountedIdent );
+
+					existingPackage = null;
+				}
+			}
+		}
+
 		if ( existingPackage != null )
 		{
 			existingPackage.AddContextTag( options.ContextTag );

--- a/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
@@ -1,4 +1,4 @@
-using Sandbox.Internal;
+﻿using Sandbox.Internal;
 using Sandbox.Menu;
 using Sandbox.Network;
 using System.Threading;
@@ -243,41 +243,10 @@ internal class ServerPackages
 
 	internal static PackageDownload Get( string packageIdent )
 	{
-		if ( Downloads.TryGetValue( packageIdent, out var dl ) )
-			return dl;
+		if ( !Downloads.TryGetValue( packageIdent, out var dl ) )
+			return null;
 
-		if ( !packageIdent.Contains( '#' ) )
-		{
-			foreach ( var kvp in Downloads )
-			{
-				if ( kvp.Key.StartsWith( packageIdent + "#", StringComparison.OrdinalIgnoreCase ) )
-					return kvp.Value;
-			}
-		}
-
-		return null;
-	}
-
-	internal static void Remove( string packageIdent )
-	{
-		Downloads.Remove( packageIdent, out _ );
-
-		// Also remove versioned downloads for this ident
-		if ( !packageIdent.Contains( '#' ) )
-		{
-			var keysToRemove = new System.Collections.Generic.List<string>();
-			foreach ( var key in Downloads.Keys )
-			{
-				if ( key.StartsWith( packageIdent + "#", StringComparison.OrdinalIgnoreCase ) )
-				{
-					keysToRemove.Add( key );
-				}
-			}
-			foreach ( var key in keysToRemove )
-			{
-				Downloads.Remove( key, out _ );
-			}
-		}
+		return dl;
 	}
 }
 

--- a/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Internal;
+using Sandbox.Internal;
 using Sandbox.Menu;
 using Sandbox.Network;
 using System.Threading;
@@ -247,6 +247,28 @@ internal class ServerPackages
 			return null;
 
 		return dl;
+	}
+
+	internal static void Remove( string packageIdent )
+	{
+		Downloads.Remove( packageIdent, out _ );
+
+		// Also remove versioned downloads for this ident
+		if ( !packageIdent.Contains( '#' ) )
+		{
+			var keysToRemove = new System.Collections.Generic.List<string>();
+			foreach ( var key in Downloads.Keys )
+			{
+				if ( key.StartsWith( packageIdent + "#", StringComparison.OrdinalIgnoreCase ) )
+				{
+					keysToRemove.Add( key );
+				}
+			}
+			foreach ( var key in keysToRemove )
+			{
+				Downloads.Remove( key, out _ );
+			}
+		}
 	}
 }
 

--- a/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Tables/ServerPackages.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Internal;
+using Sandbox.Internal;
 using Sandbox.Menu;
 using Sandbox.Network;
 using System.Threading;
@@ -243,10 +243,41 @@ internal class ServerPackages
 
 	internal static PackageDownload Get( string packageIdent )
 	{
-		if ( !Downloads.TryGetValue( packageIdent, out var dl ) )
-			return null;
+		if ( Downloads.TryGetValue( packageIdent, out var dl ) )
+			return dl;
 
-		return dl;
+		if ( !packageIdent.Contains( '#' ) )
+		{
+			foreach ( var kvp in Downloads )
+			{
+				if ( kvp.Key.StartsWith( packageIdent + "#", StringComparison.OrdinalIgnoreCase ) )
+					return kvp.Value;
+			}
+		}
+
+		return null;
+	}
+
+	internal static void Remove( string packageIdent )
+	{
+		Downloads.Remove( packageIdent, out _ );
+
+		// Also remove versioned downloads for this ident
+		if ( !packageIdent.Contains( '#' ) )
+		{
+			var keysToRemove = new System.Collections.Generic.List<string>();
+			foreach ( var key in Downloads.Keys )
+			{
+				if ( key.StartsWith( packageIdent + "#", StringComparison.OrdinalIgnoreCase ) )
+				{
+					keysToRemove.Add( key );
+				}
+			}
+			foreach ( var key in keysToRemove )
+			{
+				Downloads.Remove( key, out _ );
+			}
+		}
 	}
 }
 

--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp;
 using Sandbox.Audio;
 using Sandbox.Diagnostics;
 using Sandbox.Internal;
@@ -684,6 +684,8 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 
 				throw new Exception( "GameInstance load failed" );
 			}
+
+			FinishLoadingAssemblies();
 
 			Json.PopulateReflectionCache( Game.TypeLibrary );
 

--- a/engine/Sandbox.Tools/Assets/AssetSystem.Cloud.cs
+++ b/engine/Sandbox.Tools/Assets/AssetSystem.Cloud.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Engine;
+using Sandbox.Engine;
 using System;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -35,7 +35,7 @@ public static partial class AssetSystem
 		if ( !CanCloudInstall( package ) )
 			return null;
 
-		if ( !skipIfInstalled || !IsCloudInstalled( package ) )
+		if ( !skipIfInstalled || !IsCloudInstalled( package, exactVersion: true ) )
 		{
 			// download the manifest
 			await package.Revision.DownloadManifestAsync( token );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Previously, remote packages (such as addons) were downloaded once and then perpetually reloaded from local cache on subsequent mounts/scene launches, ignoring newer published revisions on the backend.

This PR updates package mounting to always check the backend for the latest package revision on mount, ensuring remote addons automatically update and load their newest version when launched.

## Motivation & Context

When working with or testing published addons, the engine would lock onto the first installed version in cache and refuse to fetch newer revisions published to the backend during the session. Developers had to manually restart the editor or clear local cache files to test addon updates.

This change ensures remote packages dynamically check for and mount the latest revision whenever a scene or addon manager requests to mount them.

Fixes: N/A

## Implementation Details

- **Package Mounting (`Package.Download.cs` / `Package.Mount.cs`)**: Added backend version checking during `MountAsync` to query for the latest versionless ident before downloading/mounting.
- **Revision Replacement (`PackageManager.cs` & `ServerPackages.cs`)**: Added version mismatch detection during `InstallAsync`. If a newer package revision is requested, the stale mounted package entry and download cache are unmounted and replaced.
- **Reference Preservation (`Package.Static.cs`)**: Updated `FetchAsync` to update existing cached `RemotePackage` instances in-place when fetching updated DTOs, maintaining object reference integrity across C# scripts.
- **Early Assembly Hotload (`GameInstanceDll.cs`)**: Called `FinishLoadingAssemblies()` immediately after `LoadAsync` to apply assembly swaps before the startup scene opens, preventing scenes from instantiating with stale types.
- **Dependency Assembly Reuse (`PackageLoader.cs`)**: Skipped re-instantiating assemblies if their version ID has not changed, preventing hotload type substitution errors on unchanged dependencies.
- **Editor Asset Check (`AssetSystem.Cloud.cs`)**: Enabled `exactVersion: true` in `IsCloudInstalled` to ensure the editor asset browser detects version changes and downloads updated cloud packages.

## Screenshots / Videos (if applicable)

N/A

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂