### PR TITLE
[Clutter] Cache scene bound for scatterer

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Clutter/ClutterGenerationJob.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/ClutterGenerationJob.cs
@@ -92,8 +92,9 @@ class ClutterGenerationJob
 				seed = Scatterer.GenerateSeed( Tile.SeedOffset, Tile.Coordinates.x, Tile.Coordinates.y );
 			}
 
+			var scene = Parent.Scene;
 			var instances = Clutter.Scatterer.HasValue
-				? Clutter.Scatterer.Value.Scatter( Bounds, Clutter, seed, Parent.Scene )
+				? Clutter.Scatterer.Value.Scatter( Bounds, Clutter, seed, scene, GetSceneBounds( scene ) )
 				: null;
 
 			if ( LocalBounds.HasValue && VolumeTransform.HasValue )
@@ -119,6 +120,34 @@ class ClutterGenerationJob
 		{
 			OnComplete?.Invoke();
 		}
+	}
+
+	private static Scene _sceneBoundsScene;
+	private static BBox _sceneBounds;
+	private static bool _sceneBoundsDirty = true;
+
+	/// <summary>
+	/// Invalidates the cached scene bounds. Usefull for height changes in the scene.
+	/// </summary>
+	internal static void InvalidateSceneBounds()
+	{
+		_sceneBoundsDirty = true;
+	}
+
+	/// <summary>
+	/// Cached scene bounds for ground traces; only Z is used. Expensive to query, so cache until invalidated. 
+	/// Unguarded statics—jobs run on main thread only.
+	/// </summary>
+	private static BBox GetSceneBounds( Scene scene )
+	{
+		if ( !_sceneBoundsDirty && _sceneBoundsScene == scene )
+			return _sceneBounds;
+
+		_sceneBoundsScene = scene;
+		_sceneBounds = scene.GetBounds();
+		_sceneBoundsDirty = false;
+
+		return _sceneBounds;
 	}
 
 	private static void ApplyEntryLocalScale( List<ClutterInstance> instances )

--- a/engine/Sandbox.Engine/Scene/Components/Clutter/Scatterer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/Scatterer.cs
@@ -26,9 +26,10 @@ public abstract class Scatterer
 	/// </summary>
 	/// <param name="bounds">World-space bounds to scatter within</param>
 	/// <param name="clutter">The clutter containing objects to scatter</param>
-	/// <param name="scene">Scene to use for tracing (null falls back to Game.ActiveScene)</param>
+	/// <param name="scene">Scene to use for tracing</param>
+	/// <param name="sceneBounds">World bounds of the scene, used as the vertical span of ground traces</param>
 	/// <returns>Collection of clutter instances to spawn</returns>
-	protected abstract List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene = null );
+	protected abstract List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene, BBox sceneBounds );
 
 	/// <summary>
 	/// Public entry point for scattering. Creates Random from seed and calls Generate().
@@ -36,13 +37,15 @@ public abstract class Scatterer
 	/// <param name="bounds">World-space bounds to scatter within</param>
 	/// <param name="clutter">The clutter containing objects to scatter</param>
 	/// <param name="seed">Seed for deterministic random generation</param>
-	/// <param name="scene">Scene to use for tracing (required in editor mode)</param>
-	/// <returns>Collection of clutter instances to spawn</returns>
-	public List<ClutterInstance> Scatter( BBox bounds, ClutterDefinition clutter, int seed, Scene scene = null )
+	/// <param name="scene">Scene to use for tracing (null falls back to Game.ActiveScene)</param>
+	/// <param name="sceneBounds">Scene vertical bounds for ground traces. Pass a cached value if possible.</param>
+	/// <returns>Clutter instances to spawn</returns>
+	public List<ClutterInstance> Scatter( BBox bounds, ClutterDefinition clutter, int seed, Scene scene = null, BBox? sceneBounds = null )
 	{
+		scene ??= Game.ActiveScene;
 		Random = new Random( seed );
 
-		return Generate( bounds, clutter, scene );
+		return Generate( bounds, clutter, scene, sceneBounds ?? scene.GetBounds() );
 	}
 
 	/// <summary>

--- a/engine/Sandbox.Engine/Scene/Components/Clutter/Scatterer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/Scatterer.cs
@@ -43,6 +43,9 @@ public abstract class Scatterer
 	public List<ClutterInstance> Scatter( BBox bounds, ClutterDefinition clutter, int seed, Scene scene = null, BBox? sceneBounds = null )
 	{
 		scene ??= Game.ActiveScene;
+		if ( scene is null || clutter is null || clutter.IsEmpty )
+			return [];
+
 		Random = new Random( seed );
 
 		return Generate( bounds, clutter, scene, sceneBounds ?? scene.GetBounds() );

--- a/engine/Sandbox.Engine/Scene/Components/Clutter/SimpleScatterer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/SimpleScatterer.cs
@@ -26,10 +26,6 @@ public class SimpleScatterer : Scatterer
 
 	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene, BBox sceneBounds )
 	{
-		scene ??= Game.ActiveScene;
-		if ( scene == null || clutter == null )
-			return [];
-
 		var pointCount = CalculatePointCount( bounds, Density );
 		var points = JitteredGridPoints( bounds, pointCount );
 		var totalPoints = points.Length;

--- a/engine/Sandbox.Engine/Scene/Components/Clutter/SimpleScatterer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/SimpleScatterer.cs
@@ -24,7 +24,7 @@ public class SimpleScatterer : Scatterer
 	[Property, Group( "Placement" ), ShowIf( nameof( PlaceOnGround ), true )]
 	public bool AlignToNormal { get; set; }
 
-	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene = null )
+	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene, BBox sceneBounds )
 	{
 		scene ??= Game.ActiveScene;
 		if ( scene == null || clutter == null )
@@ -48,7 +48,7 @@ public class SimpleScatterer : Scatterer
 		}
 
 		using var pooledTraces = PlaceOnGround
-			? RentGroundTraces( scene, points, scene.GetBounds() )
+			? RentGroundTraces( scene, points, sceneBounds )
 			: default;
 		var traces = pooledTraces.Span;
 

--- a/engine/Sandbox.Engine/Scene/Components/Clutter/TerrainScatterer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/TerrainScatterer.cs
@@ -76,10 +76,6 @@ public class SlopeScatterer : Scatterer
 
 	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene, BBox sceneBounds )
 	{
-		scene ??= Game.ActiveScene;
-		if ( scene == null || clutter == null || clutter.IsEmpty )
-			return [];
-
 		var pointCount = CalculatePointCount( bounds, Density );
 		var points = JitteredGridPoints( bounds, pointCount );
 		var instances = new List<ClutterInstance>( points.Length );
@@ -261,10 +257,6 @@ public class TerrainMaterialScatterer : Scatterer
 
 	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene, BBox sceneBounds )
 	{
-		scene ??= Game.ActiveScene;
-		if ( scene == null || clutter == null || clutter.IsEmpty )
-			return [];
-
 		// Clear terrain cache for new generation
 		_cachedTerrain = null;
 		_cachedTerrainObject = null;

--- a/engine/Sandbox.Engine/Scene/Components/Clutter/TerrainScatterer.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/TerrainScatterer.cs
@@ -74,7 +74,7 @@ public class SlopeScatterer : Scatterer
 	[Property]
 	public bool UseFallback { get; set; } = true;
 
-	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene = null )
+	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene, BBox sceneBounds )
 	{
 		scene ??= Game.ActiveScene;
 		if ( scene == null || clutter == null || clutter.IsEmpty )
@@ -87,7 +87,6 @@ public class SlopeScatterer : Scatterer
 		if ( points.Length == 0 )
 			return instances;
 
-		var sceneBounds = scene.GetBounds();
 		using var pooledTraces = RentGroundTraces( scene, points, sceneBounds );
 
 		foreach ( var trace in pooledTraces.Span )
@@ -260,7 +259,7 @@ public class TerrainMaterialScatterer : Scatterer
 	[JsonIgnore, Hide]
 	private GameObject _cachedTerrainObject;
 
-	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene = null )
+	protected override List<ClutterInstance> Generate( BBox bounds, ClutterDefinition clutter, Scene scene, BBox sceneBounds )
 	{
 		scene ??= Game.ActiveScene;
 		if ( scene == null || clutter == null || clutter.IsEmpty )
@@ -277,7 +276,6 @@ public class TerrainMaterialScatterer : Scatterer
 		if ( points.Length == 0 )
 			return instances;
 
-		var sceneBounds = scene.GetBounds();
 		using var pooledTraces = RentGroundTraces( scene, points, sceneBounds );
 
 		foreach ( var trace in pooledTraces.Span )

--- a/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
+++ b/engine/Sandbox.Engine/Scene/GameObjectSystems/ClutterGridSystem.cs
@@ -17,12 +17,14 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 	private readonly List<ClutterGenerationJob> _pendingJobs = [];
 	private readonly HashSet<ClutterTile> _pendingTiles = [];
 	private readonly HashSet<Terrain> _subscribedTerrains = [];
+	private readonly HashSet<MapInstance> _subscribedMaps = [];
 	private Vector3 _lastCameraPosition;
 
 	// Reused by the update path so an idle scene doesn't allocate.
 	private readonly List<ClutterComponent> _activeInfinite = [];
 	private readonly List<ClutterComponent> _componentsToRemove = [];
 	private readonly List<Terrain> _sceneTerrains = [];
+	private readonly List<MapInstance> _sceneMaps = [];
 	private readonly HashSet<ClutterLayer> _layersToRebuild = [];
 
 	/// <summary>
@@ -51,7 +53,7 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 	public ClutterGridSystem( Scene scene ) : base( scene )
 	{
 		Listen( Stage.FinishUpdate, 0, OnUpdate, "ClutterGridSystem.Update" );
-		Listen( Stage.SceneLoaded, 0, RestorePaintedLayer, "ClutterGridSystem.RestorePainted" );
+		Listen( Stage.SceneLoaded, 0, OnSceneLoaded, "ClutterGridSystem.RestorePainted" );
 	}
 
 	public override void Dispose()
@@ -61,6 +63,14 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 		foreach ( var terrain in _subscribedTerrains )
 			if ( terrain.IsValid() ) terrain.OnTerrainModified -= OnTerrainModified;
 		_subscribedTerrains.Clear();
+
+		foreach ( var map in _subscribedMaps )
+		{
+			if ( !map.IsValid() ) continue;
+			map.OnMapLoaded -= OnWorldGeometryChanged;
+			map.OnMapUnloaded -= OnWorldGeometryChanged;
+		}
+		_subscribedMaps.Clear();
 
 		_painted?.ClearAllTiles();
 		_painted = null;
@@ -83,7 +93,7 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 
 			PublishLodParameters( camera );
 
-			SubscribeToTerrains();
+			SubscribeToWorldGeometry();
 			UpdateInfiniteLayers( _lastCameraPosition );
 			ProcessJobs();
 		}
@@ -103,8 +113,11 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 		}
 	}
 
-	private void RestorePaintedLayer()
+	private void OnSceneLoaded()
 	{
+		// Whatever the scene had before this is gone, and its bounds went with it.
+		ClutterGenerationJob.InvalidateSceneBounds();
+
 		RebuildPaintedLayer();
 		_dirty = false;
 	}
@@ -124,20 +137,47 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 		};
 	}
 
-	private void SubscribeToTerrains()
+	/// <summary>
+	/// Tracks the things that define how tall the world is - terrains and maps - so the cached
+	/// scene bounds used for ground traces can be invalidated when one appears, loads or leaves.
+	/// </summary>
+	private void SubscribeToWorldGeometry()
 	{
 		_sceneTerrains.Clear();
 		Scene.GetAll( _sceneTerrains );
 
 		foreach ( var terrain in _sceneTerrains )
 		{
-			if ( _subscribedTerrains.Add( terrain ) )
-			{
-				terrain.OnTerrainModified += OnTerrainModified;
-			}
+			if ( !_subscribedTerrains.Add( terrain ) )
+				continue;
+
+			terrain.OnTerrainModified += OnTerrainModified;
+			ClutterGenerationJob.InvalidateSceneBounds();
 		}
 
-		_subscribedTerrains.RemoveWhere( t => !t.IsValid() );
+		if ( _subscribedTerrains.RemoveWhere( t => !t.IsValid() ) > 0 )
+			ClutterGenerationJob.InvalidateSceneBounds();
+
+		_sceneMaps.Clear();
+		Scene.GetAll( _sceneMaps );
+
+		foreach ( var map in _sceneMaps )
+		{
+			if ( !_subscribedMaps.Add( map ) )
+				continue;
+
+			map.OnMapLoaded += OnWorldGeometryChanged;
+			map.OnMapUnloaded += OnWorldGeometryChanged;
+			ClutterGenerationJob.InvalidateSceneBounds();
+		}
+
+		if ( _subscribedMaps.RemoveWhere( m => !m.IsValid() ) > 0 )
+			ClutterGenerationJob.InvalidateSceneBounds();
+	}
+
+	private static void OnWorldGeometryChanged()
+	{
+		ClutterGenerationJob.InvalidateSceneBounds();
 	}
 
 	private void UpdateActiveComponents( List<ClutterComponent> components, Vector3 cameraPosition )
@@ -257,6 +297,9 @@ public sealed partial class ClutterGridSystem : GameObjectSystem
 
 	private void OnTerrainModified( Terrain.SyncFlags flags, RectInt region )
 	{
+		// Sculpting moves the terrain's vertical extent, which is what ground traces span.
+		ClutterGenerationJob.InvalidateSceneBounds();
+
 		var bounds = TerrainRegionToWorldBounds( _subscribedTerrains.First(), region );
 		InvalidateTilesInBounds( bounds );
 	}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

It will basically cache the scene bound till it's dirty (scene changes, terrain modified or even manually via a static function call), so if we have multiples layers of clutter renderer, it wont calculate it per each scatterer again each frames

## Motivation & Context

So i was trying to figure out why do i have only 100fps on my map even with lower camera far z or disabled shadow etc,
Find out this 
<img width="3594" height="1652" alt="image" src="https://github.com/user-attachments/assets/c8f9f1d1-3f67-417c-82c9-4d04bd85543e" />
So it mean it takes 30ms per layer and 98% of it is the scene bound calculation :(

## Implementation Details

I did a bit of refactor to make more sense,

- First i passed sceneBounds as argument to each scatterer
- I added a function `GetSceneBounds` into ClutterGenerationJob that will do the cache and verify if the scene bound is dirty and should be recalculated (scene has changed or is manually set as dirty)
- Then i renamed a bit and rework the `ClutterGridSystem`, so RestorePaintedLayer is now OnSceneLoaded cause it will also recalculate the scene bound and it's called on sceneload so make more sense - And i made that `SubscribeToTerrains` is now `SubscribeToWorldGeometry` and tackle terrain but also add a callback on scene with OnMapLoaded / OnMapUnloaded to make sure bound take count of the MapInstance that is lazy loaded
- And finally i unified the scatter verification of `if ( scene is null || clutter is null || clutter.IsEmpty )` cause i saw that SimpleScatter didnt contain `clutter.IsEmpty` and it was just copy pasted across every scatterer, made more sense to put it directly into `Scatter` function that call each scatter generate 

## Screenshots / Videos (if applicable)

Before when shaking camera (30ms for ClutterGridSystem.OnUpdate)
<img width="3479" height="859" alt="image" src="https://github.com/user-attachments/assets/84603e9b-9a30-4cc7-9f39-0b0850d7bba6" />

After (the small white thing)  (1ms for ClutterGridSystem.OnUpdate)
<img width="3460" height="1143" alt="image" src="https://github.com/user-attachments/assets/55624d1f-ecdb-4f2b-973b-12abf215176d" />

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂