### PR TITLE
Mount GoldSrc maps and data files as raw ResourceType.Binary resources

### DIFF
--- a/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs
+++ b/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs
@@ -1,3 +1,5 @@
+using System;
+
 /// <summary>
 /// A mounting implementation for Half-Life 1
 /// </summary>
@@ -9,7 +11,35 @@ public abstract class GameMount : BaseGameMount
 
 	public abstract IReadOnlyList<string> GameDirs { get; }
 
+	// Bytes as well as converted, not instead: a WAD holds font lumps beside its textures, an MDL
+	// holds attachments and events the converted model drops, and a WAV's cue loop can't be turned
+	// off once it's a SoundFile.
+	static readonly HashSet<string> RawExtensions = [".bsp", ".spr", ".wad", ".mdl", ".wav"];
+
+	// By name: a .cfg rule would catch a server config with rcon details in it.
+	static readonly HashSet<string> RawFiles = new( StringComparer.OrdinalIgnoreCase )
+	{
+		"liblist.gam", "titles.txt", "skill.cfg", "sound/sentences.txt", "sound/materials.txt",
+		"media/cdaudio.txt",
+	};
+
 	string appDir;
+
+	// Paths are relative to the game directory. Images and audio are scoped to where the game keeps
+	// them; the .txt patterns cover files a mod names itself.
+	static bool IsRawData( string path, string ext ) =>
+		RawExtensions.Contains( ext )
+		|| RawFiles.Contains( path )
+		|| (ext == ".mp3" && IsDirectChildOf( path, "media/" ))
+		|| (ext is ".tga" or ".bmp"
+			&& (IsDirectChildOf( path, "gfx/env/" ) || IsDirectChildOf( path, "resource/background/" )))
+		|| (ext == ".txt"
+			&& (IsDirectChildOf( path, "sprites/" )
+				|| (IsDirectChildOf( path, "resource/" ) && path.EndsWith( "Layout.txt", StringComparison.OrdinalIgnoreCase ))));
+
+	static bool IsDirectChildOf( string path, string directory ) =>
+		path.StartsWith( directory, StringComparison.OrdinalIgnoreCase )
+		&& path.IndexOf( '/', directory.Length ) < 0;
 
 	protected override void Initialize( InitializeContext context )
 	{
@@ -31,6 +61,8 @@ public abstract class GameMount : BaseGameMount
 			if ( !System.IO.Directory.Exists( root ) )
 				continue;
 
+			var dirPrefix = $"{dir}/";
+
 			foreach ( var fullPath in System.IO.Directory.GetFiles( root, "*.*", SearchOption.AllDirectories ) )
 			{
 				var ext = Path.GetExtension( fullPath )?.ToLowerInvariant();
@@ -38,6 +70,11 @@ public abstract class GameMount : BaseGameMount
 					continue;
 
 				var path = Path.GetRelativePath( appDir, fullPath ).Replace( '\\', '/' );
+
+				// Typed resources rename themselves ("models/x.mdl" -> "models/x.mdl.vmdl"), so raw
+				// and converted never collide.
+				if ( IsRawData( path[dirPrefix.Length..], ext ) )
+					context.Add( ResourceType.Binary, path, new RawFileLoader( fullPath ) );
 
 				if ( ext == ".wad" )
 				{

--- a/engine/Mounting/Sandbox.Mounting.GoldSrc/Resource/RawFile.cs
+++ b/engine/Mounting/Sandbox.Mounting.GoldSrc/Resource/RawFile.cs
@@ -1,0 +1,7 @@
+﻿/// <summary>
+/// Returns a file from the mounted game as bytes. Only paths on GameMount's allowlist reach this.
+/// </summary>
+class RawFileLoader( string fullPath ) : ResourceLoader<GameMount>
+{
+	protected override object Load() => File.ReadAllBytes( fullPath );
+}

--- a/engine/Tests/Sandbox.Test.Integration/Mounting/MountingTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Mounting/MountingTests.cs
@@ -125,4 +125,24 @@ public partial class MountingTest
 		}
 	}
 
+	/// <summary>
+	/// Binary resources keep their registered path (no engine extension) and return the raw bytes.
+	/// </summary>
+	[TestMethod]
+	public async Task BinaryResource()
+	{
+		using var system = new MountHost( Config );
+		system.RegisterTypes( GetType().Assembly );
+		var quake = system.GetSource( "testgame" );
+		await system.Mount( "testgame" );
+
+		var target = quake.Resources.Where( x => x.Type == ResourceType.Binary ).FirstOrDefault();
+
+		Assert.IsNotNull( target, "binary resource is null - no binaries??" );
+		Assert.AreEqual( "maps/testlevel.bsp", target.RelativePath, "Binary paths shouldn't gain an engine extension" );
+
+		var bytes = (byte[])await target.GetOrCreate();
+		CollectionAssert.AreEqual( TestGameBinaryResource.Bytes, bytes );
+	}
+
 }

--- a/engine/Tests/Sandbox.Test.Integration/Mounting/TestGameMount.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Mounting/TestGameMount.cs
@@ -20,6 +20,7 @@ public partial class TestGameMount : Sandbox.Mounting.BaseGameMount
 	{
 		context.Add( ResourceType.Texture, "/gfx/sprites/mario.png", new TestGameTextureResource() );
 		context.Add( ResourceType.Scene, "/maps/testlevel", new TestGameSceneResource() );
+		context.Add( ResourceType.Binary, "/maps/testlevel.bsp", new TestGameBinaryResource() );
 
 		IsMounted = true;
 		return Task.CompletedTask;
@@ -59,4 +60,12 @@ public class TestGameSceneResource : SceneLoader<TestGameMount>
 		var child = new GameObject( true, "MountedChild" );
 		child.Parent = root;
 	}
+}
+
+
+public class TestGameBinaryResource : ResourceLoader<TestGameMount>
+{
+	public static readonly byte[] Bytes = new byte[] { 1, 2, 3, 4, 5 };
+
+	protected override object Load() => Bytes;
 }


### PR DESCRIPTION
## Summary

Registers an allowlisted set of GoldSrc data files as lazy `ResourceType.Binary` resources, alongside the existing `.wad`/`.mdl`/`.wav` conversions. Two additions to the GoldSrc mount: an allowlist check inside `GameMount.Mount()`'s existing directory scan, and a `RawFileLoader`. Nothing outside the mount changes, aside from a new case in the mounting integration tests.

## Motivation & Context

I'm reimplementing the original Half-Life campaign on s&box, reading everything from the player's own Steam install per [the mounting docs](https://github.com/Facepunch/sbox-docs/blob/master/docs/game-mounts/index.md). The mount converts three extensions and drops the rest; reproducing Half-Life needs the raw bytes of its data files, especially `maps/*.bsp`. Sandboxed game code has no `System.IO`, so only the mount can expose them.

[#10620](https://github.com/Facepunch/sbox-public/pull/10620) asked for all the heavy lifting to sit on the loader; the loader here follows that split.

## Implementation Details

`RawFileLoader` stores the full path, and `Load()` returns `File.ReadAllBytes`, synchronous like the four existing loaders. Files on the allowlist register as `ResourceType.Binary` under their game-directory-relative path. Nothing loads until first use, and `GetOrCreate()` keeps loaded bytes for the mounted resource's lifetime.

No engine or API changes are involved. [`MountContext.Add`](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Mounting/Sandbox.Mounting/MountedGame/MountContext.cs#L18-L21) already accepts any `ResourceType`, including [`Binary`](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceType.cs#L9-L10). The [extension map](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceLoader.cs#L22-L30) has no `Binary` entry, so paths keep their original extension, and [`Sandbox.Mounting` is whitelisted](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Sandbox.Access/Config/AccessRules.Assemblies.cs#L12), so game code can read what a mount registers. Nothing uses `Binary` yet; it's also absent from [the docs' resource-type table](https://github.com/Facepunch/sbox-docs/blob/master/docs/game-mounts/creating-mounts.md).

The allowlist, matched case-insensitively against the game-directory-relative path, covers two groups. First, files the mount doesn't register in any form today: `.bsp` maps (the entity lump, level-change landmarks, brush-model indices, and GoldSrc lightmap semantics all live there), `.spr` sprites, the `media/*.mp3` soundtrack, skybox and menu images (`gfx/env/` and `resource/background/` `.tga`/`.bmp`, direct children only), and the named data files `liblist.gam`, `titles.txt`, `skill.cfg`, `sound/sentences.txt`, `sound/materials.txt`, and `media/cdaudio.txt`, plus the patterns `sprites/*.txt` and `resource/*Layout.txt` (direct children only). Second, files whose conversions are lossy, registered raw alongside them: `.wad`, where [only miptex lumps convert](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs#L52) and the qfont/qpic lumps drawing the HUD and menus are skipped; `.mdl`, where the converted `Model` lacks attachments and sequence events, which is what defines and triggers muzzle flashes; and `.wav`, where [the conversion keeps the WAV's cue loop and no `LoadOptions` value disables it](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Sandbox.Engine/Resources/Sound/SoundFile.cs#L313-L316) (overrides only move the region), while GoldSrc's `ambient_generic` "streamed" flag plays a cue-looped sample once. Typed resources get an engine extension (`models/x.mdl` becomes `models/x.mdl.vmdl`), so raw and converted paths never collide.

Text files register as `Binary` rather than `Text` because prehistoric GoldSrc-era files aren't reliably UTF-8 (retail sentences.txt carries CP1252 hieroglyphs wtf?), and the consumer can decode them. Paths reuse the mount's existing [`Path.GetRelativePath( appDir, fullPath )`](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs#L40) over `GameDirs`, so a map is `mount://hl1/valve/maps/c1a0.bsp` and HD files keep `valve_hd/`. Usage:

```csharp
var loader = MountUtility.FindLoader( "mount://hl1/valve/maps/c1a0.bsp" );
var bytes  = (byte[])await loader.GetOrCreate();
```

The existing mounting integration tests gain a `BinaryResource` case where `TestGameMount` registers a `Binary` entry, and the test asserts the path keeps its original extension and `GetOrCreate()` roundtrips the exact bytes.

### Safety

[`InitializeContext` already raises this](https://github.com/Facepunch/sbox-public/blob/38aab3aa5da6de910b79d99bc6872dcfdf8d249f/engine/Mounting/Sandbox.Mounting/MountedGame/InitializeContext.cs#L42-L44):

> Maybe we want to return a sandboxed, readonly filesystem to this directory instead? but even then, what if there are files with passwords or rcon details in …

Named registration avoids that and the mount decides what is exposed; game code never gets a directory to read. Every path comes from the mount's own scan of the selected `GameDirs` (nothing resolves from caller input), the only patterns are the two above, and nothing is exposed by bare extension; `skill.cfg` is named explicitly, since a blanket `.cfg` rule would also catch a `server.cfg` containing an rcon password.

## Screenshots / Videos

Half-Life's `c1a0` loaded entirely through the mount:

https://github.com/user-attachments/assets/f68c8b86-1d0f-4509-ab1f-651a26950d0a

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (no new public API; the loader is internal to the mount)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂
