### PR TITLE
Use InvariantCulture in InteropGen to fix hash mismatch on non-Englis…

### DIFF
--- a/engine/Tools/InteropGen/Parsers/BaseParser.cs
+++ b/engine/Tools/InteropGen/Parsers/BaseParser.cs
@@ -130,7 +130,7 @@ internal class BaseParser
 		string fullname = Path.Combine( path, filename );
 
 		// Directory.GetFiles returns rooted paths, so include them directly.
-		foreach ( string file in Directory.GetFiles( fullname.TrimEnd( '*' ), "*.def", option ).OrderBy( x => x ) )
+		foreach ( string file in Directory.GetFiles( fullname.TrimEnd( '*' ), "*.def", option ).OrderBy( x => x, StringComparer.InvariantCulture ) )
 		{
 			IncludeFile( file );
 		}

--- a/engine/Tools/InteropGen/Pipeline/InteropPipeline.cs
+++ b/engine/Tools/InteropGen/Pipeline/InteropPipeline.cs
@@ -46,12 +46,12 @@ internal static class InteropPipeline
 
 	private static void Sort( Definition d )
 	{
-		d.Structs = d.Structs.OrderBy( x => x.NativeName ).ToList();
-		d.Classes = d.Classes.OrderBy( x => x.NativeNameWithNamespace ).ToList();
+		d.Structs = d.Structs.OrderBy( x => x.NativeName, StringComparer.InvariantCulture ).ToList();
+		d.Classes = d.Classes.OrderBy( x => x.NativeNameWithNamespace, StringComparer.InvariantCulture ).ToList();
 
 		foreach ( Class c in d.Classes )
 		{
-			c.Functions = c.Functions.OrderBy( x => x.MangledName ).ToList();
+			c.Functions = c.Functions.OrderBy( x => x.MangledName, StringComparer.InvariantCulture ).ToList();
 		}
 	}
 

--- a/engine/Tools/InteropGen/Program.cs
+++ b/engine/Tools/InteropGen/Program.cs
@@ -55,6 +55,11 @@ public static class Program
 	/// </summary>
 	public static void ProcessManifest( string directory, bool skipNative = false )
 	{
+		System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+		System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+		System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+		System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+
 		string filename = System.IO.Path.Combine( directory, "manifest.def" );
 		if ( !System.IO.File.Exists( filename ) )
 		{

--- a/engine/Tools/SboxBuild/Program.cs
+++ b/engine/Tools/SboxBuild/Program.cs
@@ -12,6 +12,11 @@ internal class Program
 {
 	static int Main( string[] args )
 	{
+		System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+		System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+		System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+		System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+
 		var rootCommand = new RootCommand( "sboxbuild - Build and deployment tool for s&box\n\nRun this from your sbox project root." );
 
 		// Compound commands (handle multiple related steps with flags)


### PR DESCRIPTION

## Summary

Fixes a fatal crash (`igen_engine: interop hash mismatch - managed sent 20152, native was built with 53717`) occurring during `Bootstrap.bat` / shader compilation on systems with Turkish locales.

## Motivation & Context

When building `sbox-public` on a Windows machine with a Turkish system locale (`tr-TR`), `Bootstrap.bat` fails at the `build-shaders` step with:

"igen_engine: interop hash mismatch - managed sent 20152, native was built with 53717. The two sides are out of sync - rebuild both.
Fatal error.
0xC0000005
   at Managed.SandboxEngine.NativeInterop.Initialize()
   at NetCore.InitializeInterop(System.String)
   at Sandbox.AppSystem.Init()
   at Sandbox.ToolAppSystem.Init()
   at Sandbox.ToolAppSystem..ctor()
   at Facepunch.ShaderCompiler.Program.Main(System.String[])
Process failed with exit code: -1073741819

Shader compiler failed"

### Root Cause
In `BaseParser.cs`, directory `.def` files were gathered using: 
"Directory.GetFiles( fullname.TrimEnd( '*' ), "*.def", option ).OrderBy( x => x )"

Because LINQ's .OrderBy( x => x ) defaults to StringComparer.CurrentCulture, the ["Turkish I" problem](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#the-details-of-string-comparison) (you can search the page for "the Turkish-I problem") causes Latin I and i to sort in a different sequence under tr-TR (I <-> ı, İ <-> i). Because engine definitions contain numerous files starting with I (e.g. Animgraph.def, IPhysicsBody.def, CSceneObject.def), the definition lines were parsed in a different order.

This produced an MD5 hash of 20152 in the generated C# bindings instead of 53717, causing an immediate mismatch against the prebuilt native engine2.dll downloaded from the artifact server.

Fixes: [#10573](https://github.com/Facepunch/sbox-public/issues/10573)

## Implementation Details

1- Added StringComparer.InvariantCulture to BaseParser.cs when discovering .def files in folders.
2- Added StringComparer.InvariantCulture to InteropPipeline.cs when sorting structs, classes, and member functions.
3- Explicitly set CultureInfo.DefaultThreadCurrentCulture and CultureInfo.DefaultThreadCurrentUICulture to CultureInfo.InvariantCulture at the entry points of SboxBuild and InteropGen.

## Screenshots / Videos (if applicable)

Before:
<img width="1675" height="426" alt="image" src="https://github.com/user-attachments/assets/61503c30-c67c-411f-bef1-ef47a936c940" />

After:
<img width="1630" height="690" alt="image" src="https://github.com/user-attachments/assets/67e32dfe-6589-4f8b-90d7-d588921803e8" />


## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [x] I’m okay with this PR being rejected or requested to change 🙂