### PR TITLE
Fix procedural render layer callback being collected while in use

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/RenderPipeline/RenderLayer.cs
+++ b/engine/Sandbox.Engine/Systems/Render/RenderPipeline/RenderLayer.cs
@@ -52,7 +52,9 @@ internal abstract class RenderLayer
 
 		if ( this is ProceduralRenderLayer proceduralRenderLayer )
 		{
-			proceduralRenderLayer.ProceduralCallback = DelegateFunctionPointer.Get<ProceduralRenderLayer.OnRenderCallback>( proceduralRenderLayer.Internal_OnRender );
+			if ( (nint)proceduralRenderLayer.ProceduralCallback == IntPtr.Zero )
+				proceduralRenderLayer.ProceduralCallback = DelegateFunctionPointer.Get<ProceduralRenderLayer.OnRenderCallback>( proceduralRenderLayer.Internal_OnRender );
+
 			nativeLayer = view.AddManagedProceduralLayer( Name, viewport, proceduralRenderLayer.ProceduralCallback, IntPtr.Zero, true );
 		}
 		else


### PR DESCRIPTION
The game aborts with `SIGABRT` from .NET's `CallbackOnCollectedDelegate`. Native code called a render layer callback whose delegate had already been garbage-collected:

```
CallbackOnCollectedDelegate
TheUMEntryPrestub
FastDelegate1<ManagedRenderSetup_t, void>::InvokeStaticFunction
CManagedProceduralLayerRenderer::Render
RenderAView(...) job
```

### Cause
- `RenderLayer.AddToView` made a new delegate every time it ran, and overwrote the one `ProceduralCallback` was keeping alive.
- `Skybox3DPipeline` puts its pipeline back in the pool as soon as it has added its layers, before that view has rendered.
- The next view picks up the same pipeline and calls `AddToView` again on the same layers. The previous delegate then has no references, while the earlier view's render job still holds its function pointer.
- A garbage collection in that window frees it, and the render job calls a dead thunk.

### Fix
Create the delegate once per layer and keep it. It always wraps the same `Internal_OnRender`, so the function pointer stays the same across views. It also saves an allocation per procedural layer per view.

### Testing
- Before: one crash in the first full benchmark run.
- After: about 30 benchmark and botmatch runs, roughly 1.5 hours of rendering, with no crash.
- The bug is timing-dependent; it needs a GC between a view being set up and it rendering, so there's no deterministic unit test for it.