### PR TITLE
Fix linux runtime staging picking other .NET versions other than 10

### DIFF
--- a/engine/Tools/SboxBuild/Steps/BuildManaged.cs
+++ b/engine/Tools/SboxBuild/Steps/BuildManaged.cs
@@ -164,8 +164,13 @@ internal class BuildManaged( bool clean = false )
 
 		var framework = Path.Combine( dotnetRoot, "shared", "Microsoft.NETCore.App" );
 		var source = Directory.Exists( framework )
-			? Directory.GetDirectories( framework ).OrderBy( d => d ).LastOrDefault()
-			: null;
+		    ? Directory.GetDirectories( framework )
+		        .Select( d => new { Dir = d, Version = new Version( Path.GetFileName( d ) ) } )
+		        .Where( x => x.Version.Major == 10 )
+		        .OrderBy( x => x.Version )
+		        .LastOrDefault()
+		        ?.Dir
+		    : null;
 
 		if ( source is null )
 		{

--- a/engine/Tools/SboxBuild/Steps/BuildManaged.cs
+++ b/engine/Tools/SboxBuild/Steps/BuildManaged.cs
@@ -164,13 +164,13 @@ internal class BuildManaged( bool clean = false )
 
 		var framework = Path.Combine( dotnetRoot, "shared", "Microsoft.NETCore.App" );
 		var source = Directory.Exists( framework )
-		    ? Directory.GetDirectories( framework )
-		        .Select( d => new { Dir = d, Version = new Version( Path.GetFileName( d ) ) } )
-		        .Where( x => x.Version.Major == 10 )
-		        .OrderBy( x => x.Version )
-		        .LastOrDefault()
-		        ?.Dir
-		    : null;
+			? Directory.GetDirectories( framework )
+				.Select( d => new { Dir = d, Version = new Version( Path.GetFileName( d ) ) } )
+				.Where( x => x.Version.Major == 10 )
+				.OrderBy( x => x.Version )
+				.LastOrDefault()
+				?.Dir
+			: null;
 
 		if ( source is null )
 		{


### PR DESCRIPTION
Sort by the parsed Version instead, always staging the highest 10 major
version runtime available in the shared framework folder.
