### PR TITLE
Inspector Component Context Menu: Insert Below and Insert Above

### DIFF
--- a/game/addons/tools/Code/Scene/GameObjectInspector/ComponentListWidget.cs
+++ b/game/addons/tools/Code/Scene/GameObjectInspector/ComponentListWidget.cs
@@ -291,6 +291,64 @@ public class ComponentListWidget : Widget
 			menu.AddSeparator();
 		}
 
+
+		static int FindComponentIndex( ComponentList list, Component component )
+		{
+			var index = 0;
+			foreach ( var element in list.GetAll() )
+			{
+				if ( component == element )
+				{
+					break;
+				}
+				index += 1;
+			}
+
+			return index;
+		}
+
+		var insertAbove = menu.AddMenu( "Insert Component Above", "vertical_align_top" );
+		insertAbove.AddWidget( new MenuComponentTypeSelectorWidget( insertAbove )
+		{
+			OnComponentSelect = ( t ) =>
+			{
+				var session = SceneEditorSession.Resolve( gameObject );
+				using var scene = session.Scene.Push();
+				using ( session.UndoScope( $"Insert {component.GetType().Name} Component Above" ).WithComponentCreations().Push() )
+				{
+					var go = component.GameObject;
+					var index = FindComponentIndex( go.Components, component );
+					var delta = index - go.Components.Count;
+					var newComponent = go.Components.Create( t );
+					if ( delta < 0 )
+					{
+						go.Components.Move( newComponent, delta );
+					}
+				}
+			}
+		} );
+
+		var insertBelow = menu.AddMenu( "Insert Component Below", "vertical_align_bottom" );
+		insertBelow.AddWidget( new MenuComponentTypeSelectorWidget( insertBelow )
+		{
+			OnComponentSelect = ( t ) =>
+			{
+				var session = SceneEditorSession.Resolve( gameObject );
+				using var scene = session.Scene.Push();
+				using ( session.UndoScope( $"Insert {component.GetType().Name} Component Below" ).WithComponentCreations().Push() )
+				{
+					var go = component.GameObject;
+					var index = FindComponentIndex( go.Components, component );
+					var delta = index - go.Components.Count + 1;
+					var newComponent = go.Components.Create( t );
+					if ( delta < 0 )
+					{
+						go.Components.Move( newComponent, delta );
+					}
+				}
+			}
+		} );
+
 		menu.AddOption( "Remove Component", "remove", action: () =>
 		{
 			var session = SceneEditorSession.Resolve( gameObject );


### PR DESCRIPTION
## Summary
You have to scroll all the way down the component list to "+ Add Component".

## Motivation & Context
Editor / Inspector ergonomics, yada-yada

Fixes: me being vexed (No attached issue)

## Implementation Details
Have to search the `ComponentList` for the index to calculate the delta for `ComponentList.Move`.
`ComponentList.Move` doesn't seem to break the `UndoScope`'s `.WithComponentCreations()`, it properly undoes and everything.

## Screenshots / Videos
<img width="213" height="156" alt="image" src="https://github.com/user-attachments/assets/5d8e8bbf-8f04-4e01-8c1f-40ff922836b8" />