### PR TITLE
Case insensitive string to enum

### DIFF
--- a/engine/Sandbox.System/Extend/StringExtensions.cs
+++ b/engine/Sandbox.System/Extend/StringExtensions.cs
@@ -658,7 +658,12 @@ public static partial class SandboxSystemExtensions
 		if ( t == typeof( Angles ) ) { Value = global::Angles.Parse( str ); return true; }
 		if ( t == typeof( Color ) ) { Value = global::Color.Parse( str ); return true; }
 		if ( t == typeof( RangedFloat ) ) { Value = RangedFloat.Parse( str ); return true; }
-		if ( t.IsEnum ) { Value = Enum.Parse( t, str ); return true; }
+		if ( t.IsEnum )
+		{
+			if ( !Enum.TryParse( t, str, out Value ) )
+				Value = Enum.Parse( t, str, true );
+			return true;
+		}
 
 		if ( t == typeof( Rotation ) )
 		{

--- a/engine/Tests/Sandbox.Test.Engine/UI/Panel/DataBinding.cs
+++ b/engine/Tests/Sandbox.Test.Engine/UI/Panel/DataBinding.cs
@@ -95,20 +95,34 @@ public class PanelDataBindingTest
 	}
 
 	/// <summary>
-	/// SetProperty parses enum properties with Enum.Parse, which is case sensitive - an exact
-	/// value name applies, while a wrong-cased name fails the conversion and leaves the
-	/// property unchanged.
+	/// SetProperty parses enum properties with Enum.Parse, which is normally case
+	/// sensitive - an exact value name applies, but if no exact match can be found
+	/// it will settle for a case insensitive match.
 	/// </summary>
 	[TestMethod]
 	public void SetPropertyEnumConversion()
 	{
 		var p = new BindingProbePanel();
 
+		// exact match
 		p.SetProperty( "BoundMode", "Second" );
 		Assert.AreEqual( BindingProbeMode.Second, p.BoundMode );
 
-		p.SetProperty( "BoundMode", "third" );
+		// falls back to case insensitive
+		p.SetProperty( "BoundMode", "second" );
 		Assert.AreEqual( BindingProbeMode.Second, p.BoundMode );
+
+		// exact match
+		p.SetProperty( "BoundMode", "third" );
+		Assert.AreEqual( BindingProbeMode.third, p.BoundMode );
+
+		// exact match
+		p.SetProperty( "BoundMode", "Third" );
+		Assert.AreEqual( BindingProbeMode.Third, p.BoundMode );
+
+		// property is not set on invalid value
+		p.SetProperty( "BoundMode", "BadValue" );
+		Assert.AreEqual( BindingProbeMode.Third, p.BoundMode );
 	}
 
 	/// <summary>
@@ -177,7 +191,8 @@ public enum BindingProbeMode
 {
 	First,
 	Second,
-	Third
+	Third,
+	third
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
`StringExtensions.ToType` is now attempts a case insensitive conversion if an exact match fails.
<img width="174" height="62" alt="image" src="https://github.com/user-attachments/assets/d5837140-e908-4038-b77d-167ca33c70ea" />

## Motivation & Context
Console commands seemed a bit too picky with capitalization for enums.

## Implementation Details
Initially thought running the conversion twice was overkill but there's a test to ensure it's case sensitive for enums so I put the more complicated version back in. However, the original test still fails as it requires the enum conversion to fail completely. This seems a bit extreme to me and I can't imagine a scenario where that would be required, so I've modified the test with what I believe correct behavior should be. The only scenarios where this would change behavior would have previously been throwing exceptions.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂