### PR TITLE
[Terrain] Add move/scale wizard

### DIFF
--- a/game/addons/tools/Code/Scene/Terrain/RescaleTerrain.cs
+++ b/game/addons/tools/Code/Scene/Terrain/RescaleTerrain.cs
@@ -1,0 +1,213 @@
+namespace Editor.TerrainEditor;
+
+class RescaleTerrainPopup : Widget, EditorEvent.ISceneView
+{
+	class RescaleSettings
+	{
+		public enum RescaleMode
+		{
+			[Title( "Stretch Proportionally" ), Description( "Geometry scales with the new size and height. Lossless." )]
+			StretchProportionally,
+
+			[Title( "Keep World Geometry" ), Description( "Terrain keeps its current world-space shape; the heightmap is rescaled to compensate." )]
+			KeepWorldGeometry,
+		}
+
+		[Property, Title( "Mode" )]
+		public RescaleMode Mode { get; set; } = RescaleMode.StretchProportionally;
+
+		[Property, Title( "New Size" ), Description( "World size of the terrain's width and length." )]
+		public float NewSize { get; set; }
+
+		[Property, Title( "New Max Height" ), Description( "World size of the terrain's maximum height." )]
+		public float NewMaxHeight { get; set; }
+	}
+
+	RescaleSettings Settings { get; set; }
+	Terrain terrain;
+
+	WarningBox warning;
+
+	// Dialogs size themselves from their content, and a control sheet will happily ask for
+	// the whole screen, so pin the width and let text wrap inside it.
+	const int PopupWidth = 400;
+	const int ContentWidth = PopupWidth - 32;
+
+	public RescaleTerrainPopup( Widget parent, Terrain terrain ) : base( parent )
+	{
+		WindowFlags = WindowFlags.Dialog | WindowFlags.Customized | WindowFlags.WindowTitle | WindowFlags.CloseButton | WindowFlags.WindowSystemMenuHint;
+		DeleteOnClose = true;
+		WindowTitle = "Rescale Terrain";
+		SetWindowIcon( "aspect_ratio" );
+
+		this.terrain = terrain;
+
+		var storage = terrain.Storage;
+
+		Settings = new()
+		{
+			NewSize = storage.TerrainSize,
+			NewMaxHeight = storage.TerrainHeight
+		};
+
+		ushort maxTexel = storage.HeightMap.Length > 0 ? storage.HeightMap.Max() : (ushort)0;
+		float peakWorldHeight = storage.TerrainHeight * maxTexel / 65535f;
+
+		Layout = Layout.Column();
+		Layout.Spacing = 8;
+		Layout.Margin = 16;
+
+		warning = new WarningBox(
+			$"Keep World Geometry is quality-destructive: raising max height reduces height precision; " +
+			$"lowering it below the highest point ({peakWorldHeight:0.#} units) flattens peaks; growing " +
+			$"size resamples existing detail into fewer texels; shrinking crops the far edges. " +
+			$"Terrain grows and shrinks from its origin corner - use Move Terrain to reposition it." );
+		warning.MaximumWidth = ContentWidth;
+		Layout.Add( warning );
+
+		// Must be the TypeLibrary-backed object: EditorUtility.GetSerializedObject returns a
+		// reflection fallback whose properties can't expose value-type sub-objects (x/y/z).
+		var so = Settings.GetSerialized();
+
+		Layout.Add( ControlSheet.Create( so ) );
+
+		so.OnPropertyChanged += ( prop ) =>
+		{
+			if ( prop?.Name == nameof( RescaleSettings.Mode ) )
+				UpdateModeVisibility();
+
+			UpdatePreview();
+		};
+
+		UpdateModeVisibility();
+		UpdatePreview();
+
+		var bottomToolbar = new BottomToolbar();
+		bottomToolbar.Done.Pressed = Rescale;
+		Layout.Add( bottomToolbar );
+
+		Visible = false;
+		Width = PopupWidth;
+		MinimumWidth = 350;
+		MaximumWidth = PopupWidth;
+
+		AdjustSize();
+		Position = Application.CursorPosition - new Vector2( Width * 0.5f, 3 );
+
+		ConstrainToScreen();
+
+		Show();
+		Focus();
+	}
+
+	/// <summary>
+	/// Only the compensating mode can lose quality, so only it gets the warning.
+	/// </summary>
+	void UpdateModeVisibility()
+	{
+		if ( !warning.IsValid() ) return;
+
+		warning.Hidden = Settings.Mode != RescaleSettings.RescaleMode.KeepWorldGeometry;
+		AdjustSize();
+	}
+
+	/// <summary>
+	/// Wireframe the footprint the values would produce, without touching anything.
+	/// </summary>
+	void UpdatePreview()
+	{
+		if ( !terrain.IsValid() ) return;
+
+		TerrainBoundsPreview.Show( this, terrain, terrain.WorldPosition, Settings.NewSize, Settings.NewMaxHeight );
+	}
+
+	/// <summary>
+	/// Runs for every scene viewport frame regardless of the active editor tool, so the preview
+	/// shows while the terrain sculpting tool is in use too.
+	/// </summary>
+	public void DrawGizmos( Scene scene ) => TerrainBoundsPreview.Draw( this );
+
+	protected override void OnClosed()
+	{
+		TerrainBoundsPreview.Clear( this );
+		base.OnClosed();
+	}
+
+	void Rescale()
+	{
+		var storage = terrain.Storage;
+		float oldSize = storage.TerrainSize, newSize = Settings.NewSize;
+		float oldHeight = storage.TerrainHeight, newHeight = Settings.NewMaxHeight;
+
+		if ( newSize <= 0.0f || newHeight <= 0.0f || oldSize <= 0.0f || oldHeight <= 0.0f
+			|| !float.IsFinite( newSize ) || !float.IsFinite( newHeight )
+			|| (newSize == oldSize && newHeight == oldHeight) )
+		{
+			Close();
+			return;
+		}
+
+		ushort[] heightBefore = storage.HeightMap.ToArray();
+		uint[] controlBefore = storage.ControlMap.ToArray();
+
+		ushort[] heightAfter = heightBefore;
+		uint[] controlAfter = controlBefore;
+
+		if ( Settings.Mode == RescaleSettings.RescaleMode.KeepWorldGeometry )
+		{
+			if ( newHeight != oldHeight )
+				heightAfter = TerrainImportHelper.RescaleHeightmap( heightAfter, oldHeight, newHeight );
+
+			if ( newSize != oldSize )
+				(heightAfter, controlAfter) = TerrainImportHelper.CanvasResize( heightAfter, controlAfter, storage.Resolution, oldSize, newSize );
+		}
+		// StretchProportionally: maps untouched, only the two properties change.
+
+		ApplySnapshot( terrain, newSize, newHeight, heightAfter, controlAfter );
+
+		SceneEditorSession.Active.UndoSystem.Insert( "Rescale Terrain",
+			() => ApplySnapshot( terrain, oldSize, oldHeight, heightBefore, controlBefore ),
+			() => ApplySnapshot( terrain, newSize, newHeight, heightAfter, controlAfter ) );
+
+		Close();
+	}
+
+	/// <summary>
+	/// Copies the maps in, so no snapshot array is ever aliased by live storage that sculpting
+	/// could then mutate underneath an undo entry.
+	/// </summary>
+	static void ApplySnapshot( Terrain terrain, float terrainSize, float terrainHeight, ushort[] heightMap, uint[] controlMap )
+	{
+		if ( !terrain.IsValid() || terrain.Storage is null ) return;
+
+		terrain.Storage.TerrainSize = terrainSize;
+		terrain.Storage.TerrainHeight = terrainHeight;
+		terrain.Storage.HeightMap = heightMap.ToArray();
+		terrain.Storage.ControlMap = controlMap.ToArray();
+		terrain.Create();
+	}
+}
+
+
+file class BottomToolbar : Widget
+{
+	public Button Done { get; }
+
+	public BottomToolbar()
+	{
+		Done = new Button.Primary( "Rescale", "aspect_ratio", this );
+
+		Layout = Layout.Row();
+		Layout.Margin = 16;
+		Layout.AddStretchCell();
+		Layout.Add( Done );
+	}
+
+	protected override void OnPaint()
+	{
+		Paint.Pen = Theme.ControlBackground.WithAlpha( 0.5f );
+		Paint.PenSize = 2;
+
+		Paint.DrawLine( LocalRect.TopLeft, LocalRect.TopRight );
+	}
+}

--- a/game/addons/tools/Code/Scene/Terrain/TerrainBoundsPreview.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainBoundsPreview.cs
@@ -1,0 +1,105 @@
+using Sandbox;
+
+namespace Editor.TerrainEditor;
+
+/// <summary>
+/// Pending terrain bounds published by the rescale / move popups so they can be drawn in the
+/// viewport while values are being edited. Purely visual - nothing here touches storage.
+/// The owner is whichever popup is driving the preview; it draws from
+/// <see cref="EditorEvent.ISceneView.DrawGizmos"/> so the preview shows under every editor tool,
+/// not just the object tool.
+/// </summary>
+internal static class TerrainBoundsPreview
+{
+	static object owner;
+
+	static Terrain Target;
+	static Vector3 Position;
+	static float Size;
+	static float Height;
+
+	/// <summary>Bounds the pending operation drops.</summary>
+	static BBox[] Lost = Array.Empty<BBox>();
+
+	/// <summary>Bounds the pending operation gains, filled from the border average.</summary>
+	static BBox[] Added = Array.Empty<BBox>();
+
+	public static void Show( object source, Terrain terrain, Vector3 position, float size, float height,
+		BBox[] lost = null, BBox[] added = null )
+	{
+		if ( !terrain.IsValid() || size <= 0.0f || height <= 0.0f
+			|| !float.IsFinite( size ) || !float.IsFinite( height )
+			|| !float.IsFinite( position.x ) || !float.IsFinite( position.y ) || !float.IsFinite( position.z ) )
+		{
+			Clear( source );
+			return;
+		}
+
+		owner = source;
+		Target = terrain;
+		Position = position;
+		Size = size;
+		Height = height;
+		Lost = lost ?? Array.Empty<BBox>();
+		Added = added ?? Array.Empty<BBox>();
+	}
+
+	/// <summary>
+	/// Only the popup that owns the preview may clear it, so a closing dialog can't wipe another's.
+	/// </summary>
+	public static void Clear( object source )
+	{
+		if ( owner is not null && !ReferenceEquals( owner, source ) )
+			return;
+
+		owner = null;
+		Target = null;
+		Lost = Array.Empty<BBox>();
+		Added = Array.Empty<BBox>();
+	}
+
+	public static void Draw( object source )
+	{
+		if ( !ReferenceEquals( owner, source ) ) return;
+
+		var terrain = Target;
+		if ( !terrain.IsValid() || terrain.Storage is null ) return;
+
+		var rotation = terrain.WorldRotation;
+		var storage = terrain.Storage;
+
+		using ( Gizmo.Scope( "TerrainBoundsCurrent", new Transform( terrain.WorldPosition, rotation ) ) )
+		{
+			Gizmo.Draw.IgnoreDepth = true;
+			Gizmo.Draw.LineThickness = 1;
+			Gizmo.Draw.Color = Color.White.WithAlpha( 0.35f );
+			Gizmo.Draw.LineBBox( new BBox( Vector3.Zero, new Vector3( storage.TerrainSize, storage.TerrainSize, storage.TerrainHeight ) ) );
+		}
+
+		using ( Gizmo.Scope( "TerrainBoundsPending", new Transform( Position, rotation ) ) )
+		{
+			Gizmo.Draw.IgnoreDepth = true;
+			Gizmo.Draw.LineThickness = 2;
+			Gizmo.Draw.Color = Color.Orange;
+			Gizmo.Draw.LineBBox( new BBox( Vector3.Zero, new Vector3( Size, Size, Height ) ) );
+
+			Gizmo.Draw.ScreenText( $"{Size:0.#} x {Size:0.#} x {Height:0.#}",
+				Gizmo.Camera.ToScreen( Position + rotation * new Vector3( Size * 0.5f, Size * 0.5f, Height ) ),
+				size: 14 );
+		}
+
+		// Regions are old-footprint-local. Solid only - outlines turned every slab into a thicket.
+		using ( Gizmo.Scope( "TerrainRegions", new Transform( terrain.WorldPosition, rotation ) ) )
+		{
+			Gizmo.Draw.IgnoreDepth = true;
+
+			Gizmo.Draw.Color = Color.Red.WithAlpha( 0.2f );
+			foreach ( var box in Lost )
+				Gizmo.Draw.SolidBox( box );
+
+			Gizmo.Draw.Color = Color.Green.WithAlpha( 0.2f );
+			foreach ( var box in Added )
+				Gizmo.Draw.SolidBox( box );
+		}
+	}
+}

--- a/game/addons/tools/Code/Scene/Terrain/TerrainComponentWidget.Settings.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainComponentWidget.Settings.cs
@@ -18,6 +18,11 @@ partial class TerrainComponentWidget : ComponentEditorWidget
 		if ( o.Name == nameof( Collider.Surface ) ) return false;
 		if ( o.Name == nameof( Collider.IsTrigger ) ) return false;
 
+		// Size and height are only editable through the Rescale Terrain tool, which can
+		// compensate the heightmap instead of silently stretching the sculpted geometry.
+		if ( o.Name == nameof( Terrain.TerrainSize ) ) return false;
+		if ( o.Name == nameof( Terrain.TerrainHeight ) ) return false;
+
 		return true;
 	}
 
@@ -191,6 +196,28 @@ partial class TerrainComponentWidget : ComponentEditorWidget
 
 		container.Layout.Add( sheet );
 
+		var scaleColumn = container.Layout.AddColumn();
+		scaleColumn.Spacing = 8;
+		scaleColumn.Margin = 16;
+
+		var scaleHeader = new Label( "Size & Placement" );
+		scaleHeader.SetStyles( "font-weight: bold" );
+		scaleColumn.Add( scaleHeader );
+
+		// Read-only mirrors of the properties the tools own, so the current values stay visible.
+		var sizeSheet = new ControlSheet();
+		foreach ( var name in new[] { nameof( Terrain.TerrainSize ), nameof( Terrain.TerrainHeight ) } )
+		{
+			var control = sizeSheet.AddRow( SerializedObject.GetProperty( name ) );
+			if ( control.IsValid() ) control.ReadOnly = true;
+		}
+		scaleColumn.Add( sizeSheet );
+
+		var toolRow = scaleColumn.AddRow();
+		toolRow.Spacing = 8;
+		toolRow.Add( new Button( "Rescale Terrain...", "aspect_ratio" ) { Clicked = RescaleTerrain }, 1 );
+		toolRow.Add( new Button( "Move Terrain...", "open_with" ) { Clicked = TranslateTerrain }, 1 );
+
 		return container;
 	}
 
@@ -346,5 +373,21 @@ partial class TerrainComponentWidget : ComponentEditorWidget
 			return;
 
 		new ImportHeightmapPopup( this, terrain, fd.SelectedFile );
+	}
+
+	void RescaleTerrain()
+	{
+		var terrain = SerializedObject.Targets.FirstOrDefault() as Terrain;
+		if ( !terrain.IsValid() || terrain.Storage is null ) return;
+
+		new RescaleTerrainPopup( this, terrain );
+	}
+
+	void TranslateTerrain()
+	{
+		var terrain = SerializedObject.Targets.FirstOrDefault() as Terrain;
+		if ( !terrain.IsValid() || terrain.Storage is null ) return;
+
+		new TranslateTerrainPopup( this, terrain );
 	}
 }

--- a/game/addons/tools/Code/Scene/Terrain/TerrainImportHelper.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainImportHelper.cs
@@ -45,6 +45,170 @@ internal static class TerrainImportHelper
 	}
 
 	/// <summary>
+	/// Rescales heightmap texels so world-space heights are unchanged after
+	/// TerrainHeight changes from oldHeight to newHeight. Values clamp at ushort.MaxValue.
+	/// Returns a new array; never mutates the input.
+	/// </summary>
+	internal static ushort[] RescaleHeightmap( ushort[] original, float oldHeight, float newHeight )
+	{
+		var result = new ushort[original.Length];
+		double scale = (double)oldHeight / newHeight;
+		for ( int i = 0; i < original.Length; i++ )
+		{
+			result[i] = (ushort)Math.Min( (uint)Math.Round( original[i] * scale ), ushort.MaxValue );
+		}
+		return result;
+	}
+
+	/// <summary>
+	/// Resizes the terrain's world footprint from oldSize to newSize keeping geometry
+	/// fixed in world space (corner-anchored, like the engine). Growing pads flat ground
+	/// (height 0, control 0) at the far edges; shrinking crops them. Resolution unchanged.
+	/// Use the Move Terrain tool afterwards to place the result.
+	/// Returns new arrays; never mutates the inputs.
+	/// </summary>
+	internal static (ushort[] heightMap, UInt32[] controlMap) CanvasResize(
+		ushort[] heightMap, UInt32[] controlMap, int resolution, float oldSize, float newSize )
+	{
+		if ( newSize == oldSize )
+			return (heightMap, controlMap);
+
+		if ( newSize > oldSize )
+		{
+			// Grow: existing content shrinks into the corner k×k block, the rest is flat ground.
+			int k = Math.Clamp( (int)MathF.Round( resolution * oldSize / newSize ), 1, resolution );
+			if ( k == resolution )
+				return (heightMap, controlMap);
+
+			var smallHeight = ResampleHeightmap( heightMap, resolution, k );
+			var smallControl = ResampleControlMap( controlMap, resolution, k );
+
+			var newHeightMap = new ushort[resolution * resolution];
+			var newControlMap = new UInt32[resolution * resolution];
+
+			for ( int y = 0; y < k; y++ )
+			{
+				Array.Copy( smallHeight, y * k, newHeightMap, y * resolution, k );
+				Array.Copy( smallControl, y * k, newControlMap, y * resolution, k );
+			}
+
+			return (newHeightMap, newControlMap);
+		}
+
+		// Shrink: keep the corner k×k block the new footprint covers, stretch it back out.
+		int keep = Math.Clamp( (int)MathF.Round( resolution * newSize / oldSize ), 1, resolution );
+		if ( keep == resolution )
+			return (heightMap, controlMap);
+
+		var croppedHeight = new ushort[keep * keep];
+		var croppedControl = new UInt32[keep * keep];
+
+		for ( int y = 0; y < keep; y++ )
+		{
+			Array.Copy( heightMap, y * resolution, croppedHeight, y * keep, keep );
+			Array.Copy( controlMap, y * resolution, croppedControl, y * keep, keep );
+		}
+
+		return (ResampleHeightmap( croppedHeight, keep, resolution ),
+			ResampleControlMap( croppedControl, keep, resolution ));
+	}
+
+	/// <summary>
+	/// Average height of the map's outer ring. Used as the fill level for ground exposed by a
+	/// shift, so the new edge sits level with the terrain's borders instead of dropping to zero.
+	/// </summary>
+	internal static ushort BorderAverage( ushort[] heightMap, int resolution )
+	{
+		if ( resolution <= 0 || heightMap.Length == 0 ) return 0;
+		if ( resolution == 1 ) return heightMap[0];
+
+		long total = 0;
+		int count = 0;
+
+		for ( int x = 0; x < resolution; x++ )
+		{
+			total += heightMap[x];                                       // bottom row
+			total += heightMap[(resolution - 1) * resolution + x];       // top row
+			count += 2;
+		}
+
+		// corners already counted, so skip them on the sides
+		for ( int y = 1; y < resolution - 1; y++ )
+		{
+			total += heightMap[y * resolution];                          // left column
+			total += heightMap[y * resolution + resolution - 1];         // right column
+			count += 2;
+		}
+
+		return (ushort)(total / count);
+	}
+
+	/// <summary>
+	/// Slides the maps by whole texels. Heights are never touched - a vertical move is just the
+	/// terrain object moving, which costs nothing and keeps the sculpt exactly as it is.
+	/// Ground exposed by the slide is filled at the border average (see <see cref="BorderAverage"/>)
+	/// and inherits the nearest edge's materials, so no cliff or bald patch appears.
+	/// Content pushed past an edge is discarded.
+	/// Returns new arrays; never mutates the inputs.
+	/// </summary>
+	internal static (ushort[] heightMap, UInt32[] controlMap) ShiftContent(
+		ushort[] heightMap, UInt32[] controlMap, int resolution, int shiftX, int shiftY )
+	{
+		if ( shiftX == 0 && shiftY == 0 )
+			return (heightMap, controlMap);
+
+		var newHeightMap = new ushort[heightMap.Length];
+		var newControlMap = new UInt32[controlMap.Length];
+
+		ushort fill = BorderAverage( heightMap, resolution );
+
+		for ( int y = 0; y < resolution; y++ )
+		{
+			int srcY = y - shiftY;
+			bool rowInside = srcY >= 0 && srcY < resolution;
+			int clampedY = Math.Clamp( srcY, 0, resolution - 1 );
+
+			for ( int x = 0; x < resolution; x++ )
+			{
+				int srcX = x - shiftX;
+				int dst = y * resolution + x;
+
+				if ( rowInside && srcX >= 0 && srcX < resolution )
+				{
+					int src = srcY * resolution + srcX;
+					newHeightMap[dst] = heightMap[src];
+					newControlMap[dst] = controlMap[src];
+					continue;
+				}
+
+				// Exposed ground: level fill, materials taken from the nearest edge texel
+				newHeightMap[dst] = fill;
+				newControlMap[dst] = controlMap[clampedY * resolution + Math.Clamp( srcX, 0, resolution - 1 )];
+			}
+		}
+
+		return (newHeightMap, newControlMap);
+	}
+
+	/// <summary>
+	/// Raises or lowers every height by a constant, keeping the terrain object where it is.
+	/// Values clamp at the floor and the ceiling, so ground driven past either is flattened
+	/// against it and lost. Returns a new array; never mutates the input.
+	/// </summary>
+	internal static ushort[] OffsetHeights( ushort[] heightMap, int delta )
+	{
+		if ( delta == 0 )
+			return heightMap;
+
+		var result = new ushort[heightMap.Length];
+
+		for ( int i = 0; i < heightMap.Length; i++ )
+			result[i] = (ushort)Math.Clamp( heightMap[i] + delta, 0, ushort.MaxValue );
+
+		return result;
+	}
+
+	/// <summary>
 	/// Resamples a TerrainStorage to a new resolution in-place.
 	/// HeightMap is bilinearly interpolated via SkiaSharp; ControlMap uses nearest-neighbor.
 	/// </summary>

--- a/game/addons/tools/Code/Scene/Terrain/TranslateTerrain.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TranslateTerrain.cs
@@ -1,0 +1,294 @@
+namespace Editor.TerrainEditor;
+
+class TranslateTerrainPopup : Widget, EditorEvent.ISceneView
+{
+	class TranslateSettings
+	{
+		[Property, Title( "Offset" ), Description( "Move the sculpted terrain inside its footprint. X/Y shift the maps by whole texels; Z raises or lowers every height." )]
+		public Vector3 Offset { get; set; }
+	}
+
+	TranslateSettings Settings { get; set; }
+	Terrain terrain;
+
+	Label snapLabel;
+
+	// Dialogs size themselves from their content, and a control sheet will happily ask for
+	// the whole screen, so pin the width and let text wrap inside it.
+	const int PopupWidth = 400;
+	const int ContentWidth = PopupWidth - 32;
+
+	public TranslateTerrainPopup( Widget parent, Terrain terrain ) : base( parent )
+	{
+		WindowFlags = WindowFlags.Dialog | WindowFlags.Customized | WindowFlags.WindowTitle | WindowFlags.CloseButton | WindowFlags.WindowSystemMenuHint;
+		DeleteOnClose = true;
+		WindowTitle = "Move Terrain";
+		SetWindowIcon( "open_with" );
+
+		this.terrain = terrain;
+
+		Settings = new();
+
+		Layout = Layout.Column();
+		Layout.Spacing = 8;
+		Layout.Margin = 16;
+
+		var warning = new WarningBox(
+			"Moving loses some data. The red zone is terrain that will be lost, the green zone is what gets added. Sideways moves the terrain and its origin; up and down keeps the origin and lifts the ground inside it." );
+		warning.MaximumWidth = ContentWidth;
+		Layout.Add( warning );
+
+		// Must be the TypeLibrary-backed object: EditorUtility.GetSerializedObject returns a
+		// reflection fallback whose properties can't expose value-type sub-objects, so the
+		// Vector3 row would come up empty and VectorControlWidget would throw.
+		var so = Settings.GetSerialized();
+		Layout.Add( ControlSheet.Create( so ) );
+
+		snapLabel = new Label( "" );
+		snapLabel.WordWrap = true;
+		snapLabel.MaximumWidth = ContentWidth;
+		Layout.Add( snapLabel );
+
+		so.OnPropertyChanged += ( _ ) => UpdatePreview();
+		UpdatePreview();
+
+		var bottomToolbar = new BottomToolbar();
+		bottomToolbar.Done.Pressed = Translate;
+		Layout.Add( bottomToolbar );
+
+		Visible = false;
+		Width = PopupWidth;
+		MinimumWidth = 350;
+		MaximumWidth = PopupWidth;
+
+		AdjustSize();
+		Position = Application.CursorPosition - new Vector2( Width * 0.5f, 3 );
+
+		ConstrainToScreen();
+
+		Show();
+		Focus();
+	}
+
+	float UnitsPerTexel => terrain.Storage.TerrainSize / terrain.Storage.Resolution;
+
+	/// <summary>
+	/// The horizontal move in whole texels - the only part that touches the maps.
+	/// </summary>
+	(int x, int y) SnappedTexels()
+	{
+		var offset = Settings.Offset;
+
+		if ( !float.IsFinite( offset.x ) || !float.IsFinite( offset.y ) )
+			return (0, 0);
+
+		float unitsPerTexel = UnitsPerTexel;
+		if ( unitsPerTexel <= 0.0f )
+			return (0, 0);
+
+		return ((int)MathF.Round( offset.x / unitsPerTexel ), (int)MathF.Round( offset.y / unitsPerTexel ));
+	}
+
+	/// <summary>
+	/// The vertical part, in 16-bit height units. This raises the ground inside the terrain rather
+	/// than moving the terrain, so the origin and the footprint stay exactly where they are.
+	/// </summary>
+	int HeightDelta()
+	{
+		float z = Settings.Offset.z;
+		var storage = terrain.Storage;
+
+		if ( !float.IsFinite( z ) || storage.TerrainHeight <= 0.0f )
+			return 0;
+
+		return (int)MathF.Round( z / storage.TerrainHeight * ushort.MaxValue );
+	}
+
+	/// <summary>
+	/// How far the terrain object itself travels: the snapped horizontal move only. Preview and
+	/// apply both go through this so the box you line up is exactly the box you get.
+	/// </summary>
+	Vector3 ObjectOffset()
+	{
+		var (texelX, texelY) = SnappedTexels();
+
+		return new Vector3( texelX * UnitsPerTexel, texelY * UnitsPerTexel, 0.0f );
+	}
+
+	/// <summary>
+	/// Outlines where the terrain lands. Red marks what the move destroys, green what it gains.
+	/// </summary>
+	void UpdatePreview()
+	{
+		if ( !terrain.IsValid() || terrain.Storage is null ) return;
+
+		var storage = terrain.Storage;
+		var (texelX, texelY) = SnappedTexels();
+		var objectOffset = ObjectOffset();
+		float lift = HeightDelta() / (float)ushort.MaxValue * storage.TerrainHeight;
+
+		if ( snapLabel.IsValid() )
+		{
+			snapLabel.Text = $"Moves {objectOffset.x:0.#}, {objectOffset.y:0.#} units ({texelX} x {texelY} texels) sideways and lifts the ground {lift:0.#} units. The origin only moves sideways.";
+		}
+
+		var (lost, added) = Regions( objectOffset, lift, storage.TerrainSize, storage.TerrainHeight );
+
+		TerrainBoundsPreview.Show( this, terrain, terrain.WorldPosition + terrain.WorldRotation * objectOffset,
+			storage.TerrainSize, storage.TerrainHeight, lost, added );
+	}
+
+	/// <summary>
+	/// Runs for every scene viewport frame regardless of the active editor tool, so the preview
+	/// shows while the terrain sculpting tool is in use too.
+	/// </summary>
+	public void DrawGizmos( Scene scene ) => TerrainBoundsPreview.Draw( this );
+
+	/// <summary>
+	/// What the move destroys and gains, in old-footprint-local space.
+	/// Sideways: the terrain box moves, so it abandons ground on one side and gains it on the other.
+	/// Vertically: the box stays put and the ground slides inside it, so whatever is driven past
+	/// the ceiling or the floor is flattened against it - a band of existing terrain, marked lost.
+	/// </summary>
+	static (BBox[] lost, BBox[] added) Regions( Vector3 objectOffset, float lift, float size, float height )
+	{
+		var extent = new Vector3( size, size, height );
+		var oldBox = new BBox( Vector3.Zero, extent );
+		var newBox = new BBox( objectOffset, objectOffset + extent );
+
+		var lost = Difference( oldBox, newBox );
+		var added = Difference( newBox, oldBox );
+
+		// The band that clamps away, over the ground the sideways move keeps
+		float keepMinX = MathF.Max( 0.0f, objectOffset.x ), keepMaxX = MathF.Min( size, size + objectOffset.x );
+		float keepMinY = MathF.Max( 0.0f, objectOffset.y ), keepMaxY = MathF.Min( size, size + objectOffset.y );
+		float clamped = MathF.Min( MathF.Abs( lift ), height );
+
+		if ( clamped > 0.0f && keepMaxX > keepMinX && keepMaxY > keepMinY )
+		{
+			float z0 = lift > 0.0f ? height - clamped : 0.0f;
+			lost.Add( new BBox(
+				new Vector3( keepMinX, keepMinY, z0 ),
+				new Vector3( keepMaxX, keepMaxY, z0 + clamped ) ) );
+		}
+
+		return (lost.ToArray(), added.ToArray());
+	}
+
+	/// <summary>
+	/// a minus b, as up to six disjoint slabs: the X pair spans all of a, the Y pair is clipped to
+	/// the shared X range, the Z pair to the shared X and Y. Disjoint by construction, so the
+	/// translucent slabs never double-blend where they meet.
+	/// </summary>
+	static List<BBox> Difference( BBox a, BBox b )
+	{
+		var result = new List<BBox>();
+
+		void Add( float x0, float x1, float y0, float y1, float z0, float z1 )
+		{
+			if ( x1 - x0 <= 0.0f || y1 - y0 <= 0.0f || z1 - z0 <= 0.0f ) return;
+			result.Add( new BBox( new Vector3( x0, y0, z0 ), new Vector3( x1, y1, z1 ) ) );
+		}
+
+		float x0 = MathF.Max( a.Mins.x, b.Mins.x ), x1 = MathF.Min( a.Maxs.x, b.Maxs.x );
+		float y0 = MathF.Max( a.Mins.y, b.Mins.y ), y1 = MathF.Min( a.Maxs.y, b.Maxs.y );
+		float z0 = MathF.Max( a.Mins.z, b.Mins.z ), z1 = MathF.Min( a.Maxs.z, b.Maxs.z );
+
+		// They don't touch at all, so all of a survives the subtraction
+		if ( x1 <= x0 || y1 <= y0 || z1 <= z0 )
+		{
+			Add( a.Mins.x, a.Maxs.x, a.Mins.y, a.Maxs.y, a.Mins.z, a.Maxs.z );
+			return result;
+		}
+
+		Add( a.Mins.x, x0, a.Mins.y, a.Maxs.y, a.Mins.z, a.Maxs.z );
+		Add( x1, a.Maxs.x, a.Mins.y, a.Maxs.y, a.Mins.z, a.Maxs.z );
+
+		Add( x0, x1, a.Mins.y, y0, a.Mins.z, a.Maxs.z );
+		Add( x0, x1, y1, a.Maxs.y, a.Mins.z, a.Maxs.z );
+
+		Add( x0, x1, y0, y1, a.Mins.z, z0 );
+		Add( x0, x1, y0, y1, z1, a.Maxs.z );
+
+		return result;
+	}
+
+	protected override void OnClosed()
+	{
+		TerrainBoundsPreview.Clear( this );
+		base.OnClosed();
+	}
+
+	void Translate()
+	{
+		var storage = terrain.Storage;
+		var (texelX, texelY) = SnappedTexels();
+		int heightDelta = HeightDelta();
+
+		if ( texelX == 0 && texelY == 0 && heightDelta == 0 )
+		{
+			Close();
+			return;
+		}
+
+		ushort[] heightBefore = storage.HeightMap.ToArray();
+		uint[] controlBefore = storage.ControlMap.ToArray();
+		Vector3 positionBefore = terrain.WorldPosition;
+		Vector3 positionAfter = positionBefore + terrain.WorldRotation * ObjectOffset();
+
+		// Sideways the terrain moves but the landscape does not: the maps travel the opposite way
+		// by the same amount, so every surviving texel keeps its world position, the new box gets
+		// the border-average fill, and what it leaves behind falls off the map.
+		var (heightAfter, controlAfter) = TerrainImportHelper.ShiftContent(
+			heightBefore, controlBefore, storage.Resolution, -texelX, -texelY );
+
+		// Vertically the origin stays and the ground travels instead, clamping at floor/ceiling
+		heightAfter = TerrainImportHelper.OffsetHeights( heightAfter, heightDelta );
+
+		Apply( terrain, positionAfter, heightAfter, controlAfter );
+
+		SceneEditorSession.Active.UndoSystem.Insert( "Move Terrain",
+			() => Apply( terrain, positionBefore, heightBefore, controlBefore ),
+			() => Apply( terrain, positionAfter, heightAfter, controlAfter ) );
+
+		Close();
+	}
+
+	/// <summary>
+	/// Copies the maps in, so no snapshot array is ever aliased by live storage that sculpting
+	/// could then mutate underneath an undo entry.
+	/// </summary>
+	static void Apply( Terrain terrain, Vector3 position, ushort[] heightMap, uint[] controlMap )
+	{
+		if ( !terrain.IsValid() || terrain.Storage is null ) return;
+
+		terrain.Storage.HeightMap = heightMap.ToArray();
+		terrain.Storage.ControlMap = controlMap.ToArray();
+		terrain.WorldPosition = position;
+		terrain.Create();
+	}
+}
+
+
+file class BottomToolbar : Widget
+{
+	public Button Done { get; }
+
+	public BottomToolbar()
+	{
+		Done = new Button.Primary( "Move", "open_with", this );
+
+		Layout = Layout.Row();
+		Layout.Margin = 16;
+		Layout.AddStretchCell();
+		Layout.Add( Done );
+	}
+
+	protected override void OnPaint()
+	{
+		Paint.Pen = Theme.ControlBackground.WithAlpha( 0.5f );
+		Paint.PenSize = 2;
+
+		Paint.DrawLine( LocalRect.TopLeft, LocalRect.TopRight );
+	}
+}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Just a little panel to let you scale / move terrain easily with bound visualisation

## Motivation & Context

The terrain tool is really good but once you started doing your terrain and then realize fuck i wanted it a bit bigger / higher, you're fucked, even like if you wanted to dig deeper, you can't.

So i made something that let us scale (as before with uniform scaling) but also scale while keep actual geometry size (so you basically keep what you had and then earn more space)

And a tool to translate the height data (like moving up / down / left / right) 

## Implementation Details

Ngl jean claude helped me a lot but i was like that might be helping you as a good base

- So first i added a TerrainBoundPreview that let us visualize what's ur terrain limit, and that's useful for after you'll see
- Then i remove the input to change terrain height / wide to a non editable input with 2 button
- And so into TerrainImportHelper there is now `ShiftContent` that will manage the x and y translation
- I also added `OffsetHeights` that will manage the z translation so height clamped to to prevent to high values / negative ones
- And lastly the `CanvasResize` that doesnt mutate the input but return a modified array so we can support undo
- And i also added a green / red zone indicator when i translate a zone that will lose detail / have some part "interpolated"

## Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/4df8d0f6-9a5b-405a-8d78-cc7a906a625c

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂