### PR TITLE
Read Steam item definitions lazily, and don't hold the editor for them

### DIFF
--- a/engine/Sandbox.Engine/Core/Bootstrap.cs
+++ b/engine/Sandbox.Engine/Core/Bootstrap.cs
@@ -197,7 +197,9 @@ internal static class Bootstrap
 				Settings.RenderSettings.Instance.EnsureFirstRunPreset();
 			}
 
-			if ( !Application.IsHeadless && !Application.IsStandalone )
+			// The menu wants the items before it shows. The editor has no use for them at
+			// startup and shouldn't wait on Steam for them
+			if ( !Application.IsHeadless && !Application.IsStandalone && !Application.IsEditor )
 			{
 				// we really want the items available before we continue
 				// here we'll wait up to 5 seconds for them, but they're

--- a/engine/Sandbox.Engine/Game/Services/Inventory/ItemDefinition.cs
+++ b/engine/Sandbox.Engine/Game/Services/Inventory/ItemDefinition.cs
@@ -10,18 +10,18 @@ public static partial class Inventory
 		internal int DefinitionId;
 
 		public int Id => DefinitionId;
-		public string Name { get; private set; }
-		public string Description { get; private set; }
-		public string DescriptionWithMeta { get; private set; }
-		public string IconUrl { get; private set; }
-		public string IconUrlLarge { get; private set; }
-		public string PackageIdent { get; private set; }
-		public string Category { get; private set; }
-		public bool StoreHidden { get; private set; }
-		public string Asset { get; private set; }
-		public string Rarity { get; private set; }
-		public DateTime? SellStart { get; private set; }
-		public DateTime? SellEnd { get; private set; }
+		public string Name { get { EnsureProperties(); return field; } private set; }
+		public string Description { get { EnsureProperties(); return field; } private set; }
+		public string DescriptionWithMeta { get { EnsureProperties(); return field; } private set; }
+		public string IconUrl { get { EnsureProperties(); return field; } private set; }
+		public string IconUrlLarge { get { EnsureProperties(); return field; } private set; }
+		public string PackageIdent { get { EnsureProperties(); return field; } private set; }
+		public string Category { get { EnsureProperties(); return field; } private set; }
+		public bool StoreHidden { get { EnsureProperties(); return field; } private set; }
+		public string Asset { get { EnsureProperties(); return field; } private set; }
+		public string Rarity { get { EnsureProperties(); return field; } private set; }
+		public DateTime? SellStart { get { EnsureProperties(); return field; } private set; }
+		public DateTime? SellEnd { get { EnsureProperties(); return field; } private set; }
 
 		/// <summary>
 		/// If we're for sale, this is our price
@@ -38,6 +38,19 @@ public static partial class Inventory
 		public ItemDefinition( int id )
 		{
 			DefinitionId = id;
+		}
+
+		bool propertiesLoaded;
+
+		/// <summary>
+		/// Every property is a call into Steam, a dozen per definition, and there are hundreds
+		/// of definitions - about a second all told, on the main thread, for items most
+		/// sessions never look at. So they're read the first time something asks.
+		/// </summary>
+		void EnsureProperties()
+		{
+			if ( propertiesLoaded ) return;
+			propertiesLoaded = true;
 
 			UpdateProperties();
 		}


### PR DESCRIPTION
## Read Steam item definitions lazily, and don't hold the editor for them

`Inventory.LoadDefinitions` constructs an `ItemDefinition` for every Steam item definition, and each constructor read a dozen properties through `SteamInventory.GetDefinitionProperty` — **~1 s on the main thread** (988 ms self in the trace), for items most sessions never look at. Separately, `Bootstrap.Init` waited up to 5 s for the definitions to arrive, in the editor as well as the game.

### Fix
- `ItemDefinition` reads its properties on first access (`EnsureProperties`), not in the constructor. `Price`/`BasePrice` are unchanged (they come from the price callback).
- The bootstrap wait is skipped when `Application.IsEditor` — the menu wants items before it shows, the editor has no use for them at startup.

### Results
- ~1 s off editor boot; the game pays the property reads only for definitions it actually displays.

### Testing
- Editor boots without waiting on Steam; game menu inventory/avatar still populate (properties resolve on first read).

### Part of a set: shortening editor startup

This PR is one of five, each independent, that together cut the time from launching `sbox-dev -project` to the editor being up. All came from tracing the editor boot on an M3 Max / macOS 27; the rows below are the main-thread cost each one removes. Exec → "Bootstrap Init Done", warm caches: **21–26 s → 12.5–16 s (~1.7×)**. Together with [mesa-kosmickrisp#5](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) (driver dlopen: `SourceEnginePreInit` 1.4 s → 0.3 s in the editor) and the launcher set ([#11837](https://github.com/Facepunch/sbox-public/pull/11837)–[#11840](https://github.com/Facepunch/sbox-public/pull/11840)).

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [Watch folders with FSEvents on macOS](https://github.com/Facepunch/sbox-public/pull/11841) | 49 × `FileSystemWatcher` start | 5,160 | ~0 | ~5,100 |
| [Lazy Cecil parse of trusted assemblies](https://github.com/Facepunch/sbox-public/pull/11842) | `TrustUnsafe` Cecil reads | 1,100 | 8 | ~1,100 |
| **Lazy Steam item definitions (this PR)** | `GetDefinitionProperty` + inventory wait | 990 | 0 | ~1,000 |
| [Solution generation off the main thread](https://github.com/Facepunch/sbox-public/pull/11844) | `GenerateSolution` awaited mid-load | 900 | 0 (off-thread) | ~900 |
| [No GC on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11849) (superseded #11845 — now part of the ResetEnvironment rework) | `GC.Collect` + finalizers ×2 | 330 | 0 | ~330 |
| **Total, exec → Bootstrap Init Done** | | **21,000–26,000** | **12,500–16,000** | **~9,500 (1.7×)** |

Per-row numbers are trace-attributed (dotnet-trace, main thread) and stable; the end-to-end range is wide because the machine was shared with other builds during measurement.
