### PR TITLE
Fix Linux editor multiplayer launch, lobby creation, and joining

### DIFF
--- a/engine/Sandbox.Engine/Platform/Steam/Utility/Platform.cs
+++ b/engine/Sandbox.Engine/Platform/Steam/Utility/Platform.cs
@@ -10,7 +10,11 @@ namespace Steamworks
 {
 	internal static class Platform
 	{
+#if STEAMWORKS_POSIX
+		internal const int StructPlatformPackSize = 4;
+#else
 		internal const int StructPlatformPackSize = 8;
+#endif
 		internal const string LibraryName = "steam_api64";
 
 		internal const CallingConvention CC = CallingConvention.Cdecl;

--- a/engine/Sandbox.Engine/Sandbox.Engine.csproj
+++ b/engine/Sandbox.Engine/Sandbox.Engine.csproj
@@ -33,6 +33,10 @@
 		<DefineConstants>WIN;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+		<DefineConstants>$(DefineConstants);STEAMWORKS_POSIX</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Facepunch.ActionGraphs" Version="1.9.27" />
 		<PackageReference Include="Fleck" Version="1.2.0" />

--- a/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpChannel.cs
@@ -11,6 +11,7 @@ namespace Sandbox.Network;
 /// </summary>
 internal class TcpChannel : Connection
 {
+	[SkipHotload]
 	internal readonly Channel<byte[]> incoming = Channel.CreateUnbounded<byte[]>();
 
 	string _address = "Tcp";
@@ -69,6 +70,8 @@ internal class TcpChannel : Connection
 		}
 	}
 
+	// Socket cancellation registrations contain runtime-owned callbacks, not hotloaded game code.
+	[SkipHotload]
 	readonly CancellationTokenSource tokenSource;
 
 	public bool IsValid => true;
@@ -76,6 +79,7 @@ internal class TcpChannel : Connection
 	bool isHost;
 	public override bool IsHost => isHost;
 
+	[SkipHotload]
 	TcpClient client;
 
 	public TcpChannel( TcpClient client )
@@ -109,6 +113,7 @@ internal class TcpChannel : Connection
 		tokenSource?.Cancel();
 	}
 
+	[SkipHotload]
 	Channel<byte[]> sendChannel = Channel.CreateUnbounded<byte[]>();
 
 	private ConcurrentQueue<(byte[], RealTimeUntil, NetworkSystem.MessageHandler)> fakeLagIncoming = new();

--- a/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpSocket.cs
+++ b/engine/Sandbox.Engine/Systems/Networking/Transports/Tcp/TcpSocket.cs
@@ -51,6 +51,7 @@ internal class TcpSocket : NetworkSocket, IValid
 		listener.Stop();
 	}
 
+	[SkipHotload]
 	CancellationTokenSource tokenSource;
 
 	public bool IsValid => true;

--- a/engine/Tests/Sandbox.Test.Engine/Steam/LobbyCallbackLayout.cs
+++ b/engine/Tests/Sandbox.Test.Engine/Steam/LobbyCallbackLayout.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using Steamworks;
+using Steamworks.Data;
+
+namespace SteamTests;
+
+[TestClass]
+public class LobbyCallbackLayout
+{
+	[TestMethod]
+	public unsafe void CreatedLobbyPreservesNativeSteamId()
+	{
+		const ulong lobbyId = 109775244746026750;
+		var idOffset = OperatingSystem.IsWindows() ? 8 : 4;
+		var nativeSize = idOffset + sizeof( ulong );
+		Span<byte> data = stackalloc byte[16];
+		data.Clear();
+		BinaryPrimitives.WriteInt32LittleEndian( data, (int)Result.OK );
+		BinaryPrimitives.WriteUInt64LittleEndian( data[idOffset..], lobbyId );
+
+		fixed ( byte* ptr = data )
+		{
+			var result = Marshal.PtrToStructure<LobbyCreated_t>( (IntPtr)ptr );
+			Assert.AreEqual( Result.OK, result.Result );
+			Assert.AreEqual( lobbyId, result.SteamIDLobby );
+			Assert.AreEqual( nativeSize, result.DataSize );
+		}
+	}
+
+	[TestMethod]
+	public unsafe void EnteredLobbyMatchesNativeCallbackSize()
+	{
+		const ulong lobbyId = 109775244746026750;
+		Span<byte> data = stackalloc byte[24];
+		data.Clear();
+		BinaryPrimitives.WriteUInt64LittleEndian( data, lobbyId );
+		data[12] = 1;
+		BinaryPrimitives.WriteUInt32LittleEndian( data[16..], (uint)RoomEnter.Success );
+
+		fixed ( byte* ptr = data )
+		{
+			var result = Marshal.PtrToStructure<LobbyEnter_t>( (IntPtr)ptr );
+			Assert.AreEqual( lobbyId, result.SteamIDLobby );
+			Assert.IsTrue( result.Locked );
+			Assert.AreEqual( (uint)RoomEnter.Success, result.EChatRoomEnterResponse );
+			Assert.AreEqual( OperatingSystem.IsWindows() ? 24 : 20, result.DataSize );
+		}
+	}
+}

--- a/game/addons/tools/Code/Scene/SceneView/ViewportTools.Network.cs
+++ b/game/addons/tools/Code/Scene/SceneView/ViewportTools.Network.cs
@@ -103,7 +103,7 @@ partial class ViewportTools
 	void SpawnDedicatedServer()
 	{
 		using var p = new Process();
-		p.StartInfo.FileName = "sbox-server.exe";
+		p.StartInfo.FileName = System.IO.Path.Combine( Environment.CurrentDirectory, OperatingSystem.IsWindows() ? "sbox-server.exe" : "sbox-server" );
 		p.StartInfo.WorkingDirectory = Environment.CurrentDirectory;
 
 		p.StartInfo.ArgumentList.Add( "+game" );
@@ -118,7 +118,7 @@ partial class ViewportTools
 	{
 		using var p = new Process();
 
-		p.StartInfo.FileName = "sbox.exe";
+		p.StartInfo.FileName = System.IO.Path.Combine( Environment.CurrentDirectory, OperatingSystem.IsWindows() ? "sbox.exe" : "sbox" );
 		p.StartInfo.WorkingDirectory = Environment.CurrentDirectory;
 		p.StartInfo.CreateNoWindow = true;
 		p.StartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
# Pull Request

## Summary

Fix Linux editor multiplayer testing: launch the native client and dedicated-server executables, create a valid Steam lobby when playing a scene, and let local clients complete the join handshake.

## Motivation & Context

On Linux, **Join via new instance** fails with `System.ComponentModel.Win32Exception (2)` because it tries to start `sbox.exe`, but the installed executable is `sbox`. The dedicated-server action similarly hardcodes `sbox-server.exe`. Removing `.exe` alone is not enough: Unix process lookup does not search the configured working directory for a bare executable name.

After fixing executable startup, testing exposed two more blockers:

- Steam callbacks used Windows' 8-byte struct packing on Linux. The managed lobby-creation result contained a corrupted lobby ID, so hosting failed with "Didn't enter lobby in a reasonable time!" before opening the local TCP listener.
- During client game-code loading, hotload traversed the TCP transport's live queues and cancellation registrations and attempted to rewrite internal .NET socket callbacks. The client then stalled in the join handshake at `MountVPKs`.

Fixes the Linux editor launch, lobby-creation, and local joining failures described above; no linked issue.

## Implementation Details

- In `ViewportTools.Network.cs`, use `Path.Combine(Environment.CurrentDirectory, ...)` for executable paths. Keep `sbox.exe` and `sbox-server.exe` on Windows; use `sbox` and `sbox-server` on other platforms, matching the existing engine convention.
- Define `STEAMWORKS_POSIX` for non-Windows builds and use 4-byte Steam callback packing there. Windows retains 8-byte packing.
- Mark the TCP transport's runtime-owned byte queues, client, and cancellation sources with `[SkipHotload]`. Game message handlers remain eligible for hotload.
- Add regression tests for decoding the native lobby-created callback's Steam ID and for the lobby-entered callback's fields and size.

Working directories and all join, instance ID, window, project, and custom command-line arguments remain unchanged. No game-project or scene changes are required.

### Verification

On Linux:

- Played a scene with `NetworkHelper.StartServer` enabled and confirmed that it created a Steam lobby and opened the local TCP listener.
- Launched two separate native clients against that host. Both completed the handshake, triggered the joined-game callback, and remained `Connected` with network traffic flowing. Host status showed three connected participants.
- Both `SteamTests.LobbyCallbackLayout` regression tests passed.

Earlier startup smoke checks also passed: the native client with `-joinlocal +instanceid 2 -sw -720 +quit` initialized Steam and Vulkan and exited with code 0; the native dedicated server with `+quit` reached its welcome console and exited with code 0. The dedicated server logged mount-loading and missing-shader errors during that startup check.

Dedicated-server joining, remote-machine joining, Windows, and macOS were not runtime-tested. The full test suite was not run.

## Screenshots / Videos (if applicable)

Not applicable: no visual changes. Runtime verification is described above.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable): no public API changes
- [x] Unit tests added where applicable and all passing: both added Steam callback tests pass; full suite not run
- [x] I'm okay with this PR being rejected or requested to change
