### PR TITLE
[MCP] Expose compile state on editor_status

### DIFF
--- a/engine/Sandbox.Tools/Mcp/TopLevelTools.cs
+++ b/engine/Sandbox.Tools/Mcp/TopLevelTools.cs
@@ -139,10 +139,21 @@ internal static class TopLevelTools
 	}
 
 	[McpTool.ReadOnly( "editor_status" ), McpListed]
-	[Description( "Get the current state of the editor - engine version, which project is open, the active scene and whether it has unsaved changes, whether play mode is running or paused, how many tools are registered, and the directory paths that matter (logs, project code and assets)." )]
+	[Description( "Get the current state of the editor - engine version, which project is open, the active scene and whether it has unsaved changes, whether play mode is running or paused, whether code is compiling and how the last compile went, how many tools are registered, and the directory paths that matter (logs, project code and assets)." )]
 	public static EditorStatus GetEditorStatus()
 	{
 		var scene = Game.ActiveScene;
+		var compileGroup = Project.CompileGroup;
+
+		// Diagnostics is only allocated once a build has actually run, so a null one means nothing
+		// has compiled yet. Without that check a fresh editor would report the default Results,
+		// whose Success is true, and claim a compile succeeded that never happened.
+		bool? lastBuildSucceeded = null;
+
+		if ( compileGroup is not null && compileGroup.BuildResult.Diagnostics is not null )
+		{
+			lastBuildSucceeded = compileGroup.BuildResult.Success;
+		}
 
 		return new EditorStatus
 		{
@@ -154,6 +165,8 @@ internal static class TopLevelTools
 			SceneHasUnsavedChanges = SceneEditorSession.Active?.HasUnsavedChanges ?? false,
 			IsPlaying = Game.IsPlaying,
 			IsPaused = Game.IsPaused,
+			IsCompiling = compileGroup?.IsBuilding ?? false,
+			LastBuildSucceeded = lastBuildSucceeded,
 			ToolCount = ToolRegistry.All().Count(),
 			Paths = new EditorPaths
 			{
@@ -238,6 +251,19 @@ internal class EditorStatus
 	public bool SceneHasUnsavedChanges { get; set; }
 	public bool IsPlaying { get; set; }
 	public bool IsPaused { get; set; }
+
+	/// <summary>
+	/// True while code is being compiled - anything read right now may be about to change.
+	/// </summary>
+	public bool IsCompiling { get; set; }
+
+	/// <summary>
+	/// Whether the last code compile succeeded, or null when nothing has compiled yet this
+	/// session. Read this instead of inferring the result from console history, which only
+	/// records failures.
+	/// </summary>
+	public bool? LastBuildSucceeded { get; set; }
+
 	public int ToolCount { get; set; }
 	public EditorPaths Paths { get; set; }
 }


### PR DESCRIPTION
## Summary

An agent driving the editor through the MCP server has no way to *query* build state — it can only infer it from console history, and the console logs compile failures but never successes. After fixing a compile error, the most recent trace an agent can see is still `Compile of '<project>' Failed`, so it concludes its fix didn't take effect and starts undoing correct work.

This adds `IsCompiling` and `LastBuildSucceeded` to `editor_status`, so the agent reads a fact instead of inferring one from silence.

## Motivation & Context

Fixes: #11545

Reproduced on `26.07.22` — full step-by-step with console buffer counts in [this comment](https://github.com/Facepunch/sbox-public/issues/11545#issuecomment-5074246439). Short version: a failing compile logs 2/2, a succeeding one logs 0/1, and the file watcher provably recompiled in between.

## Implementation Details

- Values come from the `CompileGroup` the editor already maintains, reached through the existing `Project.CompileGroup` extension in `Sandbox.Tools`. No new state, no new plumbing.
- `LastBuildSucceeded` is `bool?` on purpose. `Results` is a struct whose `Success` is `true` by default, so reading it directly would make a freshly opened editor claim a compile succeeded that never ran. `Diagnostics` is only allocated once `BuildAsync` starts, so a null one is the reliable "nothing has compiled yet" signal.
- `ToolRegistry.SchemaForType` already unwraps nullables, so `bool?` serialises as a plain boolean in the tool schema.

Two adjacent problems surfaced while reproducing this, deliberately left out to keep the PR in scope — happy to follow up if you want them addressed:

1. Compile errors are logged at `Warn`, not `Error`, so an agent filtering `read_console` on `minimumLevel: Error` sees nothing at all.
2. `read_console` documents "oldest first", but engine and managed entries interleave with non-monotonic timestamps, so the tail of the buffer isn't reliably the most recent activity.

## Screenshots / Videos (if applicable)

N/A — the observable change is the `editor_status` payload, quoted in the linked issue comment.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂

**On tests and local build, for full disclosure:** there is no existing test coverage for the MCP layer, and `GetEditorStatus()` depends on a live editor (`Game.ActiveScene`, `Project.Current`, `ToolRegistry`), so a unit test would mean building mock infrastructure well beyond the scope of this change — I'd rather follow your steer than invent that here. I also could not run a local engine build: Windows Smart App Control on my machine blocks the freshly compiled `CodeGen.exe`, which fails `Sandbox.Engine.csproj` before it ever reaches `Sandbox.Tools`. I verified this change by reading `ToolRegistry`'s schema generation and `CompileGroup`'s build lifecycle rather than by compiling it, and I'm relying on CI to confirm. Flagging that so you can weigh the review accordingly.