### PR TITLE
Add terrain storage change synchronization

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Terrain/Terrain.Edit.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Terrain/Terrain.Edit.cs
@@ -112,6 +112,20 @@ public partial class Terrain
 	}
 
 	/// <summary>
+	/// Applies CPU-side storage changes to rendering and collision, then notifies terrain-dependent systems.
+	/// </summary>
+	public void ApplyStorageChanges( SyncFlags flags, RectInt region )
+	{
+		Assert.NotNull( Storage );
+
+		region = ClampToResolution( region );
+
+		SyncGPUTexture();
+		UpdateCollision( flags, region );
+		OnTerrainModified?.Invoke( flags, region );
+	}
+
+	/// <summary>
 	/// Update the collider heights/materials from the current CPU data for a region.
 	/// </summary>
 	public void UpdateCollision( SyncFlags flags, RectInt region )

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/TerrainTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/TerrainTests.cs
@@ -430,6 +430,53 @@ public class TerrainComponentTest
 	}
 
 	/// <summary>
+	/// Applying CPU storage changes updates terrain dependencies and emits one notification.
+	/// Collision-only refreshes remain side-effect free for modification listeners.
+	/// </summary>
+	[TestMethod]
+	public void StorageChangesSynchronizeAndNotify()
+	{
+		var scene = new Scene();
+		using var sceneScope = scene.Push();
+
+		var storage = CreateSmallStorage();
+		var go = scene.CreateObject();
+		var terrain = go.Components.Create<Terrain>( false );
+		terrain.Storage = storage;
+		terrain.Enabled = true;
+
+		var notificationCount = 0;
+		var notifiedFlags = default( Terrain.SyncFlags );
+		var notifiedRegion = default( RectInt );
+		var colliderHeightAtNotification = 0.0f;
+		terrain.OnTerrainModified += ( flags, region ) =>
+		{
+			notificationCount++;
+			notifiedFlags = flags;
+			notifiedRegion = region;
+			colliderHeightAtNotification = terrain.Shapes[0].LocalBounds.Maxs.y;
+		};
+
+		var dirtyRegion = new RectInt( -16, -16, 96, 96 );
+		terrain.UpdateCollision( Terrain.SyncFlags.Height, dirtyRegion );
+		Assert.AreEqual( 0, notificationCount, "Updating collision alone is not a terrain modification" );
+
+		storage.HeightMap[^1] = ushort.MaxValue;
+		terrain.ApplyStorageChanges( Terrain.SyncFlags.Height, dirtyRegion );
+
+		Assert.AreEqual( 1, notificationCount );
+		Assert.AreEqual( Terrain.SyncFlags.Height, notifiedFlags );
+		Assert.AreEqual( 0, notifiedRegion.Left );
+		Assert.AreEqual( 64, notifiedRegion.Right );
+		Assert.AreEqual( 0, notifiedRegion.Top );
+		Assert.AreEqual( 64, notifiedRegion.Bottom );
+		Assert.AreEqual( 1000.0f, colliderHeightAtNotification, 1.0f, "Storage changes reach the live collider before notification" );
+
+		go.Destroy();
+		scene.ProcessDeletes();
+	}
+
+	/// <summary>
 	/// RayIntersects casts against the CPU heightmap without needing the component enabled.
 	/// The heightfield occupies half a cell to (resolution - 0.5) cells on the local X and Y
 	/// axes with height along local Z: a downward ray over the raised plateau hits at the

--- a/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/BaseBrushTool.cs
@@ -270,8 +270,7 @@ public abstract class BaseBrushTool : EditorTool
 				dest[dirtyRegion.Left + x + (dirtyRegion.Top + y) * terrain.Storage.Resolution] = region[x + y * dirtyRegion.Width];
 			}
 		}
-		terrain.SyncGPUTexture();
-		terrain.UpdateCollision( flags, dirtyRegion );
+		terrain.ApplyStorageChanges( flags, dirtyRegion );
 	};
 
 	protected virtual void OnPaintEnded( Terrain terrain )

--- a/game/addons/tools/Code/Scene/Terrain/Tools/PaintTextureTool.cs
+++ b/game/addons/tools/Code/Scene/Terrain/Tools/PaintTextureTool.cs
@@ -92,8 +92,7 @@ public class PaintTextureTool : BaseBrushTool
 				}
 			}
 
-			terrain.SyncGPUTexture();
-			terrain.UpdateCollision( Terrain.SyncFlags.Control, dirtyRegion );
+			terrain.ApplyStorageChanges( Terrain.SyncFlags.Control, dirtyRegion );
 		};
 
 		SceneEditorSession.Active.UndoSystem.Insert( $"Terrain {DisplayInfo.For( this ).Name}", CreateUndoAction( regionBefore ), CreateUndoAction( regionAfter ) );


### PR DESCRIPTION


# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

Adds `ApplyStorageChanges` which applies storage changes to collision and rendering and notifies terrain-dependent systems.

Previously, modifying terrain would trigger `OnTerrainModified`, but using the undo feature in the editor would not. This centralizes the storage changes triggered by the Undo process to prevent future drift and alerts terrain-dependent systems like normal terrain operations.

## Motivation & Context

<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Editor user experience improvement. Without this change, systems subscribing to `OnTerrainModified` would not be notified appropriately when a terrain change was undone via the Undo system.

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂