### PR TITLE
Don't enumerate display modes on the main menu's critical path

### DIFF
--- a/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.VideoMode.cs
+++ b/engine/Sandbox.Engine/Systems/Render/Settings/RenderSettings.VideoMode.cs
@@ -111,17 +111,32 @@ public partial class RenderSettings
 		}
 	}
 
+	static VideoDisplayMode[] cachedFullscreenModes;
+	static VideoDisplayMode[] cachedWindowedModes;
+
+	/// <summary>
+	/// The modes the display can do. Asking the platform is not free - on macOS the first
+	/// enumeration is close to a second on the main thread - so the answer is kept for the
+	/// life of the process, the same way the menu keeps its resolution list.
+	/// </summary>
 	public unsafe VideoDisplayMode[] DisplayModes( bool windowed )
 	{
-		var modes = new VideoDisplayMode[256];
+		ref var cache = ref (windowed ? ref cachedWindowedModes : ref cachedFullscreenModes);
 
-		fixed ( VideoDisplayMode* ptr = modes )
+		if ( cache is null )
 		{
-			var c = NativeEngine.RenderDeviceManager.GetDisplayModes( ptr, modes.Length, windowed );
-			Array.Resize( ref modes, c );
+			var modes = new VideoDisplayMode[256];
+
+			fixed ( VideoDisplayMode* ptr = modes )
+			{
+				var c = NativeEngine.RenderDeviceManager.GetDisplayModes( ptr, modes.Length, windowed );
+				Array.Resize( ref modes, c );
+			}
+
+			cache = modes;
 		}
 
-		return modes;
+		return (VideoDisplayMode[])cache.Clone();
 	}
 
 

--- a/game/addons/menu/Code/MainMenu.razor
+++ b/game/addons/menu/Code/MainMenu.razor
@@ -45,9 +45,6 @@
 
         Instance = this;
 
-        // Fetch resolutions now so opening the settings doesn't stutter later.
-        MenuProject.Settings.SettingsCatalog.FetchResolutions();
-
         _ = ShowStartupModalsIfNeeded();
     }
 

--- a/game/addons/menu/Code/Settings/SettingsCatalog.cs
+++ b/game/addons/menu/Code/Settings/SettingsCatalog.cs
@@ -937,20 +937,24 @@ public class SettingsCatalog
 		_ => ""
 	};
 
-	static List<Option> resolutionOptions = [];
+	static List<Option> resolutionOptions;
 
+	/// <summary>
+	/// The resolutions the display can do, asked for the first time they're needed. The engine
+	/// keeps the display modes for the process, so this is only ever slow once - and not
+	/// before the main menu is on screen, which is what asking during startup cost on macOS.
+	/// </summary>
 	public static List<Option> ResolutionOptions
 	{
 		get
 		{
-			if ( resolutionOptions.Count == 0 )
+			if ( resolutionOptions is null )
 				FetchResolutions();
 
 			return resolutionOptions;
 		}
 	}
 
-	/// <summary>Asks DXGI what the display can do. Can stutter, so it's done once on startup.</summary>
 	public static void FetchResolutions()
 	{
 		const float smallestAspect = 1.5f;


### PR DESCRIPTION
## Don't enumerate display modes on the main menu's critical path

`MainMenu.OnEnabled` called `SettingsCatalog.FetchResolutions()` so the settings page wouldn't stutter later. On macOS that one call to `RenderSettings.DisplayModes` is **~930 ms on the main thread**, and it ran inside the menu scene load, before the first frame. DXGI on Windows answers the same question in a few milliseconds, which is why it never showed there.

```
DisplayModes call #1 took 928ms
   at Sandbox.Engine.Settings.RenderSettings.DisplayModes(Boolean windowed)
   at MenuProject.Settings.SettingsCatalog.FetchResolutions()   SettingsCatalog.cs:958
   at MenuProject.MainMenu.OnEnabled()                           MainMenu.razor:55
   at Sandbox.Scene.Load(SceneLoadOptions options)
   at Sandbox.MenuScene.Startup(String sceneName)
```

Time Profiler puts the cost in `SDL_GetFullscreenDisplayModes` → `Cocoa_GetDisplayModes` → `display_mode_equal` → `CFEqual`: every mode Cocoa reports compared against every other, a few hundred modes on a Retina display.

### Fix
- `RenderSettings.DisplayModes` keeps the answer for the life of the process (per `windowed` flag; callers get a copy).
- The menu asks for the resolution list the first time the Display settings page needs it, not in `OnEnabled`. The one-time cost moves from startup to that first open, a pause of under a second there on macOS, once per launch.
- I tried hiding it behind the menu compile wait in `MenuDll.Initialize` instead; the compile's continuations need the main thread, so a blocking call there only delayed the compile by the same amount.

### Results
- Menu scene load 980 → 70 ms.
- Exec → first menu frame 11,100 → ~9,500 ms with this PR alone.

### Testing
- Main menu renders as before; the Display settings page lists the same resolutions, with the one-time pause on macOS the first time it opens.
- Changing resolution and fullscreen in settings still applies (`ChangeVideoMode` untouched).

### Part of a set: shortening game startup

This PR is one of four, each independent, that together cut the time from starting the game to the first menu frame. All came from tracing the game boot on an M3 Max / macOS 27; the rows below are the cost each one removes. Exec → first menu frame, warm caches: **~11.1 s → ~5.9 s (1.9×)**; the first launch after an engine build, which still compiles the menu, ~11.1 s → ~8.4 s. The TypeLibrary PR stacks on [#11845](https://github.com/Facepunch/sbox-public/pull/11845) from the editor set ([#11841](https://github.com/Facepunch/sbox-public/pull/11841)–[#11845](https://github.com/Facepunch/sbox-public/pull/11845)); the two `ResetEnvironment` gates interact, and together take game-instance init 696 → ~270 ms.

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [Cache the menu assembly for the game](https://github.com/Facepunch/sbox-public/pull/11846) | Menu Roslyn compile (`Project.CompileAsync`) | 3,460 | 0 on a cache hit | ~3,450 (every launch but the first after an engine build) |
| **Display modes off the menu critical path (this PR)** | `SDL_GetFullscreenDisplayModes` in the menu scene load | 980 | 70 | ~910 |
| [Generator: bind only string-literal calls](https://github.com/Facepunch/sbox-public/pull/11848) | Generator `GetSymbolInfo` per invocation, cold compile | 3,460 | 2,600 | ~860 (launches that compile) |
| [No TypeLibrary rebuild on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11849) | `Game.InitTypeLibrary` ×2 on the first pass | 700 | 600 alone, ~270 with #11845 | ~90 alone, ~275 with #11845 |
| [No GC on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11845) | `GC.Collect` + finalizers on the first pass | 700 | ~270 with the TypeLibrary PR | ~200–340 |
| **Total, exec → first menu frame** | | **~11,100** | **~5,900** | **~5,200 (1.9×)** |

Per-row numbers are each PR's own before/after against master, medians of 3–4 runs with `StartupTiming` scopes on the main thread; single phases swung a few hundred ms because the machine was shared with other work, so the rows don't sum exactly to the total.
