### PR TITLE
Destroy game resources before unmounting content #778 fix

### DIFF
--- a/engine/Sandbox.GameInstance/GameInstance.cs
+++ b/engine/Sandbox.GameInstance/GameInstance.cs
@@ -112,6 +112,9 @@ internal class GameInstance : IGameInstance
 
 		GlobalContext.Current.UISystem.Clear();
 
+		// Destroy resource manifests before unmounting their package or network-backed files.
+		Game.Resources.Clear();
+
 		if ( activePackage != null && !Application.IsStandalone )
 		{
 			Game.Language?.Shutdown();

--- a/engine/Tests/Sandbox.Test.Integration/Resources/GameInstanceShutdownTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Resources/GameInstanceShutdownTests.cs
@@ -1,0 +1,120 @@
+using Sandbox.Engine;
+using System;
+using System.Reflection;
+
+namespace ResourceTests;
+
+[TestClass]
+[DoNotParallelize]
+public class GameInstanceShutdownTests
+{
+	private const string MarkerPath = "__game_instance_shutdown_marker.txt";
+	private const string ResourcePath = "__game_instance_shutdown_probe.resource";
+
+	private sealed class ShutdownProbeResource : GameResource
+	{
+		public bool WasDestroyed { get; private set; }
+		public bool MountWasAvailableOnDestroy { get; private set; }
+
+		protected override void OnDestroy()
+		{
+			WasDestroyed = true;
+			MountWasAvailableOnDestroy = FileSystem.Mounted.FileExists( MarkerPath );
+		}
+	}
+
+	private sealed class ShutdownGameInstance : GameInstance
+	{
+		public ShutdownGameInstance( PackageManager.ActivePackage package )
+			: base( "__shutdown_resource_test", default )
+		{
+			activePackage = package;
+		}
+	}
+
+	[TestMethod]
+	public void ShutdownClearsResourcesBeforeUnmountingActivePackage()
+	{
+		var previousIsPlaying = Game.IsPlaying;
+		var previousIsClosing = Game.IsClosing;
+		var originalPackageTags = PackageManager.ActivePackages
+			.ToDictionary( package => package, package => package.Tags.ToArray() );
+		var holdTag = $"__shutdown_resource_test_{Guid.NewGuid():N}";
+
+		var packageFiles = new MemoryFileSystem();
+		var mountedFiles = new AggregateFileSystem();
+		var testContext = new GlobalContext();
+
+		try
+		{
+			// Shutdown removes the process-wide game/gamemenu tags. Keep any pre-existing
+			// packages alive for this isolated test, then restore their exact tag sets.
+			foreach ( var package in originalPackageTags.Keys )
+			{
+				package.Tags.Add( holdTag );
+			}
+
+			using ( new GlobalContext.GlobalContextScope( testContext ) )
+			{
+				try
+				{
+					testContext.FileMount = mountedFiles;
+					testContext.UISystem = new UISystem();
+
+					packageFiles.WriteAllText( MarkerPath, "mounted" );
+					mountedFiles.Mount( packageFiles );
+
+					var package = new PackageManager.ActivePackage();
+					var fileSystemProperty = typeof( PackageManager.ActivePackage ).GetProperty(
+						nameof( PackageManager.ActivePackage.FileSystem ),
+						BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic )
+						?? throw new MissingMemberException( nameof( PackageManager.ActivePackage.FileSystem ) );
+					fileSystemProperty.SetValue( package, packageFiles );
+
+					var probe = new ShutdownProbeResource();
+					probe.Register( ResourcePath );
+
+					Assert.IsTrue( FileSystem.Mounted.FileExists( MarkerPath ) );
+					Assert.AreSame( probe, ResourceLibrary.Get<ShutdownProbeResource>( ResourcePath ) );
+
+					new ShutdownGameInstance( package ).Shutdown();
+
+					Assert.IsTrue( probe.WasDestroyed,
+						"GameInstance.Shutdown must clear game resources." );
+					Assert.IsTrue( probe.MountWasAvailableOnDestroy,
+						"Resources must be destroyed while active-package files are still mounted." );
+					Assert.IsFalse( probe.IsValid );
+					Assert.IsNull( ResourceLibrary.Get<ShutdownProbeResource>( ResourcePath ) );
+					Assert.IsFalse( FileSystem.Mounted.FileExists( MarkerPath ),
+						"Shutdown must still unmount the active-package filesystem." );
+				}
+				finally
+				{
+					testContext.Shutdown();
+				}
+			}
+		}
+		finally
+		{
+			Game.IsPlaying = previousIsPlaying;
+			Game.IsClosing = previousIsClosing;
+
+			foreach ( var (package, tags) in originalPackageTags )
+			{
+				package.Tags.Clear();
+				package.Tags.UnionWith( tags );
+			}
+
+			if ( mountedFiles.IsValid )
+			{
+				mountedFiles.UnMount( packageFiles );
+				mountedFiles.Dispose();
+			}
+
+			if ( packageFiles.IsValid )
+			{
+				packageFiles.Dispose();
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Destroy game resources during GameInstance.Shutdown() while their package and network-backed filesystems are still mounted.
This prevents an intermittent teardown-time ERROR_FILEOPEN for locally transferred resources during reconnect. It does not change cache keys, download behavior, or mount creation.

## Motivation & Context

Fixes: #778
Local multiplayer testing through “Join via new instance” and reconnect should work without publishing a cloud package.
On current master, the baseline produced two scene ERROR_FILEOPEN errors across 20 reconnects. Resources were being destroyed after their package and network-backed filesystems had already been unmounted.
Commit 70435c6c appears to have fixed the original persistent missing-asset behavior reported in #778. This change fixes the remaining reproducible teardown-order error.
Implementation Details
- Clear Game.Resources after scene and UI teardown, but before unmounting the active package and network-backed filesystems.
- Keep the existing cleanup in GlobalContext.Reset() as a safety net for resources created during the remainder of shutdown.
- Add an integration test verifying that resources are destroyed while their filesystem is still mounted and that shutdown subsequently unmounts it.
- No public APIs, cache behavior, download logic, or mount creation were changed.
Validation completed:
- Focused regression test passed.
- Formatting verification passed.
- Developer build passed with zero managed warnings and errors.
- Full non-LiveBackend suite passed: 3,809 passed, 4 skipped, 0 failed.
- Patched multiplayer testing completed 40 reconnects with all 44 resource probes passing and zero target-path errors.

## Screenshots / Videos (if applicable)

Not applicable. This is a resource-lifecycle fix verified through automated tests and source-built multiplayer reconnect testing.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change. 🙂