### PR TITLE
Fix Hammer light_environment SkyColor not applying to DirectionalLight

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -726,7 +726,13 @@ file class MapComponentMapLoader : SceneMapLoader
 		}
 		else
 		{
-			light = go.Components.Create<DirectionalLight>();
+			var directional = go.Components.Create<DirectionalLight>();
+			directional.SkyColor =
+				kv.GetValue( "SkyColor", Color.White ) *
+				kv.GetValue( "SkyIntensity", 1.0f );
+
+
+			light = directional;
 		}
 
 		// Hammer lights have no concept of "hardness" — let's make them reasonably sharp by default.

--- a/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Map/MapInstance.cs
@@ -731,7 +731,6 @@ file class MapComponentMapLoader : SceneMapLoader
 				kv.GetValue( "SkyColor", Color.White ) *
 				kv.GetValue( "SkyIntensity", 1.0f );
 
-
 			light = directional;
 		}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Fixes the `SkyColor` property not being transferred from Hammer's `light_environment` entity to the generated `DirectionalLight` component.

The Sky Color selected in Hammer is now correctly preserved when the map is loaded instead of defaulting to `#00000000`.

## Motivation & Context

`light_environment` exposes a Sky Color property in Hammer, but when the compiled map is loaded, the generated `DirectionalLight` component does not receive this value.

As a result, `SkyColor` defaults to transparent black (`#00000000`), causing the expected ambient sky lighting to be missing.

Fixes: #11486

## Implementation Details

Ensures the Hammer `light_environment` Sky Color value is passed through when creating the corresponding `DirectionalLight` component.

This keeps the Hammer lighting configuration consistent with the generated scene component and prevents `SkyColor` from falling back to its default value.

## Screenshots / Videos (if applicable)

See #11486 for screenshots demonstrating the issue.

proof of work:

https://github.com/user-attachments/assets/fb04e5a8-39e9-418e-9bc9-24098f4a2b72


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂