### PR TITLE
GoldSrc mount: register source files as ResourceType.Binary

### DIFF
--- a/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs
+++ b/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs
@@ -39,6 +39,9 @@ public abstract class GameMount : BaseGameMount
 
 				var path = Path.GetRelativePath( appDir, fullPath ).Replace( '\\', '/' );
 
+				if ( ext is not ".cfg" and not ".sav" and not ".dem" and not ".log" and not ".hpk" || path.EndsWith( "/skill.cfg", System.StringComparison.OrdinalIgnoreCase ) )
+					context.Add( ResourceType.Binary, path, new RawFileLoader( fullPath ) );
+
 				if ( ext == ".wad" )
 				{
 					try

--- a/engine/Mounting/Sandbox.Mounting.GoldSrc/Resource/RawFile.cs
+++ b/engine/Mounting/Sandbox.Mounting.GoldSrc/Resource/RawFile.cs
@@ -1,0 +1,4 @@
+class RawFileLoader( string fullPath ) : ResourceLoader
+{
+	protected override object Load() => File.ReadAllBytes( fullPath );
+}

--- a/engine/Tests/Sandbox.Test.Integration/Mounting/MountingTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Mounting/MountingTests.cs
@@ -125,4 +125,24 @@ public partial class MountingTest
 		}
 	}
 
+	/// <summary>
+	/// Binary resources keep their registered path (no engine extension) and return the raw bytes.
+	/// </summary>
+	[TestMethod]
+	public async Task BinaryResource()
+	{
+		using var system = new MountHost( Config );
+		system.RegisterTypes( GetType().Assembly );
+		var quake = system.GetSource( "testgame" );
+		await system.Mount( "testgame" );
+
+		var target = quake.Resources.Where( x => x.Type == ResourceType.Binary ).FirstOrDefault();
+
+		Assert.IsNotNull( target, "binary resource is null - no binaries??" );
+		Assert.AreEqual( "maps/testlevel.bsp", target.RelativePath, "Binary paths shouldn't gain an engine extension" );
+
+		var bytes = (byte[])await target.GetOrCreate();
+		CollectionAssert.AreEqual( TestGameBinaryResource.Bytes, bytes );
+	}
+
 }

--- a/engine/Tests/Sandbox.Test.Integration/Mounting/TestGameMount.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Mounting/TestGameMount.cs
@@ -20,6 +20,7 @@ public partial class TestGameMount : Sandbox.Mounting.BaseGameMount
 	{
 		context.Add( ResourceType.Texture, "/gfx/sprites/mario.png", new TestGameTextureResource() );
 		context.Add( ResourceType.Scene, "/maps/testlevel", new TestGameSceneResource() );
+		context.Add( ResourceType.Binary, "/maps/testlevel.bsp", new TestGameBinaryResource() );
 
 		IsMounted = true;
 		return Task.CompletedTask;
@@ -59,4 +60,12 @@ public class TestGameSceneResource : SceneLoader<TestGameMount>
 		var child = new GameObject( true, "MountedChild" );
 		child.Parent = root;
 	}
+}
+
+
+public class TestGameBinaryResource : ResourceLoader<TestGameMount>
+{
+	public static readonly byte[] Bytes = new byte[] { 1, 2, 3, 4, 5 };
+
+	protected override object Load() => Bytes;
 }


### PR DESCRIPTION
# Summary

A mounted GoldSrc game currently exposes only what [the mount converts](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs#L23-L86): WAD textures and materials, MDL models, WAV sounds. There's no way to get at the source files.

This registers every scanned file as the engine's unused [`ResourceType.Binary`](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceType.cs#L10), so a game can read the raw bytes. Player files (configs, saves, demos, logs, sprays) are excluded.

This isn't a map loader, and a map loader doesn't replace it, because loading a map and exposing its bytes are separate registrations. The Quake mount has a full map loader and [registers no raw files](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting.Quake/QuakeMount.cs#L144-L173). The same registration would fit there too, since Quake keeps its entities in the same BSP lump and its game logic in `progs.dat`, which has no converted form either.

## Motivation & Context

The converted resources don't keep everything the source files contain. A BSP's entity lump, where Half-Life keeps its monsters, scripted sequences and target wiring, has no converted form at all, because the scan only handles [`.wad`](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs#L42), [`.mdl`](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs#L67) and [`.wav`](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting.GoldSrc/GameMount.cs#L81). An MDL's attachments and events don't survive model conversion; the parser [reads them](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting.GoldSrc/Mdl/MdlFile.cs#L504-L506) but [the model builder](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting.GoldSrc/Resource/Model.cs) never uses them. Sprites, skyboxes, HUD sprite manifests, `sentences.txt`, `skill.cfg` and the soundtrack aren't registered at all.

Reading them directly is a [whitelist](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Sandbox.Access/Rules/BaseAccess.cs#L83-L90) no-no, so the mount is the only route to a mounted game's bytes.

I'm using this in a Half-Life recreation where the entity lump is used for the map's monsters and triggers, `skill.cfg` for damage tables, `sentences.txt` for scripted speech, and the skies and HUD come from `gfx/env/` and `sprites/*.txt`. With this addition the whole game runs off the mount.

## Implementation Details

Uses the existing [`MountContext.Add`](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting/MountedGame/MountContext.cs#L18) with [`ResourceType.Binary`](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceType.cs#L10). Paths don't clash because the engine [appends an extension](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceLoader.cs#L22-L30) to converted resources, so a converted model registers as `models/x.mdl.vmdl` while the raw file stays `models/x.mdl`.

lazy loading: `File.ReadAllBytes` runs only when someone actually asks for the resource, through the [same `ResourceLoader` caching](https://github.com/Facepunch/sbox-public/blob/80b6e01704bbcf3e1ea1c263c893a1b6251859f2/engine/Mounting/Sandbox.Mounting/MountedAsset/ResourceLoader.cs#L92-L105) every other mount type uses.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂
