### PR TITLE
Generator: only bind calls that pass a string literal

### DIFF
--- a/engine/Sandbox.Generator/Worker.cs
+++ b/engine/Sandbox.Generator/Worker.cs
@@ -199,16 +199,38 @@ namespace Sandbox.Generator
 		public override SyntaxNode VisitInvocationExpression( InvocationExpressionSyntax node )
 		{
 			var location = node.GetLocation();
-			var symbolInfo = Model.GetSymbolInfo( node.Expression );
-			node = base.VisitInvocationExpression( node ) as InvocationExpressionSyntax;
 
-			var symlist = symbolInfo.CandidateSymbols;
-			if ( symbolInfo.Symbol is not null ) symlist = ImmutableArray.Create( symbolInfo.Symbol );
+			// Both rewrites below only ever touch a call that passes a string literal - the
+			// cloud asset provider wants exactly one, the token upgrader wants at least one.
+			// Binding the callee is the expensive part: the semantic model enumerates every
+			// extension method in scope for it, and it was asked for on every call in every
+			// file - more time than Roslyn then spent compiling the code. Ask only for the
+			// calls the rewrites can act on.
+			var symlist = ImmutableArray<ISymbol>.Empty;
+			if ( HasStringLiteralArgument( node ) )
+			{
+				var symbolInfo = Model.GetSymbolInfo( node.Expression );
+				symlist = symbolInfo.CandidateSymbols;
+				if ( symbolInfo.Symbol is not null ) symlist = ImmutableArray.Create( symbolInfo.Symbol );
+			}
+
+			node = base.VisitInvocationExpression( node ) as InvocationExpressionSyntax;
 
 			CloudAssetProvider.VisitInvocation( ref node, location, symlist, this );
 			StringTokenUpgrader.VisitInvocation( ref node, location, symlist, this );
 
 			return node;
+		}
+
+		static bool HasStringLiteralArgument( InvocationExpressionSyntax node )
+		{
+			foreach ( var argument in node.ArgumentList.Arguments )
+			{
+				if ( argument.Expression.IsKind( SyntaxKind.StringLiteralExpression ) )
+					return true;
+			}
+
+			return false;
 		}
 
 		public override SyntaxNode VisitIdentifierName( IdentifierNameSyntax node )


### PR DESCRIPTION
## Generator: only bind calls that pass a string literal

`Worker.VisitInvocationExpression` asked the semantic model for the callee of every invocation in every file it rewrote. Binding an invocation makes Roslyn enumerate every extension method in scope, and a cold editor trace put **~200 s of pool CPU in the generator's `GetSymbolInfo` against ~120 s in Roslyn's own `MethodCompiler`** - the generator cost more than compiling the code:

```
Sandbox.Generator.Worker.VisitClassDeclaration
 → VisitInvocationExpression
   → CSharpSemanticModel.GetSymbolInfoForNode
     → Binder.EnumerateAllExtensionMembersInSingleBinder   ~120 s of the 200 s
```

The two rewrites that consume that answer only act on a call that passes a string literal: `CloudAssetProvider` wants exactly one, `StringTokenUpgrader` wants at least one and only rewrites the string-literal arguments.

### Fix
- Look at the argument list first; only bind the calls that have a string-literal argument. Everything else gets an empty candidate list, which both rewrites already treat as "not for me". No change to what gets rewritten.

### Results
- Menu addon compile, cold: 3,460 → 2,600 ms (−25%). Matters on every launch that compiles - the first after an engine build once the menu cache PR is in, every launch before it - and on every editor compile.

### Testing
- Menu compiles and runs; `StringToken` literal upgrades and `[CloudAssetProvider]` calls still rewrite (both take string literals).
- Editor compiles of the tools projects unchanged in output.

### Part of a set: shortening game startup

This PR is one of four, each independent, that together cut the time from starting the game to the first menu frame. All came from tracing the game boot on an M3 Max / macOS 27; the rows below are the cost each one removes. Exec → first menu frame, warm caches: **~11.1 s → ~5.9 s (1.9×)**; the first launch after an engine build, which still compiles the menu, ~11.1 s → ~8.4 s. The TypeLibrary PR stacks on [#11845](https://github.com/Facepunch/sbox-public/pull/11845) from the editor set ([#11841](https://github.com/Facepunch/sbox-public/pull/11841)–[#11845](https://github.com/Facepunch/sbox-public/pull/11845)); the two `ResetEnvironment` gates interact, and together take game-instance init 696 → ~270 ms.

| PR | Main-thread cost | Before (ms) | After (ms) | Saved (ms) |
|---|---|---|---|---|
| [Cache the menu assembly for the game](https://github.com/Facepunch/sbox-public/pull/11846) | Menu Roslyn compile (`Project.CompileAsync`) | 3,460 | 0 on a cache hit | ~3,450 (every launch but the first after an engine build) |
| [Display modes off the menu critical path](https://github.com/Facepunch/sbox-public/pull/11847) | `SDL_GetFullscreenDisplayModes` in the menu scene load | 980 | 70 | ~910 |
| **Generator: bind only string-literal calls (this PR)** | Generator `GetSymbolInfo` per invocation, cold compile | 3,460 | 2,600 | ~860 (launches that compile) |
| [No TypeLibrary rebuild on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11849) | `Game.InitTypeLibrary` ×2 on the first pass | 700 | 600 alone, ~270 with #11845 | ~90 alone, ~275 with #11845 |
| [No GC on the first ResetEnvironment](https://github.com/Facepunch/sbox-public/pull/11845) | `GC.Collect` + finalizers on the first pass | 700 | ~270 with the TypeLibrary PR | ~200–340 |
| **Total, exec → first menu frame** | | **~11,100** | **~5,900** | **~5,200 (1.9×)** |

Per-row numbers are each PR's own before/after against master, medians of 3–4 runs with `StartupTiming` scopes on the main thread; single phases swung a few hundred ms because the machine was shared with other work, so the rows don't sum exactly to the total.
