### PR TITLE
Fix memory leak r.e. File Watchers over long editor sessions

### DIFF
--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -392,9 +392,8 @@ public class BaseFileSystem
 
 	internal FileWatch Watch( string pathglob = null )
 	{
-		watcher?.Dispose();
-		watcher = null;
-
+		// One recursive watcher feeds every FileWatch on this filesystem, so only ever build it once.
+		// Tearing it down and rebuilding it per caller churned a watcher over the whole mount tree.
 		if ( watcher == null )
 		{
 			watcher = system.Watch( "/" );

--- a/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.cs
@@ -31,9 +31,24 @@ class FolderNode : TreeNode<LocalAssetBrowser.Location>
 		}
 	}
 
-	~FolderNode()
+	/// <summary>
+	/// Release the watcher as soon as we leave the tree. A finalizer is no good here - an
+	/// enabled FileSystemWatcher is kept alive by its own pending overlapped read, so it
+	/// never becomes collectable and the finalizer never runs.
+	/// </summary>
+	protected internal override void OnRemoved()
 	{
-		watcher?.Dispose();
+		base.OnRemoved();
+
+		if ( watcher is null )
+			return;
+
+		watcher.EnableRaisingEvents = false;
+		watcher.Created -= OnExternalChanges;
+		watcher.Deleted -= OnExternalChanges;
+		watcher.Renamed -= OnExternalChanges;
+		watcher.Dispose();
+		watcher = null;
 	}
 
 	private void OnExternalChanges( object sender, FileSystemEventArgs e )

--- a/game/addons/tools/Code/Widgets/TreeView/TreeNode.cs
+++ b/game/addons/tools/Code/Widgets/TreeView/TreeNode.cs
@@ -66,8 +66,42 @@ public partial class TreeNode
 
 	public virtual void Clear()
 	{
+		foreach ( var child in children )
+		{
+			if ( child is null ) continue;
+
+			Release( child );
+		}
+
 		children.Clear();
 		Dirty();
+	}
+
+	/// <summary>
+	/// Called when this node has been dropped from the tree. Anything that needs releasing
+	/// deterministically - file watchers, native handles - should be released here. Nothing
+	/// else will do it for us, and the node isn't reused afterwards.
+	/// </summary>
+	protected internal virtual void OnRemoved()
+	{
+
+	}
+
+	/// <summary>
+	/// Drop a node and everything below it, giving each one a chance to release what it holds.
+	/// </summary>
+	internal static void Release( TreeNode node )
+	{
+		foreach ( var child in node.children )
+		{
+			if ( child is null ) continue;
+
+			Release( child );
+		}
+
+		node.children.Clear();
+		node.parent = null;
+		node.OnRemoved();
 	}
 
 	internal void InternalBuildChildren()
@@ -166,18 +200,29 @@ public partial class TreeNode
 
 	public void RemoveItem( TreeNode item )
 	{
-		item.parent = null;
 		children.Remove( item );
+		Release( item );
 
 		TreeView?.Dirty( this );
 	}
 
 	public void SetItems( IEnumerable<TreeNode> items )
 	{
-		children.Clear();
-		children.AddRange( items );
+		var incoming = items.ToArray();
 
-		foreach ( var item in items )
+		// Anything we're not keeping is being dropped, so let it clean up
+		foreach ( var child in children )
+		{
+			if ( child is null ) continue;
+			if ( incoming.Contains( child ) ) continue;
+
+			Release( child );
+		}
+
+		children.Clear();
+		children.AddRange( incoming );
+
+		foreach ( var item in incoming )
 		{
 			item.parent = this;
 		}

--- a/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
+++ b/game/addons/tools/Code/Widgets/TreeView/TreeView.cs
@@ -98,6 +98,17 @@ public partial class TreeView : BaseItemWidget
 		}
 	}
 
+	public override void OnDestroyed()
+	{
+		base.OnDestroyed();
+
+		// Closing the view drops the whole tree, so let every node release what it holds
+		foreach ( var node in _items.OfType<TreeNode>().ToArray() )
+		{
+			TreeNode.Release( node );
+		}
+	}
+
 	protected override void Rebuild()
 	{
 		Frame();


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Fixes file watcher leaks and unnecessary watcher recreation in the filesystem and Asset Browser.

Filesystem watchers are now disposed deterministically when their owning tree nodes are removed, while the shared `BaseFileSystem` watcher remains alive for the lifetime of the filesystem.

## Motivation & Context

Asset Browser folder nodes each create a `FileSystemWatcher`. These were previously cleaned up by a finalizer, but an enabled watcher and its event handlers can keep the node reachable, preventing the finalizer from running. Rebuilding folder trees could therefore leave watchers and their OS resources alive indefinitely.

Additionally, `BaseFileSystem.Watch()` disposed and recreated its shared recursive watcher whenever a logical `FileWatch` was added. This caused unnecessary watcher churn and introduced windows where filesystem events could be missed.

Fixes: N/A

## Implementation Details

- Reuses one recursive Zio watcher for each `BaseFileSystem`. It remains responsible for feeding all logical `FileWatch` subscriptions and is disposed with the filesystem.
- Adds a deterministic `TreeNode.OnRemoved()` lifecycle hook for releasing resources owned by tree nodes.
- Recursively releases removed subtrees from:
  - `TreeNode.Clear()`
  - `TreeNode.RemoveItem()`
  - `TreeNode.SetItems()`
  - `TreeView.OnDestroyed()`
- Ensures `SetItems()` only releases nodes that are not retained in the incoming collection.
- Replaces the `FolderNode` finalizer with deterministic cleanup in `OnRemoved()`.
- Disables watcher events, unsubscribes event handlers, disposes the watcher, and clears its reference when a folder node leaves the tree.

## Screenshots / Videos (if applicable)

N/A — this change affects resource lifetime and has no visible UI changes.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂