### PR TITLE
Destroy a ScenePanel's scene when its parent panel is deleted

### DIFF
--- a/engine/Sandbox.Engine/Systems/UI/Controls/ScenePanel.cs
+++ b/engine/Sandbox.Engine/Systems/UI/Controls/ScenePanel.cs
@@ -186,6 +186,22 @@ namespace Sandbox.UI
 
 		public override void Delete( bool immediate = false )
 		{
+			ReleaseRenderResources();
+
+			base.Delete( immediate );
+		}
+
+		public override void OnDeleted()
+		{
+			base.OnDeleted();
+
+			// Deleting a parent only calls OnDeleted on its children, never Delete,
+			// so a ScenePanel inside a deleted tree has to release its scene here too.
+			ReleaseRenderResources();
+		}
+
+		void ReleaseRenderResources()
+		{
 			RenderTexture?.Dispose();
 			RenderTexture = null;
 
@@ -196,8 +212,6 @@ namespace Sandbox.UI
 			}
 
 			_renderScene = null;
-
-			base.Delete( immediate );
 		}
 
 		public override void OnDraw()

--- a/engine/Sandbox.Engine/Systems/UI/UISystem.cs
+++ b/engine/Sandbox.Engine/Systems/UI/UISystem.cs
@@ -523,6 +523,12 @@ internal partial class UISystem
 			}
 		}
 
+		// A panel that was detached from its parent and queued for deletion is in no
+		// root's tree, so the loop above never reaches it. Nothing will run the pump
+		// after this, so delete them now or they keep whatever they own - scene panels
+		// keep an entire Scene alive.
+		RunDeferredDeletion( true );
+
 		RootPanels.Clear();
 		DeletionList.Clear();
 

--- a/engine/Tests/Sandbox.Test.Engine/UI/Panel/DeleteLifecycle.cs
+++ b/engine/Tests/Sandbox.Test.Engine/UI/Panel/DeleteLifecycle.cs
@@ -100,6 +100,32 @@ public partial class PanelDeleteTest
 	}
 
 	/// <summary>
+	/// Clearing the UI system deletes panels that are still queued. A panel detached from its
+	/// parent before being deleted is in no root's tree, so clearing the roots doesn't reach it,
+	/// and nothing runs the pump afterwards - without this it would keep everything it owns.
+	/// </summary>
+	[TestMethod]
+	public void ClearDeletesQueuedPanels()
+	{
+		var root = new RootPanel();
+		root.PanelBounds = new Rect( 0, 0, 1000, 1000 );
+
+		var p = new RecordingPanel { Parent = root };
+		root.Layout();
+
+		// What a PanelComponent does when its GameObject is destroyed
+		p.Parent = null;
+		p.Delete();
+
+		Assert.AreEqual( 0, p.DeletedCount );
+
+		GlobalContext.Current.UISystem.Clear();
+
+		Assert.IsFalse( p.IsValid );
+		Assert.AreEqual( 1, p.DeletedCount );
+	}
+
+	/// <summary>
 	/// A panel whose :outro rule starts a transition is kept alive by the deferred deletion
 	/// pump until the transition has finished, and only then deleted.
 	/// </summary>

--- a/engine/Tests/Sandbox.Test.Integration/Scene/UI/ScenePanelTests.cs
+++ b/engine/Tests/Sandbox.Test.Integration/Scene/UI/ScenePanelTests.cs
@@ -20,6 +20,37 @@ public class ScenePanelTest
 	}
 
 	[TestMethod]
+	public void DeleteParent_DestroysOwnedScene()
+	{
+		var parent = new Panel();
+		var panel = parent.AddChild<ScenePanel>();
+		var ownedScene = panel.RenderScene;
+
+		Assert.IsTrue( ownedScene.IsValid() );
+
+		// Deleting the parent tears down its children without calling their Delete
+		parent.Delete( true );
+
+		Assert.IsFalse( ownedScene.IsValid() );
+		Assert.IsNull( panel.RenderScene );
+	}
+
+	[TestMethod]
+	public void DeleteParent_DoesNotDestroyExternalScene()
+	{
+		var parent = new Panel();
+		var panel = parent.AddChild<ScenePanel>();
+		var externalScene = new Scene();
+
+		panel.RenderScene = externalScene;
+		parent.Delete( true );
+
+		Assert.IsTrue( externalScene.IsValid() );
+
+		externalScene.Destroy();
+	}
+
+	[TestMethod]
 	public void Delete_DoesNotDestroyExternalScene()
 	{
 		var panel = new ScenePanel();


### PR DESCRIPTION
## Summary

Quitting the client logs `Leaked scene <guid> during shutdown` on every session that has been to
the main menu. The leaked scene belongs to a `ScenePanel`: the panel destroys the scene it owns in
`Delete()`, but a panel that goes away as part of its parent's tree never gets `Delete()` called on
it, only `OnDeleted()`.

`Panel.Delete( immediate: true )` runs `OnDeleteRecursive()`, which walks the children calling
`OnDeleteRecursive()` on each and then `OnDeleted()`. The virtual `Delete()` is only ever called on
the panel you asked to delete, so every `ScenePanel` below it keeps its `Scene` and its render
target for the life of the process.

The main menu hits this on every run: `AvatarButton` adds a `ScenePanel` for the portrait, so
tearing down the menu page (entering a game, or quitting) leaks that scene.

There is a second hole on the shutdown path. `PanelComponent.DestroyPanel` detaches its panel
(`panel.Parent = null`) before calling `Delete()`, so the panel sits in `UISystem.DeletionList` and
is in no root's tree. `UISystem.Clear()` deletes the roots and then clears that list without
deleting anything in it, and no frame runs afterwards to pump it. `DeleteAllRoots()` already calls
`RunDeferredDeletion( true )` for this reason; `Clear()` now does the same.

## Motivation & Context

Found while chasing `Leaked scene` warnings in a game's shutdown log. Both halves are engine side and
reproduce with no game code involved: launching the client, sitting on the menu and quitting is
enough.

Measured on the client (`2adfcb34`, Windows, before and after this change):

| Session | Leaked scenes | `NativeResourceCache` total leaks |
|---|---|---|
| Launch, main menu, quit (before) | 1 | 18 |
| Launch, main menu, quit (after) | 0 | 1 |
| Launch, menu, play a game, quit from the game (before) | 1 | 0 |
| Launch, menu, play a game, quit from the game (after) | 0 | 0 |

The leaked scene was identified by temporarily recording `Environment.StackTrace` in the `Scene`
constructor and printing it next to the existing warning:

```
[AppSystem] LEAKDEBUG type=Scene name=Scene source= children=3
   at Sandbox.Scene..ctor()
   at Sandbox.UI.ScenePanel..ctor() in Systems/UI/Controls/ScenePanel.cs:line 71
   at Sandbox.UI.Panel.AddChild[T](String classnames)
   at MenuProject.MenuUI.Front.AvatarButton.OnAfterTreeRender(Boolean firstTime) in MenuUI/Front/AvatarButton.razor:line 65
```

That instrumentation is not part of this PR.

## Implementation Details

- `ScenePanel`: the cleanup moves into a private `ReleaseRenderResources()` called from both
  `Delete()` and `OnDeleted()`. It nulls what it releases, so the second call is a no-op and a
  direct `Delete()` still frees the scene immediately, exactly as before. Kept that way so the
  existing `ScenePanelTest` behaviour (and anyone relying on it) does not change.
- `UISystem.Clear()`: `RunDeferredDeletion( true )` before clearing the lists, matching
  `DeleteAllRoots()`.
- A scene supplied by the user is still left alone in both paths: `_ownsScene` governs it, and there
  is a test for the parent-delete case.

## Tests

Two added, each watched failing without its own half of the fix and passing with it:

- `Sandbox.Test.Integration` `ScenePanelTest.DeleteParent_DestroysOwnedScene` and
  `DeleteParent_DoesNotDestroyExternalScene`.
- `Sandbox.Test.Engine` `PanelDeleteTest.ClearDeletesQueuedPanels`, which reproduces the
  `PanelComponent` sequence: detach, queue, clear.

`ScenePanelTest` 6/6 and `PanelDeleteTest` 5/5 pass on the committed code.

## Checklist

- [x] Code follows existing style and conventions
- [x] No unnecessary formatting or unrelated changes
- [x] Public APIs are documented (if applicable)
- [x] Unit tests added where applicable and all passing
- [x] I'm okay with this PR being rejected or requested to change 🙂
