### PR TITLE
Faster Transform.Lerp Transform.ToLocal and constructor

### DIFF
--- a/engine/Sandbox.System/Math/Transform.cs
+++ b/engine/Sandbox.System/Math/Transform.cs
@@ -61,7 +61,7 @@ public struct Transform : System.IEquatable<Transform>, IInterpolator<Transform>
 	{
 		Position = pos;
 		Rotation = Rotation.Identity;
-		Scale = 1.0f;
+		Scale = Vector3.One;
 	}
 
 	public Transform() : this( default )
@@ -154,19 +154,33 @@ public struct Transform : System.IEquatable<Transform>, IInterpolator<Transform>
 	public Transform ToLocal( in Transform child )
 	{
 		var rotInv = Rotation.Inverse;
+		var pos = (child.Position - Position) * rotInv;
+		var rot = rotInv * child.Rotation;
 
-		var localSafeScale = new Vector3(
-			Scale.x != 0f ? child.Scale.x / Scale.x : child.Scale.x,
-			Scale.y != 0f ? child.Scale.y / Scale.y : child.Scale.y,
-			Scale.z != 0f ? child.Scale.z / Scale.z : child.Scale.z
-		);
-
-		return new Transform
+		if ( Scale.Equals( Vector3.One ) && child.Scale.Equals( Vector3.One ) )
 		{
-			Position = ((child.Position - Position) * rotInv) / SafeScale,
-			Rotation = rotInv * child.Rotation,
-			Scale = localSafeScale
-		};
+			// Cheap conversion ignoring scale
+			return new Transform
+			{
+				Position = pos,
+				Rotation = rot,
+				Scale = Vector3.One
+			};
+		}
+		else
+		{
+			// Expensive conversion with scale
+			return new Transform
+			{
+				Position = pos / SafeScale,
+				Rotation = rot,
+				Scale = new Vector3(
+					Scale.x != 0f ? child.Scale.x / Scale.x : child.Scale.x,
+					Scale.y != 0f ? child.Scale.y / Scale.y : child.Scale.y,
+					Scale.z != 0f ? child.Scale.z / Scale.z : child.Scale.z
+				),
+			};
+		}
 	}
 
 	/// <summary>
@@ -187,11 +201,14 @@ public struct Transform : System.IEquatable<Transform>, IInterpolator<Transform>
 	/// </summary>
 	public static Transform Lerp( in Transform a, in Transform b, float t, bool clamp )
 	{
+		if ( clamp ) t = t.Clamp( 0, 1 );
+		if ( t == 0f ) return a;
+		if ( t == 1f ) return b;
 		return new Transform
 		{
-			Position = Vector3.Lerp( a.Position, b.Position, t, clamp ),
-			Rotation = Rotation.Slerp( a.Rotation, b.Rotation, t, clamp ),
-			Scale = Vector3.Lerp( a.Scale, b.Scale, t, clamp ),
+			Position = Vector3.Lerp( a.Position, b.Position, t, false ),
+			Rotation = Rotation.Slerp( a.Rotation, b.Rotation, t, false ),
+			Scale = Vector3.Lerp( a.Scale, b.Scale, t, false ),
 		};
 	}
 

--- a/engine/Sandbox.System/Math/Transform.cs
+++ b/engine/Sandbox.System/Math/Transform.cs
@@ -154,33 +154,14 @@ public struct Transform : System.IEquatable<Transform>, IInterpolator<Transform>
 	public Transform ToLocal( in Transform child )
 	{
 		var rotInv = Rotation.Inverse;
-		var pos = (child.Position - Position) * rotInv;
-		var rot = rotInv * child.Rotation;
+		var scale = SafeScale;
 
-		if ( Scale.Equals( Vector3.One ) && child.Scale.Equals( Vector3.One ) )
+		return new Transform
 		{
-			// Cheap conversion ignoring scale
-			return new Transform
-			{
-				Position = pos,
-				Rotation = rot,
-				Scale = Vector3.One
-			};
-		}
-		else
-		{
-			// Expensive conversion with scale
-			return new Transform
-			{
-				Position = pos / SafeScale,
-				Rotation = rot,
-				Scale = new Vector3(
-					Scale.x != 0f ? child.Scale.x / Scale.x : child.Scale.x,
-					Scale.y != 0f ? child.Scale.y / Scale.y : child.Scale.y,
-					Scale.z != 0f ? child.Scale.z / Scale.z : child.Scale.z
-				),
-			};
-		}
+			Position = (child.Position - Position) * rotInv / scale,
+			Rotation = rotInv * child.Rotation,
+			Scale = child.Scale / scale
+		};
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
`Transform.Lerp` and `Transform.ToLocal` as well as the constructor were all a bit more expensive than they usually need to be.

## Motivation & Context
Easier than optimizing my animation system lol

## Implementation Details
The Transform constructor previously used the shorthand `Scale = 1.0f`. Using `Scale = Vector3.One` instead saves having to go through a stack of `Vector3` constructors every time a transform is created

`Transform.ToLocal` does a lot of fairly complex stuff to handle scale, but I find that the vast majority of time I use it the scale on both transforms is set to 1. Under that assumption it now skips the scale calculation if both scales equal 1, making it roughly equal to `ToWorld` in terms of performance.

I tend to leave `Transform.Lerp` sitting at 0 or 1, adding specific checks for that saves a lot of time in my code, perhaps it will for others as well.

## Screenshots 
<img width="378" height="135" alt="image" src="https://github.com/user-attachments/assets/c2b54315-966c-4fb8-a1af-60f74e8eaba8" />
<img width="242" height="128" alt="image" src="https://github.com/user-attachments/assets/0982a166-45b2-4ff1-84e2-14d7801bc7dc" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂