### PR TITLE
Qol for curve presets

### DIFF
--- a/game/addons/tools/Code/Curves/CurveEditorPopup.cs
+++ b/game/addons/tools/Code/Curves/CurveEditorPopup.cs
@@ -60,20 +60,34 @@ public class CurveEditorPopup : Widget
 			Presets.OnCurveClicked = c =>
 			{
 				var existingCurve = serializedProperty.GetValue<Curve>();
+				c.UpdateTimeRange( InheritRange( existingCurve.TimeRange, c.TimeRange ), false );
+				c.UpdateValueRange( InheritRange( existingCurve.ValueRange, c.ValueRange ), false );
+				serializedProperty.SetValue( c );
+			};
+			Presets.OnCurveRangesClicked = c =>
+			{
+				var existingCurve = serializedProperty.GetValue<Curve>();
 				if ( !Editor.CanEditTimeRange )
 				{
-					c.UpdateTimeRange( existingCurve.TimeRange, false );
+					c.UpdateTimeRange( InheritRange( existingCurve.TimeRange, c.TimeRange ), false );
 				}
 				if ( !Editor.CanEditValueRange )
 				{
-					c.UpdateValueRange( existingCurve.ValueRange, false );
+					c.UpdateValueRange( InheritRange( existingCurve.ValueRange, c.ValueRange ), false );
 				}
 				serializedProperty.SetValue( c );
 			};
+			Presets.CanApplyRanges = () => Editor.CanEditTimeRange || Editor.CanEditValueRange;
 			Presets.GetCurveToSave = () => serializedProperty.GetValue<Curve>();
 			Layout.Add( Presets );
 		}
 	}
+
+	/// <summary>
+	/// Keep the range of the curve being edited, unless it's degenerate (an unset curve), in which
+	/// case the preset's own range is the only sane thing to use.
+	/// </summary>
+	static Vector2 InheritRange( Vector2 existing, Vector2 fallback ) => existing.x == existing.y ? fallback : existing;
 
 	/// <summary>
 	/// Set this editor to be a range editor

--- a/game/addons/tools/Code/Curves/CurvePresets.cs
+++ b/game/addons/tools/Code/Curves/CurvePresets.cs
@@ -6,7 +6,23 @@
 public class CurvePresets : ListView
 {
 	public Func<Curve?> GetCurveToSave { get; set; }
+
+	/// <summary>
+	/// Apply a preset to the curve being edited. The preset's own time/value ranges are ignored,
+	/// the edited curve keeps the ranges it already has.
+	/// </summary>
 	public Action<Curve> OnCurveClicked { get; set; }
+
+	/// <summary>
+	/// Apply a preset including its saved time/value ranges. Optional.
+	/// </summary>
+	public Action<Curve> OnCurveRangesClicked { get; set; }
+
+	/// <summary>
+	/// Whether <see cref="OnCurveRangesClicked"/> can do anything right now - ranges are locked
+	/// by the property being edited otherwise.
+	/// </summary>
+	public Func<bool> CanApplyRanges { get; set; }
 
 	List<Curve> curveList = new();
 
@@ -97,6 +113,12 @@ public class CurvePresets : ListView
 		if ( obj is not Curve c ) return;
 
 		var m = new ContextMenu( this );
+
+		if ( OnCurveRangesClicked is not null && (CanApplyRanges?.Invoke() ?? true) )
+		{
+			m.AddOption( "Apply With Ranges", "open_in_full", () => OnCurveRangesClicked( c ) );
+			m.AddSeparator();
+		}
 
 		m.AddOption( "Copy Json", "content_copy", () =>
 		{


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
This pr aims to improve the usage of presets on curves
Now if you click on a preset the curve editor will keep the current range by default.
The old mechanism has been moved to a right click option on the preset
<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

## Motivation & Context
I saw @Fortune117 issue on the matter and I totally agree with his opinion because what interests me 80% of the time is the shape of a preset but with my current range. But i do still think havin ranges on the presets is a good idea just for reusability purposes. Moving it to a right click option is the best moovee in my opinion
<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->

Fixes: #1546

## Implementation Details
Nothing specific that should be noted else than the fact I added summaries to the already present OnCurveClicked property and the two new ones I created to explicit their role without having to use complex property names. I think it's better, if you disagree I can remove them.
<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)
**Before**

https://github.com/user-attachments/assets/6acd618f-5bf6-4655-95a3-8062dba1d934


**After**

https://github.com/user-attachments/assets/552ed783-edd0-47ac-ac48-921f71d8f4cc


<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂