### PR TITLE
Fix PositionToValue() for EditorCurve.Handle when curve length <= 1

### DIFF
--- a/game/addons/tools/Code/Curves/Graphics/EditableCurve.Handle.cs
+++ b/game/addons/tools/Code/Curves/Graphics/EditableCurve.Handle.cs
@@ -53,12 +53,9 @@ public partial class EditableCurve
 			// Map the position to the viewport range
 			var x = pos.x.Remap( 0, EditableCurve.Size.x, EditableCurve.ViewportRangeX.x, EditableCurve.ViewportRangeX.y, false );
 			var y = pos.y.Remap( 0, EditableCurve.Size.y, EditableCurve.ViewportRangeY.y, EditableCurve.ViewportRangeY.x, false );
-			// Now remap the viewport range to the actual range
-			if ( EditableCurve.Value.Length > 1 )
-			{
-				x = x.Remap( EditableCurve.TimeRange.x, EditableCurve.TimeRange.y, 0, 1, false );
-				y = y.Remap( EditableCurve.ValueRange.x, EditableCurve.ValueRange.y, 0, 1, false );
-			}
+			// Now remap the viewport range to the normalized (0-1) range that frames are stored in
+			x = x.Remap( EditableCurve.TimeRange.x, EditableCurve.TimeRange.y, 0, 1, false );
+			y = y.Remap( EditableCurve.ValueRange.x, EditableCurve.ValueRange.y, 0, 1, false );
 			return new Vector2( x, y );
 		}
 

--- a/game/addons/tools/Code/Curves/Graphics/EditableCurve.Handle.cs
+++ b/game/addons/tools/Code/Curves/Graphics/EditableCurve.Handle.cs
@@ -53,7 +53,7 @@ public partial class EditableCurve
 			// Map the position to the viewport range
 			var x = pos.x.Remap( 0, EditableCurve.Size.x, EditableCurve.ViewportRangeX.x, EditableCurve.ViewportRangeX.y, false );
 			var y = pos.y.Remap( 0, EditableCurve.Size.y, EditableCurve.ViewportRangeY.y, EditableCurve.ViewportRangeY.x, false );
-			// Now remap the viewport range to the normalized (0-1) range that frames are stored in
+			// Now remap the viewport range to the actual range
 			x = x.Remap( EditableCurve.TimeRange.x, EditableCurve.TimeRange.y, 0, 1, false );
 			y = y.Remap( EditableCurve.ValueRange.x, EditableCurve.ValueRange.y, 0, 1, false );
 			return new Vector2( x, y );


### PR DESCRIPTION
…is set

# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
This fixes a bug with the curve editor where if you have only 1 keyframes set , the computed value of PositionToValue() for any consumer would be the square root of what it should actually be
<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

## Motivation & Context
This is clearly a bug and makes it really annoying to play with curves. This bug also caused an unstable state to the range curves, even with multiple keyframes set, the computed value was of. Now since you can't have that behaviour again the curve with ranges never gets in this state
<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details
Looking at it I realized it was pretty straightforward. A guarding prevented normalization of the time and value viewport ranges if the curve length was less or equal to 1 .  Simply removing the guard fixed it and it didn't introduce any bug on all my tests. It also fixed the same issue for curve ranges so that's a win win
<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

**Before**

https://github.com/user-attachments/assets/edcc846d-f133-4bfd-95c1-f27dfa308d2b


**After**

https://github.com/user-attachments/assets/56fd6716-9b66-43d2-bfc1-985682a62d18


<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂 (if it introduces any issue else , i don't know why it would get rejected)