### PR TITLE
[Terrain] Make normal dirty when painting

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Terrain/Terrain.Edit.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Terrain/Terrain.Edit.cs
@@ -105,6 +105,13 @@ public partial class Terrain
 	/// <summary>
 	/// Updates the GPU texture maps with the CPU data
 	/// </summary>
+
+	/// <summary>
+	/// Call after modifying the GPU height map texture directly (e.g. an editor sculpt compute dispatch).
+	/// Schedules a rebake of the baked normal/AO maps so shading updates live during a brush stroke.
+	/// </summary>
+	public void NotifyHeightMapEdited() => RebakeNormalMap();
+
 	public void SyncGPUTexture()
 	{
 		HeightMap.Update( new ReadOnlySpan<ushort>( Storage.HeightMap ) );

--- a/engine/Sandbox.Engine/Scene/Components/Terrain/Terrain.Rendering.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Terrain/Terrain.Rendering.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Rendering;
+using Sandbox.Rendering;
 using System.Runtime.InteropServices;
 using static Sandbox.ModelRenderer;
 

--- a/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
@@ -1,4 +1,4 @@
-using Sandbox;
+﻿using Sandbox;
 
 namespace Editor.TerrainEditor;
 
@@ -241,6 +241,9 @@ public abstract class BaseBrushTool : EditorTool
 
 		// Grow the dirty region (+1 to be conservative of the floor) 
 		_dirtyRegion.Add( new RectInt( x, y, size + 1, size + 1 ) );
+
+		// Heights changed on the GPU - schedule a normal rebake for live feedback
+		terrain.NotifyHeightMapEdited();
 	}
 
 	T[] CopyRegion<T>( T[] data, int stride, RectInt rect ) where T : unmanaged


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Will bake the normal as we paint, so it's easier to see what we do

## Motivation & Context

SO since the normal has been baked for perf purpose, when painting there was a lag before see the shadow change, and it lead to issue while painting that wasnt present before, so i made it dirty as we paint

Fixes: #11508

## Implementation Details
Simply make it dirty into the OnPaint

## Screenshots / Videos (if applicable)

Before:

https://github.com/user-attachments/assets/5de3ef78-e755-4db3-a68a-1bb1fbdacb07

After:
https://github.com/user-attachments/assets/0169e617-1e02-4899-8413-33cb6b747c31

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂