### PR TITLE
Copy dll and runtimeconfig in standalone build

### DIFF
--- a/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.cs
+++ b/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.cs
@@ -296,6 +296,8 @@ public partial class StandaloneExporter
 		//
 		{
 			QueueCopy( $"{engineDir}/sbox-standalone.exe", $"{baseDir}/{StandaloneManifest.ExecutableName}.exe", BuildStep.FinalizeExecutable );
+			QueueCopy( $"{engineDir}/sbox-standalone.dll", $"{baseDir}/sbox-standalone.dll", BuildStep.FinalizeExecutable );
+			QueueCopy( $"{engineDir}/sbox-standalone.runtimeconfig.json", $"{baseDir}/sbox-standalone.runtimeconfig.json", BuildStep.FinalizeExecutable );
 		}
 
 		//


### PR DESCRIPTION
## Summary
`sbox-standalone.dll` and `sbox-standalone.runtimeconfig.json` have fairly recently stopped getting copied into standalone builds. This adds them to the copy queue so they get copied. Not sure how they were getting copied before now or why that stopped working, which is a little concerning.

## Motivation & Context
working standalone builds is nice to have

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂