### PR TITLE
Don't load the engine to hand sbox-dev off to the launcher

### DIFF
--- a/engine/Launcher/SboxDev/Launcher.cs
+++ b/engine/Launcher/SboxDev/Launcher.cs
@@ -1,7 +1,9 @@
 ﻿using Sandbox.Engine;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Sandbox;
 
@@ -10,20 +12,17 @@ public static class Launcher
 	public static int Main()
 	{
 		if ( HasCommandLineSwitch( "-generatesolution" ) )
-		{
-			NetCore.InitializeInterop( Environment.CurrentDirectory );
-			Bootstrap.InitMinimal( Environment.CurrentDirectory );
-			Project.InitializeBuiltIn( false ).GetAwaiter().GetResult();
-			Project.GenerateSolution().GetAwaiter().GetResult();
-			Managed.SandboxEngine.NativeInterop.Free();
-			EngineFileSystem.Shutdown();
-			return 0;
-		}
+			return GenerateSolution();
 
 		if ( !HasCommandLineSwitch( "-project" ) && !HasCommandLineSwitch( "-test" ) )
 		{
+			// Nothing to edit - hand over to the launcher. This path touches nothing from the
+			// engine on purpose: the moment a method that uses it is jitted the whole engine
+			// assembly loads, and that's tens of milliseconds the launcher is waiting on
+			var launcher = Path.Combine( AppContext.BaseDirectory, OperatingSystem.IsWindows() ? "sbox-launcher.exe" : "sbox-launcher" );
+
 			// we pass the command line, so we can pass it on to the sbox-launcher (for -game etc)
-			ProcessStartInfo info = new ProcessStartInfo( NetCore.GetExecutablePath( "sbox-launcher" ), Environment.CommandLine );
+			ProcessStartInfo info = new ProcessStartInfo( launcher, Environment.CommandLine );
 
 			// Only let the shell start it on Windows - on Linux UseShellExecute goes through
 			// xdg-open, which opens the launcher in a web browser rather than running it.
@@ -35,6 +34,26 @@ public static class Launcher
 			return 0;
 		}
 
+		return RunEditor();
+	}
+
+	// Kept out of Main so that jitting Main doesn't load the engine - see above
+
+	[MethodImpl( MethodImplOptions.NoInlining )]
+	static int GenerateSolution()
+	{
+		NetCore.InitializeInterop( Environment.CurrentDirectory );
+		Bootstrap.InitMinimal( Environment.CurrentDirectory );
+		Project.InitializeBuiltIn( false ).GetAwaiter().GetResult();
+		Project.GenerateSolution().GetAwaiter().GetResult();
+		Managed.SandboxEngine.NativeInterop.Free();
+		EngineFileSystem.Shutdown();
+		return 0;
+	}
+
+	[MethodImpl( MethodImplOptions.NoInlining )]
+	static int RunEditor()
+	{
 		var appSystem = new EditorAppSystem();
 		appSystem.Run();
 


### PR DESCRIPTION
## Don't load the engine to hand sbox-dev off to the launcher

`./sbox-dev` with no `-project` only starts `sbox-launcher` and exits, but `Main` used `NetCore.GetExecutablePath` for the path and had the editor and the solution generator inline. Jitting `Main` therefore loaded `Sandbox.Engine.dll` - tens of milliseconds, all of it before the launcher process even exists.

### Fix
- Build the launcher path locally from `AppContext.BaseDirectory`.
- Keep the engine-using branches (`-generatesolution`, the editor) in their own `[MethodImpl(NoInlining)]` methods so `Main` never references an engine type.

### Results
- `./sbox-dev` → launcher's first log line: ~170 ms → ~135 ms (the direct `./sbox-launcher` path is ~100 ms).

### Testing
- `./sbox-dev`, `./sbox-dev -project <sbproj>` and `./sbox-dev -generatesolution` all still do what they did.

### Part of a set: shortening editor launcher startup

This PR is one of six, across the driver and the engine, each independent, that together cut the time from starting `sbox-dev` to the editor launcher (the project picker) being on screen. All came from tracing the launcher's boot on an M3 Max / macOS 27; the rows below are the cost each one removes. `exec` → window on screen: **~2.1 s → ~0.95 s (−55%)**.

| PR | Phase | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [kk: weak entrypoints through a stub library](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) | `SourceEnginePreInit` (driver dlopen) | 560–650 | 250–300 | ~330 |
| [kk: disk shader cache](https://github.com/Facepunch/mesa-kosmickrisp/pull/6) | First frame (UI shader compile) | ~290 | ~180 | ~110 |
| [Skip the AppKit show animation](https://github.com/Facepunch/sbox-public/pull/11837) | First frame (`PanelWindowNative.Show`) | ~500 | ~290 | ~150–230 |
| [Boot managed side alongside native](https://github.com/Facepunch/sbox-public/pull/11840) | Managed init + fonts + app init | 350 + 150 + 340 | 40 + 0 + 80 (+35 join) | ~650 |
| [Single instance via mutex](https://github.com/Facepunch/sbox-public/pull/11839) | Process start → `Init` | ~130 | ~85 | ~50 |
| **sbox-dev hand-off without the engine (this PR)** | `./sbox-dev` → launcher start | ~170 | ~135 | ~35 (`./sbox-dev` path only) |
| **Total, exec → window on screen** | | **~2100** | **~950** | **~1150 (2.2× faster)** |

Phase numbers are each PR's own before/after and don't sum exactly to the total: rounds were hours apart on a machine that drifts (the same build's first frame swung 350–600 ms), and the two first-frame PRs were measured against each other's baseline.
