### PR TITLE
[Terrain] Fix artifact on AMD due to not uniform Nho texture

### DIFF
--- a/game/addons/base/Assets/shaders/common/classes/Bindless.hlsl
+++ b/game/addons/base/Assets/shaders/common/classes/Bindless.hlsl
@@ -58,6 +58,7 @@ struct Bindless
     static inline SamplerState GetSampler( int nIndex ) { return g_bindless_Sampler[ nIndex ]; }
     static inline SamplerComparisonState GetSamplerComparison( int nIndex ) { return g_bindless_SamplerComparison[ nIndex ]; }
 #endif
+    static inline Texture2D GetTexture2DNonUniform( int nIndex, bool srgb = false ) { return g_bindless_Texture2D[ NonUniformResourceIndex( nIndex + (srgb ? 1 : 0) ) ]; }
 
     static inline int GetPipelineTextureIndex( PipelineTextureSlot slot ) { return g_PipelineTextureIndices[slot]; }
 

--- a/game/addons/base/Assets/shaders/terrain.shader
+++ b/game/addons/base/Assets/shaders/terrain.shader
@@ -105,7 +105,8 @@ VS
                 if( baseMat.HasFlag( TerrainFlags::NoTile ) )
                     baseLayerUV = Terrain_SampleSeamlessUV( baseLayerUV );
 
-                float4 baseNho = Bindless::GetTexture2D( baseMat.nho_texid ).SampleLevel( materialSampler, baseLayerUV, 0 );
+                // Use NonUniform for nho_texid to avoid AMD lane divergence issues (#11291).
+                float4 baseNho = Bindless::GetTexture2DNonUniform( baseMat.nho_texid ).SampleLevel( materialSampler, baseLayerUV, 0 );
                 float baseDisplacement = ( baseNho.b - 0.5f ) * 2.0f * baseMat.displacementscale;
 
                 float blend = controlMat.GetNormalizedBlend();
@@ -119,7 +120,7 @@ VS
                     if( overlayMat.HasFlag( TerrainFlags::NoTile ) )
                         overlayLayerUV = Terrain_SampleSeamlessUV( overlayLayerUV );
 
-                    float4 overlayNho = Bindless::GetTexture2D( overlayMat.nho_texid ).SampleLevel( materialSampler, overlayLayerUV, 0 );
+                    float4 overlayNho = Bindless::GetTexture2DNonUniform( overlayMat.nho_texid ).SampleLevel( materialSampler, overlayLayerUV, 0 );
                     float overlayDisplacement = ( overlayNho.b - 0.5f ) * 2.0f * overlayMat.displacementscale;
 
                     // Height-aware blend, matching the surface color/normal blend


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

My friend had a crazy displacement slivers issue but only on some AMD card

The VS samples each material's height texture with nho_texid from the per-vertex control map an index that diverges within a wave at material boundaries and coarse LODs. The    
 non-fragment Bindless::GetTexture2D indexes raw (no NonUniformResourceIndex), so AMD broadcasts lane 0's descriptor and divergent lanes displace with the wrong material's heights. NVIDIA reads descriptors per-lane, so it never showed there.
 
 Gotta thx anto that help me not sending a shitty fix and pushed me do better, thx bro!

Fixes: #11291

## Implementation Details

Basically instead of using a GetTexture2D, i now use a non uniform texture

## Screenshots / Videos (if applicable)

Just show up straight, see issue for before video

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂