### PR TITLE
Asset browser better multiple selection

### DIFF
--- a/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
@@ -214,8 +214,18 @@ public partial class AssetList
 			OpenFolderContextMenu( directories[0].DirectoryInfo.FullName, false );
 			return;
 		}
-	
+
+		// Only folders we found no assets in - the asset menu has nothing to act on and its handlers
+		// assume at least one entry, but the selection is still deletable.
 		var selection = ExpandDirectories( assets, directories );
+		if ( selection.Count == 0 )
+		{
+			var menu = new ContextMenu( this );
+			menu.AddOption( $"Delete ({directories.Count})", "delete", DeleteAsset, "editor.delete" );
+			menu.OpenAtCursor();
+			return;
+		}
+
 		var ac = new AssetContextMenu
 		{
 			SelectedList = selection,
@@ -296,30 +306,29 @@ public partial class AssetList
 	[Event( "asset.contextmenu", Priority = 1 )]
 	private protected static void OnAssetContextMenu_OpenSection( AssetContextMenu e )
 	{
+		if ( e.SelectedList.Count <= 0 ) return;
+
 		var entry = e.SelectedList.First();
 		var count = e.SelectedList.Count;
 		var asset = entry.Asset;
 
-		if ( count > 0 )
+		if ( e.SelectedList.All( x => x.Asset is { CanOpenInEditor: true } ) )
 		{
-			if ( e.SelectedList.All( x => x.Asset is { CanOpenInEditor: true } ) )
+			e.Menu.AddOption( count == 1 ? "Open in Editor" : $"Open {count} in Editor(s)", "edit",
+				() => e.SelectedList.ForEach( x => x.Asset.OpenInEditor() ) );
+		}
+		else if ( !asset?.IsProcedural ?? true )
+		{
+			if ( e.SelectedList.All( x => EditorUtility.IsCodeFile( x.FileInfo.FullName ) ) )
 			{
-				e.Menu.AddOption( count == 1 ? "Open in Editor" : $"Open {count} in Editor(s)", "edit",
-					() => e.SelectedList.ForEach( x => x.Asset.OpenInEditor() ) );
+				string editorName = CodeEditor.Title;
+				e.Menu.AddOption( count == 1 ? $"Open in {editorName}" : $"Open {count} in {editorName}", "edit",
+					() => e.SelectedList.ForEach( x => CodeEditor.OpenFile( x.FileInfo.FullName ) ) );
 			}
-			else if ( !asset?.IsProcedural ?? true )
+			else
 			{
-				if ( e.SelectedList.All( x => EditorUtility.IsCodeFile( x.FileInfo.FullName ) ) )
-				{
-					string editorName = CodeEditor.Title;
-					e.Menu.AddOption( count == 1 ? $"Open in {editorName}" : $"Open {count} in {editorName}", "edit",
-						() => e.SelectedList.ForEach( x => CodeEditor.OpenFile( x.FileInfo.FullName ) ) );
-				}
-				else
-				{
-					e.Menu.AddOption( count == 1 ? "Open" : $"Open {count} files", "open_in_new",
-					() => e.SelectedList.ForEach( x => EditorUtility.OpenFolder( x.FileInfo.FullName ) ) );
-				}
+				e.Menu.AddOption( count == 1 ? "Open" : $"Open {count} files", "open_in_new",
+				() => e.SelectedList.ForEach( x => EditorUtility.OpenFolder( x.FileInfo.FullName ) ) );
 			}
 		}
 

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
@@ -1,4 +1,4 @@
-using Editor.Widgets.Packages;
+﻿using Editor.Widgets.Packages;
 using System.IO;
 using System.Security;
 
@@ -634,6 +634,7 @@ public partial class AssetList
 			"editor.delete"
 			);
 
+			if ( count == 1 )
 				e.Menu.AddOption( $"Rename", "edit", action: () => e.AssetList.OpenRenameFlyout( entry, e.ScreenPosition ), shortcut: "editor.rename" );
 		}
 

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
@@ -207,21 +207,15 @@ public partial class AssetList
 		var directories = SelectedItems.OfType<DirectoryEntry>().ToList();
 
 		var onlyOneFolder = assets.Count == 0 && directories.Count == 1;
+
+		// Show the folder menu if there's only one folder selected
 		if ( onlyOneFolder )
 		{
 			OpenFolderContextMenu( directories[0].DirectoryInfo.FullName, false );
 			return;
 		}
-
+	
 		var selection = ExpandDirectories( assets, directories );
-		if ( selection.Count == 0 )
-		{
-			// Only asset-less folders are selected - the folder menu is all we can offer. Right click
-			// always selects what's under the cursor, so an empty expansion means we have folders.
-			OpenFolderContextMenu( directories[0].DirectoryInfo.FullName, false );
-			return;
-		}
-
 		var ac = new AssetContextMenu
 		{
 			SelectedList = selection,

--- a/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
+++ b/game/addons/tools/Code/Editor/AssetList/AssetList.ContextMenu.cs
@@ -1,4 +1,4 @@
-﻿using Editor.Widgets.Packages;
+using Editor.Widgets.Packages;
 using System.IO;
 using System.Security;
 
@@ -10,8 +10,8 @@ namespace Editor;
 public struct AssetContextMenu
 {
 	/// <summary>
-	/// List of selected assets when the context menu was opened.
-	/// These are the assets context menu should be affecting.
+	/// List of selected assets when the context menu was opened, including every asset found inside
+	/// any selected folder. These are the assets context menu should be affecting.
 	/// </summary>
 	public List<AssetEntry> SelectedList;
 
@@ -203,15 +203,22 @@ public partial class AssetList
 			return;
 		}
 
-		var selection = SelectedItems.OfType<AssetEntry>().ToList();
+		var assets = SelectedItems.OfType<AssetEntry>().ToList();
 		var directories = SelectedItems.OfType<DirectoryEntry>().ToList();
 
-		if ( directories.Any() )
+		var onlyOneFolder = assets.Count == 0 && directories.Count == 1;
+		if ( onlyOneFolder )
 		{
-			var dir = directories.First();
+			OpenFolderContextMenu( directories[0].DirectoryInfo.FullName, false );
+			return;
+		}
 
-			OpenFolderContextMenu( dir.DirectoryInfo.FullName, false );
-
+		var selection = ExpandDirectories( assets, directories );
+		if ( selection.Count == 0 )
+		{
+			// Only asset-less folders are selected - the folder menu is all we can offer. Right click
+			// always selects what's under the cursor, so an empty expansion means we have folders.
+			OpenFolderContextMenu( directories[0].DirectoryInfo.FullName, false );
 			return;
 		}
 
@@ -229,6 +236,50 @@ public partial class AssetList
 			return;
 
 		ac.Menu.OpenAt( ac.ScreenPosition, false );
+	}
+
+	/// <summary>
+	/// Every registered asset that lives inside <paramref name="directory"/>, recursively.
+	/// </summary>
+	internal static IEnumerable<Asset> AssetsInDirectory( DirectoryInfo directory )
+	{
+		if ( directory is null )
+			return Enumerable.Empty<Asset>();
+
+		var prefix = directory.FullName.NormalizeFilename( false );
+		if ( !prefix.EndsWith( '/' ) ) prefix += '/';
+
+		return AssetSystem.All.Where( x => x.AbsolutePath?.StartsWith( prefix, StringComparison.OrdinalIgnoreCase ) ?? false );
+	}
+
+	/// <summary>
+	/// Flatten selected assets and folders into a single list of asset entries, so context menu
+	/// options act on everything that is selected and not just the loose files.
+	/// </summary>
+	private static List<AssetEntry> ExpandDirectories( List<AssetEntry> assets, List<DirectoryEntry> directories )
+	{
+		if ( directories.Count == 0 )
+			return assets;
+
+		var seen = new HashSet<string>( assets.Count, StringComparer.OrdinalIgnoreCase );
+		var result = new List<AssetEntry>( assets.Count );
+
+		foreach ( var entry in assets )
+		{
+			if ( seen.Add( entry.AbsolutePath.NormalizeFilename( false, false ) ) )
+				result.Add( entry );
+		}
+
+		foreach ( var directory in directories )
+		{
+			foreach ( var asset in AssetsInDirectory( directory.DirectoryInfo ) )
+			{
+				if ( seen.Add( asset.AbsolutePath ) )
+					result.Add( new AssetEntry( asset ) );
+			}
+		}
+
+		return result;
 	}
 
 	[Event( "asset.nativecontextmenu" )]
@@ -583,7 +634,7 @@ public partial class AssetList
 			"editor.delete"
 			);
 
-			e.Menu.AddOption( $"Rename", "edit", action: () => e.AssetList.OpenRenameFlyout( entry, e.ScreenPosition ), shortcut: "editor.rename" );
+				e.Menu.AddOption( $"Rename", "edit", action: () => e.AssetList.OpenRenameFlyout( entry, e.ScreenPosition ), shortcut: "editor.rename" );
 		}
 
 		if ( asset is not null )
@@ -703,7 +754,7 @@ public partial class AssetList
 
 		e.Menu.AddSeparator();
 
-		var assets = AssetSystem.All.Where( x => x.AbsolutePath.StartsWith( e.Target.FullName.Replace( '\\', '/' ), StringComparison.OrdinalIgnoreCase ) ).ToList();
+		var assets = AssetsInDirectory( e.Target ).ToList();
 		var assetCount = assets.Count;
 		if ( assetCount > 0 )
 		{
@@ -723,8 +774,7 @@ public partial class AssetList
 
 		if ( !e.ThisFolder )
 		{
-			var folder = e.Target.FullName.NormalizeFilename( false );
-			var assets = AssetSystem.All.Where( x => x.AbsolutePath.StartsWith( folder, StringComparison.OrdinalIgnoreCase ) ).ToArray();
+			var assets = AssetsInDirectory( e.Target ).ToArray();
 			var o = e.Menu.AddOption( $"Batch Publish ({assets.Length})..", "cloud_upload", () => BatchPublisher.FromAssets( assets ) );
 			o.Enabled = assets.Length > 0;
 		}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to **s&box** ❤️  
Please fill out the sections below to help us review your change efficiently.

---

## Summary

Right now selecting multiples assets work well in asset browser but try selecting multiples folder or folder + assets and you'll see it's kinda weird, you can't rebuild multiples folders, or it let you rename multiples selection (even tho only 1 is really renamed)

## Motivation & Context

It was annoying to rebuild my full item of my gamejam projects, i wanted to select 2 folder, but i saw this feature wasnt working with multiples selection so i did a pass of it

## Implementation Details

First i made so if we select more than a folder, we retrieve full assets even recursively into the selected folder, not just selecting the 1st folder and using it

Then i made that the `OpenFolderContextMenu` is only called when 1 folder is selected (cause it make no sense to have rename when mutiples folder selected) or when only empty folder are selected (i created a custom menu to just delete)

And finally i did disable rename on assets if more than 1 assets is selected

## Screenshots / Videos (if applicable)

# No more rename with multiples assets 

Before :
<img width="1086" height="759" alt="image" src="https://github.com/user-attachments/assets/e5059959-8ec8-4be4-9375-6ce36086b80f" />

After:
<img width="823" height="577" alt="image" src="https://github.com/user-attachments/assets/d4d5d734-f3e2-4442-81b6-6272ed4323f1" />

# Better multiples folder selection

Before :
<img width="789" height="784" alt="image" src="https://github.com/user-attachments/assets/fb24666a-0242-4b1c-9993-4d801a6e9c4d" />

After : 
<img width="618" height="627" alt="image" src="https://github.com/user-attachments/assets/b6aa80b6-a4f4-4fef-b112-52a40c04893b" />

## Checklist

- [ ] Code follows existing style and conventions
- [ ] No unnecessary formatting or unrelated changes
- [ ] Public APIs are documented (if applicable)
- [ ] Unit tests added where applicable and all passing
- [ ] I’m okay with this PR being rejected or requested to change 🙂