### PR TITLE
[Terrain] Refactor so tmat use Texture instead of string

### DIFF
--- a/engine/Sandbox.Engine/Resources/Terrain/TerrainMaterial.cs
+++ b/engine/Sandbox.Engine/Resources/Terrain/TerrainMaterial.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Sandbox;
@@ -17,13 +18,24 @@ public enum TerrainFlags : uint
 public class TerrainMaterial : GameResource
 {
 	//
-	// Editor only
+	// Source images used when a slot is left empty
 	//
-	[Category( "Source Images" ), ImageAssetPath] public string AlbedoImage { get; set; } = "materials/default/default_color.tga";
-	[Category( "Source Images" ), ImageAssetPath] public string RoughnessImage { get; set; } = "materials/default/default_rough.tga";
-	[Category( "Source Images" ), ImageAssetPath] public string NormalImage { get; set; } = "materials/default/default_normal.tga";
-	[Category( "Source Images" ), ImageAssetPath] public string HeightImage { get; set; } = "materials/default/default_ao.tga";
-	[Category( "Source Images" ), ImageAssetPath, Title( "AO Image" )] public string AOImage { get; set; } = "materials/default/default_ao.tga";
+	internal const string DefaultAlbedoImage = "materials/default/default_color.tga";
+	internal const string DefaultRoughnessImage = "materials/default/default_rough.tga";
+	internal const string DefaultNormalImage = "materials/default/default_normal.tga";
+	internal const string DefaultHeightImage = "materials/default/default_ao.tga";
+	internal const string DefaultAOImage = "materials/default/default_ao.tga";
+
+	//
+	// Editor only. These get packed into the two generated textures below when the
+	// material compiles, which means they have to resolve to an image file - the
+	// packing runs through the texture compiler, not through the generator.
+	//
+	[Category( "Source Images" )] public Texture AlbedoImage { get; set; }
+	[Category( "Source Images" )] public Texture RoughnessImage { get; set; }
+	[Category( "Source Images" )] public Texture NormalImage { get; set; }
+	[Category( "Source Images" )] public Texture HeightImage { get; set; }
+	[Category( "Source Images" ), Title( "AO Image" )] public Texture AOImage { get; set; }
 
 	//
 	// Compiled generated textures
@@ -37,7 +49,7 @@ public class TerrainMaterial : GameResource
 	[Category( "Material" ), Range( 0.1f, 10 )] public float HeightBlendStrength { get; set; } = 1.0f;
 
 	[JsonIgnore, Hide]
-	public bool HasHeightTexture => !string.IsNullOrEmpty( HeightImage ) && HeightImage != "materials/default/default_ao.tga";
+	public bool HasHeightTexture => HeightImage is not null;
 
 	[Category( "Material" ), Range( 0.0f, 10.0f ), Title( "Displacement Scale" ), ShowIf( nameof( HasHeightTexture ), true )]
 	public float DisplacementScale { get; set; } = 0.0f;
@@ -60,6 +72,51 @@ public class TerrainMaterial : GameResource
 	}
 
 	[Category( "Misc" )] public Surface Surface { get; set; }
+
+	[Hide, JsonIgnore] public override int ResourceVersion => 1;
+
+	/// <summary>
+	/// v1
+	/// - Source images were bare image paths, they're textures now. An empty slot falls
+	///   back to its default image, so drop the paths that were only ever the default.
+	/// </summary>
+	[Expose, JsonUpgrader( typeof( TerrainMaterial ), 1 )]
+	static void Upgrader_v1_ImagePathsToTextures( JsonObject json )
+	{
+		Upgrade( json, nameof( AlbedoImage ), DefaultAlbedoImage );
+		Upgrade( json, nameof( RoughnessImage ), DefaultRoughnessImage );
+		Upgrade( json, nameof( NormalImage ), DefaultNormalImage );
+		Upgrade( json, nameof( HeightImage ), DefaultHeightImage );
+		Upgrade( json, nameof( AOImage ), DefaultAOImage );
+
+		static void Upgrade( JsonObject json, string name, string defaultPath )
+		{
+			if ( !json.TryGetPropertyValue( name, out var node ) )
+				return;
+
+			// Only a bare path is the old format
+			if ( node is not JsonValue value || !value.TryGetValue<string>( out var filePath ) )
+				return;
+
+			if ( string.IsNullOrWhiteSpace( filePath ) || filePath == defaultPath )
+			{
+				json[name] = null;
+				return;
+			}
+
+			json[name] = new JsonObject
+			{
+				["$compiler"] = "texture",
+				["$source"] = "imagefile",
+				["data"] = new JsonObject
+				{
+					["FilePath"] = filePath,
+					["MaxSize"] = 4096
+				},
+				["compiled"] = null
+			};
+		}
+	}
 
 	void LoadGeneratedTextures()
 	{

--- a/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pack.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pack.cs
@@ -45,29 +45,30 @@ public partial class Bitmap
 		foreach ( var group in channels.GroupBy( x => x.Source ) )
 		{
 			var source = group.Key;
-			Bitmap resized = null;
 
-			try
+			if ( source.Width == width && source.Height == height )
 			{
-				if ( source.Width != width || source.Height != height )
-					resized = source.Resize( width, height );
-
-				var pixels = (resized ?? source).GetBuffer();
-
-				foreach ( var (_, from, to) in group )
-				{
-					for ( int i = 0; i < width * height; i++ )
-					{
-						destination[i * 4 + (int)to] = pixels[i * 4 + (int)from];
-					}
-				}
+				CopyChannels( source, group, destination, width, height );
+				continue;
 			}
-			finally
-			{
-				resized?.Dispose();
-			}
+
+			using var resized = source.Resize( width, height );
+			CopyChannels( resized, group, destination, width, height );
 		}
 
 		return packed;
+	}
+
+	static void CopyChannels( Bitmap bitmap, IEnumerable<(Bitmap Source, ColorChannel From, ColorChannel To)> channels, Span<byte> destination, int width, int height )
+	{
+		var pixels = bitmap.GetBuffer();
+
+		foreach ( var (_, from, to) in channels )
+		{
+			for ( int i = 0; i < width * height; i++ )
+			{
+				destination[i * 4 + (int)to] = pixels[i * 4 + (int)from];
+			}
+		}
 	}
 }

--- a/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pack.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pack.cs
@@ -1,0 +1,70 @@
+namespace Sandbox;
+
+public partial class Bitmap
+{
+	/// <summary>
+	/// A single color channel of an 8 bit per channel bitmap.
+	/// </summary>
+	internal enum ColorChannel
+	{
+		Red = 0,
+		Green = 1,
+		Blue = 2,
+		Alpha = 3
+	}
+
+	/// <summary>
+	/// Copy single channels out of other bitmaps into one new bitmap - packing a set of
+	/// grayscale maps into one texture, for example. The result is as big as the largest
+	/// source, and smaller sources are scaled up to match. Channels that nothing is copied
+	/// into are left at zero.
+	/// </summary>
+	internal static Bitmap PackChannels( params (Bitmap Source, ColorChannel From, ColorChannel To)[] channels )
+	{
+		ArgumentNullException.ThrowIfNull( channels );
+
+		if ( channels.Length == 0 )
+			throw new ArgumentException( "Need at least one channel to pack", nameof( channels ) );
+
+		foreach ( var (source, _, _) in channels )
+		{
+			if ( source is null || !source.IsValid )
+				throw new ArgumentException( "Can't pack an invalid bitmap", nameof( channels ) );
+
+			if ( source.IsFloatingPoint )
+				throw new ArgumentException( "Channel packing works on 8 bit per channel bitmaps", nameof( channels ) );
+		}
+
+		var width = channels.Max( x => x.Source.Width );
+		var height = channels.Max( x => x.Source.Height );
+
+		var packed = new Bitmap( width, height );
+		var destination = packed.GetBuffer();
+
+		// A source can feed more than one channel, so only scale it once
+		foreach ( var group in channels.GroupBy( x => x.Source ) )
+		{
+			var source = group.Key;
+			var resized = source.Width == width && source.Height == height ? null : source.Resize( width, height );
+
+			try
+			{
+				var pixels = (resized ?? source).GetBuffer();
+
+				foreach ( var (_, from, to) in group )
+				{
+					for ( int i = 0; i < width * height; i++ )
+					{
+						destination[i * 4 + (int)to] = pixels[i * 4 + (int)from];
+					}
+				}
+			}
+			finally
+			{
+				resized?.Dispose();
+			}
+		}
+
+		return packed;
+	}
+}

--- a/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pack.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Bitmap/Bitmap.Pack.cs
@@ -45,10 +45,13 @@ public partial class Bitmap
 		foreach ( var group in channels.GroupBy( x => x.Source ) )
 		{
 			var source = group.Key;
-			var resized = source.Width == width && source.Height == height ? null : source.Resize( width, height );
+			Bitmap resized = null;
 
 			try
 			{
+				if ( source.Width != width || source.Height != height )
+					resized = source.Resize( width, height );
+
 				var pixels = (resized ?? source).GetBuffer();
 
 				foreach ( var (_, from, to) in group )

--- a/engine/Sandbox.Engine/Resources/Textures/Generators/ImageFileTextureGenerator.cs
+++ b/engine/Sandbox.Engine/Resources/Textures/Generators/ImageFileTextureGenerator.cs
@@ -197,8 +197,26 @@ public class ImageFileGenerator : TextureGenerator
 			return Texture.Load( FilePath );
 		}
 
-		var bitmap = await LoadCached();
+		var bitmap = await CreateBitmap( options, ct );
 		if ( bitmap is null ) return Texture.Invalid;
+
+		var texture = bitmap.ToTexture();
+		bitmap.Dispose();
+
+		return texture;
+	}
+
+	/// <summary>
+	/// The fully processed image, before it becomes a texture. Compilers that pack images
+	/// together (terrain materials) need the pixels, not a texture.
+	/// </summary>
+	internal async Task<Bitmap> CreateBitmap( Options options, CancellationToken ct )
+	{
+		if ( string.IsNullOrWhiteSpace( FilePath ) )
+			return null;
+
+		var bitmap = await LoadCached();
+		if ( bitmap is null ) return null;
 
 		//
 		// Tell the compiler we're using this file, so to add it as a compile reference
@@ -274,10 +292,7 @@ public class ImageFileGenerator : TextureGenerator
 		}
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-		var tex = bitmap.ToTexture();
-		bitmap?.Dispose();
-
-		return tex;
+		return bitmap;
 	}
 
 	public override EmbeddedResource? CreateEmbeddedResource()

--- a/engine/Sandbox.Tools/Assets/TerrainMaterialCompiler.cs
+++ b/engine/Sandbox.Tools/Assets/TerrainMaterialCompiler.cs
@@ -1,5 +1,7 @@
-﻿using Sandbox.Resources;
+using Sandbox.Resources;
+using System;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 
 namespace Sandbox;
@@ -8,7 +10,15 @@ namespace Sandbox;
 [ResourceIdentity( "tmat" )]
 internal class TerrainMaterialCompiler : ResourceCompiler
 {
-	protected override Task<bool> Compile()
+	/// <summary>
+	/// The two textures the terrain samples. Every source image is baked - with whatever
+	/// adjustments it was set up with - into one of these on the CPU, then handed to the
+	/// texture compiler for mips and block compression.
+	/// </summary>
+	const string BCRSuffix = "_tmat_bcr.generated";
+	const string NHOSuffix = "_tmat_nho.generated";
+
+	protected override async Task<bool> Compile()
 	{
 		var filename = Context.AbsolutePath;
 		var jsonString = File.ReadAllText( filename );
@@ -21,215 +31,203 @@ internal class TerrainMaterialCompiler : ResourceCompiler
 		var path = Path.GetDirectoryName( filename );
 		var file = Path.GetFileNameWithoutExtension( filename );
 
-		var albedo = doc.RootElement.TryGetProperty( "AlbedoImage", out var albedoValue ) ? albedoValue.GetString() : "";
-		var roughness = doc.RootElement.TryGetProperty( "RoughnessImage", out var roughnessValue ) ? roughnessValue.GetString() : "";
-		var normal = doc.RootElement.TryGetProperty( "NormalImage", out var normalValue ) ? normalValue.GetString() : "";
-		var height = doc.RootElement.TryGetProperty( "HeightImage", out var heightValue ) ? heightValue.GetString() : "";
-		var ao = doc.RootElement.TryGetProperty( "AOImage", out var aoValue ) ? aoValue.GetString() : "";
+		var root = doc.RootElement;
 
-		var bcrPath = $"{path}/{file}_tmat_bcr.generated.vtex";
-		var nhoPath = $"{path}/{file}_tmat_nho.generated.vtex";
+		using var albedo = await LoadSourceImage( root, nameof( TerrainMaterial.AlbedoImage ), TerrainMaterial.DefaultAlbedoImage );
+		using var roughness = await LoadSourceImage( root, nameof( TerrainMaterial.RoughnessImage ), TerrainMaterial.DefaultRoughnessImage );
+		using var normal = await LoadSourceImage( root, nameof( TerrainMaterial.NormalImage ), TerrainMaterial.DefaultNormalImage );
+		using var height = await LoadSourceImage( root, nameof( TerrainMaterial.HeightImage ), TerrainMaterial.DefaultHeightImage );
+		using var ao = await LoadSourceImage( root, nameof( TerrainMaterial.AOImage ), TerrainMaterial.DefaultAOImage );
 
+		//
+		// Albedo in rgb, roughness in alpha
+		//
 		{
-			var childContext = Context.CreateChild( bcrPath );
-			childContext.SetInputData( string.Format( BCRTextureDefinition, albedo, roughness ) );
+			using var packed = Bitmap.PackChannels(
+				( albedo, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red ),
+				( albedo, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green ),
+				( albedo, Bitmap.ColorChannel.Blue, Bitmap.ColorChannel.Blue ),
+				( roughness, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha ) );
+
+			WritePacked( path, file, BCRSuffix, packed );
+
+			var childContext = Context.CreateChild( $"{path}/{file}{BCRSuffix}.vtex" );
+			childContext.SetInputData( BuildTextureDefinition( RelativeGeneratedPath( file, BCRSuffix ),
+				[
+					( "color", "srgb", "rgb", "rgb" ),
+					( "roughness", "linear", "a", "a" ),
+				] ) );
 			childContext.Compile();
 		}
 
+		//
+		// Normal in rg, height in b, ambient occlusion in alpha
+		//
 		{
-			var childContext = Context.CreateChild( nhoPath );
-			childContext.SetInputData( string.Format( NHOTextureDefinition, normal, height, ao ) );
+			using var packed = Bitmap.PackChannels(
+				( normal, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red ),
+				( normal, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green ),
+				( height, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Blue ),
+				( ao, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha ) );
+
+			WritePacked( path, file, NHOSuffix, packed );
+
+			var childContext = Context.CreateChild( $"{path}/{file}{NHOSuffix}.vtex" );
+			childContext.SetInputData( BuildTextureDefinition( RelativeGeneratedPath( file, NHOSuffix ),
+				[
+					( "nho", "linear", "rgba", "rgba" ),
+				] ) );
 			childContext.Compile();
 		}
 
 		Context.Data.Write( jsonString );
-		return Task.FromResult( true );
+		return true;
+	}
 
-		/*
-		using var stream = new MemoryStream();
-		using var writer = new Utf8JsonWriter( stream );
+	/// <summary>
+	/// Run a source image slot through its own image generator, so what gets packed is what the
+	/// material was set up with - adjustments, cropping, height to normal and all.
+	/// </summary>
+	async Task<Bitmap> LoadSourceImage( JsonElement root, string name, string defaultPath )
+	{
+		var generator = ReadGenerator( root, name, defaultPath );
 
-		writer.WriteStartObject();
-		foreach ( JsonProperty property in doc.RootElement.EnumerateObject() )
+		Context.AddCompileReference( generator.FilePath );
+
+		var bitmap = await generator.CreateBitmap( ResourceGenerator.Options.Default, default );
+		if ( bitmap is null )
+			throw new Exception( $"{name}: couldn't load the image '{generator.FilePath}'" );
+
+		return bitmap;
+	}
+
+	/// <summary>
+	/// The image generator behind a source image slot. An empty slot falls back to its default
+	/// image, and anything that isn't an image file can't be packed.
+	/// </summary>
+	static ImageFileGenerator ReadGenerator( JsonElement root, string name, string defaultPath )
+	{
+		if ( !root.TryGetProperty( name, out var value ) || value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined )
+			return new ImageFileGenerator { FilePath = defaultPath };
+
+		// Pre-v1 materials stored a bare image path
+		if ( value.ValueKind == JsonValueKind.String )
 		{
-			property.WriteTo( writer );
+			var legacyPath = value.GetString();
+			return new ImageFileGenerator { FilePath = string.IsNullOrWhiteSpace( legacyPath ) ? defaultPath : legacyPath };
 		}
-		writer.WriteString( "BCRTexture", bcrPath );
-		writer.WriteString( "NHOTexture", nhoPath );
-		writer.WriteEndObject();
-		writer.Flush();
-		return Encoding.UTF8.GetString( stream.ToArray() );
-		*/
+
+		if ( value.ValueKind != JsonValueKind.Object )
+			throw new Exception( $"{name} should be a texture, but it's a {value.ValueKind}" );
+
+		var source = value.TryGetProperty( "$source", out var sourceValue ) ? sourceValue.GetString() : null;
+		if ( source != "imagefile" )
+			throw new Exception( $"{name} is a '{source}' texture. A terrain material bakes its source images into its own packed textures, so this slot has to be an image file." );
+
+		if ( !value.TryGetProperty( "data", out var data ) )
+			return new ImageFileGenerator { FilePath = defaultPath };
+
+		// Use the engine serializer, the generator's properties need its converters
+		var generator = Json.Deserialize<ImageFileGenerator>( data.GetRawText() ) ?? new ImageFileGenerator();
+
+		if ( string.IsNullOrWhiteSpace( generator.FilePath ) )
+			return new ImageFileGenerator { FilePath = defaultPath };
+
+		if ( generator.FilePath.EndsWith( ".vtex", StringComparison.OrdinalIgnoreCase ) || generator.FilePath.EndsWith( ".vtex_c", StringComparison.OrdinalIgnoreCase ) )
+			throw new Exception( $"{name} points at a compiled texture ({generator.FilePath}). Point it at the source image instead - it gets baked into the material's own packed texture." );
+
+		return generator;
+	}
+
+	/// <summary>
+	/// The packed image goes next to the material as a png - the texture compiler works from
+	/// files, and this is also the thing to look at when a material doesn't look right.
+	/// </summary>
+	static void WritePacked( string path, string file, string suffix, Bitmap packed )
+	{
+		File.WriteAllBytes( $"{path}/{file}{suffix}.png", packed.ToPng() );
+	}
+
+	string RelativeGeneratedPath( string file, string suffix )
+	{
+		var directory = Path.GetDirectoryName( Context.RelativePath )?.Replace( "\\", "/" );
+
+		return string.IsNullOrEmpty( directory )
+			? $"{file}{suffix}.png"
+			: $"{directory}/{file}{suffix}.png";
 	}
 
 	//
 	// Templates cause I don't want to spend hours binding dmx for sometihng we might hate
 	//
 
-	public static string BCRTextureDefinition => @"<!-- dmx encoding keyvalues2_noids 1 format vtex 1 -->
-""CDmeVtex""
-{{
-	""m_inputTextureArray"" ""element_array"" 
-	[
-		""CDmeInputTexture""
-		{{
-			""m_name"" ""string"" ""color""
-			""m_fileName"" ""string"" ""{0}""
-			""m_colorSpace"" ""string"" ""srgb""
-			""m_typeString"" ""string"" ""2D""
-			""m_imageProcessorArray"" ""element_array"" 
-			[
-			]
-		}},
-		""CDmeInputTexture""
-		{{
-			""m_name"" ""string"" ""roughness""
-			""m_fileName"" ""string"" ""{1}""
-			""m_colorSpace"" ""string"" ""linear""
-			""m_typeString"" ""string"" ""2D""
-			""m_imageProcessorArray"" ""element_array"" 
-			[
-			]
-		}}
-	]
-	""m_outputTypeString"" ""string"" ""2D""
-	""m_outputFormat"" ""string"" ""BC7""
-	""m_outputClearColor"" ""vector4"" ""0 0 0 0""
-	""m_nOutputMinDimension"" ""int"" ""0""
-	""m_nOutputMaxDimension"" ""int"" ""0""
-	""m_textureOutputChannelArray"" ""element_array"" 
-	[
-		""CDmeTextureOutputChannel""
-		{{
-			""m_inputTextureArray"" ""string_array"" 
-			[
-				""color""
-			]
-			""m_srcChannels"" ""string"" ""rgb""
-			""m_dstChannels"" ""string"" ""rgb""
-			""m_mipAlgorithm"" ""CDmeImageProcessor""
-			{{
-				""m_algorithm"" ""string"" ""Box""
-				""m_stringArg"" ""string"" """"
-				""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
-			}}
-			""m_outputColorSpace"" ""string"" ""srgb""
-		}},
-		""CDmeTextureOutputChannel""
-		{{
-			""m_inputTextureArray"" ""string_array"" 
-			[
-				""roughness""
-			]
-			""m_srcChannels"" ""string"" ""r""
-			""m_dstChannels"" ""string"" ""a""
-			""m_mipAlgorithm"" ""CDmeImageProcessor""
-			{{
-				""m_algorithm"" ""string"" ""Box""
-				""m_stringArg"" ""string"" """"
-				""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
-			}}
-			""m_outputColorSpace"" ""string"" ""linear""
-		}}
-	]
-	""m_vClamp"" ""vector3"" ""0 0 0""
-	""m_bNoLod"" ""bool"" ""0""
-}}";
+	/// <summary>
+	/// Build the vtex definition for one packed image. Every channel set reads the same file,
+	/// they just differ in which channels they take and what color space those are in.
+	/// </summary>
+	static string BuildTextureDefinition( string filePath, (string Name, string ColorSpace, string SrcChannels, string DstChannels)[] channels )
+	{
+		var builder = new StringBuilder();
 
-	public static string NHOTextureDefinition => @"<!-- dmx encoding keyvalues2_noids 1 format vtex 1 -->
-""CDmeVtex""
-{{
-	""m_inputTextureArray"" ""element_array"" 
-	[
-		""CDmeInputTexture""
-		{{
-			""m_name"" ""string"" ""normal""
-			""m_fileName"" ""string"" ""{0}""
-			""m_colorSpace"" ""string"" ""linear""
-			""m_typeString"" ""string"" ""2D""
-			""m_imageProcessorArray"" ""element_array"" 
-			[
-			]
-		}},
-		""CDmeInputTexture""
-		{{
-			""m_name"" ""string"" ""height""
-			""m_fileName"" ""string"" ""{1}""
-			""m_colorSpace"" ""string"" ""linear""
-			""m_typeString"" ""string"" ""2D""
-			""m_imageProcessorArray"" ""element_array"" 
-			[
-			]
-		}},
-		""CDmeInputTexture""
-		{{
-			""m_name"" ""string"" ""ao""
-			""m_fileName"" ""string"" ""{2}""
-			""m_colorSpace"" ""string"" ""linear""
-			""m_typeString"" ""string"" ""2D""
-			""m_imageProcessorArray"" ""element_array"" 
-			[
-			]
-		}}
-	]
-	""m_outputTypeString"" ""string"" ""2D""
-	""m_outputFormat"" ""string"" ""BC7""
-	""m_outputClearColor"" ""vector4"" ""0 0 0 0""
-	""m_nOutputMinDimension"" ""int"" ""0""
-	""m_nOutputMaxDimension"" ""int"" ""0""
-	""m_textureOutputChannelArray"" ""element_array"" 
-	[
-		""CDmeTextureOutputChannel""
-		{{
-			""m_inputTextureArray"" ""string_array"" 
-			[
-				""normal""
-			]
-			""m_srcChannels"" ""string"" ""rg""
-			""m_dstChannels"" ""string"" ""rg""
-			""m_mipAlgorithm"" ""CDmeImageProcessor""
-			{{
-				""m_algorithm"" ""string"" ""Box""
-				""m_stringArg"" ""string"" """"
-				""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
-			}}
-			""m_outputColorSpace"" ""string"" ""linear""
-		}},
-		""CDmeTextureOutputChannel""
-		{{
-			""m_inputTextureArray"" ""string_array"" 
-			[
-				""height""
-			]
-			""m_srcChannels"" ""string"" ""r""
-			""m_dstChannels"" ""string"" ""b""
-			""m_mipAlgorithm"" ""CDmeImageProcessor""
-			{{
-				""m_algorithm"" ""string"" ""Box""
-				""m_stringArg"" ""string"" """"
-				""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
-			}}
-			""m_outputColorSpace"" ""string"" ""linear""
-		}},
-		""CDmeTextureOutputChannel""
-		{{
-			""m_inputTextureArray"" ""string_array"" 
-			[
-				""ao""
-			]
-			""m_srcChannels"" ""string"" ""r""
-			""m_dstChannels"" ""string"" ""a""
-			""m_mipAlgorithm"" ""CDmeImageProcessor""
-			{{
-				""m_algorithm"" ""string"" ""Box""
-				""m_stringArg"" ""string"" """"
-				""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
-			}}
-			""m_outputColorSpace"" ""string"" ""linear""
-		}}
-	]
-	""m_vClamp"" ""vector3"" ""0 0 0""
-	""m_bNoLod"" ""bool"" ""0""
-}}";
+		builder.AppendLine( "<!-- dmx encoding keyvalues2_noids 1 format vtex 1 -->" );
+		builder.AppendLine( "\"CDmeVtex\"" );
+		builder.AppendLine( "{" );
 
+		builder.AppendLine( "\t\"m_inputTextureArray\" \"element_array\"" );
+		builder.AppendLine( "\t[" );
+
+		for ( int i = 0; i < channels.Length; i++ )
+		{
+			builder.AppendLine( "\t\t\"CDmeInputTexture\"" );
+			builder.AppendLine( "\t\t{" );
+			builder.AppendLine( $"\t\t\t\"m_name\" \"string\" \"{channels[i].Name}\"" );
+			builder.AppendLine( $"\t\t\t\"m_fileName\" \"string\" \"{filePath}\"" );
+			builder.AppendLine( $"\t\t\t\"m_colorSpace\" \"string\" \"{channels[i].ColorSpace}\"" );
+			builder.AppendLine( "\t\t\t\"m_typeString\" \"string\" \"2D\"" );
+			builder.AppendLine( "\t\t\t\"m_imageProcessorArray\" \"element_array\"" );
+			builder.AppendLine( "\t\t\t[" );
+			builder.AppendLine( "\t\t\t]" );
+			builder.AppendLine( i == channels.Length - 1 ? "\t\t}" : "\t\t}," );
+		}
+
+		builder.AppendLine( "\t]" );
+
+		builder.AppendLine( "\t\"m_outputTypeString\" \"string\" \"2D\"" );
+		builder.AppendLine( "\t\"m_outputFormat\" \"string\" \"BC7\"" );
+		builder.AppendLine( "\t\"m_outputClearColor\" \"vector4\" \"0 0 0 0\"" );
+		builder.AppendLine( "\t\"m_nOutputMinDimension\" \"int\" \"0\"" );
+		builder.AppendLine( "\t\"m_nOutputMaxDimension\" \"int\" \"0\"" );
+
+		builder.AppendLine( "\t\"m_textureOutputChannelArray\" \"element_array\"" );
+		builder.AppendLine( "\t[" );
+
+		for ( int i = 0; i < channels.Length; i++ )
+		{
+			var (name, colorSpace, srcChannels, dstChannels) = channels[i];
+
+			builder.AppendLine( "\t\t\"CDmeTextureOutputChannel\"" );
+			builder.AppendLine( "\t\t{" );
+			builder.AppendLine( "\t\t\t\"m_inputTextureArray\" \"string_array\"" );
+			builder.AppendLine( "\t\t\t[" );
+			builder.AppendLine( $"\t\t\t\t\"{name}\"" );
+			builder.AppendLine( "\t\t\t]" );
+			builder.AppendLine( $"\t\t\t\"m_srcChannels\" \"string\" \"{srcChannels}\"" );
+			builder.AppendLine( $"\t\t\t\"m_dstChannels\" \"string\" \"{dstChannels}\"" );
+			builder.AppendLine( "\t\t\t\"m_mipAlgorithm\" \"CDmeImageProcessor\"" );
+			builder.AppendLine( "\t\t\t{" );
+			builder.AppendLine( "\t\t\t\t\"m_algorithm\" \"string\" \"Box\"" );
+			builder.AppendLine( "\t\t\t\t\"m_stringArg\" \"string\" \"\"" );
+			builder.AppendLine( "\t\t\t\t\"m_vFloat4Arg\" \"vector4\" \"0 0 0 0\"" );
+			builder.AppendLine( "\t\t\t}" );
+			builder.AppendLine( $"\t\t\t\"m_outputColorSpace\" \"string\" \"{colorSpace}\"" );
+			builder.AppendLine( i == channels.Length - 1 ? "\t\t}" : "\t\t}," );
+		}
+
+		builder.AppendLine( "\t]" );
+		builder.AppendLine( "\t\"m_vClamp\" \"vector3\" \"0 0 0\"" );
+		builder.AppendLine( "\t\"m_bNoLod\" \"bool\" \"0\"" );
+		builder.Append( "}" );
+
+		return builder.ToString();
+	}
 }

--- a/engine/Sandbox.Tools/Assets/TerrainMaterialCompiler.cs
+++ b/engine/Sandbox.Tools/Assets/TerrainMaterialCompiler.cs
@@ -44,10 +44,10 @@ internal class TerrainMaterialCompiler : ResourceCompiler
 		//
 		{
 			using var packed = Bitmap.PackChannels(
-				( albedo, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red ),
-				( albedo, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green ),
-				( albedo, Bitmap.ColorChannel.Blue, Bitmap.ColorChannel.Blue ),
-				( roughness, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha ) );
+				(albedo, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red),
+				(albedo, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green),
+				(albedo, Bitmap.ColorChannel.Blue, Bitmap.ColorChannel.Blue),
+				(roughness, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha) );
 
 			WritePacked( path, file, BCRSuffix, packed );
 
@@ -65,10 +65,10 @@ internal class TerrainMaterialCompiler : ResourceCompiler
 		//
 		{
 			using var packed = Bitmap.PackChannels(
-				( normal, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red ),
-				( normal, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green ),
-				( height, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Blue ),
-				( ao, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha ) );
+				(normal, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red),
+				(normal, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green),
+				(height, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Blue),
+				(ao, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha) );
 
 			WritePacked( path, file, NHOSuffix, packed );
 

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/TerrainTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/TerrainTests.cs
@@ -173,9 +173,9 @@ public class TerrainComponentTest
 		mask.SetPixels( [new Color( 0.25f, 0.5f, 0.75f, 1.0f )] );
 
 		using var packed = Bitmap.PackChannels(
-			( color, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red ),
-			( color, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green ),
-			( mask, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha ) );
+			(color, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red),
+			(color, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green),
+			(mask, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha) );
 
 		Assert.AreEqual( 2, packed.Width, "The packed image takes the size of the largest source" );
 		Assert.AreEqual( 2, packed.Height );

--- a/engine/Tests/Sandbox.Test.Integration/Scene/Components/TerrainTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/Components/TerrainTests.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Text.Json.Nodes;
 
 namespace SceneTests.Components;
 
@@ -122,10 +123,9 @@ public class TerrainComponentTest
 	}
 
 	/// <summary>
-	/// A programmatic TerrainMaterial has pinned defaults - the default source images, unit
+	/// A programmatic TerrainMaterial has pinned defaults - empty source images, unit
 	/// scales and no surface. NoTiling is the only flag source, HasHeightTexture flips once
-	/// the height image differs from the default, and the materials list on the storage is
-	/// plain in-memory state.
+	/// a height image is set, and the materials list on the storage is plain in-memory state.
 	/// </summary>
 	[TestMethod]
 	public void StorageMaterialsListState()
@@ -133,7 +133,7 @@ public class TerrainComponentTest
 		var storage = new TerrainStorage();
 		var material = new TerrainMaterial();
 
-		Assert.AreEqual( "materials/default/default_color.tga", material.AlbedoImage, "Default albedo image is pinned" );
+		Assert.IsNull( material.AlbedoImage, "Source images start empty and fall back to the default image when compiled" );
 		Assert.AreEqual( 1.0f, material.UVScale );
 		Assert.AreEqual( 0.0f, material.Metalness );
 		Assert.AreEqual( 1.0f, material.NormalStrength );
@@ -141,7 +141,7 @@ public class TerrainComponentTest
 		Assert.AreEqual( 0.0f, material.DisplacementScale );
 		Assert.IsFalse( material.NoTiling );
 		Assert.AreEqual( TerrainFlags.None, material.Flags );
-		Assert.IsFalse( material.HasHeightTexture, "The default height image does not count as a height texture" );
+		Assert.IsFalse( material.HasHeightTexture, "An empty height image does not count as a height texture" );
 		Assert.IsNull( material.Surface );
 		Assert.IsNull( material.BCRTexture, "Generated textures only exist for materials loaded from disk" );
 		Assert.IsNull( material.NHOTexture );
@@ -149,12 +149,84 @@ public class TerrainComponentTest
 		material.NoTiling = true;
 		Assert.AreEqual( TerrainFlags.NoTile, material.Flags, "NoTiling maps onto the NoTile flag" );
 
-		material.HeightImage = "materials/custom/height.tga";
-		Assert.IsTrue( material.HasHeightTexture, "A non-default height image enables displacement" );
+		material.HeightImage = Texture.White;
+		Assert.IsTrue( material.HasHeightTexture, "A height image enables displacement" );
 
 		storage.Materials.Add( material );
 		Assert.AreEqual( 1, storage.Materials.Count );
 		Assert.AreSame( material, storage.Materials[0] );
+	}
+
+	/// <summary>
+	/// Terrain materials are two packed textures, so the compiler copies single channels out of
+	/// the source images: channels land where they're routed, a source can feed more than one
+	/// channel, the result takes the size of the largest source and smaller sources are scaled
+	/// up into it, and channels nothing was routed into stay at zero.
+	/// </summary>
+	[TestMethod]
+	public void PackChannelsRoutesSourceChannels()
+	{
+		using var color = new Bitmap( 2, 2 );
+		color.SetPixels( [Color.Red, Color.Green, Color.Blue, Color.White] );
+
+		using var mask = new Bitmap( 1, 1 );
+		mask.SetPixels( [new Color( 0.25f, 0.5f, 0.75f, 1.0f )] );
+
+		using var packed = Bitmap.PackChannels(
+			( color, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Red ),
+			( color, Bitmap.ColorChannel.Green, Bitmap.ColorChannel.Green ),
+			( mask, Bitmap.ColorChannel.Red, Bitmap.ColorChannel.Alpha ) );
+
+		Assert.AreEqual( 2, packed.Width, "The packed image takes the size of the largest source" );
+		Assert.AreEqual( 2, packed.Height );
+
+		var pixels = packed.GetPixels();
+
+		Assert.AreEqual( 1.0f, pixels[0].r, 0.01f, "Red comes from the color image" );
+		Assert.AreEqual( 0.0f, pixels[0].g, 0.01f );
+		Assert.AreEqual( 0.0f, pixels[1].r, 0.01f );
+		Assert.AreEqual( 1.0f, pixels[1].g, 0.01f, "Green comes from the color image" );
+
+		foreach ( var pixel in pixels )
+		{
+			Assert.AreEqual( 0.0f, pixel.b, 0.01f, "Nothing was routed into blue" );
+			Assert.AreEqual( 0.25f, pixel.a, 0.01f, "Alpha comes from the mask's red, scaled up to the packed size" );
+		}
+	}
+
+	/// <summary>
+	/// Terrain material source images used to be bare image paths and are textures now, so a
+	/// pre-v1 tmat runs the v1 upgrader: a real path becomes an image file texture keeping its
+	/// file, a path that was only ever the default image becomes empty (the compiler falls back
+	/// to that same default), and a slot that is already a texture is left alone.
+	/// </summary>
+	[TestMethod]
+	public void MaterialSourceImagePathsUpgradeToTextures()
+	{
+		JsonUpgrader.UpdateUpgraders( Game.TypeLibrary );
+
+		var json = JsonNode.Parse( """
+		{
+			"AlbedoImage": "terrain/grass_color.png",
+			"RoughnessImage": "materials/default/default_rough.tga",
+			"NormalImage": "",
+			"HeightImage": { "$compiler": "texture", "$source": "imagefile", "data": { "FilePath": "terrain/grass_height.png" } },
+			"UVScale": 4
+		}
+		""" ).AsObject();
+
+		JsonUpgrader.Upgrade( 0, json, typeof( TerrainMaterial ) );
+
+		var albedo = json["AlbedoImage"].AsObject();
+		Assert.AreEqual( "texture", (string)albedo["$compiler"] );
+		Assert.AreEqual( "imagefile", (string)albedo["$source"] );
+		Assert.AreEqual( "terrain/grass_color.png", (string)albedo["data"]["FilePath"], "The image path should survive the upgrade" );
+
+		Assert.IsNull( json["RoughnessImage"], "A path that was just the default image becomes an empty slot" );
+		Assert.IsNull( json["NormalImage"], "An empty path becomes an empty slot" );
+
+		Assert.AreEqual( "terrain/grass_height.png", (string)json["HeightImage"]["data"]["FilePath"], "An already upgraded slot is untouched" );
+		Assert.AreEqual( 4, (int)json["UVScale"], "Unrelated properties are untouched" );
 	}
 
 	/// <summary>

--- a/game/addons/tools/Code/Scene/Terrain/TerrainMaterialEditor.cs
+++ b/game/addons/tools/Code/Scene/Terrain/TerrainMaterialEditor.cs
@@ -1,5 +1,5 @@
-﻿using System.IO;
-using System.Text.Json;
+﻿using Sandbox.Resources;
+using System.IO;
 
 namespace Editor.TerrainEditor;
 
@@ -37,7 +37,8 @@ class TerrainMaterialEditor : BaseResourceEditor<TerrainMaterial>
 		// Only work from albedo for now
 		if ( p.Name != nameof( TerrainMaterial.AlbedoImage ) ) return;
 
-		string albedoPath = p.GetValue<string>();
+		string albedoPath = GetImagePath( p.GetValue<Texture>() );
+		if ( string.IsNullOrWhiteSpace( albedoPath ) ) return;
 
 		var directoryname = Path.GetDirectoryName( albedoPath );
 		var filename = Path.GetFileNameWithoutExtension( albedoPath );
@@ -66,8 +67,25 @@ class TerrainMaterialEditor : BaseResourceEditor<TerrainMaterial>
 			if ( !FileSystem.Content.FileExists( name ) ) continue;
 
 			var property = Object.GetProperty( a.Item1 );
-			property.SetValue<string>( name );
+			property.SetValue( CreateImageTexture( name ) );
 		}
+	}
+
+	/// <summary>
+	/// The image file a source image slot was set up from, if it came from one.
+	/// </summary>
+	static string GetImagePath( Texture texture )
+	{
+		if ( texture?.EmbeddedResource is not { } embedded ) return null;
+		if ( embedded.ResourceGenerator != "imagefile" ) return null;
+
+		return embedded.Data?["FilePath"]?.GetValue<string>();
+	}
+
+	static Texture CreateImageTexture( string filePath )
+	{
+		var generator = new ImageFileGenerator { FilePath = filePath };
+		return generator.Create( ResourceGenerator.Options.Default );
 	}
 
 	void UpdateSceneTerrain()


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Before you could only put path to a texture and it fetched it, but no operation were possible unlike what Decals have with builtin Texture type

## Motivation & Context

I wanted a way to add roughness easily #11510 but then wheatley point out that adding this feature would be better than just a roughness slider

## Implementation Details

So i did a huge refactor cause we gotta do a json upgrade, but basically i changed every slot for Texture type, a upgrader and i did change how  we generate the texture then, so i unify the template (thx jean claude) and create Bitmap.PackChannel so we can build the baked texture easily

## Screenshots / Videos (if applicable)

Now :
<img width="1325" height="1572" alt="image" src="https://github.com/user-attachments/assets/16f4d516-cf73-4ebb-91e6-1d1030382251" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂