### PR TITLE
Optimisation of Scene undo when working with prefab

### DIFF
--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
@@ -290,7 +290,6 @@ internal sealed class SceneUndoSnapshot : IDisposable
 				}
 				var serializeOptions = new GameObject.SerializeOptions { IgnoreChildren = !flags.HasFlag( GameObjectUndoFlags.Children ), IgnoreComponents = !flags.HasFlag( GameObjectUndoFlags.Components ) };
 				GameObjectRefs.Add( GameObjectReference.FromInstance( go ) );
-				if ( go.IsOutermostPrefabInstanceRoot ) go.PrefabInstance.RefreshPatch();
 
 				using var blobs = BlobDataSerializer.Capture();
 

--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Helpers;
+using Sandbox.Helpers;
 using System;
 using System.Text.Json.Nodes;
 
@@ -416,6 +416,27 @@ internal sealed class SceneUndoSnapshot : IDisposable
 
 	private Dictionary<Component, ComponentReference> _destroyedComponents { get; } = new();
 
+	// Prefab instance roots that need their cached patch recomputed, by id since undo/redo may recreate them
+	private readonly HashSet<Guid> _prefabRootsToRefresh = new();
+
+	/// <summary>
+	/// Recomputes the cached patch of the given instance roots. Unpatched instance changes get
+	/// discarded when the prefab refreshes.
+	/// </summary>
+	private static void RefreshPrefabPatches( Scene scene, IReadOnlyCollection<Guid> rootIds )
+	{
+		foreach ( var id in rootIds )
+		{
+			var root = scene.Directory.FindByGuid( id );
+
+			// May have been destroyed or unlinked since
+			if ( !root.IsValid() || !root.IsOutermostPrefabInstanceRoot )
+				continue;
+
+			root.PrefabInstance.RefreshPatch();
+		}
+	}
+
 	private bool _captureDestructions = false;
 
 	private bool _captureComponentCreations = false;
@@ -443,11 +464,10 @@ internal sealed class SceneUndoSnapshot : IDisposable
 		{
 			foreach ( var go in gos )
 			{
-				// Need to capture the prefab root and only the prefab root if we edited an instance
+				// Capture instance members directly, the root's patch is reconciled in RefreshPrefabPatches instead
 				if ( go.IsPrefabInstance )
 				{
-					_initalCapturedGameObjects[go.OutermostPrefabInstanceRoot] = GameObjectUndoFlags.All;
-					continue;
+					_prefabRootsToRefresh.Add( go.OutermostPrefabInstanceRoot.Id );
 				}
 
 				if ( _initalCapturedGameObjects.ContainsKey( go ) )
@@ -490,11 +510,10 @@ internal sealed class SceneUndoSnapshot : IDisposable
 
 		foreach ( var comp in builder.CapturedComponents )
 		{
-			// Need to capture the prefab root and only the prefab root if we edited an instance
+			// Same as above for components
 			if ( comp.GameObject.IsPrefabInstance )
 			{
-				_initalCapturedGameObjects[comp.GameObject.OutermostPrefabInstanceRoot] = GameObjectUndoFlags.All;
-				continue;
+				_prefabRootsToRefresh.Add( comp.GameObject.OutermostPrefabInstanceRoot.Id );
 			}
 
 			// only add if parent is not already watched or does not have component flag
@@ -598,16 +617,10 @@ internal sealed class SceneUndoSnapshot : IDisposable
 				continue;
 			}
 
+			// May have been moved into a prefab instance during the scope
 			if ( go.IsPrefabInstance )
 			{
-				disposeWatchedGameObjects[go.OutermostPrefabInstanceRoot] = GameObjectUndoFlags.All;
-			}
-
-			// We may have moved this object to a different prefab instance => update prefabroot instead of it
-			if ( go.Parent.IsValid() && go.Parent.IsPrefabInstance )
-			{
-				disposeWatchedGameObjects[go.Parent.OutermostPrefabInstanceRoot] = GameObjectUndoFlags.All;
-				continue;
+				_prefabRootsToRefresh.Add( go.OutermostPrefabInstanceRoot.Id );
 			}
 
 			if ( !disposeWatchedGameObjects.ContainsKey( go ) )
@@ -680,13 +693,14 @@ internal sealed class SceneUndoSnapshot : IDisposable
 				continue;
 			}
 
-			// Need to capture the prefab root and only the prefab root if we edited an instance
+			// Same as the initial capture
 			if ( comp.GameObject.IsPrefabInstance )
 			{
-				disposeWatchedGameObjects[comp.GameObject.OutermostPrefabInstanceRoot] = GameObjectUndoFlags.All;
+				_prefabRootsToRefresh.Add( comp.GameObject.OutermostPrefabInstanceRoot.Id );
 			}
+
 			// only add if parent is not already watched or does not have component flag
-			else if ( !_initalCapturedGameObjects.ContainsKey( comp.GameObject ) || !_initalCapturedGameObjects[comp.GameObject].Contains( GameObjectUndoFlags.Components ) )
+			if ( !_initalCapturedGameObjects.ContainsKey( comp.GameObject ) || !_initalCapturedGameObjects[comp.GameObject].Contains( GameObjectUndoFlags.Components ) )
 			{
 				disposeWatchedComponents.Add( comp );
 			}
@@ -709,8 +723,6 @@ internal sealed class SceneUndoSnapshot : IDisposable
 		var destroyedGameObjectRefs = _destroyedGameObjects.Select( x => x.Value ).ToArray();
 		var destroyedComponentRefs = _destroyedComponents.Select( x => x.Value ).ToArray();
 
-		var prefabInstanceRootsRequiringRefresh = new HashSet<GameObject>();
-
 		// if nothing changed, don't add an undo
 		if ( _initialState == disposeState )
 		{
@@ -722,6 +734,20 @@ internal sealed class SceneUndoSnapshot : IDisposable
 		{
 			_session.HasUnsavedChanges = true;
 		}
+
+		// Roots captured in patch form just refreshed their patch, don't do it twice
+		foreach ( var (go, flags) in disposeWatchedGameObjects )
+		{
+			if ( go.IsOutermostPrefabInstanceRoot && flags.HasFlag( GameObjectUndoFlags.Children ) )
+			{
+				_prefabRootsToRefresh.Remove( go.Id );
+			}
+		}
+
+		// Fold this scope's changes into the cached patches of the touched prefab instances
+		RefreshPrefabPatches( _session.Scene, _prefabRootsToRefresh );
+
+		var prefabRootsToRefresh = _prefabRootsToRefresh.ToArray();
 
 		// copy we want to avoid capture this
 		var preChangeStateCopy = _initialState;
@@ -770,6 +796,12 @@ internal sealed class SceneUndoSnapshot : IDisposable
 					{
 						goRef.Resolve( _session.Scene )?.Destroy();
 					}
+				}
+
+				// Reconcile patches after the batch flush, blob-backed components need their state back first
+				if ( preChangeStateCopy.Scene == null )
+				{
+					RefreshPrefabPatches( _session.Scene, prefabRootsToRefresh );
 				}
 
 				// At last restore selection

--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
@@ -288,12 +288,27 @@ internal sealed class SceneUndoSnapshot : IDisposable
 					Log.Info( $"Undo GameObjectSnapshot: GameObject queued for snapshot is not valid" );
 					continue;
 				}
-				var serializeOptions = new GameObject.SerializeOptions { IgnoreChildren = !flags.HasFlag( GameObjectUndoFlags.Children ), IgnoreComponents = !flags.HasFlag( GameObjectUndoFlags.Components ) };
+				var serializeOptions = new GameObject.SerializeOptions
+				{
+					IgnoreChildren = !flags.HasFlag( GameObjectUndoFlags.Children ),
+					IgnoreComponents = !flags.HasFlag( GameObjectUndoFlags.Components ),
+
+					// No children captured means no need for the patch form and its expensive RefreshPatch
+					SerializePrefabForDiff = go.IsOutermostPrefabInstanceRoot && !flags.HasFlag( GameObjectUndoFlags.Children ),
+				};
 				GameObjectRefs.Add( GameObjectReference.FromInstance( go ) );
 
 				using var blobs = BlobDataSerializer.Capture();
 
 				var json = go.Serialize( serializeOptions );
+
+				if ( serializeOptions.SerializePrefabForDiff )
+				{
+					// Don't let the restore treat the root as a nested instance and wipe its patch
+					json.Remove( GameObject.JsonKeys.EditorPrefabInstanceNestedSource );
+					json[GameObject.JsonKeys.EditorSkipPrefabBreakOnRefresh] = true;
+				}
+
 				blobs.SaveTo( json );
 				State.Add( json );
 				GameObjectNextSiblingRefs.Add( go.GetNextSibling( false ).IsValid() ? GameObjectReference.FromInstance( go.GetNextSibling( false ) ) : GameObjectReference.FromId( Guid.Empty ) );

--- a/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
+++ b/engine/Sandbox.Tools/Scene/Session/SceneEditorSession.Undo.cs
@@ -594,19 +594,20 @@ internal sealed class SceneUndoSnapshot : IDisposable
 		// add all gos still valid and not destroyed
 		foreach ( var (go, flags) in _initalCapturedGameObjects )
 		{
+			if ( !go.IsValid() || go.IsDestroyed )
+			{
+				continue;
+			}
+
 			if ( go.IsPrefabInstance )
 			{
 				disposeWatchedGameObjects[go.OutermostPrefabInstanceRoot] = GameObjectUndoFlags.All;
 			}
 
-			// We may have moved this object to a different prefab instance => update prefabroot instead of it 
+			// We may have moved this object to a different prefab instance => update prefabroot instead of it
 			if ( go.Parent.IsValid() && go.Parent.IsPrefabInstance )
 			{
 				disposeWatchedGameObjects[go.Parent.OutermostPrefabInstanceRoot] = GameObjectUndoFlags.All;
-				continue;
-			}
-			if ( !go.IsValid() || go.IsDestroyed )
-			{
 				continue;
 			}
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary - Motivation & Context

When doing any action with the scene mapping that involve a undo action, it was taking 2-3s, and i profile and discover that it would serialize twice for doing 1 action

(there is only 1 action done, you see the 2 part with serialization)
<img width="2891" height="1595" alt="image" src="https://github.com/user-attachments/assets/1564979d-b7c4-4e87-a622-cce07a624e79" />

## Motivation & Context
 
I use only scene mapping, and one of the biggest complain of my mappers when using it with prefab was #11630 
So i dig a bit using SuperLuminal and my friend JeanClaude and i discover that it would Serialize the prefab on ctor and dispose, so 2 time serialization + i think we could do it better for sure

This pr is made with help of ai but i did reread it and verify it myself to not doing shit, i dont have the holytruth but i tried it as i can and seem to work, might be good tackle some of these issues :)

## Implementation Details

Basicly i tried to break it down into multiples commit and limit the footprint:

- First i discover that there was a issue where it tried to access a `go.Parent` and `go.IsPrefabInstance` before the `!go.IsValid() || go.IsDestroyed`

- Then there was a duplicate of RefreshPatch when snapshotting prefab instance root, cause `GameObjectSnapshot` called `RefreshPatch()` explicitly right before `go.Serialize()`,
which already calls it internally via `SerializePrefabInstance`. Each call serializes and
diffs the whole instance, so every snapshot of an instance root paid that cost twice.

- Then it was the bigger and most important part, that was why it snapshotted the entire instance twice when undo due to `_initalCapturedGameObjects[OutermostPrefabInstanceRoot] = All`, now :

  - Edited objects/components are captured directly with their declared flags; the
  instance root's id is collected instead (by id — undo/redo can recreate objects).
  - `RefreshPrefabPatches` recomputes the cached patch of collected roots once at scope
  close. This keeps the contract the promotion satisfied implicitly: unpatched instance
  changes are discarded when the prefab refreshes, and the override indicators read it.
  - The undo/redo actions refresh the same roots after restoring, after the callback batch
  has flushed — deferred `PostDeserialize` rebuilds blob-backed component state (meshes)
  that patch serialization reads (hence the redo batch becoming block-scoped).
  - Roots still captured in patch form (flags include `Children`, e.g. deletions) already
  refresh during serialization and are skipped.

- Finally i made so if i simply move something, it will forces the standard serialization path via
`SerializePrefabForDiff`, storing just the root's own properties instead of the patch
form and its full-instance `RefreshPatch`.


## Screenshots / Videos (if applicable)
Before:
https://github.com/user-attachments/assets/ee104553-dc9c-460a-940d-b5a1c97ee3f9

After:
https://github.com/user-attachments/assets/673c72f8-f8b1-433f-b18a-b17af45ce5db


With that commit, now i can move easily the props i have, but it will freeze on dispose (around 1s time to serialize everything + my pr #11631 can help reduice the time), anyway my map is big so i'd except a 1s freeze sometimes, but i prefer it after release mouse / doing action, rather than on ctor when pressing mouse

Before (1 translation):
<img width="2891" height="1595" alt="image" src="https://github.com/user-attachments/assets/1564979d-b7c4-4e87-a622-cce07a624e79" />

After (2 translation):
<img width="3516" height="1286" alt="image" src="https://github.com/user-attachments/assets/36ca8f6e-cff4-421f-96d6-2f8fdd4cd8b1" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂