### PR TITLE
Generate the solution off the main thread while the project loads

### DIFF
--- a/engine/Sandbox.Tools/StartupLoadProject.cs
+++ b/engine/Sandbox.Tools/StartupLoadProject.cs
@@ -171,11 +171,11 @@ static class StartupLoadProject
 
 		ExportSettings( project );
 
+		// The solution is for the IDE, nothing here reads it, and writing it is most of a
+		// second of walking every project's code. It goes on the pool and the load carries
+		// on; the projects are all known by now and it only reads them
 		Step( "Generating solution" );
-		using ( var _ = Bootstrap.StartupTiming?.ScopeTimer( $"Load Project: Generate Solution" ) )
-		{
-			await Project.GenerateSolution();
-		}
+		_ = Task.Run( Project.GenerateSolution );
 
 		Step( "Creating filesystem" );
 		using ( var _ = Bootstrap.StartupTiming?.ScopeTimer( $"Load Project: Update ProjectFilesystem" ) )


### PR DESCRIPTION
## Generate the solution off the main thread while the project loads

`StartupLoadProject.OpenProject` awaited `Project.GenerateSolution()` in the middle of loading — walking every project's code folders and writing the csproj/slnx files — **~900 ms** on the main thread. Nothing during the load reads those files; they're for the IDE.

### Fix
- `_ = Task.Run( Project.GenerateSolution )` at the same point. All projects are known by then and generation only reads them (and writes the IDE files, as before).

### Results
- 0.9 s off the critical path; the files still land within the first second or two.

### Testing
- `my_project.slnx` / csproj regenerate as before (byte-identical output in the test project, so mtime unchanged when nothing changed).

### Part of a set: shortening editor startup

This PR is one of five, each independent, that together cut the time from launching `sbox-dev -project` to the editor being up. All came from tracing the editor boot on an M3 Max / macOS 27; the rows below are the main-thread cost each one removes. Exec → "Bootstrap Init Done", warm caches: **21–26 s → 12.5–16 s (~1.7×)**. Together with [mesa-kosmickrisp#5](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) (driver dlopen: `SourceEnginePreInit` 1.4 s → 0.3 s in the editor) and the launcher set ([#11837](https://github.com/Facepunch/sbox-public/pull/11837)–[#11840](https://github.com/Facepunch/sbox-public/pull/11840)).

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [Watch folders with FSEvents on macOS](https://github.com/Facepunch/sbox-public/pull/11841) | 49 × `FileSystemWatcher` start | 5,160 | ~0 | ~5,100 |
| [Lazy Cecil parse of trusted assemblies](https://github.com/Facepunch/sbox-public/pull/11842) | `TrustUnsafe` Cecil reads | 1,100 | 8 | ~1,100 |
| [Lazy Steam item definitions](https://github.com/Facepunch/sbox-public/pull/11843) | `GetDefinitionProperty` + inventory wait | 990 | 0 | ~1,000 |
| **Solution generation off the main thread (this PR)** | `GenerateSolution` awaited mid-load | 900 | 0 (off-thread) | ~900 |
| [No GC on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11849) (superseded #11845 — now part of the ResetEnvironment rework) | `GC.Collect` + finalizers ×2 | 330 | 0 | ~330 |
| **Total, exec → Bootstrap Init Done** | | **21,000–26,000** | **12,500–16,000** | **~9,500 (1.7×)** |

Per-row numbers are trace-attributed (dotnet-trace, main thread) and stable; the end-to-end range is wide because the machine was shared with other builds during measurement.
