### PR TITLE
Copy core files using whitelist for standalone export

### DIFF
--- a/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.Files.cs
+++ b/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.Files.cs
@@ -34,34 +34,35 @@ partial class StandaloneExporter
 	}
 
 	private static string[] CoreWhitelist = [
-		// Error particle
-		"particles/error/error.vtex_c",
-		"particles/error_particle.vtex_c",
-		
 		// Shaders
-		"shaders/*.shader_c",
+		"shaders/**/*.shader_c",
 		
-		// Dev textures, materials, models (contains error assets etc.)
+		// Dev textures, models (contains error assets etc.)
 		"textures/dev/**/*.vtex_c",
 		"models/dev/**/*.vmdl_c",
-		"materials/dev/**/*.vmat_c",
-		"materials/dev/**/*.vtex_c",
+		"models/dev/**/*.vmat_c",
+		"models/dev/**/*.vtex_c",
+		"textures/**/*.vtex_c",
+		"debug/*",
 
-		// Default materials (solid colors)
-		"materials/default/**/*.vmat_c",
-		"materials/default/**/*.vtex_c",
+		// Default materials
+		"materials/**/*.vmat_c",
+		"materials/**/*.vtex_c",
 		"dev/helper/**/*.vmat_c",
 		"dev/helper/**/*.vtex_c",
-		"materials/error.vmat_c",
+		"dev/vgui/**/*.vmat_c",
+		"dev/*.vtex_c",
 		
 		// Splash screen
 		"materials/startup_background.vtex_c",
 
+		// Interface
+		"fonts/*.ttf",
+		"styles/**/*",
+		"ui/**/*",
+
 		// Config files
 		"cfg/*",
-
-		// Sound mixers (required for engine boot?)
-		"scripts/soundmixers.txt",
 	];
 
 	private IEnumerable<string> GetCoreFiles( string engineDir )

--- a/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.cs
+++ b/engine/Sandbox.Tools/Utility/Standalone/StandaloneExporter.cs
@@ -209,26 +209,6 @@ public partial class StandaloneExporter
 		// Copy core compiled files
 		//
 		{
-			void QueueCompiled( string dir, BuildStep type )
-			{
-				foreach ( var subdir in Directory.GetDirectories( dir ) )
-				{
-					QueueCompiled( subdir, type );
-				}
-
-				foreach ( var file in Directory.GetFiles( dir ) )
-				{
-					var relativePath = Path.GetRelativePath( engineDir, file );
-					var targetPath = Path.Combine( baseDir, relativePath );
-
-					if ( Path.GetExtension( file ).EndsWith( "_c", StringComparison.OrdinalIgnoreCase ) )
-						QueueCopy( file, targetPath, type );
-				}
-			}
-
-			// Copy all compiled core content, in case anything references it at runtime
-			QueueCompiled( $"{engineDir}/core", BuildStep.CopyProjectAssets );
-
 			// Get all core files - only the ones we absolutely need, because everything else should
 			// already have been copied into the addon itself.
 			// This is mainly stuff like dev textures that are necessary for the engine to run.
@@ -262,34 +242,6 @@ public partial class StandaloneExporter
 
 				QueueCopy( sourcePath, targetPath, BuildStep.CopyCode );
 			}
-		}
-
-		//
-		// Copy:
-		// - core/ui/*
-		// - core/styles/*
-		// - core/fonts/*
-		//
-		{
-			void QueueAll( string dir, BuildStep type )
-			{
-				foreach ( var subdir in Directory.GetDirectories( dir ) )
-				{
-					QueueAll( subdir, type );
-				}
-
-				foreach ( var file in Directory.GetFiles( dir ) )
-				{
-					var relativePath = Path.GetRelativePath( engineDir, file );
-					var targetPath = Path.Combine( baseDir, relativePath );
-
-					QueueCopy( file, targetPath, type );
-				}
-			}
-
-			QueueAll( $"{engineDir}/core/ui", BuildStep.CopyBaseAssets ); // Necessary
-			QueueAll( $"{engineDir}/core/styles", BuildStep.CopyBaseAssets ); // Necessary
-			QueueAll( $"{engineDir}/core/fonts", BuildStep.CopyBaseAssets ); // Necessary
 		}
 
 		//


### PR DESCRIPTION
## Summary
Standalone export previously used a fairly strict whitelist for core, but when base addon was merged into core extra code was added to ensure all base addon files were copied, at the cost of also copying junk files from what used to be core. This instead adds the important files formerly in base addon to the core whitelist and uses only the whitelist to queue files.

## Motivation & Context
I like a clean directory

## Implementation Details

The new whitelist is
```cs
[
	// Shaders
	"shaders/**/*.shader_c",

	// Dev textures, models (contains error assets etc.)
	"textures/dev/**/*.vtex_c",
	"models/dev/**/*.vmdl_c",
	"models/dev/**/*.vmat_c",
	"models/dev/**/*.vtex_c",
	"textures/**/*.vtex_c",
	"debug/*",

	// Default materials
	"materials/**/*.vmat_c",
	"materials/**/*.vtex_c",
	"dev/helper/**/*.vmat_c",
	"dev/helper/**/*.vtex_c",
	"dev/vgui/**/*.vmat_c",
	"dev/*.vtex_c",

	// Splash screen
	"materials/startup_background.vtex_c",

	// Interface
	"fonts/*.ttf",
	"styles/**/*",
	"ui/**/*",

	// Config files
	"cfg/*",
];
```
Which is notably a bit stricter than it was before, there are a few things previously in base now in core that seem generally useless (9mm.ammo_c for example) that I can't imagine standalone games would ever need and would in theory be included via the package references if they were to be used. I've also omitted decals and surfaces, as they reference textures not present in standalone builds (and should also get automatically included if referenced).

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂