### PR TITLE
Fix editor_status reporting the game scene instead of the active editor tab

### DIFF
--- a/engine/Sandbox.Tools/Mcp/TopLevelTools.cs
+++ b/engine/Sandbox.Tools/Mcp/TopLevelTools.cs
@@ -143,7 +143,7 @@ internal static class TopLevelTools
 	[Description( "Get the current state of the editor - engine version, which project is open, the active scene and whether it has unsaved changes, whether play mode is running or paused, how many tools are registered, the directory paths that matter (logs, project code and assets), and the state of the code compiler. Check IsCompiling/LastCompileSucceeded here after editing code instead of relying on read_console - a successful compile can scroll out of view or be mistaken for the last failure you saw." )]
 	public static EditorStatus GetEditorStatus()
 	{
-		var scene = Game.ActiveScene;
+		var scene = SceneEditorSession.Active?.Scene ?? Game.ActiveScene;
 		var compileGroup = Project.CompileGroup;
 		var buildResult = compileGroup?.BuildResult;
 

--- a/engine/Tests/Sandbox.Test.Engine/Mcp/EditorStatus.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Mcp/EditorStatus.cs
@@ -1,0 +1,116 @@
+using Editor;
+using Editor.Mcp;
+using SceneTests;
+using System;
+
+namespace McpTests;
+
+/// <summary>
+/// <para>
+/// editor_status reports the scene the user is looking at, which is the active editor
+/// session's scene - not the game scene. Reading Game.ActiveScene instead made the tool
+/// report the wrong scene (or none at all) whenever the two differed.
+/// </para>
+/// <para>
+/// Reproduces <see href="https://github.com/Facepunch/sbox-public/issues/11640">Facepunch/sbox-public#11640</see>.
+/// </para>
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class EditorStatusTest : SceneTest
+{
+	/// <summary>
+	/// <see cref="TopLevelTools.GetEditorStatus"/> reports FileSystem.Root, which this tier
+	/// never initializes - Bootstrap is what normally does it, and Bootstrap never runs here.
+	/// Point it at the game folder (already the working directory, see the assembly fixture)
+	/// with the base folder mounts skipped, since nothing here reads content.
+	/// </summary>
+	[ClassInitialize]
+	public static void InitializeFilesystem( TestContext context )
+	{
+		if ( EngineFileSystem.Root is null )
+		{
+			EngineFileSystem.Initialize( Environment.CurrentDirectory, skipBaseFolderInit: true );
+		}
+	}
+
+	/// <summary>
+	/// Editor sessions live in a static list, so a session left behind would change what the
+	/// next test's editor_status reports. Destroy is the supported teardown and is headless
+	/// safe: it has no game session to stop, and the editor window and scene dock it would
+	/// otherwise touch are both null outside the editor.
+	/// </summary>
+	[TestCleanup]
+	public void DestroyRemainingSessions()
+	{
+		foreach ( var session in SceneEditorSession.All.ToArray() )
+		{
+			session.Destroy();
+		}
+
+		Assert.IsNull( SceneEditorSession.Active, "A session survived teardown" );
+	}
+
+	/// <summary>
+	/// A GameEditorSession is the session type that can be built headlessly - the plain
+	/// SceneEditorSession constructor is protected and creates a scene dock, which needs an
+	/// editor window. The parent is only used by StopPlaying and FrameTo, neither of which
+	/// this test calls.
+	/// </summary>
+	static SceneEditorSession Session( string sceneName )
+	{
+		var scene = new Scene { Name = sceneName };
+
+		return new GameEditorSession( null, scene );
+	}
+
+	/// <summary>
+	/// The reported active scene is the active session's scene.
+	/// </summary>
+	[TestMethod]
+	public void ReportsTheActiveSessionsScene()
+	{
+		Session( "My Editor Scene" ).MakeActive();
+
+		Assert.AreEqual( "My Editor Scene", TopLevelTools.GetEditorStatus().ActiveScene );
+	}
+
+	/// <summary>
+	/// With several sessions open it follows whichever one is active, which is the tab the
+	/// user is actually looking at.
+	/// </summary>
+	[TestMethod]
+	public void FollowsWhicheverSessionIsActive()
+	{
+		var first = Session( "First Scene" );
+		var second = Session( "Second Scene" );
+
+		first.MakeActive();
+
+		Assert.AreEqual( "First Scene", TopLevelTools.GetEditorStatus().ActiveScene );
+
+		second.MakeActive();
+
+		Assert.AreEqual( "Second Scene", TopLevelTools.GetEditorStatus().ActiveScene );
+	}
+
+	/// <summary>
+	/// A scene the user hasn't touched reports no unsaved changes, and an unsaved scene has
+	/// no source path - both read off the same active session.
+	/// </summary>
+	[TestMethod]
+	public void ReportsTheActiveSessionsSaveState()
+	{
+		var session = Session( "Unsaved Scene" );
+		session.MakeActive();
+
+		var status = TopLevelTools.GetEditorStatus();
+
+		Assert.IsFalse( status.SceneHasUnsavedChanges );
+		Assert.IsNull( status.ActiveScenePath );
+
+		session.HasUnsavedChanges = true;
+
+		Assert.IsTrue( TopLevelTools.GetEditorStatus().SceneHasUnsavedChanges );
+	}
+}


### PR DESCRIPTION
## Summary

Fix editor_status to report the active editor tab's scene instead of always reporting the game scene.

## Motivation & Context

editor_status was reporting ActiveScene:"Scene" and ActiveScenePath:null regardless of which editor tab was focused. Meanwhile, list_scenes returned the correct scene for the focused tab. This inconsistency broke MCP tooling that relies on editor_status to know which scene is being edited.

The root cause: editor_status read Game.ActiveScene, which is the game scene handle, not the editor tab. The line below it already read the correct source — SceneHasUnsavedChanges comes from SceneEditorSession.Active — and the same resolution idiom appears in SceneTools.ResolveScene's empty-string case.

Before this fix, a single editor_status response could report one scene's name alongside a different scene's dirty flag, since both properties came from different sources.

Fixes: #11639

## Implementation Details

Changed line 146 in TopLevelTools.cs from:
```
var scene = Game.ActiveScene;
```
to:
```
var scene = SceneEditorSession.Active?.Scene ?? Game.ActiveScene;
```

This reads the active editor tab's scene (SceneEditorSession.Active?.Scene) with Game.ActiveScene as fallback — the same source of truth used by SceneHasUnsavedChanges on the next line and SceneTools.ResolveScene elsewhere. No schema or description changes needed; the existing tool description ("the active scene and whether it has unsaved changes") now matches the actual behaviour.

Verification so far: compile-verified (Release, TreatWarningsAsErrors=true, 0 warnings). Behavioural verification over MCP needs an editor restarted against the rebuilt DLL — I'll post the results as a comment here once done (repro steps are in #11639).

## Screenshots / Videos (if applicable)

None — internal fix, no visual change.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
  - Regression test added in Sandbox.Test.Engine: fails on master (ActiveScene comes back null headless), passes with this fix.
- [x] I'm okay with this PR being rejected or requested to change 🙂
