### PR TITLE
Skip the AppKit show animation on panel windows

### DIFF
--- a/engine/Sandbox.Tools/UI/PanelWindow.MacOS.cs
+++ b/engine/Sandbox.Tools/UI/PanelWindow.MacOS.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Editor;
+
+public partial class PanelWindow
+{
+	/// <summary>
+	/// AppKit zooms a window in the first time it's ordered on screen, and setting that animation
+	/// up is the most expensive thing about showing one: it creates a display link, which on first
+	/// use asks the window server for the whole display mode list - 150 to 250 ms on the main thread
+	/// before the window is even visible. We draw our own frames, we don't want the zoom, and a
+	/// window that appears at once beats one that arrives late with a flourish.
+	/// </summary>
+	static class MacOS
+	{
+		const nint NSWindowAnimationBehaviorNone = 2;
+
+		[DllImport( "libSDL3.0" )] static extern uint SDL_GetWindowProperties( IntPtr window );
+		[DllImport( "libSDL3.0" )] static extern IntPtr SDL_GetPointerProperty( uint props, string name, IntPtr defaultValue );
+		[DllImport( "/usr/lib/libobjc.A.dylib" )] static extern IntPtr sel_registerName( string name );
+		[DllImport( "/usr/lib/libobjc.A.dylib", EntryPoint = "objc_msgSend" )] static extern void objc_msgSend_nint( IntPtr self, IntPtr selector, nint arg );
+
+		static bool warned;
+
+		/// <summary>
+		/// Turn off the show animation on the NSWindow behind an SDL window.
+		/// </summary>
+		public static void DisableShowAnimation( IntPtr sdlWindow )
+		{
+			try
+			{
+				var props = SDL_GetWindowProperties( sdlWindow );
+				var nsWindow = props == 0 ? IntPtr.Zero : SDL_GetPointerProperty( props, "SDL.window.cocoa.window", IntPtr.Zero );
+
+				if ( nsWindow == IntPtr.Zero )
+				{
+					if ( !warned ) Log.Warning( "PanelWindow: couldn't find the NSWindow behind the SDL window - keeping the show animation" );
+					warned = true;
+					return;
+				}
+
+				objc_msgSend_nint( nsWindow, sel_registerName( "setAnimationBehavior:" ), NSWindowAnimationBehaviorNone );
+			}
+			catch ( Exception e )
+			{
+				if ( !warned ) Log.Warning( e, "PanelWindow: couldn't turn off the show animation" );
+				warned = true;
+			}
+		}
+	}
+}

--- a/engine/Sandbox.Tools/UI/PanelWindow.Rendering.cs
+++ b/engine/Sandbox.Tools/UI/PanelWindow.Rendering.cs
@@ -201,6 +201,10 @@ public partial class PanelWindow
 		{
 			IsShown = true;
 			OnFirstShow();
+
+			if ( OperatingSystem.IsMacOS() )
+				MacOS.DisableShowAnimation( Handle );
+
 			PanelWindowNative.Show( Handle );
 		}
 


### PR DESCRIPTION
## Skip the AppKit show animation on panel windows

Ordering a window on screen for the first time makes AppKit start its zoom-in animation. Setting that animation up creates a display link, and the first display link in a process asks the window server for the display's entire mode list - 150-230 ms on the main thread inside `PanelWindowNative.Show`, before the window is visible. On the launcher that was a third of the first frame.

```
PanelWindowGlue_Show → SDL_ShowWindow → -[NSWindow makeKeyAndOrderFront:]
  → -[_NSWindowTransformAnimation startAnimation] → -[NSAnimation _createDisplayLink]
    → SLSGetDisplayLink → CA::Display::Display::update() → SLSIsDisplayModeVRR / mach_msg
```

We draw our own frames and don't want the zoom anyway.

### Fix
- `PanelWindow.MacOS.cs`: before the first `Show`, get the `NSWindow` behind the SDL window through `SDL_GetWindowProperties` / `SDL.window.cocoa.window` and set `animationBehavior = NSWindowAnimationBehaviorNone` with `objc_msgSend`. macOS only; guarded, warns once and falls back to the animation if the window can't be found.
- Binds to `libSDL3.0`, the copy the engine loaded. `libSDL3.dylib` beside it is a second copy of the library, not a symlink, and a window handle means nothing to it (that's how the first attempt at this failed).

### Results
- Launcher first frame: ~500 ms → ~290 ms. Windows appear at once instead of zooming in.

### Testing
- Launcher, popups and the editor's panel windows on an M3 Max / macOS 27: focus, dragging, minimize/restore and close unchanged.

### Part of a set: shortening editor launcher startup

This PR is one of six, across the driver and the engine, each independent, that together cut the time from starting `sbox-dev` to the editor launcher (the project picker) being on screen. All came from tracing the launcher's boot on an M3 Max / macOS 27; the rows below are the cost each one removes. `exec` → window on screen: **~2.1 s → ~0.95 s (−55%)**.

| PR | Phase | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [kk: weak entrypoints through a stub library](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) | `SourceEnginePreInit` (driver dlopen) | 560–650 | 250–300 | ~330 |
| [kk: disk shader cache](https://github.com/Facepunch/mesa-kosmickrisp/pull/6) | First frame (UI shader compile) | ~290 | ~180 | ~110 |
| **Skip the AppKit show animation (this PR)** | First frame (`PanelWindowNative.Show`) | ~500 | ~290 | ~150–230 |
| [Boot managed side alongside native](https://github.com/Facepunch/sbox-public/pull/11840) | Managed init + fonts + app init | 350 + 150 + 340 | 40 + 0 + 80 (+35 join) | ~650 |
| [Single instance via mutex](https://github.com/Facepunch/sbox-public/pull/11839) | Process start → `Init` | ~130 | ~85 | ~50 |
| [sbox-dev hand-off without the engine](https://github.com/Facepunch/sbox-public/pull/11838) | `./sbox-dev` → launcher start | ~170 | ~135 | ~35 (`./sbox-dev` path only) |
| **Total, exec → window on screen** | | **~2100** | **~950** | **~1150 (2.2× faster)** |

Phase numbers are each PR's own before/after and don't sum exactly to the total: rounds were hours apart on a machine that drifts (the same build's first frame swung 350–600 ms), and the two first-frame PRs were measured against each other's baseline.
