### PR TITLE
Launcher: find a running instance with a mutex off Windows

### DIFF
--- a/engine/Launcher/StandaloneTest/Launcher.cs
+++ b/engine/Launcher/StandaloneTest/Launcher.cs
@@ -29,6 +29,27 @@ public static class Launcher
 	/// </summary>
 	static bool FindExisting()
 	{
+		// Enumerating every process on the machine is the slowest thing the launcher does
+		// before it starts booting - 50ms on a Mac. Only Windows needs the process, to bring
+		// its window to the front; everywhere else a named mutex answers the same question
+		// for nothing. The mutex is held for the life of the process. A launcher that crashed
+		// leaves it behind, so whether it already existed says nothing - whether it can be
+		// taken does, and taking one that was abandoned throws, which is the same answer as
+		// taking it clean
+		if ( !OperatingSystem.IsWindows() )
+		{
+			instanceLock = new Mutex( false, "sbox-launcher-instance" );
+
+			try
+			{
+				return !instanceLock.WaitOne( 0 );
+			}
+			catch ( AbandonedMutexException )
+			{
+				return false;
+			}
+		}
+
 		var currentId = Process.GetCurrentProcess().Id;
 		var currentName = Process.GetCurrentProcess().ProcessName;
 
@@ -60,6 +81,8 @@ public static class Launcher
 
 		return false;
 	}
+
+	static Mutex instanceLock;
 
 	const int SW_RESTORE = 9;
 


### PR DESCRIPTION
## Launcher: find a running instance with a mutex off Windows

`FindExisting` enumerated every process on the machine to see whether a launcher was already running. On a Mac that's ~50 ms, spent before anything else has started. Only Windows needs the process itself, to restore and bring its window to the front.

### Fix
- Off Windows, open a named `Mutex` (`sbox-launcher-instance`) and try to take it with `WaitOne(0)`, holding it for the life of the process. If it can't be taken, another launcher is running and we exit as before. Whether the mutex already *existed* isn't the test: a launcher that crashed leaves it behind, and taking an abandoned one throws `AbandonedMutexException`, which counts as taking it.
- Windows keeps the process scan and the bring-to-front behaviour.

### Results
- Process start → `Init`: ~130 ms → ~85 ms on macOS.

### Testing
- Starting a second launcher while one is open still exits immediately; the first keeps running (verified with `pgrep`).
- `kill -9` the launcher, start it again: it comes up (abandoned mutex case).

### Part of a set: shortening editor launcher startup

This PR is one of six, across the driver and the engine, each independent, that together cut the time from starting `sbox-dev` to the editor launcher (the project picker) being on screen. All came from tracing the launcher's boot on an M3 Max / macOS 27; the rows below are the cost each one removes. `exec` → window on screen: **~2.1 s → ~0.95 s (−55%)**.

| PR | Phase | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [kk: weak entrypoints through a stub library](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) | `SourceEnginePreInit` (driver dlopen) | 560–650 | 250–300 | ~330 |
| [kk: disk shader cache](https://github.com/Facepunch/mesa-kosmickrisp/pull/6) | First frame (UI shader compile) | ~290 | ~180 | ~110 |
| [Skip the AppKit show animation](https://github.com/Facepunch/sbox-public/pull/11837) | First frame (`PanelWindowNative.Show`) | ~500 | ~290 | ~150–230 |
| [Boot managed side alongside native](https://github.com/Facepunch/sbox-public/pull/11840) | Managed init + fonts + app init | 350 + 150 + 340 | 40 + 0 + 80 (+35 join) | ~650 |
| **Single instance via mutex (this PR)** | Process start → `Init` | ~130 | ~85 | ~50 |
| [sbox-dev hand-off without the engine](https://github.com/Facepunch/sbox-public/pull/11838) | `./sbox-dev` → launcher start | ~170 | ~135 | ~35 (`./sbox-dev` path only) |
| **Total, exec → window on screen** | | **~2100** | **~950** | **~1150 (2.2× faster)** |

Phase numbers are each PR's own before/after and don't sum exactly to the total: rounds were hours apart on a machine that drifts (the same build's first frame swung 350–600 ms), and the two first-frame PRs were measured against each other's baseline.
