### PR TITLE
[Clutter] Fix SSS shadow showed even tho cast shadow is disabled

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Clutter/ClutterBatchSceneObject.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Clutter/ClutterBatchSceneObject.cs
@@ -167,6 +167,7 @@ internal class ClutterBatchSceneObject : SceneCustomObject
 		_commandList.Attributes.Set( "AllInstanceSpheres", _spheres );
 		_commandList.Attributes.Set( "InstanceCount", _count );
 		_commandList.Attributes.Set( "ClutterModelRadius", _modelRadius );
+		_commandList.Attributes.Set( "ReceiveScreenSpaceShadows", Flags.CastShadows ? 1.0f : 0.0f );
 		_commandList.Attributes.Set( "ClutterLodCount", _lodCount );
 		_commandList.Attributes.Set( "ClutterLodSwitchDistances", _lodDistances );
 

--- a/game/core/shaders/Shadows/DirectionalLightShadow.hlsl
+++ b/game/core/shaders/Shadows/DirectionalLightShadow.hlsl
@@ -30,6 +30,7 @@ cbuffer DirectionalLightCB
 };
 
 int DirectionalLightDebug < Attribute( "DirectionalLightDebug" ); >;
+float g_flReceiveScreenSpaceShadows < Attribute( "ReceiveScreenSpaceShadows" ); Default( 1.0f ); >;
 
 static const float3 DebugColors[4] = {
     float3( 1.0f, 0.0f, 0.0f ),
@@ -93,7 +94,8 @@ struct DirectionalLightShadow
 
         Texture2D tMask = Bindless::GetTexture2D(g_DirectionalLightScreenSpaceShadowIndex);
         vPositionSs.xy -= g_vViewportOffset.xy;
-		return MSAAUtils::SampleRed( tMask, vPositionSs );
+		float shadow = MSAAUtils::SampleRed( tMask, vPositionSs );
+		return lerp( 1.0f, shadow, saturate( g_flReceiveScreenSpaceShadows ) );
 	}
 
 	static float3 GetOccludedPosition( float3 fragPos )


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Since the SSS was added, there was no attributes to say disable SSS shadow, so i added one so we can easily plug it to clutter and avoid screen space shadow when no cast shadow (on my grass i didnt want some)

## Motivation & Context

My mappers find ugly the SSS on grass, so i fixed the option

Fixes: #11493

## Implementation Details

I just added a attribute to DirectionalLightShadow that disable SSS 
i tried to make it work with any object but doesnt seem to work, sam might be better at tackling that than me

## Screenshots / Videos (if applicable)

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂