### PR TITLE
Restore multiple asset browser instances

### DIFF
--- a/engine/Sandbox.Tools/Qt/DockManager/DockManager.Register.cs
+++ b/engine/Sandbox.Tools/Qt/DockManager/DockManager.Register.cs
@@ -77,6 +77,62 @@ public partial class DockManager
 	}
 
 	/// <summary>
+	/// Create an additional floating instance of a registered dock type. The first instance
+	/// keeps the registered name, extras get "Name 2", "Name 3"... and delete on close.
+	/// </summary>
+	public DockWidget CreateDockInstance( string name )
+	{
+		if ( !docks.TryGetValue( name, out var info ) )
+			return null;
+
+		var instanceName = info.Title;
+		for ( var i = 2; FindDockWidget( instanceName ) is not null; i++ )
+		{
+			instanceName = $"{info.Title} {i}";
+		}
+
+		var dock = CreateInstance( info, instanceName );
+		if ( dock is null ) return null;
+
+		_nativeDockManager.addDockWidgetFloating( dock._nativeDockWidget );
+
+		return dock;
+	}
+
+	readonly List<string> instanceNames = new();
+
+	internal DockWidget CreateInstance( DockInfo info, string instanceName )
+	{
+		var widget = info.CreateAction();
+		if ( widget is null ) return null;
+
+		var dock = CreateDockWidget( instanceName, info.Icon, widget );
+
+		if ( instanceName != info.Title )
+		{
+			dock._nativeDockWidget.setFeature( DockWidgetFeature.DeleteOnClose, true );
+
+			if ( !instanceNames.Contains( instanceName ) )
+				instanceNames.Add( instanceName );
+		}
+
+		return dock;
+	}
+
+	/// <summary>
+	/// Close every additional dock instance, leaving only the primary of each type.
+	/// </summary>
+	public void CloseDockInstances()
+	{
+		foreach ( var name in instanceNames )
+		{
+			FindDockWidget( name )?.CloseDockWidget();
+		}
+
+		instanceNames.Clear();
+	}
+
+	/// <summary>
 	/// Unregister a dock type by name.
 	/// </summary>
 	public void UnregisterDockType( string name )

--- a/engine/Sandbox.Tools/Qt/DockManager/DockManager.State.cs
+++ b/engine/Sandbox.Tools/Qt/DockManager/DockManager.State.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text.RegularExpressions;
 
 namespace Editor;
 
@@ -26,10 +29,65 @@ public partial class DockManager
 	/// </summary>
 	public bool RestoreState( string state )
 	{
+		CreateMissingInstances( state );
+
 		if ( !_nativeDockManager.restoreState( state, 1 ) )
 			return false;
 
 		OnLayoutLoaded?.Invoke();
 		return true;
+	}
+
+	/// <summary>
+	/// A saved layout can contain extra instances of a dock type ("Asset Browser 2") that
+	/// don't exist right now - create them first so the restore has something to place.
+	/// </summary>
+	void CreateMissingInstances( string state )
+	{
+		var xml = DecodeState( state );
+
+		if ( string.IsNullOrEmpty( xml ) )
+			return;
+
+		foreach ( var info in docks.Values.ToArray() )
+		{
+			foreach ( Match match in Regex.Matches( xml, $"\"{Regex.Escape( info.Title )} (\\d+)\"" ) )
+			{
+				var instanceName = match.Value.Trim( '"' );
+
+				if ( FindDockWidget( instanceName ) is not null )
+					continue;
+
+				var dock = CreateInstance( info, instanceName );
+				if ( dock is null ) continue;
+
+				AddDock( dock, DockArea.Center );
+			}
+		}
+	}
+
+	/// <summary>
+	/// The native state is base64( qCompress( xml ) ): a 4 byte length prefix, then zlib.
+	/// </summary>
+	static string DecodeState( string state )
+	{
+		if ( string.IsNullOrEmpty( state ) )
+			return state;
+
+		try
+		{
+			var bytes = Convert.FromBase64String( state );
+			if ( bytes.Length <= 6 ) return state;
+
+			using var input = new MemoryStream( bytes, 4, bytes.Length - 4 );
+			using var zlib = new ZLibStream( input, CompressionMode.Decompress );
+			using var reader = new StreamReader( zlib );
+
+			return reader.ReadToEnd();
+		}
+		catch
+		{
+			return state;
+		}
 	}
 }

--- a/engine/Sandbox.Tools/Qt/DockManager/DockWindow.cs
+++ b/engine/Sandbox.Tools/Qt/DockManager/DockWindow.cs
@@ -63,6 +63,8 @@ public partial class DockWindow : Window
 	/// </summary>
 	public void ResetLayout()
 	{
+		DockManager.CloseDockInstances();
+
 		foreach ( var dock in DockManager.DockTypes )
 			DockManager.SetDockState( dock.Title, false );
 

--- a/game/addons/tools/Code/Editor/AssetBrowser/MainAssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/MainAssetBrowser.cs
@@ -78,4 +78,11 @@ public class MainAssetBrowser : WrappedAssetBrowser
 		EditorUtility.InspectorObject = asset;
 		return true;
 	}
+
+	[Event( "tools.editorwindow.postcreateview" )]
+	private static void AddViewMenuButtons( Menu menu )
+	{
+		menu.AddSeparator();
+		menu.AddOption( "New Asset Browser", "create_new_folder", () => EditorWindow.DockManager.CreateDockInstance( "Asset Browser" ) );
+	}
 }


### PR DESCRIPTION
Fixes #11474
Fixes #11542

https://github.com/user-attachments/assets/5e018fb2-0547-478d-91dd-e4a7c7ed47a1

The docking migration keyed docks by title, so a second Asset Browser resolved to the first and creation short-circuited.

- Registered dock types can spawn extra floating instances with unique names (Asset Browser 2) that delete on close
- Saved layouts recreate missing instances on restore (the state is base64 + qCompress, decoded before scanning for instance names)
- Reset Layout closes extra instances
- Restores the pre-migration New Asset Browser option in the View menu, verbatim