### PR TITLE
Linux: Handle exhausted inotify watcher limits

### DIFF
--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
@@ -102,7 +102,14 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 			if ( _showRecursive == value ) return;
 			_showRecursive = value;
 
-			watcher.IncludeSubdirectories = value;
+			try
+			{
+				watcher.IncludeSubdirectories = value;
+			}
+			catch ( IOException e )
+			{
+				Log.Warning( $"Couldn't update the file watcher for {CurrentLocation?.Path} ({e.Message})" );
+			}
 
 			UpdateAssetList();
 			SaveSettings();


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Prevents the Asset Browser from crashing editor startup when Linux cannot allocate another inotify instance. The editor continues without automatic filesystem refresh for that watcher and logs a warning with the affected path and the operating system error.

## Motivation & Context

Setting `FileSystemWatcher.IncludeSubdirectories` restarts an active watcher. On Linux, that restart throws an `IOException` when `inotify_init` cannot allocate an instance because the user or file descriptor limit has been reached. The exception previously escaped from Asset Browser settings loading and prevented editor startup.

Fixes: N/A

## Implementation Details

Catch `IOException` at the optional watcher reconfiguration boundary. The recursive asset view still updates and saves its setting, while only automatic external-file refresh is lost. Later navigation can retry enabling the watcher. This avoids changing system limits or hiding unrelated startup exceptions.

Verified by launching the affected project with `fs.inotify.max_user_instances = 128` already exhausted. The editor continued starting and the console reported that the watcher could not be updated because the user limit had been reached.

This follows existing patterns in the file while configuring and handling watcher exceptions.

## Screenshots / Videos (if applicable)

Not applicable.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂