### PR TITLE
Lazy init global keystore cache (.source/cache)

### DIFF
--- a/engine/Sandbox.Engine/Systems/Filesystem/FileSystem.cs
+++ b/engine/Sandbox.Engine/Systems/Filesystem/FileSystem.cs
@@ -32,7 +32,7 @@ public static class FileSystem
 	/// <summary>
 	/// A cached keystore that can be used for anything. This is stored in a global cache folder, and may be deleted at any time.
 	/// </summary>
-	public static KeyStore Cache = KeyStore.CreateGlobalCache();
+	public static KeyStore Cache { get => field ??= KeyStore.CreateGlobalCache(); }
 
 	/// <summary>
 	/// Create a filesystem that exists only in memory


### PR DESCRIPTION
## Summary
Avoids creating the `.source2/cache` directory until something actually tries to use `FileSystem.Cache` (which isn't very common). Has no real impact outside of keeping standalone install folder tidy.

## Motivation & Context
Standalone game creating a folder on launch that never gets used annoys me a little.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂