### PR TITLE
Linux: Prevent unavailable native tools from crashing

### DIFF
--- a/engine/Sandbox.Tools/AssemblyInitialize.cs
+++ b/engine/Sandbox.Tools/AssemblyInitialize.cs
@@ -29,21 +29,23 @@ internal static class AssemblyInitialize
 		// Hammer, ModelDoc and Animgraph each live in their own native library, and those
 		// aren't built on every platform yet. The editor itself doesn't need them - it's the
 		// individual tool that won't open - so don't take the whole thing down over one.
-		InitializeTool( "Hammer", Managed.SourceHammer.NativeInterop.Initialize );
-		InitializeTool( "ModelDoc", Managed.SourceModelDoc.NativeInterop.Initialize );
-		InitializeTool( "Animgraph", Managed.SourceAnimgraph.NativeInterop.Initialize );
+		InitializeTool( "Hammer", "hammer", Managed.SourceHammer.NativeInterop.Initialize );
+		InitializeTool( "ModelDoc", "modeldoc_editor", Managed.SourceModelDoc.NativeInterop.Initialize );
+		InitializeTool( "Animgraph", "animgraph_editor", Managed.SourceAnimgraph.NativeInterop.Initialize );
 
 		IToolsDll.Current = new ToolsDll();
 	}
 
-	static void InitializeTool( string name, System.Action initialize )
+	static void InitializeTool( string name, string library, System.Action initialize )
 	{
 		try
 		{
 			initialize();
+			EngineTools.SetAvailable( library );
 		}
 		catch ( System.Exception e )
 		{
+			EngineTools.SetUnavailable( library, e.Message );
 			Log.Warning( $"{name} is unavailable, its native library didn't load ({e.Message})" );
 		}
 	}

--- a/engine/Sandbox.Tools/AssemblyInitialize.cs
+++ b/engine/Sandbox.Tools/AssemblyInitialize.cs
@@ -43,10 +43,10 @@ internal static class AssemblyInitialize
 			initialize();
 			EngineTools.SetAvailable( library );
 		}
-		catch ( System.Exception e )
+		catch ( System.Exception )
 		{
-			EngineTools.SetUnavailable( library, e.Message );
-			Log.Warning( $"{name} is unavailable, its native library didn't load ({e.Message})" );
+			EngineTools.SetUnavailable( library );
+			Log.Warning( $"{name} is unavailable. {EngineTools.GetUnavailableMessage()}" );
 		}
 	}
 

--- a/engine/Sandbox.Tools/Assets/NativeAsset/NativeAsset.cs
+++ b/engine/Sandbox.Tools/Assets/NativeAsset/NativeAsset.cs
@@ -118,11 +118,20 @@ internal class NativeAsset : Asset
 
 		if ( nativeEditor != null )
 		{
+			if ( !EngineTools.EnsureAvailable( nativeEditor ) )
+			{
+				return;
+			}
+
 			native.OpenInSecondaryTool( nativeEditor );
 			return;
 		}
 
 		if ( IAssetEditor.OpenInEditor( this, out _ ) )
+		{
+			return;
+		}
+		if ( AssetType == AssetType.Model && !EngineTools.EnsureAvailable( "modeldoc_editor" ) )
 		{
 			return;
 		}

--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -422,6 +422,7 @@ public class EditorMainWindow : DockWindow, IUndoSystemProvider
 		foreach ( var tool in EngineTools.All )
 		{
 			var option = AppsMenu.AddOption( tool.Name, tool.Icon, () => EngineTools.ShowTool( tool.Name ) );
+			option.Enabled = EngineTools.IsAvailable( tool.Library );
 			option.StatusTip = tool.Description;
 			option.ToolTip = $"{tool.Name} - {tool.Description}";
 		}

--- a/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
+++ b/engine/Sandbox.Tools/Editor/EditorMainWindow.cs
@@ -421,7 +421,7 @@ public class EditorMainWindow : DockWindow, IUndoSystemProvider
 
 		foreach ( var tool in EngineTools.All )
 		{
-			var option = AppsMenu.AddOption( tool.Name, tool.Icon, () => EngineTools.ShowTool( tool.Name ) );
+			var option = AppsMenu.AddOption( tool.Name, tool.Icon, () => EngineTools.ShowTool( tool ) );
 			option.Enabled = EngineTools.IsAvailable( tool.Library );
 			option.StatusTip = tool.Description;
 			option.ToolTip = $"{tool.Name} - {tool.Description}";

--- a/engine/Sandbox.Tools/EngineTools.cs
+++ b/engine/Sandbox.Tools/EngineTools.cs
@@ -5,54 +5,64 @@
 	{
 		public record ToolDescription( string Name, string Description, string Library, string Icon );
 
-		static readonly List<ToolDescription> AllTools = new()
+		/// <summary>
+		/// All native tools registered on this machine, including unavailable tools.
+		/// </summary>
+		internal static IReadOnlyList<ToolDescription> All { get; } = new List<ToolDescription>
 		{
 			new ToolDescription( "Hammer",                  "For editing maps",                 "hammer",               "handyman" ),
 			new ToolDescription( "Material Editor",         "For editing materials",            "met",                  "insert_photo" ),
 			new ToolDescription( "Model Editor",            "For editing models",               "modeldoc_editor",      "view_in_ar" ),
 			new ToolDescription( "Animgraph Editor",        "For editing animation graphs",     "animgraph_editor",     "directions_run" ),
-		};
+		}.AsReadOnly();
 
-		static readonly Dictionary<string, string> UnavailableTools = new( System.StringComparer.OrdinalIgnoreCase );
-		static readonly IReadOnlyList<ToolDescription> AllToolsView = AllTools.AsReadOnly();
-
-		/// <summary>
-		/// All native tools registered on this machine, including unavailable tools.
-		/// </summary>
-		public static IReadOnlyList<ToolDescription> All => AllToolsView;
+		static readonly HashSet<string> UnavailableTools = new( System.StringComparer.OrdinalIgnoreCase );
 
 		internal static void SetAvailable( string library )
 		{
 			UnavailableTools.Remove( library );
 		}
 
-		internal static void SetUnavailable( string library, string reason )
+		internal static void SetUnavailable( string library )
 		{
-			UnavailableTools[library] = reason;
+			UnavailableTools.Add( library );
 		}
 
 		internal static bool IsAvailable( string library )
 		{
-			return !UnavailableTools.ContainsKey( library );
+			return !UnavailableTools.Contains( library );
 		}
 
 		internal static bool EnsureAvailable( string library )
 		{
-			if ( !UnavailableTools.TryGetValue( library, out var reason ) )
+			if ( !UnavailableTools.Contains( library ) )
+			{
 				return true;
+			}
 
-			var tool = AllTools.FirstOrDefault( x => x.Library.Equals( library, System.StringComparison.OrdinalIgnoreCase ) );
+			var tool = All.FirstOrDefault( x => x.Library.Equals( library, System.StringComparison.OrdinalIgnoreCase ) );
 			EditorUtility.DisplayDialog(
 				$"{tool?.Name ?? "Editor"} Unavailable",
-				$"The native editor library couldn't be loaded.\n\n{reason}" );
+				GetUnavailableMessage() );
 			return false;
 		}
 
-		public static void ShowTool( string name )
+		internal static string GetUnavailableMessage()
 		{
-			var tool = AllTools.First( x => x.Name == name );
+			if ( !System.OperatingSystem.IsWindows() )
+			{
+				return "Native tools aren't supported on non-Windows builds.";
+			}
+
+			return "The native editor library couldn't be loaded.";
+		}
+
+		internal static void ShowTool( ToolDescription tool )
+		{
 			if ( !EnsureAvailable( tool.Library ) )
+			{
 				return;
+			}
 
 			Native.ToolGlue.ShowTool( $"tools/{tool.Library}.dll" );
 		}

--- a/engine/Sandbox.Tools/EngineTools.cs
+++ b/engine/Sandbox.Tools/EngineTools.cs
@@ -5,7 +5,7 @@
 	{
 		public record ToolDescription( string Name, string Description, string Library, string Icon );
 
-		static List<ToolDescription> AllTools = new()
+		static readonly List<ToolDescription> AllTools = new()
 		{
 			new ToolDescription( "Hammer",                  "For editing maps",                 "hammer",               "handyman" ),
 			new ToolDescription( "Material Editor",         "For editing materials",            "met",                  "insert_photo" ),
@@ -13,20 +13,47 @@
 			new ToolDescription( "Animgraph Editor",        "For editing animation graphs",     "animgraph_editor",     "directions_run" ),
 		};
 
+		static readonly Dictionary<string, string> UnavailableTools = new( System.StringComparer.OrdinalIgnoreCase );
+		static readonly IReadOnlyList<ToolDescription> AllToolsView = AllTools.AsReadOnly();
+
 		/// <summary>
-		/// Accessor to get tools available on this machine.
+		/// All native tools registered on this machine, including unavailable tools.
 		/// </summary>
-		public static IReadOnlyList<ToolDescription> All
+		public static IReadOnlyList<ToolDescription> All => AllToolsView;
+
+		internal static void SetAvailable( string library )
 		{
-			get
-			{
-				return AllTools.AsReadOnly();
-			}
+			UnavailableTools.Remove( library );
+		}
+
+		internal static void SetUnavailable( string library, string reason )
+		{
+			UnavailableTools[library] = reason;
+		}
+
+		internal static bool IsAvailable( string library )
+		{
+			return !UnavailableTools.ContainsKey( library );
+		}
+
+		internal static bool EnsureAvailable( string library )
+		{
+			if ( !UnavailableTools.TryGetValue( library, out var reason ) )
+				return true;
+
+			var tool = AllTools.FirstOrDefault( x => x.Library.Equals( library, System.StringComparison.OrdinalIgnoreCase ) );
+			EditorUtility.DisplayDialog(
+				$"{tool?.Name ?? "Editor"} Unavailable",
+				$"The native editor library couldn't be loaded.\n\n{reason}" );
+			return false;
 		}
 
 		public static void ShowTool( string name )
 		{
-			var tool = All.FirstOrDefault( x => x.Name == name );
+			var tool = AllTools.First( x => x.Name == name );
+			if ( !EnsureAvailable( tool.Library ) )
+				return;
+
 			Native.ToolGlue.ShowTool( $"tools/{tool.Library}.dll" );
 		}
 	}

--- a/engine/Tests/Sandbox.Test.Unit/Tools/EngineToolsTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Tools/EngineToolsTest.cs
@@ -1,0 +1,24 @@
+namespace ToolsTests;
+
+[TestClass]
+[DoNotParallelize]
+public class EngineToolsTest
+{
+	[TestMethod]
+	public void UnavailableNativeEditorRemainsListed()
+	{
+		const string library = "modeldoc_editor";
+
+		try
+		{
+			Editor.EngineTools.SetUnavailable( library, "missing native library" );
+
+			Assert.IsFalse( Editor.EngineTools.IsAvailable( library ) );
+			Assert.IsTrue( Editor.EngineTools.All.Any( x => x.Library == library ) );
+		}
+		finally
+		{
+			Editor.EngineTools.SetAvailable( library );
+		}
+	}
+}

--- a/engine/Tests/Sandbox.Test.Unit/Tools/EngineToolsTest.cs
+++ b/engine/Tests/Sandbox.Test.Unit/Tools/EngineToolsTest.cs
@@ -11,7 +11,7 @@ public class EngineToolsTest
 
 		try
 		{
-			Editor.EngineTools.SetUnavailable( library, "missing native library" );
+			Editor.EngineTools.SetUnavailable( library );
 
 			Assert.IsFalse( Editor.EngineTools.IsAvailable( library ) );
 			Assert.IsTrue( Editor.EngineTools.All.Any( x => x.Library == library ) );
@@ -20,5 +20,15 @@ public class EngineToolsTest
 		{
 			Editor.EngineTools.SetAvailable( library );
 		}
+	}
+
+	[TestMethod]
+	public void UnavailableNativeEditorHasPlatformAppropriateMessage()
+	{
+		var expected = System.OperatingSystem.IsWindows()
+			? "The native editor library couldn't be loaded."
+			: "Native tools aren't supported on non-Windows builds.";
+
+		Assert.AreEqual( expected, Editor.EngineTools.GetUnavailableMessage() );
 	}
 }


### PR DESCRIPTION
## Summary

Prevent unavailable native editors from reaching their native launch paths. When Hammer, ModelDoc, or AnimGraph fails to initialize, it remains visible in the Apps menu but is disabled. Asset-opening paths now stop before dispatching to an unavailable tool and show a platform-appropriate explanation.

## Motivation & Context

Hammer, ModelDoc, and AnimGraph each depend on an optional native library. These tools are unsupported on non-Windows builds, but startup already tolerated their initialization failures so the rest of the editor could continue loading. The Apps menu and asset-opening paths did not retain that failure state and still treated the tools as usable.

This was reproducible by opening a `.vmdl` on Linux: the asset system dispatched to ModelDoc after its initialization failed, then terminated while resolving the missing application dependency.

No linked issue.

## Implementation Details

- Track each optional native tool's availability by library name when it initializes.
- Keep unavailable tools in `EngineTools.All`, but disable their Apps menu entries.
- Check availability before direct tool launches, explicit secondary-tool asset opens, and the default ModelDoc path for model assets.
- Explain that native tools are unsupported on non-Windows builds, or that the native editor library could not be loaded on Windows.
- Add unit coverage for retaining unavailable tools in the list and selecting the platform-appropriate message.

## Testing

```text
dotnet test engine/Tests/Sandbox.Test.Unit/Sandbox.Test.Unit.csproj --no-restore --filter FullyQualifiedName~ToolsTests.EngineToolsTest
Passed: 2, Failed: 0, Skipped: 0
```

## Screenshots / Videos

<img width="171" height="252" alt="image" src="https://github.com/user-attachments/assets/346d40ab-d1c3-4de9-a619-90c2781cade8" />

<img width="1917" height="1078" alt="image" src="https://github.com/user-attachments/assets/15958897-00ac-44d7-a395-b43d9e75f830" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (no public API changes)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change
