### PR TITLE
Only read microphone from steam if we requested it

### DIFF
--- a/engine/Sandbox.Engine/Utility/VoiceManager.cs
+++ b/engine/Sandbox.Engine/Utility/VoiceManager.cs
@@ -22,12 +22,14 @@ internal static class VoiceManager
 	public static bool IsValid => steamUser.IsValid;
 	public static bool IsListening { get; private set; }
 	public static bool IsRecording => timeSinceLastHear < 0.2f;
+	private static bool _listenActive;
 
 	public static bool StartRecording()
 	{
 		if ( !IsValid ) return false;
 
 		IsListening = true;
+		_listenActive = true;
 		steamUser.StartVoiceRecording();
 		return true;
 	}
@@ -61,8 +63,10 @@ internal static class VoiceManager
 		uint dataSize = 0;
 
 		// Check if there's any avaliable first, the subsequent call takes 0.1ms even if you're not recording..
-		if ( steamUser.GetAvailableVoice( out var _ ) != 0 )
+		if ( !_listenActive || steamUser.GetAvailableVoice( out var _ ) != 0 )
 		{
+			if ( _listenActive && !IsListening && !IsRecording )
+				_listenActive = false;
 			dataSize = 0;
 			compressedMemory = Memory<byte>.Empty;
 			return;


### PR DESCRIPTION
## Summary
Multiple instances of the game will try to read steam microphone input at once, which did not produce any useable audio. This adds a check so that it only attempts to get microphone input on instances that are actually trying to record.

Both instances could still be set to record at the same time if the user has their mic always open (which would bring back the audio issues) but at least for push to talk this works in a more sane way.

## Motivation & Context
Annoying when trying to test voice chat.

Fixes: https://github.com/Facepunch/sbox-public/issues/3137

## Implementation Details
Sets a bool when VoiceManager requests that steam start recording. The game will only attempt to read microphone input from steam while the bool is set. The bool is cleared once IsListening and IsRecording are both false (recording has been stopped and it's been 0.2 seconds since we've received audio from steam). I don't believe there are any instances where steam would start sending audio again after a 0.2 second delay with recording stopped.

## Videos
With both instances fighting over the microphone input it sounds like this. Note both instances show the mic icon despite only pressing push to talk on one of them.

https://github.com/user-attachments/assets/908134fc-5da3-4d1b-b69a-d695dd578c92


With the added check microphone activation is separate per instance and the signal is clean.

https://github.com/user-attachments/assets/a9adcd6d-51df-4126-91f6-e830d72c8998

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂