### PR TITLE
Don't read trusted assemblies with Cecil up front

### DIFF
--- a/engine/Sandbox.Access/AccessControl.cs
+++ b/engine/Sandbox.Access/AccessControl.cs
@@ -38,8 +38,40 @@ public partial class AccessControl : IAssemblyResolver
 	/// </summary>
 	public TrustedBinaryStream TrustUnsafe( byte[] dll )
 	{
-		var instance = new AssemblyAccess( this, dll );
+		// Reading the whole assembly with Cecil here only served the resolver, which needs the
+		// definition when some other assembly references this one - and for package.* names
+		// it already builds that on demand from the package's bytes. So just make sure a
+		// definition of an older build isn't left in the cache to answer for this one. Reading
+		// the name alone is cheap; the full read was over a second of editor startup.
+		var name = ReadAssemblyName( dll );
+
+		if ( name is not null && name.StartsWith( "package.", StringComparison.OrdinalIgnoreCase ) && PackageAssemblyResolver != null )
+		{
+			ForgetAssembly( name );
+		}
+		else
+		{
+			var instance = new AssemblyAccess( this, dll );
+		}
+
 		return TrustedBinaryStream.CreateInternal( dll );
+	}
+
+	/// <summary>
+	/// The simple name of the assembly in these bytes, without building a Cecil definition of it.
+	/// </summary>
+	static string ReadAssemblyName( byte[] dll )
+	{
+		try
+		{
+			using var pe = new System.Reflection.PortableExecutable.PEReader( new MemoryStream( dll ) );
+			var metadata = System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader( pe );
+			return metadata.GetString( metadata.GetAssemblyDefinition().Name );
+		}
+		catch ( Exception )
+		{
+			return null;
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Don't read trusted assemblies with Cecil up front

`AccessControl.TrustUnsafe` — the path every local/tool package assembly takes — built a full Cecil `AssemblyDefinition` of the DLL (`ReadSymbols = true`) and then discarded the instance. The only thing that survived was the definition in the resolver's cache, for the case where a later, access-controlled assembly references this one. For `package.*` names the resolver (`AccessControl.Resolve`) already builds exactly that on demand from the package's bytes via `PackageAssemblyResolver`.

Trace: `Mono.Cecil.ModuleDefinition.ReadModule` 1.3 s on the editor's main thread, all under `TrustUnsafe`.

### Fix
- Read just the assembly name with `System.Reflection.Metadata` (microseconds), and `ForgetAssembly(name)` so a cached definition of an older build can't answer for the new one after a hotload.
- Anything not named `package.*`, or with no `PackageAssemblyResolver`, keeps the eager parse.

### Results
- 1.1 s → 8 ms of editor boot on a Mac. Same saving anywhere local packages load.

### Testing
- Editor opens the project; tool and base packages load; hotload of a local package still resolves references (resolver path is the one the game already relies on for cloud packages).

### Part of a set: shortening editor startup

This PR is one of five, each independent, that together cut the time from launching `sbox-dev -project` to the editor being up. All came from tracing the editor boot on an M3 Max / macOS 27; the rows below are the main-thread cost each one removes. Exec → "Bootstrap Init Done", warm caches: **21–26 s → 12.5–16 s (~1.7×)**. Together with [mesa-kosmickrisp#5](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) (driver dlopen: `SourceEnginePreInit` 1.4 s → 0.3 s in the editor) and the launcher set ([#11837](https://github.com/Facepunch/sbox-public/pull/11837)–[#11840](https://github.com/Facepunch/sbox-public/pull/11840)).

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [Watch folders with FSEvents on macOS](https://github.com/Facepunch/sbox-public/pull/11841) | 49 × `FileSystemWatcher` start | 5,160 | ~0 | ~5,100 |
| **Lazy Cecil parse of trusted assemblies (this PR)** | `TrustUnsafe` Cecil reads | 1,100 | 8 | ~1,100 |
| [Lazy Steam item definitions](https://github.com/Facepunch/sbox-public/pull/11843) | `GetDefinitionProperty` + inventory wait | 990 | 0 | ~1,000 |
| [Solution generation off the main thread](https://github.com/Facepunch/sbox-public/pull/11844) | `GenerateSolution` awaited mid-load | 900 | 0 (off-thread) | ~900 |
| [No GC on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11849) (superseded #11845 — now part of the ResetEnvironment rework) | `GC.Collect` + finalizers ×2 | 330 | 0 | ~330 |
| **Total, exec → Bootstrap Init Done** | | **21,000–26,000** | **12,500–16,000** | **~9,500 (1.7×)** |

Per-row numbers are trace-attributed (dotnet-trace, main thread) and stable; the end-to-end range is wide because the machine was shared with other builds during measurement.
