### PR TITLE
Add foundational MCP unit test suite

### DIFF
--- a/engine/Tests/Sandbox.Test.Engine/Mcp/Binding.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Mcp/Binding.cs
@@ -1,0 +1,176 @@
+using Editor.Mcp;
+using SceneTests;
+using System.Text.Json.Nodes;
+
+namespace McpTests;
+
+/// <summary>
+/// Argument binding is where an agent's guess meets the tool's signature, so what binds,
+/// what clamps and what fails loudly is behaviour the agent depends on. These go through
+/// <see cref="ToolRegistry.Invoke"/> against the fixture tools, on a thread marked as the
+/// main thread so tools execute inline.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class ToolBindingTest : SceneTest
+{
+	static JsonObject Args( string json ) => JsonNode.Parse( json ).AsObject();
+
+	/// <summary>
+	/// A well formed call binds every argument and hands back the method's return value.
+	/// </summary>
+	[TestMethod]
+	public void CorrectCallRoundTrips()
+	{
+		var result = McpFixture.Invoke( "mcp_test_echo", Args( """{ "text": "hi", "count": 2 }""" ) );
+
+		Assert.AreEqual( "hi hi", result );
+	}
+
+	/// <summary>
+	/// Omitted optional arguments fall back to the method's defaults.
+	/// </summary>
+	[TestMethod]
+	public void OmittedArgumentsUseTheirDefaults()
+	{
+		Assert.AreEqual( "hi", McpFixture.Invoke( "mcp_test_echo", Args( """{ "text": "hi" }""" ) ) );
+	}
+
+	/// <summary>
+	/// Argument names bind case insensitively - agents produce all sorts of casing.
+	/// </summary>
+	[TestMethod]
+	public void ArgumentNamesBindCaseInsensitively()
+	{
+		Assert.AreEqual( "HI", McpFixture.Invoke( "mcp_test_echo", Args( """{ "TEXT": "hi", "Shout": true }""" ) ) );
+	}
+
+	/// <summary>
+	/// A name the tool doesn't take is a typo or a schema misread, so it fails loudly rather
+	/// than being silently ignored, and the error lists what the tool does take.
+	/// </summary>
+	[TestMethod]
+	public void UnknownArgumentIsRejected()
+	{
+		var e = Assert.ThrowsException<McpException>( () => { _ = McpFixture.Invoke( "mcp_test_echo", Args( """{ "text": "hi", "txt": 1 }""" ) ); } );
+
+		StringAssert.Contains( e.Message, "Unknown argument 'txt'" );
+		StringAssert.Contains( e.Message, "text (string)" );
+		StringAssert.Contains( e.Message, "count (integer, optional)" );
+	}
+
+	/// <summary>
+	/// A missing argument with no default errors, naming the argument.
+	/// </summary>
+	[TestMethod]
+	public void MissingRequiredArgumentIsRejected()
+	{
+		var e = Assert.ThrowsException<McpException>( () => { _ = McpFixture.Invoke( "mcp_test_echo", Args( "{ }" ) ); } );
+
+		StringAssert.Contains( e.Message, "Missing required argument 'text'" );
+	}
+
+	/// <summary>
+	/// A near miss on a tool name comes back with the tool it probably meant, so an agent
+	/// can correct itself in one turn instead of listing the whole registry.
+	/// </summary>
+	[TestMethod]
+	public void UnknownToolSuggestsTheNearMiss()
+	{
+		var e = Assert.ThrowsException<McpException>( () => { _ = McpFixture.Invoke( "mcp_test_ech", null ); } );
+
+		StringAssert.Contains( e.Message, "Unknown tool 'mcp_test_ech'" );
+		StringAssert.Contains( e.Message, "Did you mean" );
+		StringAssert.Contains( e.Message, "mcp_test_echo" );
+	}
+
+	/// <summary>
+	/// A tool name that resembles nothing gets no suggestion, just the pointer to search_tools.
+	/// </summary>
+	[TestMethod]
+	public void UnfamiliarToolNameGetsNoSuggestion()
+	{
+		var e = Assert.ThrowsException<McpException>( () => { _ = McpFixture.Invoke( "zzqqxx", null ); } );
+
+		StringAssert.Contains( e.Message, "Unknown tool 'zzqqxx'" );
+		Assert.IsFalse( e.Message.Contains( "Did you mean" ), e.Message );
+	}
+
+	/// <summary>
+	/// Vectors and angles arrive as the comma strings the schema advertises.
+	/// </summary>
+	[TestMethod]
+	public void MathTypesBindFromCommaStrings()
+	{
+		var result = McpFixture.Invoke( "mcp_test_vector", Args( """{ "position": "1,2,3", "angles": "0,90,0" }""" ) );
+
+		Assert.AreEqual( "1|2|3|90", result );
+	}
+
+	/// <summary>
+	/// Enum names bind whatever their case.
+	/// </summary>
+	[TestMethod]
+	public void EnumBindsCaseInsensitively()
+	{
+		Assert.AreEqual( nameof( McpTestMode.Slow ), McpFixture.Invoke( "mcp_test_mode", Args( """{ "mode": "slow" }""" ) ) );
+	}
+
+	/// <summary>
+	/// A value outside a [Range] clamps rather than erroring - agents overshoot limits, and
+	/// failing the whole call over it costs a round trip for nothing.
+	/// </summary>
+	[TestMethod]
+	[DataRow( 9999, 500 )]
+	[DataRow( 0, 1 )]
+	[DataRow( 200, 200 )]
+	public void OutOfRangeValuesClamp( int sent, int expected )
+	{
+		Assert.AreEqual( expected, McpFixture.Invoke( "mcp_test_limit", Args( $$"""{ "limit": {{sent}} }""" ) ) );
+	}
+
+	/// <summary>
+	/// A number that arrived encoded inside a string still binds.
+	/// </summary>
+	[TestMethod]
+	public void NumberEncodedInAStringUnwraps()
+	{
+		Assert.AreEqual( 42, McpFixture.Invoke( "mcp_test_limit", Args( """{ "limit": "42" }""" ) ) );
+	}
+
+	/// <summary>
+	/// A json object that arrived encoded inside a string unwraps into a JsonObject parameter -
+	/// a common enough client bug that failing on it would just waste turns.
+	/// </summary>
+	[TestMethod]
+	public void JsonObjectEncodedInAStringUnwraps()
+	{
+		Assert.AreEqual( 7, McpFixture.Invoke( "mcp_test_payload", Args( """{ "payload": "{ \"a\": 7 }" }""" ) ) );
+	}
+
+	/// <summary>
+	/// A json object sent as an object binds straight through.
+	/// </summary>
+	[TestMethod]
+	public void JsonObjectBindsDirectly()
+	{
+		Assert.AreEqual( 7, McpFixture.Invoke( "mcp_test_payload", Args( """{ "payload": { "a": 7 } }""" ) ) );
+	}
+
+	/// <summary>
+	/// A tool that declared a data return type gets its value wrapped as structured content,
+	/// because that's the shape its output schema promised.
+	/// </summary>
+	[TestMethod]
+	public void DeclaredDataReturnComesBackStructured()
+	{
+		var result = McpFixture.Invoke( "mcp_test_report", Args( """{ "name": "abcd" }""" ) );
+
+		Assert.IsInstanceOfType<McpResult>( result );
+
+		var json = ((McpResult)result).ToJson();
+
+		Assert.AreEqual( "abcd", json["structuredContent"][nameof( McpTestReport.Name )].GetValue<string>() );
+		Assert.AreEqual( 4, json["structuredContent"][nameof( McpTestReport.Count )].GetValue<int>() );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Engine/Mcp/Fixtures.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Mcp/Fixtures.cs
@@ -1,0 +1,146 @@
+using Editor.Mcp;
+using System.Text.Json.Nodes;
+
+namespace McpTests;
+
+/// <summary>
+/// Tool fixtures for the MCP registry tests. These are real <see cref="McpToolAttribute"/>
+/// methods in the test assembly, which <see cref="TestInit"/> registers into
+/// EditorTypeLibrary - so the registry discovers them exactly the way it discovers the
+/// editor's own tools, with no hand registration.
+/// Every name here is prefixed so it can't collide with a real editor tool.
+/// </summary>
+[McpToolset( "mcp_test", "Fixture tools for the MCP registry tests - never called by the editor." )]
+public static class McpTestTools
+{
+	// A read only tool with a required string and two defaulted parameters. Plain comments,
+	// not xml summaries, so nothing but the [Description] attribute can supply the description
+	// the schema tests assert on.
+	[McpTool.ReadOnly( "mcp_test_echo" )]
+	[Description( "Echoes text back so argument binding can be asserted." )]
+	public static string Echo(
+		[Description( "The text to echo." )] string text,
+		[Description( "How many times to repeat it." )] int count = 1,
+		bool shout = false )
+	{
+		var line = shout ? text.ToUpperInvariant() : text;
+
+		return string.Join( " ", Enumerable.Repeat( line, count ) );
+	}
+
+	// A write tool - no hints, so it should get no annotations block.
+	[McpTool( "mcp_test_write" )]
+	[Description( "Pretends to write something." )]
+	public static string Write( string value ) => value;
+
+	// Engine math types arrive as comma strings.
+	[McpTool( "mcp_test_vector" )]
+	[Description( "Takes a position and an angle." )]
+	public static string Vector( Vector3 position, Angles angles )
+		=> $"{position.x:0.##}|{position.y:0.##}|{position.z:0.##}|{angles.yaw:0.##}";
+
+	// An enum parameter, so the schema should list its names.
+	[McpTool( "mcp_test_mode" )]
+	[Description( "Takes a mode." )]
+	public static string Mode( McpTestMode mode ) => mode.ToString();
+
+	// A ranged integer, so the schema should carry minimum/maximum and out of range values
+	// should clamp rather than error.
+	[McpTool( "mcp_test_limit" )]
+	[Description( "Takes a limit." )]
+	public static int Limit( [Range( 1, 500 )] int limit = 50 ) => limit;
+
+	// A JsonNode parameter, which takes whatever the client sent.
+	[McpTool( "mcp_test_payload" )]
+	[Description( "Takes a json object and reads one number out of it." )]
+	public static int Payload( JsonObject payload ) => payload?["a"]?.GetValue<int>() ?? -1;
+
+	// Declares a data return type, so it should get an output schema and structured content.
+	[McpTool( "mcp_test_report" )]
+	[Description( "Returns a small data object." )]
+	public static McpTestReport Report( string name ) => new() { Name = name, Count = name?.Length ?? 0 };
+
+	// No name on the attribute, so the tool name comes from the method name in snake_case.
+	[McpTool]
+	[Description( "Named after its method." )]
+	public static string McpTestDerivedName() => "derived";
+}
+
+/// <summary>
+/// Two tools claiming the same name - the registry should keep one and skip the other.
+/// </summary>
+[McpToolset( "mcp_test_dupe" )]
+public static class McpTestDuplicateTools
+{
+	[McpTool( "mcp_test_duplicate" )]
+	[Description( "First claim on the name." )]
+	public static string First() => "first";
+
+	[McpTool( "mcp_test_duplicate" )]
+	[Description( "Second claim on the name." )]
+	public static string Second() => "second";
+}
+
+/// <summary>
+/// No [McpToolset], and a class name ending in "Tools" - the toolset name should be
+/// derived from the class name with that suffix stripped.
+/// </summary>
+public static class McpFixtureTools
+{
+	[McpTool( "mcp_test_unattributed_toolset" )]
+	[Description( "Belongs to a toolset named after its class." )]
+	public static string Something() => "something";
+}
+
+/// <summary>
+/// The mode <see cref="McpTestTools.Mode"/> takes.
+/// </summary>
+public enum McpTestMode
+{
+	Fast,
+	Slow
+}
+
+/// <summary>
+/// A plain data type, so the registry can describe its shape from its properties.
+/// </summary>
+public class McpTestReport
+{
+	public string Name { get; set; }
+	public int Count { get; set; }
+}
+
+/// <summary>
+/// A component for the result tests to collapse into a component reference.
+/// </summary>
+public class McpTestComponent : Component
+{
+}
+
+/// <summary>
+/// Shared helpers for reaching the fixture tools through the registry.
+/// </summary>
+public static class McpFixture
+{
+	/// <summary>
+	/// The registry's entry for a tool name, failing the test if discovery didn't find it -
+	/// a missing fixture means the test assembly isn't in EditorTypeLibrary, which would
+	/// otherwise show up as a confusing null reference.
+	/// </summary>
+	public static MethodDescription Tool( string name )
+	{
+		var found = ToolRegistry.All().FirstOrDefault( x => x.Name == name ).Method;
+
+		Assert.IsNotNull( found, $"Tool '{name}' isn't in the registry" );
+
+		return found;
+	}
+
+	/// <summary>
+	/// Invoke a tool and wait for it synchronously. Tools run inline when the caller is
+	/// already the main thread, so this never blocks - and staying on one thread keeps
+	/// <see cref="ThreadSafe.IsMainThread"/> (which is thread static) true for the whole call.
+	/// </summary>
+	public static object Invoke( string name, JsonObject arguments )
+		=> ToolRegistry.Invoke( name, arguments ).GetAwaiter().GetResult();
+}

--- a/engine/Tests/Sandbox.Test.Engine/Mcp/Registry.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Mcp/Registry.cs
@@ -1,0 +1,104 @@
+using Editor.Mcp;
+using System;
+
+namespace McpTests;
+
+/// <summary>
+/// Discovery goes through EditorTypeLibrary, so nothing registers by hand - which makes the
+/// registry's surface (what names tools get, what toolset they land in, what happens when two
+/// tools claim a name) the thing worth pinning down.
+/// </summary>
+[TestClass]
+public class ToolRegistrySurfaceTest
+{
+	/// <summary>
+	/// Tools declared in a loaded assembly are discovered without registering anything.
+	/// </summary>
+	[TestMethod]
+	public void FixtureToolsAreDiscovered()
+	{
+		CollectionAssert.Contains( ToolRegistry.All().Select( x => x.Name ).ToArray(), "mcp_test_echo" );
+	}
+
+	/// <summary>
+	/// A tool with no name on its attribute is named after its method, in snake_case.
+	/// </summary>
+	[TestMethod]
+	public void ToolNameFallsBackToSnakeCasedMethodName()
+	{
+		CollectionAssert.Contains( ToolRegistry.All().Select( x => x.Name ).ToArray(), "mcp_test_derived_name" );
+	}
+
+	/// <summary>
+	/// Tools come back sorted by name, so a client's tool list is stable between calls.
+	/// </summary>
+	[TestMethod]
+	public void ToolsAreSortedByName()
+	{
+		var names = ToolRegistry.All().Select( x => x.Name ).ToArray();
+
+		CollectionAssert.AreEqual( names.OrderBy( x => x, StringComparer.Ordinal ).ToArray(), names );
+	}
+
+	/// <summary>
+	/// An [McpToolset] names the group deliberately, and its description comes with it.
+	/// </summary>
+	[TestMethod]
+	public void ToolsetAttributeNamesTheGroup()
+	{
+		var toolset = ToolRegistry.ToolsetOf( McpFixture.Tool( "mcp_test_echo" ) );
+
+		Assert.AreEqual( "mcp_test", toolset.Name );
+		Assert.AreEqual( "Fixture tools for the MCP registry tests - never called by the editor.", toolset.Description );
+	}
+
+	/// <summary>
+	/// Without the attribute the toolset name comes from the class name, with a trailing
+	/// "Tools" stripped - McpFixtureTools becomes "mcp_fixture" - and there's no description.
+	/// </summary>
+	[TestMethod]
+	public void ToolsetFallsBackToTheClassNameWithoutItsSuffix()
+	{
+		var toolset = ToolRegistry.ToolsetOf( McpFixture.Tool( "mcp_test_unattributed_toolset" ) );
+
+		Assert.AreEqual( "mcp_fixture", toolset.Name );
+		Assert.IsNull( toolset.Description );
+	}
+
+	/// <summary>
+	/// Two tools claiming one name would make calls ambiguous, so the second is skipped and
+	/// the name resolves to exactly one method.
+	/// </summary>
+	[TestMethod]
+	public void DuplicateToolNamesAreSkipped()
+	{
+		Assert.AreEqual( 1, ToolRegistry.All().Count( x => x.Name == "mcp_test_duplicate" ) );
+	}
+
+	/// <summary>
+	/// No name in the whole registry is ambiguous - not just the fixture pair.
+	/// </summary>
+	[TestMethod]
+	public void EveryToolNameIsUnique()
+	{
+		var names = ToolRegistry.All().Select( x => x.Name ).ToArray();
+
+		Assert.AreEqual( names.Length, names.Distinct().Count() );
+	}
+
+	/// <summary>
+	/// Every discovered tool produces a schema without throwing - a tool whose parameters the
+	/// schema builder can't describe would break tools/list for every other tool too.
+	/// </summary>
+	[TestMethod]
+	public void EveryToolProducesASchema()
+	{
+		foreach ( var (name, method) in ToolRegistry.All() )
+		{
+			var json = ToolRegistry.ToolJson( name, method );
+
+			Assert.AreEqual( name, json["name"].GetValue<string>(), $"'{name}' didn't describe itself" );
+			Assert.AreEqual( "object", json["inputSchema"]["type"].GetValue<string>(), $"'{name}' has no input schema" );
+		}
+	}
+}

--- a/engine/Tests/Sandbox.Test.Engine/Mcp/Results.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Mcp/Results.cs
@@ -1,0 +1,160 @@
+using Editor.Mcp;
+using SceneTests;
+using System.Text.Json.Nodes;
+
+namespace McpTests;
+
+/// <summary>
+/// What a tool returns is what the agent reads, so the content blocks and the compact
+/// references for live scene objects are behaviour, not formatting. A scene object serialized
+/// in full would dump a whole subtree into the agent's context by accident.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class McpResultTest : SceneTest
+{
+	/// <summary>
+	/// A string becomes a single text block, as sent.
+	/// </summary>
+	[TestMethod]
+	public void TextResultIsOneTextBlock()
+	{
+		var json = McpResult.Text( "hello" ).ToJson();
+
+		var content = json["content"].AsArray();
+
+		Assert.AreEqual( 1, content.Count );
+		Assert.AreEqual( "text", content[0]["type"].GetValue<string>() );
+		Assert.AreEqual( "hello", content[0]["text"].GetValue<string>() );
+		Assert.IsNull( json["structuredContent"] );
+		Assert.IsNull( json["isError"] );
+	}
+
+	/// <summary>
+	/// Anything that isn't a string is serialized to json before it becomes text.
+	/// </summary>
+	[TestMethod]
+	public void NonStringTextResultIsSerialized()
+	{
+		var json = McpResult.Text( new McpTestReport { Name = "abcd", Count = 4 } ).ToJson();
+
+		var text = JsonNode.Parse( json["content"][0]["text"].GetValue<string>() );
+
+		Assert.AreEqual( "abcd", text[nameof( McpTestReport.Name )].GetValue<string>() );
+		Assert.AreEqual( 4, text[nameof( McpTestReport.Count )].GetValue<int>() );
+	}
+
+	/// <summary>
+	/// A structured result carries the value as structuredContent for clients that bind it,
+	/// paired with the same json as text for clients that don't.
+	/// </summary>
+	[TestMethod]
+	public void StructuredResultCarriesBothShapes()
+	{
+		var json = McpResult.Structured( new McpTestReport { Name = "abcd", Count = 4 } ).ToJson();
+
+		Assert.AreEqual( "abcd", json["structuredContent"][nameof( McpTestReport.Name )].GetValue<string>() );
+
+		var text = JsonNode.Parse( json["content"][0]["text"].GetValue<string>() );
+
+		Assert.AreEqual( "abcd", text[nameof( McpTestReport.Name )].GetValue<string>() );
+		Assert.AreEqual( 4, text[nameof( McpTestReport.Count )].GetValue<int>() );
+	}
+
+	/// <summary>
+	/// Errors go back in band, flagged on the result rather than as a protocol failure.
+	/// </summary>
+	[TestMethod]
+	public void ErrorResultsAreFlagged()
+	{
+		Assert.IsTrue( McpResult.Text( "nope" ).ToJson( isError: true )["isError"].GetValue<bool>() );
+	}
+
+	/// <summary>
+	/// A live game object collapses to { type, id, name } - the id chains into get_game_object,
+	/// and nobody gets a serialized scene subtree by accident.
+	/// </summary>
+	[TestMethod]
+	public void GameObjectCollapsesToAReference()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var go = scene.CreateObject();
+		go.Name = "Hero";
+
+		var reference = McpResult.Structured( go ).ToJson()["structuredContent"].AsObject();
+
+		Assert.AreEqual( nameof( GameObject ), reference["type"].GetValue<string>() );
+		Assert.AreEqual( go.Id.ToString(), reference["id"].GetValue<string>() );
+		Assert.AreEqual( "Hero", reference["name"].GetValue<string>() );
+
+		// The whole point of the converter - no hierarchy or component data comes along
+		Assert.IsNull( reference["Children"] );
+		Assert.IsNull( reference["Components"] );
+
+		scene.Destroy();
+	}
+
+	/// <summary>
+	/// A component collapses to { type, id, gameObject }, naming the component class and
+	/// pointing at its owner.
+	/// </summary>
+	[TestMethod]
+	public void ComponentCollapsesToAReference()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var go = scene.CreateObject();
+		go.Name = "Hero";
+
+		var component = go.Components.Create<McpTestComponent>();
+
+		var reference = McpResult.Structured( component ).ToJson()["structuredContent"].AsObject();
+
+		Assert.AreEqual( nameof( McpTestComponent ), reference["type"].GetValue<string>() );
+		Assert.AreEqual( component.Id.ToString(), reference["id"].GetValue<string>() );
+		Assert.AreEqual( go.Id.ToString(), reference["gameObject"].GetValue<string>() );
+
+		scene.Destroy();
+	}
+
+	/// <summary>
+	/// A destroyed object serializes as null instead of throwing - tools hand back whatever
+	/// they were holding, and a dead reference shouldn't fail the whole call.
+	/// </summary>
+	[TestMethod]
+	public void DestroyedGameObjectSerializesAsNull()
+	{
+		var scene = new Scene();
+		using var scope = scene.Push();
+
+		var go = scene.CreateObject();
+		go.Destroy();
+		scene.GameTick();
+
+		Assert.IsFalse( go.IsValid );
+
+		var json = McpResult.Structured( go ).ToJson();
+
+		Assert.IsNull( json["structuredContent"] );
+
+		scene.Destroy();
+	}
+
+	/// <summary>
+	/// Plain return values get shaped into a result: null means the tool succeeded and had
+	/// nothing to say, and an McpResult passes through untouched.
+	/// </summary>
+	[TestMethod]
+	public void ShapeWrapsPlainReturnValues()
+	{
+		Assert.AreEqual( "ok", ToolRegistry.Shape( null ).ToJson()["content"][0]["text"].GetValue<string>() );
+		Assert.AreEqual( "hello", ToolRegistry.Shape( "hello" ).ToJson()["content"][0]["text"].GetValue<string>() );
+
+		var result = McpResult.Text( "mine" );
+
+		Assert.AreSame( result, ToolRegistry.Shape( result ) );
+	}
+}

--- a/engine/Tests/Sandbox.Test.Engine/Mcp/Schema.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Mcp/Schema.cs
@@ -1,0 +1,160 @@
+using Editor.Mcp;
+using System.Text.Json.Nodes;
+
+namespace McpTests;
+
+/// <summary>
+/// The json schema the registry publishes for a tool is the only thing an agent has to go
+/// on before it calls one, so these assert the shape of <see cref="ToolRegistry.ToolJson"/>
+/// against the fixture tools in <see cref="McpTestTools"/>.
+/// </summary>
+[TestClass]
+public class ToolSchemaTest
+{
+	static JsonObject Schema( string name ) => ToolRegistry.ToolJson( name, McpFixture.Tool( name ) );
+
+	static JsonObject Properties( string name ) => Schema( name )["inputSchema"]["properties"].AsObject();
+
+	static string[] Required( string name )
+		=> Schema( name )["inputSchema"]["required"].AsArray().Select( x => x.GetValue<string>() ).ToArray();
+
+	/// <summary>
+	/// A tool's name, toolset and description come through as sent, and the input schema is
+	/// a json schema object.
+	/// </summary>
+	[TestMethod]
+	public void ToolCarriesNameToolsetAndSchemaType()
+	{
+		var json = Schema( "mcp_test_echo" );
+
+		Assert.AreEqual( "mcp_test_echo", json["name"].GetValue<string>() );
+		Assert.AreEqual( "mcp_test", json["toolset"].GetValue<string>() );
+		Assert.AreEqual( "Echoes text back so argument binding can be asserted.", json["description"].GetValue<string>() );
+		Assert.AreEqual( "object", json["inputSchema"]["type"].GetValue<string>() );
+	}
+
+	/// <summary>
+	/// The primitive parameter types map onto the json schema type names, not the C# ones.
+	/// </summary>
+	[TestMethod]
+	public void PrimitiveParametersMapToJsonSchemaTypes()
+	{
+		var properties = Properties( "mcp_test_echo" );
+
+		Assert.AreEqual( "string", properties["text"]["type"].GetValue<string>() );
+		Assert.AreEqual( "integer", properties["count"]["type"].GetValue<string>() );
+		Assert.AreEqual( "boolean", properties["shout"]["type"].GetValue<string>() );
+	}
+
+	/// <summary>
+	/// A [Description] on a parameter is what the agent reads, so it has to reach the schema.
+	/// </summary>
+	[TestMethod]
+	public void ParameterDescriptionsReachTheSchema()
+	{
+		var properties = Properties( "mcp_test_echo" );
+
+		Assert.AreEqual( "The text to echo.", properties["text"]["description"].GetValue<string>() );
+		Assert.IsNull( properties["shout"]["description"] );
+	}
+
+	/// <summary>
+	/// Engine math types serialize as comma strings, so their schema type is "string" - an
+	/// agent told "array" or "object" here would send something that never binds.
+	/// </summary>
+	[TestMethod]
+	public void MathTypesAreCommaStrings()
+	{
+		var properties = Properties( "mcp_test_vector" );
+
+		Assert.AreEqual( "string", properties["position"]["type"].GetValue<string>() );
+		Assert.AreEqual( "string", properties["angles"]["type"].GetValue<string>() );
+	}
+
+	/// <summary>
+	/// An enum parameter is a string with its names enumerated.
+	/// </summary>
+	[TestMethod]
+	public void EnumParameterListsItsNames()
+	{
+		var mode = Properties( "mcp_test_mode" )["mode"];
+
+		Assert.AreEqual( "string", mode["type"].GetValue<string>() );
+
+		CollectionAssert.AreEquivalent(
+			new[] { nameof( McpTestMode.Fast ), nameof( McpTestMode.Slow ) },
+			mode["enum"].AsArray().Select( x => x.GetValue<string>() ).ToArray() );
+	}
+
+	/// <summary>
+	/// Only parameters without a default are required, and a default that documents
+	/// something appears in the schema.
+	/// </summary>
+	[TestMethod]
+	public void DefaultedParametersAreOptionalAndDocumentTheirDefault()
+	{
+		CollectionAssert.AreEqual( new[] { "text" }, Required( "mcp_test_echo" ) );
+
+		var properties = Properties( "mcp_test_echo" );
+
+		// DefaultToNode widens every integer default to Int64
+		Assert.AreEqual( 1L, properties["count"]["default"].GetValue<long>() );
+		Assert.IsFalse( properties["shout"]["default"].GetValue<bool>() );
+	}
+
+	/// <summary>
+	/// A parameter with no default is required.
+	/// </summary>
+	[TestMethod]
+	public void ParametersWithoutDefaultsAreRequired()
+	{
+		CollectionAssert.AreEqual( new[] { "position", "angles" }, Required( "mcp_test_vector" ) );
+	}
+
+	/// <summary>
+	/// A [Range] becomes the schema's minimum and maximum.
+	/// </summary>
+	[TestMethod]
+	public void RangeBecomesMinimumAndMaximum()
+	{
+		var limit = Properties( "mcp_test_limit" )["limit"];
+
+		Assert.AreEqual( 1f, limit["minimum"].GetValue<float>() );
+		Assert.AreEqual( 500f, limit["maximum"].GetValue<float>() );
+		Assert.AreEqual( 50L, limit["default"].GetValue<long>() );
+	}
+
+	/// <summary>
+	/// A read only tool gets the readOnlyHint annotation. A tool with no hints gets no
+	/// annotations at all, so clients keep treating it as a destructive write.
+	/// </summary>
+	[TestMethod]
+	public void ReadOnlyToolsAnnounceThemselvesAndOthersDont()
+	{
+		Assert.IsTrue( Schema( "mcp_test_echo" )["annotations"]["readOnlyHint"].GetValue<bool>() );
+		Assert.IsNull( Schema( "mcp_test_write" )["annotations"] );
+	}
+
+	/// <summary>
+	/// A tool that declares a plain data return type promises its shape in an output schema.
+	/// </summary>
+	[TestMethod]
+	public void DeclaredDataReturnGetsAnOutputSchema()
+	{
+		var output = Schema( "mcp_test_report" )["outputSchema"];
+
+		Assert.AreEqual( "object", output["type"].GetValue<string>() );
+		Assert.AreEqual( "string", output["properties"][nameof( McpTestReport.Name )]["type"].GetValue<string>() );
+		Assert.AreEqual( "integer", output["properties"][nameof( McpTestReport.Count )]["type"].GetValue<string>() );
+	}
+
+	/// <summary>
+	/// A tool returning a bare string promises no shape - strings aren't objects, and the
+	/// protocol only allows an object output schema.
+	/// </summary>
+	[TestMethod]
+	public void UndeclaredReturnGetsNoOutputSchema()
+	{
+		Assert.IsNull( Schema( "mcp_test_echo" )["outputSchema"] );
+	}
+}


### PR DESCRIPTION
## Summary

Foundational unit test suite for the MCP layer, 43 tests, no production changes.

## Motivation & Context

Per #11641: tool schemas and binding behaviour are permanent public API for MCP clients and nothing would catch a regression. The harness was already wired (all test tiers reference Sandbox.Tools, InternalsVisibleTo already granted).

Fixes: #11641

## Implementation Details

Tests live in Sandbox.Test.Engine (which builds EditorTypeLibrary and supports headless Scenes). A fixture `[McpToolset]` declared in the test assembly is what the suite exercises, keeping it independent of real editor tools. `MainThread.Queue` runs inline on a main-marked thread so full ToolRegistry.Invoke round-trips run synchronously.

Areas covered:
- ToolRegistry schema generation (comma-string vector rule, optional-by-default params, Range→min/max, readOnlyHint)
- Argument binding (unknown-arg suggestions, case-insensitivity, range clamping, json-in-string unwrapping)
- McpResult serialization including GameObjectRef/ComponentRef collapse against a headless scene
- Registry surface (toolset naming, duplicate-name skip)

Verified locally — 43/43 new tests pass and the full Sandbox.Test.Engine run (TestCategory!=LiveBackend, same filter CI uses) passes 1760/1760 with the suite present.

Honest limitation — addon-side scene tools remain untestable headless (SceneEditorSession's ctor creates a Qt dock), per the note in #11641.

## Screenshots / Videos (if applicable)

None — this is a unit test suite.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂
