### PR TITLE
Update MeshComponent for ShadowsOnly with ExcludeGameLayer support

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Mesh/MeshComponent.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Mesh/MeshComponent.cs
@@ -112,6 +112,7 @@ public sealed class MeshComponent : Collider, ExecuteInEditor, ITintable, IMater
 			if ( _sceneObject.IsValid() )
 			{
 				_sceneObject.Flags.CastShadows = RenderType == ShadowRenderType.On || RenderType == ShadowRenderType.ShadowsOnly;
+				_sceneObject.Flags.ExcludeGameLayer = RenderType == ShadowRenderType.ShadowsOnly;
 			}
 		}
 	} = ShadowRenderType.On;
@@ -314,6 +315,7 @@ public sealed class MeshComponent : Collider, ExecuteInEditor, ITintable, IMater
 		_sceneObject.Tags.SetFrom( GameObject.Tags );
 		_sceneObject.ColorTint = Color;
 		_sceneObject.Flags.CastShadows = RenderType == ShadowRenderType.On || RenderType == ShadowRenderType.ShadowsOnly;
+		_sceneObject.Flags.ExcludeGameLayer = RenderType == ShadowRenderType.ShadowsOnly;
 		_sceneObject.Flags.IsStatic = GameObject.IsStatic;
 	}
 }


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Set `_sceneObject.Flags.ExcludeGameLayer` on `MeshComponent`, both in the `RenderType` setter and in `UpdateSceneObject()`, so `ShadowsOnly` mode actually hides the mesh's visual geometry while still casting shadows.

## Motivation & Context

`MeshComponent` didn't respect `ShadowsOnly`: the mesh stayed visible in Scene view and Play mode even with the render type set to shadows-only. Other renderers (e.g. `ModelRenderer`) already handle this correctly by excluding the object from the game layer, so I applied the same fix here.

Fixes: #11626

## Implementation Details

Added `_sceneObject.Flags.ExcludeGameLayer = RenderType == ShadowRenderType.ShadowsOnly;` in two places:
- The `RenderType` property setter, so the flag updates immediately when the mode is changed.
- `UpdateSceneObject()`, so the flag stays correct any time the scene object is rebuilt (e.g. after `RebuildRenderMesh()`), not just when `RenderType` changes directly.

## Screenshots / Videos (if applicable)

Old : 

https://github.com/user-attachments/assets/74181336-55e9-4a8a-a7bd-6c88ec1866a5

New: 

https://github.com/user-attachments/assets/26ca7901-a434-448a-91e1-32c40c617c93





## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂