### PR TITLE
No subfolder for game data in standalone

### DIFF
--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -703,6 +703,11 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 
 				GlobalContext.Current.FileData = FileSystem.OrganizationData.CreateSubSystem( package );
 			}
+			else if ( Application.IsStandalone && ident == Standalone.Manifest.Ident )
+			{
+				GlobalContext.Current.FileOrg = EngineFileSystem.Data;
+				GlobalContext.Current.FileData = EngineFileSystem.Data;
+			}
 			else
 			{
 				EngineFileSystem.Data.CreateDirectory( ".local" );


### PR DESCRIPTION
## Summary
Game data is normally stored at `data/.local/ident/` which I feel is kind of implied in standalone. This changes the path to just `data/` for the main (e.g. `Standalone.Manifest.Ident`) package. Any other packages use the normal `data/org/ident` path. 

## Motivation & Context
Seems a bit cleaner

<img width="497" height="132" alt="image" src="https://github.com/user-attachments/assets/669811d0-8f61-40c8-a7b9-dbfa5ef917ea" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂