### PR TITLE
Make Collider static / MeshComponent flag as static GameObject

### DIFF
--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Serialize.cs
@@ -8,7 +8,7 @@ namespace Sandbox;
 
 public partial class GameObject
 {
-	internal const int GameObjectVersion = 2;
+	internal const int GameObjectVersion = 3;
 
 	// The only flags we actually save. Everything else is runtime junk (Loading, Bone, etc) and saving it
 	// just causes phantom Flags overrides in prefab diffs. Networking is the exception, see below.

--- a/engine/Sandbox.Engine/Scene/GameObject/GameObject.Version03.cs
+++ b/engine/Sandbox.Engine/Scene/GameObject/GameObject.Version03.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Nodes;
+
+namespace Sandbox;
+
+public partial class GameObject
+{
+	/// <summary>
+	/// Before GameObjectFlags.Static, static was authored per component. Flag objects with a
+	/// static Collider or a MeshComponent (always level geometry). Rigidbodies are never static.
+	/// </summary>
+	[Expose, JsonUpgrader( typeof( GameObject ), 3 )]
+	internal static void Upgrader_v3( JsonObject obj )
+	{
+		if ( obj[JsonKeys.Components] is not JsonArray components )
+			return;
+
+		if ( Game.TypeLibrary is null )
+			return;
+
+		var flags = (GameObjectFlags)obj.GetPropertyValue( JsonKeys.Flags, 0L );
+		if ( flags.Contains( GameObjectFlags.Static ) )
+			return;
+
+		var isStatic = false;
+
+		foreach ( var componentNode in components )
+		{
+			if ( componentNode is not JsonObject component )
+				continue;
+
+			var typeName = component.GetPropertyValue( Component.JsonKeys.Type, "" );
+			if ( string.IsNullOrEmpty( typeName ) )
+				continue;
+
+			var type = Game.TypeLibrary.GetType<Component>( typeName, true );
+			if ( type is null )
+				continue;
+
+			// Rigidbody means this is a physics object
+			if ( type.TargetType.IsAssignableTo( typeof( Rigidbody ) ) )
+				return;
+
+			if ( type.TargetType.IsAssignableTo( typeof( MeshComponent ) ) )
+			{
+				isStatic = true;
+			}
+			else if ( type.TargetType.IsAssignableTo( typeof( Collider ) ) )
+			{
+				if ( component.GetPropertyValue( nameof( Collider.Static ), false ) )
+					isStatic = true;
+			}
+		}
+
+		if ( !isStatic )
+			return;
+
+		obj[JsonKeys.Flags] = (long)(flags | GameObjectFlags.Static);
+	}
+}

--- a/engine/Tests/Sandbox.Test.Engine/Scene/GameObjects/JsonUpgrader.Version03.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Scene/GameObjects/JsonUpgrader.Version03.cs
@@ -1,0 +1,167 @@
+using Sandbox.Internal;
+using SceneTests;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace SceneTests.GameObjects;
+
+[TestClass]
+[DoNotParallelize]
+public class JsonUpgrader03Test : SceneTest
+{
+	TypeLibrary TypeLibrary;
+
+	private TypeLibrary _oldTypeLibrary;
+
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		// Replace TypeLibrary / NodeLibrary with mocked ones, store the originals
+
+		_oldTypeLibrary = Game.TypeLibrary;
+
+		TypeLibrary = new Sandbox.Internal.TypeLibrary();
+		TypeLibrary.AddAssembly( typeof( ModelRenderer ).Assembly, false );
+		TypeLibrary.AddAssembly( typeof( PrefabFile ).Assembly, false );
+		JsonUpgrader.UpdateUpgraders( TypeLibrary );
+
+		Game.TypeLibrary = TypeLibrary;
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		// Make sure our mocked TypeLibrary doesn't leak out, restore old ones
+		Game.TypeLibrary = _oldTypeLibrary;
+	}
+
+	static JsonObject MakeGameObjectJson( string componentsJson, long flags = 0 )
+	{
+		var json = $$"""
+		{
+			"__guid": "5d6dad9b-96d1-45c3-a7c4-1412b8570422",
+			"Flags": {{flags}},
+			"Name": "thing",
+			"Position": "0,0,0",
+			"Enabled": true,
+			"Components": [ {{componentsJson}} ]
+		}
+		""";
+
+		return JsonNode.Parse( json ).AsObject();
+	}
+
+	static GameObjectFlags GetFlags( JsonObject jsonObject )
+	{
+		return (GameObjectFlags)jsonObject["Flags"].Deserialize<long>();
+	}
+
+	[TestMethod]
+	public void StaticColliderFlagsObjectStatic()
+	{
+		var jsonObject = MakeGameObjectJson( """
+			{
+				"__type": "Sandbox.ModelCollider",
+				"__guid": "6d5f6a19-f1ae-4270-b2b7-6a0cd0abf0c1",
+				"Static": true
+			}
+			""" );
+
+		GameObject.Upgrader_v3( jsonObject );
+
+		Assert.IsTrue( GetFlags( jsonObject ).Contains( GameObjectFlags.Static ) );
+	}
+
+	[TestMethod]
+	public void NonStaticColliderLeavesObjectAlone()
+	{
+		var jsonObject = MakeGameObjectJson( """
+			{
+				"__type": "Sandbox.ModelCollider",
+				"__guid": "6d5f6a19-f1ae-4270-b2b7-6a0cd0abf0c1",
+				"Static": false
+			}
+			""" );
+
+		GameObject.Upgrader_v3( jsonObject );
+
+		Assert.IsFalse( GetFlags( jsonObject ).Contains( GameObjectFlags.Static ) );
+	}
+
+	[TestMethod]
+	public void MeshComponentFlagsObjectStatic()
+	{
+		// MeshComponents are level geometry, presence alone marks it static
+		var jsonObject = MakeGameObjectJson( """
+			{
+				"__type": "Sandbox.MeshComponent",
+				"__guid": "6d5f6a19-f1ae-4270-b2b7-6a0cd0abf0c1",
+				"Static": false,
+				"Collision": "Hull"
+			}
+			""" );
+
+		GameObject.Upgrader_v3( jsonObject );
+
+		Assert.IsTrue( GetFlags( jsonObject ).Contains( GameObjectFlags.Static ) );
+	}
+
+	[TestMethod]
+	public void RigidbodyNeverStatic()
+	{
+		// Rigidbody wins over the static collider
+		var jsonObject = MakeGameObjectJson( """
+			{
+				"__type": "Sandbox.Rigidbody",
+				"__guid": "6d5f6a19-f1ae-4270-b2b7-6a0cd0abf0c1",
+				"MotionEnabled": false
+			},
+			{
+				"__type": "Sandbox.ModelCollider",
+				"__guid": "83b2e5a2-2f61-4d68-9d5e-0f4a53b6e1d2",
+				"Static": true
+			}
+			""" );
+
+		GameObject.Upgrader_v3( jsonObject );
+
+		Assert.IsFalse( GetFlags( jsonObject ).Contains( GameObjectFlags.Static ) );
+	}
+
+	[TestMethod]
+	public void ExistingFlagsArePreserved()
+	{
+		var jsonObject = MakeGameObjectJson( """
+			{
+				"__type": "Sandbox.BoxCollider",
+				"__guid": "6d5f6a19-f1ae-4270-b2b7-6a0cd0abf0c1",
+				"Static": true
+			}
+			""", flags: (long)GameObjectFlags.Hidden );
+
+		GameObject.Upgrader_v3( jsonObject );
+
+		var flags = GetFlags( jsonObject );
+
+		Assert.IsTrue( flags.Contains( GameObjectFlags.Static ) );
+		Assert.IsTrue( flags.Contains( GameObjectFlags.Hidden ), "upgrading must not clear existing flags" );
+	}
+
+	[TestMethod]
+	public void VersionMachineryRunsUpgrader()
+	{
+		// No explicit call - the machinery should find it by version and stamp it
+		var jsonObject = MakeGameObjectJson( """
+			{
+				"__type": "Sandbox.ModelCollider",
+				"__guid": "6d5f6a19-f1ae-4270-b2b7-6a0cd0abf0c1",
+				"Static": true
+			}
+			""" );
+
+		JsonUpgrader.Upgrade( 2, jsonObject, typeof( GameObject ) );
+
+		Assert.IsTrue( GetFlags( jsonObject ).Contains( GameObjectFlags.Static ) );
+		Assert.AreEqual( 3, jsonObject["__version"].Deserialize<int>() );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Engine/Scene/GameObjects/SerializeCoverage.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Scene/GameObjects/SerializeCoverage.cs
@@ -93,7 +93,7 @@ public class SerializeCoverageTest : SceneTest
 		var node = go.Serialize();
 
 		Assert.AreEqual( go.Id, node["__guid"].Deserialize<Guid>() );
-		Assert.AreEqual( 2, node["__version"].GetValue<int>() );
+		Assert.AreEqual( 3, node["__version"].GetValue<int>() );
 		Assert.AreEqual( "Core", node["Name"].GetValue<string>() );
 		Assert.IsTrue( node["Enabled"].GetValue<bool>() );
 		Assert.AreEqual( new Vector3( 1, 2, 3 ), node["Position"].GetValue<Vector3>() );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Now when upgraded the GameObject gonna look if it's a static Collider or MeshComponent and flag the GO as static directly

## Motivation & Context

Since sam has added static shadow almost no one has been able to experiment it since by default nothing is flagged as static and it need manually click on static button
I was like why isnt it automatic ?

## Implementation Details

Simply a upgrader that does that check

## Screenshots / Videos (if applicable)

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂