### PR TITLE
remove temporary triangle face in MergeVertices if CollapseEdge() fails

### DIFF
--- a/engine/Sandbox.Engine/Scene/Components/Mesh/HalfEdgeMesh/HalfEdgeMesh.cs
+++ b/engine/Sandbox.Engine/Scene/Components/Mesh/HalfEdgeMesh/HalfEdgeMesh.cs
@@ -2788,7 +2788,7 @@ internal sealed partial class Mesh
 
 				hFullEdge = FindFullEdgeConnectingVertices( hVertexA, hVertexB );
 				bool bSuccess = CollapseEdge( hFullEdge, out hOutNewVertex, bCheckOnly, out var _ );
-				if ( bCheckOnly )
+				if ( bCheckOnly || !bSuccess )
 				{
 					RemoveFace( hNewFace, false );
 				}
@@ -2810,7 +2810,7 @@ internal sealed partial class Mesh
 
 				hFullEdge = FindFullEdgeConnectingVertices( hVertexA, hVertexB );
 				var bSuccess = CollapseEdge( hFullEdge, out hOutNewVertex, bCheckOnly, out var _ );
-				if ( bCheckOnly )
+				if ( bCheckOnly || !bSuccess )
 				{
 					RemoveFace( hNewFace, false );
 				}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

in HalfEdgeMesh.cs, if CollapseEdge() in MergeVertices() fails the triangle face meant to join the edges gets left behind, polluting the topology

## Motivation & Context

I was working on vmap decompilation code for Source2 viewer and noticed this issue.

Fixes: <!-- #issue-number (if applicable) -->

## Implementation Details

<!--
Explain any non-obvious decisions.
Call out tricky parts, tradeoffs, or engine-specific considerations.
-->

## Screenshots / Videos (if applicable)

<!--
UI, editor, rendering, or gameplay changes are much easier to review with visuals.
-->

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂