### PR TITLE
Cache the menu's compiled assembly for the game, not just the retail editor

### DIFF
--- a/engine/Sandbox.Engine/Systems/Project/Project/Project.Compiling.cs
+++ b/engine/Sandbox.Engine/Systems/Project/Project/Project.Compiling.cs
@@ -32,9 +32,13 @@ public partial class Project
 	int CompilerHash => HashCode.Combine( Active, Current == this, Json.SerializeAsObject( Config.GetCompileSettings() ).ToJsonString(), Config.IsStandaloneOnly, Config.Org, Config.Ident, Config.Type, string.Join( ";", PackageReferences() ) );
 
 	/// <summary>
-	/// Whether to save/load compiled assemblies to disk.
+	/// Whether to save/load compiled assemblies to disk. Built-in projects (the menu, the
+	/// tools) are compiled from the same sources on every launch, and the game had no
+	/// precompiled .bin to fall back on outside of a shipped build - so a source checkout
+	/// paid a full Roslyn build of the menu (several seconds) before every main menu.
+	/// The cache is fingerprinted against the sources and the engine assemblies.
 	/// </summary>
-	bool CacheAssemblies => IsBuiltIn && Application.IsRetail && Application.IsEditor;
+	bool CacheAssemblies => IsBuiltIn && Application.IsRetail && !Application.IsUnitTest && !Application.IsHeadless;
 
 	private void UpdateCompiler()
 	{
@@ -226,6 +230,24 @@ public partial class Project
 				return false;
 
 			//
+			// The cached assembly was compiled against the engine assemblies of that time. A
+			// rebuilt engine can change the API it was bound to, which the source checks below
+			// can't see - so any newer assembly next to ours forces a recompile.
+			//
+			var managedDir = Path.GetDirectoryName( typeof( Project ).Assembly.Location );
+			if ( !string.IsNullOrEmpty( managedDir ) && Directory.Exists( managedDir ) )
+			{
+				foreach ( var dll in Directory.EnumerateFiles( managedDir, "*.dll" ) )
+				{
+					if ( File.GetLastWriteTimeUtc( dll ) > compileTime )
+					{
+						Log.Info( $"{compiler.Name}: Engine assembly {Path.GetFileName( dll )} is newer than the cached assembly. Forcing recompile." );
+						return false;
+					}
+				}
+			}
+
+			//
 			// Finally, check if it's out of date.
 			// If any source files have been modified since the assembly was compiled, we can't use it.
 			//
@@ -258,6 +280,7 @@ public partial class Project
 			// All good, swap in the assembly
 			compiler.UpdateFromAssembly( bytes );
 			AssemblyFileSystem.WriteAllBytes( $"/.bin/{compiler.AssemblyName}.dll", bytes );
+			Log.Info( $"{compiler.Name}: Using cached assembly compiled at {compileTime:u}" );
 
 			return true;
 		}


### PR DESCRIPTION
## Cache the menu's compiled assembly for the game, not just the retail editor

Every launch of the game outside a shipped build compiled the menu addon from source. `LoadPrecompiled` only looks for `addons/menu/.bin`, which a source checkout doesn't have, and the fingerprinted cache in `.sbox/bin` was gated to `IsRetail && IsEditor`. On an M3 Max that is a **~3,460 ms** Roslyn build of 35 `.cs` and 209 `.razor` files on every start, before the main menu can load - the single largest phase of game startup:

```
Menu - CompileAsync took 3608ms   (baseline run 2)
Menu - CompileAsync took 3306ms   (baseline run 3)
```

### Fix
- `CacheAssemblies` covers the retail game as well (not unit tests, not headless). On a cache hit `CompileAsync` has nothing to build.
- The fingerprint also checks the engine: the cached menu was bound against the engine assemblies of its compile time, and the existing source-file mtime checks can't see an engine rebuild. Any dll in `bin/managed` newer than the cache forces a recompile, so a stale menu can't run against a changed engine API. The first launch after an engine build still compiles; the next one hits.
- Log `Using cached assembly compiled at ...` so the startup log shows which path ran.

### Results
- Menu compile 3,460 → 0 ms on a cache hit.
- Exec → first menu frame 11,100 → ~7,800 ms with this PR alone.

### Testing
- First launch after an engine build compiles and writes `addons/menu/.sbox/bin`; the second logs the cache hit and reaches the same menu.
- Touching a menu `.cs`/`.razor`, or rebuilding any engine assembly, logs `Forcing recompile` and compiles once.
- Editor path unchanged (it already used the cache); menu hot reload in the game still watches the sources through the compiler `UpdateCompiler` creates.

### Part of a set: shortening game startup

This PR is one of four, each independent, that together cut the time from starting the game to the first menu frame. All came from tracing the game boot on an M3 Max / macOS 27; the rows below are the cost each one removes. Exec → first menu frame, warm caches: **~11.1 s → ~5.9 s (1.9×)**; the first launch after an engine build, which still compiles the menu, ~11.1 s → ~8.4 s. The TypeLibrary PR stacks on [#11845](https://github.com/Facepunch/sbox-public/pull/11845) from the editor set ([#11841](https://github.com/Facepunch/sbox-public/pull/11841)–[#11845](https://github.com/Facepunch/sbox-public/pull/11845)); the two `ResetEnvironment` gates interact, and together take game-instance init 696 → ~270 ms.

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| **Cache the menu assembly for the game (this PR)** | Menu Roslyn compile (`Project.CompileAsync`) | 3,460 | 0 on a cache hit | ~3,450 (every launch but the first after an engine build) |
| [Display modes off the menu critical path](https://github.com/Facepunch/sbox-public/pull/11847) | `SDL_GetFullscreenDisplayModes` in the menu scene load | 980 | 70 | ~910 |
| [Generator: bind only string-literal calls](https://github.com/Facepunch/sbox-public/pull/11848) | Generator `GetSymbolInfo` per invocation, cold compile | 3,460 | 2,600 | ~860 (launches that compile) |
| [No TypeLibrary rebuild on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11849) | `Game.InitTypeLibrary` ×2 on the first pass | 700 | 600 alone, ~270 with #11845 | ~90 alone, ~275 with #11845 |
| [No GC on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11845) | `GC.Collect` + finalizers on the first pass | 700 | ~270 with the TypeLibrary PR | ~200–340 |
| **Total, exec → first menu frame** | | **~11,100** | **~5,900** | **~5,200 (1.9×)** |

Per-row numbers are each PR's own before/after against master, medians of 3–4 runs with `StartupTiming` scopes on the main thread; single phases swung a few hundred ms because the machine was shared with other work, so the rows don't sum exactly to the total.
