### PR TITLE
EnvmapProbe frame spreading (Performance improvements for realtime probes)

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Light/EnvmapProbe.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Light/EnvmapProbe.cs
@@ -65,11 +65,15 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 		TimeInterval,
 	}
 
+	const int NumCubemapFaces = 6;
+
 	SceneCubemap _sceneObject;
 	Texture _dynamicTexture;
 	int _bouncesLeft;
 	int _queuedFrames;
 	float _queuedTime;
+	int _spreadFace;
+	int _spreadIdleFrames;
 
 	public bool Dirty;
 
@@ -268,6 +272,19 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 	public int FrameInterval { get; set; } = 5;
 
 	/// <summary>
+	/// How many frames a full cubemap update is spread across.
+	/// <list type="bullet">
+	/// <item><b>1</b> All six faces at once. Biggest performance impact</item>
+	/// <item><b>6</b> One face per frame.</item>
+	/// <item><b>12</b> One face every other frame.</item>
+	/// <item><b>24</b> One face every fourth frame. Cheapest, and slowest to catch up.</item>
+	/// </list>
+	/// </summary>
+	[ShowIf( nameof( Mode ), EnvmapProbeMode.Realtime )]
+	[Property, Range( 1, 24 )]
+	public int FrameSpreading { get; set; } = 1;
+
+	/// <summary>
 	/// Minimum amount of reflection bounces to render when first enabled before settling, at cost of extra performance on load
 	/// Often times you don't need this
 	/// </summary>
@@ -311,6 +328,8 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 		Transform.OnTransformChanged -= OnTransformChanged;
 
 		Dirty = false;
+
+		ResetSpread();
 
 		_sceneObject?.Delete();
 		_sceneObject = null;
@@ -485,6 +504,8 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 		if ( _dynamicTexture is not null && _dynamicTexture.Width == cubemapSize && _dynamicTexture.UAVAccess )
 			return;
 
+		ResetSpread();
+
 		// Dispose old texture if it exists
 		_dynamicTexture?.Dispose();
 
@@ -497,6 +518,12 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 
 	internal void RenderCubemap()
 	{
+		if ( FrameSpreading > 1 && (_dynamicTexture?.UAVAccess ?? false) )
+		{
+			RenderCubemapSpread( _dynamicTexture, CubemapRendering.GGXFilterType.Fast, RenderExcludeTags );
+			return;
+		}
+
 		RenderCubemap( _dynamicTexture, CubemapRendering.GGXFilterType.Fast, RenderExcludeTags );
 	}
 
@@ -512,6 +539,44 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 			CubemapRendering.Render( Scene.SceneWorld, target, WorldTransform.WithScale( 1 ), ZNear.Clamp( 1, ZFar ), ZFar.Clamp( ZNear, 1024 * 16 ), filterType, excludeTags );
 		}
 
+		FinishUpdate();
+	}
+
+	/// <summary>
+	/// Renders one face per call, holding <see cref="Dirty"/> so the scene hands this probe another frame until all
+	/// six are done. See <see cref="FrameSpreading"/>.
+	/// </summary>
+	void RenderCubemapSpread( Texture target, CubemapRendering.GGXFilterType filterType, TagSet excludeTags )
+	{
+		int framesPerFace = Math.Max( 1, FrameSpreading / NumCubemapFaces );
+
+		// Idling between faces.
+		if ( _spreadIdleFrames > 0 )
+		{
+			_spreadIdleFrames--;
+			Dirty = true;
+			return;
+		}
+
+		CubemapRendering.RenderSingleFace( Scene.SceneWorld, target, WorldTransform.WithScale( 1 ), ZNear.Clamp( 1, ZFar ), ZFar.Clamp( ZNear, 1024 * 16 ), _spreadFace, filterType, excludeTags );
+
+		_spreadFace++;
+		_spreadIdleFrames = framesPerFace - 1;
+
+		// Mid-sequence (stay dirty so Scene.RenderEnvmaps picks this probe up again).
+		if ( _spreadFace < NumCubemapFaces )
+		{
+			Dirty = true;
+			return;
+		}
+
+		// Sixth face done, and RenderSingleFace has filtered. This update is now indistinguishable from a one-shot.
+		ResetSpread();
+		FinishUpdate();
+	}
+
+	void FinishUpdate()
+	{
 		// Just finished rendering, signal to component that we're done
 		_sceneObject?.RequiresUpdate = false;
 
@@ -523,5 +588,11 @@ public sealed partial class EnvmapProbe : Component, Component.ExecuteInEditor, 
 			_bouncesLeft--;
 
 		Dirty = false;
+	}
+
+	void ResetSpread()
+	{
+		_spreadFace = 0;
+		_spreadIdleFrames = 0;
 	}
 }

--- a/engine/Sandbox.Engine/Systems/Render/CubemapRendering.cs
+++ b/engine/Sandbox.Engine/Systems/Render/CubemapRendering.cs
@@ -81,6 +81,56 @@ internal static class CubemapRendering
 	}
 
 	/// <summary>
+	/// Renders a single face of a cubemap, filtering only once the last face has been drawn.
+	/// </summary>
+	/// <param name="world">The scene world to render.</param>
+	/// <param name="cubemapTexture">The texture to render the cubemap to.</param>
+	/// <param name="cubemapTransform">The position and rotation of the cubemap camera.</param>
+	/// <param name="znear">The near plane distance for the camera.</param>
+	/// <param name="zfar">The far plane distance for the camera.</param>
+	/// <param name="faceIndex">Which face to render, 0 to 5.</param>
+	/// <param name="filterType">The quality level for GGX filtering.</param>
+	/// <param name="excludeTags">Objects with any of these tags will be excluded from the render.</param>
+	public static void RenderSingleFace( SceneWorld world, Texture cubemapTexture, Transform cubemapTransform, float znear, float zfar, int faceIndex, GGXFilterType filterType, ITagSet excludeTags = null )
+	{
+		if ( Application.IsHeadless )
+			throw new Exception( "Tried to call CubemapRendering.RenderSingleFace from a dedicated server" );
+
+		const int numFaces = 6;
+
+		if ( faceIndex < 0 || faceIndex >= numFaces )
+			return;
+
+		using var camera = new SceneCamera( "CubemapRendering" );
+		camera.FieldOfView = 90;
+		camera.ZNear = znear;
+		camera.ZFar = zfar;
+		camera.Position = cubemapTransform.Position;
+		camera.Rotation = cubemapTransform.Rotation;
+		camera.World = world;
+		camera.ExcludeFromTextureStreaming = true;
+
+		if ( excludeTags is not null )
+		{
+			camera.ExcludeTags.SetFrom( excludeTags );
+		}
+
+		// Only the last face triggers the filter.
+		if ( faceIndex == numFaces - 1 )
+		{
+			camera.OnRenderStageHook += ( stage, camera ) =>
+			{
+				if ( stage != Stage.AfterPostProcess )
+					return;
+
+				Filter( cubemapTexture, filterType ).ExecuteOnRenderThread();
+			};
+		}
+
+		camera.RenderToCubeTextureFace( cubemapTexture, faceIndex );
+	}
+
+	/// <summary>
 	/// Applies filtering to a cubemap texture, generating both downsample and GGX filtering.
 	/// </summary>
 	/// <param name="cubemapTexture">The cubemap texture to filter.</param>

--- a/engine/Sandbox.Engine/Systems/SceneSystem/SceneCamera.cs
+++ b/engine/Sandbox.Engine/Systems/SceneSystem/SceneCamera.cs
@@ -867,6 +867,38 @@ public sealed partial class SceneCamera : IDisposable, IManagedCamera
 		setup.Dispose();
 	}
 
+	/// <summary>
+	/// Renders the scene from the camera position into a single face of a cube texture.
+	/// </summary>
+	/// <param name="texture">Cube texture to render into. Must have 6 depth slices.</param>
+	/// <param name="faceIndex">Which face to render, indexing <see cref="CubeRotations"/>.</param>
+	/// <param name="config">Optional view setup overrides.</param>
+	internal void RenderToCubeTextureFace( Texture texture, int faceIndex, in ViewSetup config = default )
+	{
+		if ( texture is null || texture.native.IsNull )
+			return;
+
+		if ( texture.Depth != 6 ) throw new Exception( "Expected a texture with 6 depth slices for RenderToCubeTextureFace" );
+
+		if ( faceIndex < 0 || faceIndex >= CubeRotations.Length )
+			throw new ArgumentOutOfRangeException( nameof( faceIndex ), $"Face index must be between 0 and {CubeRotations.Length - 1}" );
+
+		var renderSize = texture.Size;
+
+		if ( renderSize.x <= 0 ) return;
+		if ( renderSize.y <= 0 ) return;
+
+		OnPreRender( renderSize );
+
+		var setup = new CameraRenderer( "RenderToCubeTextureFace", _cameraId );
+		setup.Configure( this, config );
+
+		setup.Native.CameraRotation = (Rotation * CubeRotations[faceIndex]).Angles();
+		setup.Native.RenderToCubeTexture( texture.native, faceIndex );
+
+		setup.Dispose();
+	}
+
 	private void RenderStereo( in ViewSetup config = default )
 	{
 		if ( !TargetEye.Contains( StereoTargetEye.LeftEye ) && !TargetEye.Contains( StereoTargetEye.RightEye ) )


### PR DESCRIPTION
# Pull Request

## Summary

A realtime "EnvmapProbe" component renders all 6 cubemap faces in a single frame. Thats 6 faces rendering in one spike, if like me you're using probes in Everyframe mode, you do want this to avoid killing your performance!

This PR add a "FrameSpreading" property that deals with those 6 faces refresh across N frames instead.
Default value is 1 so the original behaviour is kept.

## Motivation & Context

I'm using realtime reflection probes as a trickery to get clean and perfect reflection in my scene, I'm making an open world and with a time of day, so baked probes isn't even something to consider, it's just easier to have one giant probe in realtime mode attached to the player/the vehicle, and getting really believable reflections. But currently with no spreads the performance impact was really high, which is now miles better with this PR ! (The only cost being a bit of lagg behind of the probe refresh, but almost imperceptible in most cases)

| FrameSpreading | 720p | 1440p |
|---|---|---|
| 1 (default) | 120 fps | 103 fps |
| 6 | 460 fps | 256 fps |
| 12 | 605 fps | 301 fps |
| 24 | 740 fps | 335 fps |

(For a 1024x1024 realtime probe (the worst case scenario))

~6.8 ms saved at both resolutions.

## Implementation Details

The function `RenderToCubeTexture` already took a face index, so no engine side changes were needed.

GGX filtering runs only after the 6th face. It reads all 6 to build the mip chain, so filtering earlier would filter a mostly stale cubemap, and filtering per face would pay for the expensive half 6 times over.

## Screenshots / Videos

<img width="2030" height="840" alt="Capture d&#39;écran 2026-08-20 042346" src="https://github.com/user-attachments/assets/a9493059-57cd-4f76-be60-ca50c3b93b59" />
<img width="2039" height="838" alt="Capture d&#39;écran 2026-08-20 042331" src="https://github.com/user-attachments/assets/6e0750a3-3034-4a6b-a5eb-0bd98866727c" />
<img width="2035" height="828" alt="Capture d&#39;écran 2026-08-20 042316" src="https://github.com/user-attachments/assets/61ac56c8-75a6-4259-8554-a3519bc2abab" />
<img width="2030" height="803" alt="Capture d&#39;écran 2026-08-20 042256" src="https://github.com/user-attachments/assets/c3867163-140c-47c1-aaff-903af70ea2e4" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂