### PR TITLE
Watch folders with FSEvents on macOS

### DIFF
--- a/engine/Sandbox.Engine/Systems/Filesystem/RedirectFileSystem.cs
+++ b/engine/Sandbox.Engine/Systems/Filesystem/RedirectFileSystem.cs
@@ -7,7 +7,7 @@ namespace Sandbox.Internal;
 /// <summary>
 /// A readonly filesystem that has a list of files, and a list of redirects. When accessing a file, it'll access the redirect file invisibly.
 /// </summary>
-class RedirectFileSystem : Zio.FileSystems.PhysicalFileSystem
+class RedirectFileSystem : FSEventsPhysicalFileSystem
 {
 	public Dictionary<UPath, UPath> Files { get; } = new Dictionary<UPath, UPath>( UPathComparer.OrdinalIgnoreCase );
 

--- a/engine/Sandbox.Filesystem/FolderWatcher.cs
+++ b/engine/Sandbox.Filesystem/FolderWatcher.cs
@@ -1,0 +1,137 @@
+using System.IO;
+
+namespace Sandbox;
+
+/// <summary>
+/// Watches a folder on disk for changes - the shape of <see cref="FileSystemWatcher"/>, with the
+/// same events, but cheap to start on macOS. There .NET's watcher hands every stream to a shared
+/// run loop thread and waits on it, 50-100 ms each; this one is an FSEvents stream on a dispatch
+/// queue and starts in well under a millisecond. Elsewhere it's <see cref="FileSystemWatcher"/>.
+/// <para>
+/// FSEvents doesn't pair the two ends of a rename, so on macOS a rename arrives as
+/// <see cref="Deleted"/> for the old path and <see cref="Created"/> for the new one, never
+/// <see cref="Renamed"/>.
+/// </para>
+/// </summary>
+public sealed class FolderWatcher : IDisposable
+{
+	public event FileSystemEventHandler Changed;
+	public event FileSystemEventHandler Created;
+	public event FileSystemEventHandler Deleted;
+	public event RenamedEventHandler Renamed;
+
+	string path;
+	bool includeSubdirectories;
+	bool enabled;
+
+	FileSystemWatcher stock;
+	FSEventStream stream;
+
+	public FolderWatcher()
+	{
+	}
+
+	public FolderWatcher( string path )
+	{
+		Path = path;
+	}
+
+	/// <summary>
+	/// The folder to watch. Changing it while enabled moves the watch.
+	/// </summary>
+	public string Path
+	{
+		get => path;
+		set
+		{
+			if ( path == value ) return;
+			path = value;
+
+			if ( stock is not null ) stock.Path = value;
+			if ( stream is not null ) Restart();
+		}
+	}
+
+	/// <summary>
+	/// Whether changes anywhere under the folder count, or only its direct contents.
+	/// </summary>
+	public bool IncludeSubdirectories
+	{
+		get => includeSubdirectories;
+		set
+		{
+			includeSubdirectories = value;
+			if ( stock is not null ) stock.IncludeSubdirectories = value;
+		}
+	}
+
+	public bool EnableRaisingEvents
+	{
+		get => enabled;
+		set
+		{
+			if ( enabled == value ) return;
+			enabled = value;
+
+			if ( value ) Start();
+			else Stop();
+		}
+	}
+
+	void Start()
+	{
+		if ( string.IsNullOrEmpty( path ) )
+			throw new InvalidOperationException( "FolderWatcher needs a Path before it can be enabled" );
+
+		if ( OperatingSystem.IsMacOS() )
+		{
+			stream = new FSEventStream( path, OnEvent );
+			return;
+		}
+
+		stock = new FileSystemWatcher( path ) { IncludeSubdirectories = includeSubdirectories };
+		stock.Changed += ( s, e ) => Changed?.Invoke( this, e );
+		stock.Created += ( s, e ) => Created?.Invoke( this, e );
+		stock.Deleted += ( s, e ) => Deleted?.Invoke( this, e );
+		stock.Renamed += ( s, e ) => Renamed?.Invoke( this, e );
+		stock.EnableRaisingEvents = true;
+	}
+
+	void Stop()
+	{
+		stream?.Dispose();
+		stream = null;
+
+		stock?.Dispose();
+		stock = null;
+	}
+
+	void Restart()
+	{
+		Stop();
+		Start();
+	}
+
+	void OnEvent( string fullPath, uint flags )
+	{
+		// The stream is always recursive - drop what's deeper than asked for
+		if ( !includeSubdirectories && !string.Equals( System.IO.Path.GetDirectoryName( fullPath ), stream.Path, StringComparison.Ordinal ) )
+			return;
+
+		var changeType = FSEventStream.ChangeTypeOf( fullPath, flags );
+		var args = new FileSystemEventArgs( changeType, System.IO.Path.GetDirectoryName( fullPath ) ?? stream.Path, System.IO.Path.GetFileName( fullPath ) );
+
+		switch ( changeType )
+		{
+			case WatcherChangeTypes.Created: Created?.Invoke( this, args ); break;
+			case WatcherChangeTypes.Deleted: Deleted?.Invoke( this, args ); break;
+			default: Changed?.Invoke( this, args ); break;
+		}
+	}
+
+	public void Dispose()
+	{
+		enabled = false;
+		Stop();
+	}
+}

--- a/engine/Sandbox.Filesystem/LocalFileSystem.cs
+++ b/engine/Sandbox.Filesystem/LocalFileSystem.cs
@@ -17,10 +17,12 @@ internal class LocalFileSystem : BaseFileSystem
 			Physical = new CaseInsensitivePhysicalFileSystem();
 		}
 		// on sane operating systems with case insensitive filesystems
-		// windows + macos do the normal path
+		// windows + macos do the normal path. On macOS the watchers are FSEvents streams -
+		// .NET's watcher costs 50-100 ms to start there, and the editor starts one for every
+		// folder it mounts
 		else
 		{
-			Physical = new Zio.FileSystems.PhysicalFileSystem();
+			Physical = new FSEventsPhysicalFileSystem();
 		}
 
 		// Everything the physical filesystem hands back is in real on-disk casing, so if we root

--- a/engine/Sandbox.Filesystem/MacOS/FSEventsWatcher.cs
+++ b/engine/Sandbox.Filesystem/MacOS/FSEventsWatcher.cs
@@ -1,0 +1,283 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Zio;
+using WatcherChangeTypes = System.IO.WatcherChangeTypes;
+using Zio.FileSystems;
+
+namespace Sandbox;
+
+/// <summary>
+/// A physical filesystem whose watchers are FSEvents streams rather than <see cref="System.IO.FileSystemWatcher"/>.
+/// .NET's watcher on macOS is FSEvents underneath too, but it hands each stream to a shared run loop
+/// thread and waits on it, and that costs 50-100 ms per watcher. The editor starts about fifty at
+/// boot, one for every mounted folder - five seconds of the main thread doing nothing. A stream on a
+/// dispatch queue starts in well under a millisecond.
+/// </summary>
+internal class FSEventsPhysicalFileSystem : PhysicalFileSystem
+{
+	protected override IFileSystemWatcher WatchImpl( UPath path )
+	{
+		if ( !OperatingSystem.IsMacOS() )
+			return base.WatchImpl( path );
+
+		return new FSEventsWatcher( this, path );
+	}
+}
+
+/// <summary>
+/// One FSEvents stream over a folder, delivering every path that changes under it - the raw
+/// kernel view, symlinks resolved - with the event's flags. Shared by the Zio watcher and
+/// <see cref="FolderWatcher"/>.
+/// </summary>
+internal sealed unsafe class FSEventStream : IDisposable
+{
+	const string CoreServices = "/System/Library/Frameworks/CoreServices.framework/CoreServices";
+	const string CoreFoundation = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+	const string LibSystem = "/usr/lib/libSystem.B.dylib";
+
+	[DllImport( CoreServices )] static extern IntPtr FSEventStreamCreate( IntPtr allocator, IntPtr callback, StreamContext* context, IntPtr pathsToWatch, ulong sinceWhen, double latency, uint flags );
+	[DllImport( CoreServices )] static extern void FSEventStreamSetDispatchQueue( IntPtr stream, IntPtr queue );
+	[DllImport( CoreServices )] static extern byte FSEventStreamStart( IntPtr stream );
+	[DllImport( CoreServices )] static extern void FSEventStreamStop( IntPtr stream );
+	[DllImport( CoreServices )] static extern void FSEventStreamInvalidate( IntPtr stream );
+	[DllImport( CoreServices )] static extern void FSEventStreamRelease( IntPtr stream );
+	[DllImport( CoreFoundation )] static extern IntPtr CFStringCreateWithCString( IntPtr allocator, string cString, uint encoding );
+	[DllImport( CoreFoundation )] static extern IntPtr CFArrayCreate( IntPtr allocator, IntPtr* values, nint count, IntPtr callbacks );
+	[DllImport( CoreFoundation )] static extern void CFRelease( IntPtr cf );
+	[DllImport( LibSystem )] static extern IntPtr dispatch_queue_create( string label, IntPtr attr );
+	[DllImport( LibSystem )] static extern IntPtr realpath( string path, byte* resolved );
+
+	[StructLayout( LayoutKind.Sequential )]
+	struct StreamContext
+	{
+		public nint Version;
+		public IntPtr Info;
+		public IntPtr Retain;
+		public IntPtr Release;
+		public IntPtr CopyDescription;
+	}
+
+	const uint kCFStringEncodingUTF8 = 0x08000100;
+	const ulong kFSEventStreamEventIdSinceNow = 0xFFFFFFFFFFFFFFFF;
+
+	const uint kFSEventStreamCreateFlagNoDefer = 0x02;
+	const uint kFSEventStreamCreateFlagFileEvents = 0x10;
+
+	public const uint FlagMustScanSubDirs = 0x01;
+	public const uint FlagRootChanged = 0x20;
+	public const uint FlagItemCreated = 0x100;
+	public const uint FlagItemRemoved = 0x200;
+	public const uint FlagItemRenamed = 0x800;
+	public const uint FlagItemIsDir = 0x20000;
+
+	/// <summary>
+	/// Events for every stream arrive here, in order. One queue is plenty - the handlers just
+	/// note which paths changed.
+	/// </summary>
+	static readonly IntPtr queue = dispatch_queue_create( "sbox.fsevents", IntPtr.Zero );
+
+	/// <summary>
+	/// The folder as asked for, without a trailing slash.
+	/// </summary>
+	public string Path { get; }
+
+	// What FSEvents will call it - events come back with symlinks resolved, so a watch on
+	// /tmp/x reports /private/tmp/x
+	readonly string realPath;
+	readonly Action<string, uint> onEvent;
+
+	IntPtr stream;
+	GCHandle self;
+
+	/// <summary>
+	/// Start watching <paramref name="path"/> and everything under it. Each event is handed
+	/// to <paramref name="onEvent"/> as a path spelled under <paramref name="path"/> and the
+	/// kernel's flags for it, on a background queue.
+	/// </summary>
+	public FSEventStream( string path, Action<string, uint> onEvent )
+	{
+		Path = path.TrimEnd( '/' );
+		realPath = ResolveRealPath( Path );
+		this.onEvent = onEvent;
+
+		self = GCHandle.Alloc( this );
+
+		var context = new StreamContext { Info = GCHandle.ToIntPtr( self ) };
+		var cfPath = CFStringCreateWithCString( IntPtr.Zero, Path, kCFStringEncodingUTF8 );
+		var cfPaths = CFArrayCreate( IntPtr.Zero, &cfPath, 1, IntPtr.Zero );
+
+		try
+		{
+			// A little latency lets a burst of writes to one file arrive as one event
+			stream = FSEventStreamCreate( IntPtr.Zero, (IntPtr)(delegate* unmanaged< IntPtr, IntPtr, nuint, IntPtr, uint*, ulong*, void >)&OnEvents,
+				&context, cfPaths, kFSEventStreamEventIdSinceNow, 0.05, kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer );
+		}
+		finally
+		{
+			// The stream copied what it needs
+			CFRelease( cfPaths );
+			CFRelease( cfPath );
+		}
+
+		if ( stream == IntPtr.Zero )
+		{
+			self.Free();
+			throw new IOException( $"FSEventStreamCreate failed for {Path}" );
+		}
+
+		FSEventStreamSetDispatchQueue( stream, queue );
+
+		if ( FSEventStreamStart( stream ) == 0 )
+		{
+			FSEventStreamInvalidate( stream );
+			FSEventStreamRelease( stream );
+			stream = IntPtr.Zero;
+			self.Free();
+			throw new IOException( $"FSEventStreamStart failed for {Path}" );
+		}
+	}
+
+	public void Dispose()
+	{
+		if ( stream == IntPtr.Zero ) return;
+
+		FSEventStreamStop( stream );
+		FSEventStreamInvalidate( stream );
+		FSEventStreamRelease( stream );
+		stream = IntPtr.Zero;
+
+		// Nothing can call back once the stream is invalidated, so the handle can go
+		self.Free();
+	}
+
+	[UnmanagedCallersOnly]
+	static void OnEvents( IntPtr streamRef, IntPtr info, nuint count, IntPtr paths, uint* flags, ulong* ids )
+	{
+		if ( GCHandle.FromIntPtr( info ).Target is not FSEventStream stream )
+			return;
+
+		var cStrings = (IntPtr*)paths;
+
+		for ( nuint i = 0; i < count; i++ )
+		{
+			try
+			{
+				var path = Marshal.PtrToStringUTF8( cStrings[i] );
+				if ( path is not null ) stream.Deliver( path, flags[i] );
+			}
+			catch ( Exception )
+			{
+				// A handler's problem is not a reason to lose the rest of the batch, and
+				// nothing may escape an unmanaged callback
+			}
+		}
+	}
+
+	void Deliver( string path, uint flags )
+	{
+		// Back from what the kernel calls it to what we were asked to watch
+		if ( realPath != Path && path.StartsWith( realPath, StringComparison.Ordinal ) )
+		{
+			path = string.Concat( Path, path.AsSpan( realPath.Length ) );
+		}
+
+		if ( !path.StartsWith( Path, StringComparison.Ordinal ) )
+			return;
+
+		onEvent( path, flags );
+	}
+
+	/// <summary>
+	/// What kind of change this event is. A rename comes as one event per end with the same
+	/// flag, so the disk is asked which end this is.
+	/// </summary>
+	public static WatcherChangeTypes ChangeTypeOf( string path, uint flags )
+	{
+		// The kernel dropped events for a folder - all anyone can do is look at it again
+		if ( (flags & (FlagMustScanSubDirs | FlagRootChanged)) != 0 )
+			return WatcherChangeTypes.Changed;
+
+		if ( (flags & FlagItemRemoved) != 0 )
+			return WatcherChangeTypes.Deleted;
+
+		if ( (flags & FlagItemCreated) != 0 )
+			return WatcherChangeTypes.Created;
+
+		if ( (flags & FlagItemRenamed) != 0 )
+			return File.Exists( path ) || Directory.Exists( path ) ? WatcherChangeTypes.Created : WatcherChangeTypes.Deleted;
+
+		return WatcherChangeTypes.Changed;
+	}
+
+	static string ResolveRealPath( string path )
+	{
+		var buffer = stackalloc byte[4096];
+		var result = realpath( path, buffer );
+		if ( result == IntPtr.Zero ) return path;
+
+		return Marshal.PtrToStringUTF8( result ) ?? path;
+	}
+}
+
+/// <summary>
+/// Zio's watcher over one folder of an <see cref="FSEventsPhysicalFileSystem"/>.
+/// </summary>
+internal sealed class FSEventsWatcher : Zio.FileSystems.FileSystemWatcher
+{
+	readonly string nativePath;
+	FSEventStream stream;
+	bool enabled;
+
+	public FSEventsWatcher( FSEventsPhysicalFileSystem fileSystem, UPath path ) : base( fileSystem, path )
+	{
+		nativePath = fileSystem.ConvertPathToInternal( path );
+	}
+
+	public override bool EnableRaisingEvents
+	{
+		get => enabled;
+		set
+		{
+			if ( value == enabled ) return;
+			enabled = value;
+
+			if ( value )
+			{
+				stream = new FSEventStream( nativePath, OnEvent );
+			}
+			else
+			{
+				stream?.Dispose();
+				stream = null;
+			}
+		}
+	}
+
+	protected override void Dispose( bool disposing )
+	{
+		EnableRaisingEvents = false;
+
+		base.Dispose( disposing );
+	}
+
+	void OnEvent( string path, uint flags )
+	{
+		try
+		{
+			var changeType = FSEventStream.ChangeTypeOf( path, flags );
+			var fullPath = FileSystem.ConvertPathFromInternal( path );
+
+			switch ( changeType )
+			{
+				case WatcherChangeTypes.Created: RaiseCreated( new FileChangedEventArgs( FileSystem, Zio.WatcherChangeTypes.Created, fullPath ) ); break;
+				case WatcherChangeTypes.Deleted: RaiseDeleted( new FileChangedEventArgs( FileSystem, Zio.WatcherChangeTypes.Deleted, fullPath ) ); break;
+				default: RaiseChanged( new FileChangedEventArgs( FileSystem, Zio.WatcherChangeTypes.Changed, fullPath ) ); break;
+			}
+		}
+		catch ( Exception e )
+		{
+			RaiseError( new FileSystemErrorEventArgs( e ) );
+		}
+	}
+}

--- a/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/AssetBrowser.cs
@@ -131,7 +131,7 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 		}
 	}
 
-	private FileSystemWatcher watcher;
+	private FolderWatcher watcher;
 
 	public AssetBrowser( Widget parent ) : this( parent, null )
 	{
@@ -216,7 +216,7 @@ public partial class AssetBrowser : Widget, IBrowser, AssetSystem.IEventListener
 			Search.AssetTypes.Enabled = false;
 		}
 
-		watcher = new FileSystemWatcher();
+		watcher = new FolderWatcher();
 		watcher.Changed += OnExternalChanges;
 		watcher.Created += OnExternalChanges;
 		watcher.Deleted += OnExternalChanges;

--- a/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.Watcher.cs
+++ b/game/addons/tools/Code/Editor/AssetBrowser/Nodes/FolderNode.Watcher.cs
@@ -9,8 +9,7 @@ partial class FolderNode
 	/// <summary>
 	/// Tells folder nodes when the contents of their folder change.
 	///
-	/// This exists so we don't spam FileSystemWatcher and shit our pants.
-	/// This is the only place we use FileSystemWatcher, we should really try to use Zio instead.
+	/// This exists so we don't spam watchers and shit our pants.
 	/// </summary>
 	static class DirectoryWatcher
 	{
@@ -20,7 +19,7 @@ partial class FolderNode
 		sealed class Root
 		{
 			public string Path;
-			public FileSystemWatcher Watcher;
+			public FolderWatcher Watcher;
 		}
 
 		/// <summary>
@@ -81,7 +80,7 @@ partial class FolderNode
 
 			try
 			{
-				var watcher = new FileSystemWatcher( path ) { IncludeSubdirectories = true };
+				var watcher = new FolderWatcher( path ) { IncludeSubdirectories = true };
 
 				watcher.Created += OnChanged;
 				watcher.Deleted += OnChanged;


### PR DESCRIPTION
## Watch folders with FSEvents on macOS

Opening a project in the editor starts a filesystem watcher for every folder it mounts - core, addons, every tool and base package, the project, cloud folders - about **49 of them**. On macOS each one is `System.IO.FileSystemWatcher`, which hands its FSEvents stream to a shared run-loop thread and waits on it: **50–100 ms per watcher**, all on the main thread. That's 5.2 s of a 25 s editor boot doing nothing. A raw `FSEventStream` on a dispatch queue starts in under a millisecond (measured: 0.3–1.5 ms, no growth with stream count).

Trace, main thread, editor boot:
```
RunningInstance.Start  49×  5161 ms      (System.IO.FileSystemWatcher, via Zio)
```
Bare .NET console app, same folders: `EnableRaisingEvents` 53–66 ms each. C program, same folders, `FSEventStreamStart`: 0.3–1.5 ms.

### Fix
- `FSEventsPhysicalFileSystem` — a Zio `PhysicalFileSystem` whose `WatchImpl` returns an FSEvents-backed watcher on macOS (stock watcher elsewhere). `LocalFileSystem` and `RedirectFileSystem` use it, so every mounted filesystem gets it.
- `FSEventStream` — the interop: one stream per folder, file-level events, 50 ms latency, symlink-resolved paths mapped back to the watched spelling.
- `FolderWatcher` — public, `FileSystemWatcher`-shaped (`Path`, `IncludeSubdirectories`, `EnableRaisingEvents`, `Changed/Created/Deleted/Renamed`) for the two places in the asset browser (`AssetBrowser`, `FolderNode.DirectoryWatcher`) that watched the disk directly. FSEvents on macOS, `FileSystemWatcher` elsewhere.
- FSEvents doesn't pair the two ends of a rename, so on macOS a rename arrives as a delete + a create. Every consumer here only records "this path changed".

### Results
- Editor boot to Bootstrap Init Done: **25.6 s → 16.8 s** (this PR alone, before the others).
- Also removes ~200 ms from the launcher path in the full app, and applies to the game's mounts.

### Testing
- Hot reload: copied a `.scene` into the open project → `Detected Added File`, on-demand recompile; deleted it → detected. Asset browser folders refresh on external changes.
- Windows/Linux untouched: `WatchImpl` falls through to Zio's watcher, `FolderWatcher` wraps `FileSystemWatcher`.

### Part of a set: shortening editor startup

This PR is one of five, each independent, that together cut the time from launching `sbox-dev -project` to the editor being up. All came from tracing the editor boot on an M3 Max / macOS 27; the rows below are the main-thread cost each one removes. Exec → "Bootstrap Init Done", warm caches: **21–26 s → 12.5–16 s (~1.7×)**. Together with [mesa-kosmickrisp#5](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) (driver dlopen: `SourceEnginePreInit` 1.4 s → 0.3 s in the editor) and the launcher set ([#11837](https://github.com/Facepunch/sbox-public/pull/11837)–[#11840](https://github.com/Facepunch/sbox-public/pull/11840)).

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| **Watch folders with FSEvents on macOS (this PR)** | 49 × `FileSystemWatcher` start | 5,160 | ~0 | ~5,100 |
| [Lazy Cecil parse of trusted assemblies](https://github.com/Facepunch/sbox-public/pull/11842) | `TrustUnsafe` Cecil reads | 1,100 | 8 | ~1,100 |
| [Lazy Steam item definitions](https://github.com/Facepunch/sbox-public/pull/11843) | `GetDefinitionProperty` + inventory wait | 990 | 0 | ~1,000 |
| [Solution generation off the main thread](https://github.com/Facepunch/sbox-public/pull/11844) | `GenerateSolution` awaited mid-load | 900 | 0 (off-thread) | ~900 |
| [No GC on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11849) (superseded #11845 — now part of the ResetEnvironment rework) | `GC.Collect` + finalizers ×2 | 330 | 0 | ~330 |
| **Total, exec → Bootstrap Init Done** | | **21,000–26,000** | **12,500–16,000** | **~9,500 (1.7×)** |

Per-row numbers are trace-attributed (dotnet-trace, main thread) and stable; the end-to-end range is wide because the machine was shared with other builds during measurement.
