### PR TITLE
Add open_scene MCP tool to switch/open scene tabs

### DIFF
--- a/game/addons/tools/Code/Mcp/Scene.cs
+++ b/game/addons/tools/Code/Mcp/Scene.cs
@@ -18,16 +18,32 @@ public static partial class SceneTools
 	{
 		return new OpenSceneList
 		{
-			Scenes = SceneEditorSession.All.Select( session => new OpenScene
-			{
-				Name = session.Scene?.Name,
-				ResourcePath = session.Scene?.Source?.ResourcePath,
-				Type = session is GameEditorSession ? "Game" : session.Scene is PrefabScene ? "Prefab" : "Scene",
-				IsActive = session == SceneEditorSession.Active,
-				HasUnsavedChanges = session.HasUnsavedChanges,
-				RootObjectCount = session.Scene?.Children.Count ?? 0
-			} ).ToArray()
+			Scenes = SceneEditorSession.All.Select( SceneRow ).ToArray()
 		};
+	}
+
+	/// <summary>
+	/// Make a scene the active editor tab. Opens it from its asset path if it isn't open.
+	/// Scene edits always target the active scene, so switch before editing a background scene.
+	/// </summary>
+	/// <param name="scene">Scene name or resource path from list_scenes, or a .scene/.prefab path from asset_search.</param>
+	[McpTool( "open_scene" )]
+	public static OpenScene OpenSceneTab( string scene )
+	{
+		if ( Game.IsPlaying )
+			throw new Exception( "Can't switch scene tabs while playing - play_stop first" );
+
+		var session = ResolveSession( scene );
+
+		if ( session is GameEditorSession )
+			throw new Exception( "That's the running game session, which has no tab to switch to - play_stop first, then open the scene you want to edit" );
+
+		session ??= SceneEditorSession.CreateFromPath( scene )
+			?? throw new Exception( $"Nothing to open for '{scene}' - list_scenes shows what's already open, asset_search type:scene finds scene assets on disk" );
+
+		session.MakeActive();
+
+		return SceneRow( session );
 	}
 
 	/// <summary>
@@ -1007,12 +1023,34 @@ public static partial class SceneTools
 				?? throw new Exception( "No scene is open in the editor" );
 		}
 
-		var match = SceneEditorSession.All
-			.Select( x => x.Scene )
-			.FirstOrDefault( x => string.Equals( x?.Name, nameOrPath, StringComparison.OrdinalIgnoreCase )
-				|| string.Equals( x?.Source?.ResourcePath, nameOrPath, StringComparison.OrdinalIgnoreCase ) );
+		return ResolveSession( nameOrPath )?.Scene
+			?? throw new Exception( $"No open scene matches '{nameOrPath}' - list_scenes shows what's open" );
+	}
 
-		return match ?? throw new Exception( $"No open scene matches '{nameOrPath}' - list_scenes shows what's open" );
+	/// <summary>
+	/// The open session whose scene matches a name or resource path. Null when nothing matches.
+	/// </summary>
+	private static SceneEditorSession ResolveSession( string nameOrPath )
+	{
+		return SceneEditorSession.All
+			.FirstOrDefault( x => string.Equals( x.Scene?.Name, nameOrPath, StringComparison.OrdinalIgnoreCase )
+				|| string.Equals( x.Scene?.Source?.ResourcePath, nameOrPath, StringComparison.OrdinalIgnoreCase ) );
+	}
+
+	/// <summary>
+	/// One session as list_scenes and open_scene report it.
+	/// </summary>
+	private static OpenScene SceneRow( SceneEditorSession session )
+	{
+		return new OpenScene
+		{
+			Name = session.Scene?.Name,
+			ResourcePath = session.Scene?.Source?.ResourcePath,
+			Type = session is GameEditorSession ? "Game" : session.Scene is PrefabScene ? "Prefab" : "Scene",
+			IsActive = session == SceneEditorSession.Active,
+			HasUnsavedChanges = session.HasUnsavedChanges,
+			RootObjectCount = session.Scene?.Children.Count ?? 0
+		};
 	}
 
 	private static GameObject FindByGuid( string id )


### PR DESCRIPTION
## Summary

Adds `open_scene` to the scene MCP toolset — makes a scene the active editor tab, opening it from its asset path first if it isn't open. Fills the gap where MCP clients could read background scenes but never change which scene is active, and mutating tools (set_component, save_scene, undo) always target the active session.

## Motivation & Context

Fixes: #11637

MCP clients could read and list background scenes, but edits aimed at them silently lose data. FindByGuid takes the first match across all open sessions, so `set_component` aimed at a background tab's component does mutate that object — but the dirty flag lands on the active tab, `save_scene` saves the active scene, and the background scene reloads from disk on focus, discarding the change with no error anywhere. The only workaround was asking a human to click the tab. This tool closes that gap by letting MCP clients make the right scene active before editing it.

## Implementation Details

- Built on existing public API: `SceneEditorSession.MakeActive()` (the same call SceneTabWidget makes on tab click) and `SceneEditorSession.CreateFromPath()`, which already returns the existing session when the scene is open.
- Method is named `OpenSceneTab` because SceneTools already nests the `OpenScene` DTO; a second public method would trigger CS0102. The tool name in the MCP schema is still `open_scene`.
- No undo step, deliberately: tab focus is editor UI state, not scene state. The schema description warns that scene edits target the active scene, so callers know the contract.
- Refuses during play with a message pointing at `play_stop`. A second guard refuses `GameEditorSession` specifically — it has no tab, so `MakeActive` would half-switch the editor invisibly. In practice the play guard fires first, making this defense-in-depth for the transient state where a game session exists while `IsPlaying` is false.
- Two small shared helpers extracted: the existing `ResolveScene` now delegates to a new `ResolveSession` (its error message unchanged), and `list_scenes` row construction moved to a `SceneRow` helper both tools now use.
- Verified in a source-built editor over MCP: registration and schema, open-from-disk, tab switch by name and by path (viewport follows), no-op on already-active, both error paths returning proper `isError` results with no console exceptions, play-mode guard, and regressions on `list_scenes` shape and `scene_tree`'s explicit-scene argument including its exact not-found message. Manual Ctrl+Z after eight `open_scene` calls confirmed no undo steps pushed.

## Screenshots / Videos (if applicable)

This is a headless-visible change — tool results and tab focus in the editor. No screenshots apply.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
  - The MCP tool layer has no unit test harness; verification was manual over MCP as described above.
- [x] I'm okay with this PR being rejected or requested to change 🙂
