### PR TITLE
Collapse objects without relevant components in scene browser

### DIFF
--- a/game/addons/tools/Code/Scene/GameObjectInspector/GameObjectSceneBrowser.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/GameObjectSceneBrowser.cs
@@ -91,10 +91,10 @@ public class GameObjectSceneBrowser : Widget
 		{
 			if ( gameObj.Flags.HasFlag( GameObjectFlags.EditorOnly ) || gameObj.Flags.HasFlag( GameObjectFlags.Hidden ) )
 				continue;
-			var treeNode = AddGameObject( gameObj, header );
+			AddGameObject( gameObj, header );
 		}
 
-		SceneTree.Open( header, ComponentType is not null );
+		SceneTree.Open( header, false );
 	}
 
 	public void SelectGameObject( GameObject gameObject )
@@ -115,26 +115,30 @@ public class GameObjectSceneBrowser : Widget
 		}
 	}
 
-	TreeNode AddGameObject( GameObject gameObject, TreeNode parent )
+	bool AddGameObject( GameObject gameObject, TreeNode parent )
 	{
 		var node = new SceneGameObjectNode( gameObject, ComponentType );
 		ObjectNodes.Add( node );
 		parent.AddItem( node );
-		AddComponents( gameObject, node );
+		var open = AddComponents( gameObject, node );
 		foreach ( var child in gameObject.Children )
 		{
 			if ( child.Flags.HasFlag( GameObjectFlags.EditorOnly ) || child.Flags.HasFlag( GameObjectFlags.Hidden ) )
 				continue;
-			AddGameObject( child, node );
+			open = AddGameObject( child, node ) || open;
 		}
-		return node;
+
+		if ( open )
+			SceneTree.Open( node );
+		return open;
 	}
 
-	void AddComponents( GameObject gameObject, TreeNode parent )
+	bool AddComponents( GameObject gameObject, TreeNode parent )
 	{
 		if ( ComponentType is null )
-			return;
+			return false;
 
+		var open = false;
 		foreach ( var component in gameObject.Components.GetAll() )
 		{
 			if ( !component.GetType().IsAssignableTo( ComponentType ) )
@@ -143,7 +147,10 @@ public class GameObjectSceneBrowser : Widget
 			var node = new SceneComponentNode( component );
 			ComponentNodes.Add( node );
 			parent.AddItem( node );
+			open = true;
 		}
+
+		return open;
 	}
 }
 


### PR DESCRIPTION
## Summary
When picking components using the scene browser there tends to be a lot of empty objects between the top of the window and the available components, such that you have to scroll to reach anything clickable. This collapses any GameObject hierarchies that don't contain any valid components to help remedy that (assuming you have a decently tidy scene).

## Motivation & Context
Annoyed me

## Implementation Details
Keeps track of nodes that contain valid components when building the tree and opens them. `AddGameObject` no longer returns a `TreeNode`, as its return value isn't used anywhere and I needed it to return bool (denoting if any of its children contain a valid component) instead.

## Screenshots
<img width="820" height="532" alt="image" src="https://github.com/user-attachments/assets/88027c49-a092-44dd-800b-3ecaaa6f0103" />

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂