### PR TITLE
[Mesh Component] Fix blob lifetime during network object creation

### DIFF
--- a/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
+++ b/engine/Sandbox.Engine/Scene/Networking/SceneNetworkSystem.cs
@@ -1116,6 +1116,8 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 		if ( source is not null && !source.CanSpawnObjects )
 			return;
 
+		using var blobs = BlobDataSerializer.LoadFromMemory( [] );
+
 		using ( CallbackBatch.Batch() )
 		{
 			foreach ( var msg in message.CreateMsgs )
@@ -1131,12 +1133,11 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 					continue;
 				}
 
-				using ( BlobDataSerializer.LoadFromMemory( msg.BlobData ) )
-				{
-					var go = new GameObject();
-					go.Deserialize( JsonNode.Parse( msg.JsonData ).AsObject(), networkDeserializeOptionsCreate );
-					go.NetworkSpawnRemote( msg );
-				}
+				blobs.Load( msg.BlobData );
+
+				var go = new GameObject();
+				go.Deserialize( JsonNode.Parse( msg.JsonData ).AsObject(), networkDeserializeOptionsCreate );
+				go.NetworkSpawnRemote( msg );
 			}
 		}
 	}
@@ -1169,8 +1170,8 @@ public partial class SceneNetworkSystem : GameNetworkSystem
 
 		var go = new GameObject();
 
-		using ( CallbackBatch.Batch() )
 		using ( BlobDataSerializer.LoadFromMemory( message.BlobData ) )
+		using ( CallbackBatch.Batch() )
 		{
 			go.Deserialize( JsonNode.Parse( message.JsonData ).AsObject(), networkDeserializeOptionsCreate );
 			go.NetworkSpawnRemote( message );


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** 💖  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Fixes runtime-networked `MeshComponent` objects missing their polygon mesh on clients that were already connected when the object spawned.

The mesh was displayed correctly for late joiners receiving the initial scene snapshot, but not for clients receiving a live `ObjectCreateMsg` or `ObjectCreateBatchMsg`.

## Motivation & Context

`PolygonMesh` data is serialized through `BlobDataSerializer`.

During live network object creation, component property deserialization is deferred until `CallbackBatch` is disposed. However, the blob context was being disposed before the callback batch flushed.

Consequently, `PostDeserialize` could no longer resolve the polygon mesh blob. The resulting `MeshComponent` existed on the client, but its mesh data was missing and no render mesh could be built.

Reproduction steps:

1. Start a multiplayer session with a host and a connected client.
2. Runtime-spawn and network a prefab containing `MeshComponent`.
3. Observe that the mesh is missing on the already-connected client.
4. Reconnect the client after the object has spawned.
5. Observe that the mesh is displayed correctly through the initial scene snapshot.

## Implementation Details

For `ObjectCreateBatchMsg`, a shared `BlobDataSerializer` context now remains
active for the entire callback batch. Each message blob is loaded only after
the message has passed the existing ownership and duplicate-object
validations.

For an individual `ObjectCreateMsg`, the blob and callback scopes were
reordered so the callback batch is disposed and flushed before the blob
context is disposed.

This preserves the existing validation order and matches the blob lifetime
already used by the initial scene snapshot path.

### Testing

Manually verified using a locally built engine:

- A client connected before the network spawn now receives a valid polygon mesh.
- The `MeshComponent` renders immediately after the live spawn.
- Late-joining clients continue to receive and render the mesh correctly.

No automated regression test has been added yet because reproducing this issue
requires the live multiplayer object-creation and deferred deserialization path.

## Screenshots / Videos

### Before

Client connected before the runtime network spawn. The networked
`MeshComponent` objects exist, but their polygon geometry is not rendered.

<img width="1273" height="706" alt="Capture d&#39;écran 2026-08-12 022904" src="https://github.com/user-attachments/assets/995bc8aa-3546-404d-84b1-6f751fddce5e" />


### After

Same scenario with the patched engine. The runtime-networked
`MeshComponent` geometry renders correctly on the already-connected client.

<img width="1271" height="712" alt="Capture d&#39;écran 2026-08-12 021336" src="https://github.com/user-attachments/assets/30cb6577-87b3-49bd-82db-c3c348239486" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂