### PR TITLE
Boot the panel app's managed side alongside the native engine

### DIFF
--- a/engine/Launcher/StandaloneTest/Launcher.cs
+++ b/engine/Launcher/StandaloneTest/Launcher.cs
@@ -80,10 +80,19 @@ public class PanelLauncherAppSystem : PanelAppSystem
 {
 	Editor.PanelWindow window;
 
-	protected override void OnInitialized()
+	protected override IEnumerable<string> StyleSheetsToWarm => ["/styles/editor.scss", "/styles/launcher.scss"];
+
+	protected override void OnWarmUp()
 	{
 		LauncherPreferences.Load();
 
+		// The first Project built runs the static setup behind it - the package manager, its
+		// access rules and their compiled regexes - which is most of what the project list costs
+		System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor( typeof( Project ).TypeHandle );
+	}
+
+	protected override void OnInitialized()
+	{
 		window = new Editor.PanelWindow( "Welcome to the s&box editor", new Vector2( 1100, 660 ), new Vector2( -1, -1 ), borderless: true, vsync: true );
 		window.MinSize = new Vector2( 880, 540 );
 		window.CanMaximize = false;

--- a/engine/Sandbox.AppSystem/PanelAppSystem.cs
+++ b/engine/Sandbox.AppSystem/PanelAppSystem.cs
@@ -2,6 +2,7 @@
 using Sandbox.Engine;
 using Sandbox.UI;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
@@ -31,11 +32,29 @@ public class PanelAppSystem : AppSystem
 	{
 		bootTimer = Stopwatch.StartNew();
 
+		// Everything before this point - the runtime coming up, Main - is startup time too,
+		// and it's the part nobody instruments
+		try
+		{
+			var beforeInit = DateTime.Now - Process.GetCurrentProcess().StartTime;
+			log.Info( $"Process start to Init took {beforeInit.TotalMilliseconds:0}ms" );
+		}
+		catch ( Exception )
+		{
+			// Not worth failing boot for
+		}
+
 		base.Init();
 		Phase( "Interop" );
 
 		InitManagedMinimal();
 		Phase( "Managed init" );
+
+		// The type library, the fonts and the stylesheets are all pure managed work that
+		// doesn't need the engine, and the engine's own boot below is native work that
+		// doesn't need them - so they run on the pool while the main thread is in there,
+		// and the two halves of startup take the time of the longer one instead of the sum
+		var warmUp = WarmUp();
 
 		var createInfo = new AppSystemCreateInfo
 		{
@@ -69,9 +88,8 @@ public class PanelAppSystem : AppSystem
 
 		Phase( "Scene systems" );
 
-		// The UI reads fonts from core content, and nothing else in this app loads them
-		FontManager.Instance.LoadAll( EngineFileSystem.CoreContent );
-		Phase( "Fonts" );
+		warmUp.GetAwaiter().GetResult();
+		Phase( "Managed warm-up join" );
 
 		WarmRenderLayers();
 		Phase( "Warm render layers" );
@@ -114,6 +132,9 @@ public class PanelAppSystem : AppSystem
 		Diagnostics.Logging.Enabled = true;
 		Diagnostics.Logging.OnException = ErrorReporter.ReportException;
 
+		// Nothing here hot reloads - no editing, no compiling - so don't pay to watch the disk
+		BaseFileSystem.WatchingEnabled = false;
+
 		EngineFileSystem.Initialize( Environment.CurrentDirectory );
 		EngineFileSystem.InitializeConfigFolder();
 		EngineFileSystem.InitializeDataFolder();
@@ -124,16 +145,65 @@ public class PanelAppSystem : AppSystem
 		FileSystem.Mounted.CreateAndMount( EngineFileSystem.Root, "/core/" );
 		FileSystem.Mounted.CreateAndMount( EngineFileSystem.Root, "/addons/editor/assets/" );
 
-		// Engine controls find their [StyleSheet] attributes through the type library
+		// Engine controls find their [StyleSheet] attributes through the type library. It's
+		// filled in by WarmUp, off the main thread
 		Game.TypeLibrary = new Sandbox.Internal.TypeLibrary();
-		Game.TypeLibrary.AddIntrinsicTypes();
-		Game.TypeLibrary.AddAssembly( typeof( Vector3 ).Assembly, false );
-		Game.TypeLibrary.AddAssembly( typeof( Sandbox.UI.Panel ).Assembly, false );
 
 		Application.TryLoadVersionInfo( Environment.CurrentDirectory );
 
 		ErrorReporter.Initialize();
 	}
+
+	/// <summary>
+	/// The managed half of startup, run on a pool thread while the main thread boots the
+	/// native engine. Nothing in here may touch the engine - it isn't up yet - and nothing
+	/// on the main thread touches any of this until it's joined, before <see cref="OnInitialized"/>.
+	/// </summary>
+	Task WarmUp()
+	{
+		// Three independent jobs, each on its own thread - none of them needs the others, and
+		// the type library alone is longer than the native boot it's hiding behind
+		return Task.WhenAll(
+			Task.Run( () =>
+			{
+				// Reflecting over the engine assembly is the single biggest managed cost of boot
+				Game.TypeLibrary.AddIntrinsicTypes();
+				Game.TypeLibrary.AddAssembly( typeof( Vector3 ).Assembly, false );
+				Game.TypeLibrary.AddAssembly( typeof( Sandbox.UI.Panel ).Assembly, false );
+			} ),
+			Task.Run( () =>
+			{
+				// The UI reads fonts from core content, and nothing else in this app loads them
+				FontManager.Instance.LoadAll( EngineFileSystem.CoreContent );
+			} ),
+			Task.Run( () =>
+			{
+				// Parsed sheets are cached by path, so the windows find theirs ready-made. One
+				// thread for all of them - the cache they go into isn't built for two
+				StyleSheet.FromFile( "/styles/base/rootpanel.scss", failSilently: true );
+
+				foreach ( var sheet in StyleSheetsToWarm )
+				{
+					StyleSheet.FromFile( sheet, failSilently: true );
+				}
+			} ),
+			Task.Run( OnWarmUp ) );
+	}
+
+	/// <summary>
+	/// The app's own share of the warm-up: anything it's going to need in <see cref="OnInitialized"/>
+	/// that doesn't need the engine - settings to read, static state to build. Runs on a pool
+	/// thread while the engine boots, and is finished before <see cref="OnInitialized"/> runs.
+	/// </summary>
+	protected virtual void OnWarmUp()
+	{
+	}
+
+	/// <summary>
+	/// Stylesheets the app's windows are going to load, parsed ahead of time off the main
+	/// thread so the windows don't pay for it. Paths as <see cref="StyleSheet.FromFile"/> takes them.
+	/// </summary>
+	protected virtual IEnumerable<string> StyleSheetsToWarm => [];
 
 	/// <summary>
 	/// The app is up - make your windows. Runs before the first frame.

--- a/engine/Sandbox.Filesystem/BaseFileSystem.cs
+++ b/engine/Sandbox.Filesystem/BaseFileSystem.cs
@@ -418,6 +418,14 @@ public class BaseFileSystem
 
 	bool watchUnavailable;
 
+	/// <summary>
+	/// Whether filesystems watch the disk for changes at all. Watching is what hot reloads
+	/// assets and stylesheets, so it's on for the game and the editor. An app that never edits
+	/// anything - the launcher - turns it off: starting a watcher costs the better part of a
+	/// hundred milliseconds on macOS, and it starts one per mounted filesystem.
+	/// </summary>
+	internal static bool WatchingEnabled { get; set; } = true;
+
 	internal FileWatch Watch( string pathglob = null )
 	{
 		// One watcher for the whole filesystem, shared by every FileWatch handed out. It used
@@ -425,7 +433,7 @@ public class BaseFileSystem
 		// expecting: on Linux that means a fresh set of inotify instances per call - one per
 		// mounted filesystem in the aggregate - and the editor watches a stylesheet at a time
 		// until it hits the 128 instance limit and the whole thing falls over.
-		if ( watcher == null && !watchUnavailable )
+		if ( watcher == null && !watchUnavailable && WatchingEnabled )
 		{
 			try
 			{


### PR DESCRIPTION
## Boot the panel app's managed side alongside the native engine

`PanelAppSystem.Init` did everything in sequence on the main thread:

| phase | before |
|---|---|
| type library (reflect over the engine assembly) | ~300 ms |
| `SourceEnginePreInit` + scene systems (native) | ~300-600 ms |
| fonts | ~150 ms, 115 of it starting file watchers |
| app init - windows, stylesheet parse, project list | ~340 ms |

None of the managed work needs the engine and none of the native work needs it.

### Fix
- The type library, the font load and the stylesheet parse run on the pool while the main thread is in native code, and are joined before `OnInitialized`. Apps get an `OnWarmUp` hook and a `StyleSheetsToWarm` list for their own share; the launcher uses them for its preferences, its two sheets, and the static setup behind `Project` (the package manager and its compiled access-rule regexes), which was most of what the project list cost.
- `BaseFileSystem.WatchingEnabled` is off for panel apps. Nothing in them hot reloads, and starting a watcher is 85-110 ms on macOS - once per mounted filesystem, and fonts and stylesheets between them started three.
- Log how long the process took to reach `Init`, since the runtime's own boot and `Main` were the one part of startup nothing measured.

### Results
Launcher on an M3 Max, this PR alone:
- managed init 350 → 40 ms, fonts 150 ms → hidden behind native boot, app init 340 → ~80 ms
- exec → first frame ~1.9 s → ~1.3 s (→ ~0.9 s together with the driver and window PRs)

### Testing
- Launcher renders identically (styles, fonts, project list, news, backdrop); hot-reload paths in the editor untouched (`WatchingEnabled` defaults to true and only the panel app clears it).
- Warm-up work is joined before any window exists, so nothing on the main thread sees a half-built type library or stylesheet cache.

### Part of a set: shortening editor launcher startup

This PR is one of six, across the driver and the engine, each independent, that together cut the time from starting `sbox-dev` to the editor launcher (the project picker) being on screen. All came from tracing the launcher's boot on an M3 Max / macOS 27; the rows below are the cost each one removes. `exec` → window on screen: **~2.1 s → ~0.95 s (−55%)**.

| PR | Phase | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [kk: weak entrypoints through a stub library](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) | `SourceEnginePreInit` (driver dlopen) | 560–650 | 250–300 | ~330 |
| [kk: disk shader cache](https://github.com/Facepunch/mesa-kosmickrisp/pull/6) | First frame (UI shader compile) | ~290 | ~180 | ~110 |
| [Skip the AppKit show animation](https://github.com/Facepunch/sbox-public/pull/11837) | First frame (`PanelWindowNative.Show`) | ~500 | ~290 | ~150–230 |
| **Boot managed side alongside native (this PR)** | Managed init + fonts + app init | 350 + 150 + 340 | 40 + 0 + 80 (+35 join) | ~650 |
| [Single instance via mutex](https://github.com/Facepunch/sbox-public/pull/11839) | Process start → `Init` | ~130 | ~85 | ~50 |
| [sbox-dev hand-off without the engine](https://github.com/Facepunch/sbox-public/pull/11838) | `./sbox-dev` → launcher start | ~170 | ~135 | ~35 (`./sbox-dev` path only) |
| **Total, exec → window on screen** | | **~2100** | **~950** | **~1150 (2.2× faster)** |

Phase numbers are each PR's own before/after and don't sum exactly to the total: rounds were hours apart on a machine that drifts (the same build's first frame swung 350–600 ms), and the two first-frame PRs were measured against each other's baseline.
