### PR TITLE
Don't collect garbage on the first ResetEnvironment

### DIFF
--- a/engine/Sandbox.GameInstance/GameInstanceDll.cs
+++ b/engine/Sandbox.GameInstance/GameInstanceDll.cs
@@ -252,13 +252,22 @@ internal partial class GameInstanceDll : Engine.IGameInstanceDll
 
 		IMenuDll.Current?.Reset();
 
-		// Run GC and finalizers to clear any native resources held
-		GC.Collect();
-		GC.WaitForPendingFinalizers();
+		// Run GC and finalizers to clear any native resources held. Not the first time
+		// through - there's been no game yet, so there's nothing to clear, and a full
+		// collection during startup is a couple of hundred milliseconds of nothing
+		if ( hasResetBefore )
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
 
-		// Run the queue one more time, since some finalizers queue tasks
-		MainThread.RunQueues();
+			// Run the queue one more time, since some finalizers queue tasks
+			MainThread.RunQueues();
+		}
+
+		hasResetBefore = true;
 	}
+
+	static bool hasResetBefore;
 
 	/// <summary>
 	/// This method grabs the currently loaded assembly's code archive, strips serverside code and spits it back out into the 


### PR DESCRIPTION
## Don't collect garbage on the first ResetEnvironment

`GameInstanceDll.ResetEnvironment` does a full `GC.Collect` + `WaitForPendingFinalizers` so a game's native resources are released before the next one loads. The first time through — `Initialize` and again on the first `LoadGamePackage` — there has been no game, so it's a few hundred milliseconds of startup doing nothing.

### Fix
- `hasResetBefore` flag; the collection runs only once something has actually been reset.

### Results
- Editor: ~330 ms (two resets). Game: measured by the game-startup set ([#11846](https://github.com/Facepunch/sbox-public/pull/11846), [#11847](https://github.com/Facepunch/sbox-public/pull/11847), [#11848](https://github.com/Facepunch/sbox-public/pull/11848), [#11849](https://github.com/Facepunch/sbox-public/pull/11849)) together with the matching TypeLibrary gate ([#11849](https://github.com/Facepunch/sbox-public/pull/11849), stacked on this branch): game-instance init **696 → ~270 ms**; the two interact (skipping the TypeLibrary rebuild alone gains ~90 ms because the forced GC then grows).

### Testing
- Editor opens; game loads a package after the menu (second reset collects as before).

### Part of a set: shortening editor startup

This PR is one of five, each independent, that together cut the time from launching `sbox-dev -project` to the editor being up. All came from tracing the editor boot on an M3 Max / macOS 27; the rows below are the main-thread cost each one removes. Exec → "Bootstrap Init Done", warm caches: **21–26 s → 12.5–16 s (~1.7×)**. Together with [mesa-kosmickrisp#5](https://github.com/Facepunch/mesa-kosmickrisp/pull/5) (driver dlopen: `SourceEnginePreInit` 1.4 s → 0.3 s in the editor) and the launcher set ([#11837](https://github.com/Facepunch/sbox-public/pull/11837)–[#11840](https://github.com/Facepunch/sbox-public/pull/11840)).

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [Watch folders with FSEvents on macOS](https://github.com/Facepunch/sbox-public/pull/11841) | 49 × `FileSystemWatcher` start | 5,160 | ~0 | ~5,100 |
| [Lazy Cecil parse of trusted assemblies](https://github.com/Facepunch/sbox-public/pull/11842) | `TrustUnsafe` Cecil reads | 1,100 | 8 | ~1,100 |
| [Lazy Steam item definitions](https://github.com/Facepunch/sbox-public/pull/11843) | `GetDefinitionProperty` + inventory wait | 990 | 0 | ~1,000 |
| [Solution generation off the main thread](https://github.com/Facepunch/sbox-public/pull/11844) | `GenerateSolution` awaited mid-load | 900 | 0 (off-thread) | ~900 |
| **No GC on the first ResetEnvironment (this PR)** | `GC.Collect` + finalizers ×2 | 330 | 0 | ~330 |
| **Total, exec → Bootstrap Init Done** | | **21,000–26,000** | **12,500–16,000** | **~9,500 (1.7×)** |

Per-row numbers are trace-attributed (dotnet-trace, main thread) and stable; the end-to-end range is wide because the machine was shared with other builds during measurement.
