### PR TITLE
Fix absolute asset path lookup on Linux

### DIFF
--- a/engine/Sandbox.Tools/Assets/AssetSystem.cs
+++ b/engine/Sandbox.Tools/Assets/AssetSystem.cs
@@ -199,9 +199,18 @@ public static partial class AssetSystem
 			return null;
 
 		path = path.Replace( '\\', '/' );
-		path = path.TrimStart( '/' );
 
 		if ( assetsByPath.TryGetValue( path, out var asset ) && !asset.IsDeleted )
+		{
+			return asset;
+		}
+
+		// Unix absolute paths and rooted resource paths both begin with '/'.
+		// The exact absolute form was checked first; keep supporting the historical
+		// resource-relative form as a fallback.
+		if ( path[0] == '/' &&
+			assetsByPath.TryGetValue( path.TrimStart( '/' ), out asset ) &&
+			!asset.IsDeleted )
 		{
 			return asset;
 		}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Fix absolute asset lookup on Unix paths. 

The Asset Browser passes an absolute `FileInfo` path to `AssetSystem.FindByPath()`, which previously removed the leading `/`. The lookup then failed, so the browser treated recognized resources as plain files and opened them through the desktop file association instead of `Asset.OpenInEditor()`.

## Motivation & Context

Windows drive paths do not begin with `/`, so the bug only surfaced on Linux. It affects every resource type that the Asset Browser resolves from an absolute path, including custom GameResources and models.

The failure was reproduced with `cache/food/beef_cooked.item`: relative lookup succeeded and identified it as a GameResource, while lookup by its absolute Linux path returned no asset.

Fixes: https://github.com/Facepunch/sbox-public/issues/11727

## Implementation Details

`FindByPath()` now checks the normalized path exactly as supplied. If that lookup misses and the path begins with `/`, it tries the historical slash-stripped resource path as a fallback.

This ordering preserves Unix absolute paths while retaining compatibility with rooted resource paths and Windows file URI paths such as `/C:/...`. A source comment documents why both forms are checked. The behavior remains platform-neutral because the ambiguity belongs to the shared path lookup contract, not Asset Browser dispatch.

Verification:

```text
dotnet build engine/Sandbox.Tools/Sandbox.Tools.csproj -c Release -p:OutputPath=/tmp/sbox-tools-pr-check
Build succeeded.
```

## Screenshots / Videos (if applicable)

Not applicable. This changes path resolution and editor dispatch without changing the UI.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂
