### PR TITLE
Curve editor multiselect drag correctly clamped when out of bounds

### DIFF
--- a/game/addons/tools/Code/Curves/Graphics/EditableCurve.Handle.cs
+++ b/game/addons/tools/Code/Curves/Graphics/EditableCurve.Handle.cs
@@ -34,6 +34,9 @@ public partial class EditableCurve
 
 		internal void UpdatePositionFromValue()
 		{
+			// Rebuilding positions from the curve invalidates where a drag started
+			HandleDrag.End();
+
 			var val = new Vector2( Frame.Time, Frame.Value );
 			Position = ValueToPosition( val );
 		}
@@ -166,12 +169,12 @@ public partial class EditableCurve
 
 		protected override void OnMoved()
 		{
-			RealPosition = Position;
-			var value = PositionToValue( Position );
-			if ( Application.KeyboardModifiers.HasFlag( KeyboardModifiers.Ctrl ) )
+			// Let the drag snap all of its handles together, instead of each on its own
+			if ( !HandleDrag.IsApplying && Application.KeyboardModifiers.HasFlag( KeyboardModifiers.Ctrl ) )
 			{
 				var _xInc = EditableCurve.editor.GetBackgroundIncrementX();
 				var _yInc = EditableCurve.editor.GetBackgroundIncrementY();
+				var value = PositionToValue( Position );
 				value.x = value.x
 						.Remap( 0, 1, EditableCurve.TimeRange.x, EditableCurve.TimeRange.y, false )
 						.SnapToGrid( _xInc )
@@ -183,20 +186,39 @@ public partial class EditableCurve
 				Position = ValueToPosition( value );
 			}
 
+			UpdateValueFromPosition();
+			EditableCurve?.OnHandleMoved();
+		}
+
+		/// <summary>
+		/// Update this handle's keyframe to match where it is on the chart
+		/// </summary>
+		internal void UpdateValueFromPosition()
+		{
+			RealPosition = Position;
+			var value = PositionToValue( Position );
 			Frame.Time = value.x;
 			Frame.Value = value.y;
-
-			EditableCurve?.OnHandleMoved();
 		}
 
 		protected override void OnPositionChanged()
 		{
 			base.OnPositionChanged();
 
-			Position = Position.Clamp( 0, EditableCurve.Size );
+			// Dragged handles are limited as a group, so the selection keeps its shape
+			if ( !HandleDrag.Moved( this ) )
+			{
+				Position = Position.Clamp( 0, EditableCurve.Size );
+			}
 
 			In?.UpdatePositionFromValue();
 			Out?.UpdatePositionFromValue();
+		}
+
+		protected override void OnDestroy()
+		{
+			base.OnDestroy();
+			HandleDrag.End();
 		}
 
 		protected override void OnHoverEnter( GraphicsHoverEvent e )
@@ -214,8 +236,18 @@ public partial class EditableCurve
 		{
 			base.OnMousePressed( e );
 
+			if ( e.LeftMouseButton )
+				HandleDrag.Begin( this );
+
 			if ( e.RightMouseButton )
 				OpenContextMenu( e.ScreenPosition );
+		}
+
+		protected override void OnMouseReleased( GraphicsMouseEvent e )
+		{
+			base.OnMouseReleased( e );
+
+			HandleDrag.End();
 		}
 
 		public virtual void OpenContextMenu( Vector2 pos )

--- a/game/addons/tools/Code/Curves/Graphics/EditableCurve.HandleDrag.cs
+++ b/game/addons/tools/Code/Curves/Graphics/EditableCurve.HandleDrag.cs
@@ -1,0 +1,129 @@
+﻿namespace Editor.GraphicsItems;
+
+public partial class EditableCurve
+{
+	/// <summary>
+	/// Tracks the <see cref="Handle"/>s being dragged by the mouse. They all move by the same
+	/// offset, and stop together as soon as one of them reaches the edge of its chart, so the
+	/// shape of the selection is kept.
+	/// </summary>
+	private static class HandleDrag
+	{
+		private static readonly Dictionary<Handle, Vector2> StartPositions = new();
+		private static readonly List<Handle> Dragged = new();
+		private static readonly List<EditableCurve> DraggedCurves = new();
+
+		private static bool _started;
+		private static bool _applying;
+		private static Vector2 _minOffset;
+		private static Vector2 _maxOffset;
+
+		/// <summary>
+		/// True while we're moving the dragged handles ourselves
+		/// </summary>
+		public static bool IsApplying => _applying;
+
+		/// <summary>
+		/// A handle has been pressed. The selection isn't updated until after this, so remember
+		/// where every handle started and work out which ones are dragged on the first move.
+		/// </summary>
+		public static void Begin( Handle pressed )
+		{
+			End();
+
+			if ( pressed.GraphicsView is not { } view ) return;
+
+			foreach ( var curve in view.Items.OfType<EditableCurve>() )
+			{
+				foreach ( var handle in curve.Handles )
+				{
+					if ( !handle.IsValid() ) continue;
+
+					StartPositions[handle] = handle.Position;
+				}
+			}
+
+			_started = StartPositions.ContainsKey( pressed );
+		}
+
+		public static void End()
+		{
+			StartPositions.Clear();
+			Dragged.Clear();
+			DraggedCurves.Clear();
+
+			_started = false;
+			_applying = false;
+		}
+
+		/// <summary>
+		/// A handle has been moved. Returns false if it isn't being dragged, in which case it
+		/// should clamp itself to its chart.
+		/// </summary>
+		public static bool Moved( Handle handle )
+		{
+			if ( !_started ) return false;
+			if ( _applying ) return true;
+
+			if ( Dragged.Count == 0 )
+			{
+				Resolve( handle );
+			}
+
+			if ( !Dragged.Contains( handle ) ) return false;
+			if ( !StartPositions.TryGetValue( handle, out var start ) ) return false;
+
+			// Every dragged handle gets the same offset, so we can read it from this one
+			Apply( Vector2.Clamp( handle.Position - start, _minOffset, _maxOffset ) );
+
+			return true;
+		}
+
+		private static void Resolve( Handle moved )
+		{
+			_minOffset = new Vector2( float.NegativeInfinity );
+			_maxOffset = new Vector2( float.PositiveInfinity );
+
+			foreach ( var (handle, start) in StartPositions )
+			{
+				if ( !handle.IsValid() ) continue;
+				if ( handle != moved && !handle.Selected ) continue;
+
+				Dragged.Add( handle );
+
+				if ( !DraggedCurves.Contains( handle.EditableCurve ) )
+				{
+					DraggedCurves.Add( handle.EditableCurve );
+				}
+
+				_minOffset = Vector2.Max( _minOffset, -start );
+				_maxOffset = Vector2.Min( _maxOffset, handle.EditableCurve.Size - start );
+			}
+		}
+
+		private static void Apply( Vector2 offset )
+		{
+			_applying = true;
+
+			try
+			{
+				foreach ( var handle in Dragged )
+				{
+					if ( !handle.IsValid() ) continue;
+
+					handle.Position = StartPositions[handle] + offset;
+					handle.UpdateValueFromPosition();
+				}
+			}
+			finally
+			{
+				_applying = false;
+			}
+
+			foreach ( var curve in DraggedCurves )
+			{
+				curve.OnHandleMoved();
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary
Changes how the curve editor handles dragging multiple keyframes out of the range.

Previously , when having multiple keyframes selected and  dragging them together, if you would hit the ranges bound with some keyframes they would get clamped and all the other would continue to move. Now if you do that all the keyframes will be clamped as soon as one keyframe in the selection is getting out of bounds
<!--
Briefly explain what this PR does and why it exists.
Focus on the problem being solved, not just the implementation.
-->

## Motivation & Context
The old behaviour was really a pain in the ass and made me stop using this feature at all.
The principle reason is that I would often "break" the shape of the selected keyframes when i wanted to drag near the bounds. Coupled to the fact we don't have undo's and redo's on this widget it made for a really destructive feature ,especially when you wanted to move a big selection of keyframes.
<!--
Why is this change needed?
Link to issues, discussions, forum threads
-->


## Screenshots / Videos (if applicable)
**Before**

https://github.com/user-attachments/assets/28ae476e-422a-464e-95ee-f5757f40fa8f


**After**

https://github.com/user-attachments/assets/8c26441a-0617-421f-98c8-aa6501a861a5


<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂